### PR TITLE
@W-18564973: Add tool annotations

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -31,9 +31,10 @@ export default [
       'simple-import-sort': simpleImportSort,
     },
     rules: {
+      'no-duplicate-imports': ['error', { includeExports: true }],
       'simple-import-sort/imports': 'error',
-      '@typescript-eslint/explicit-function-return-type': ['error', { allowExpressions: true }],
       'simple-import-sort/exports': 'error',
+      '@typescript-eslint/explicit-function-return-type': ['error', { allowExpressions: true }],
       '@typescript-eslint/no-explicit-any': 'off',
       '@typescript-eslint/no-this-alias': 'off',
       '@typescript-eslint/no-unused-vars': [

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "inspect": "npx @modelcontextprotocol/inspector --config config.json --server tableau",
     "inspect:docker": "npx @modelcontextprotocol/inspector --config config.docker.json --server tableau",
     "build:inspect": "npm run build && npm run inspect",
+    "build:inspect:docker": "npm run build && npm run inspect:docker",
     "exec-perms": "shx chmod +x build/*.js",
     "test": "vitest",
     "coverage": "vitest run --coverage"

--- a/src/sdks/tableau/methods/methods.ts
+++ b/src/sdks/tableau/methods/methods.ts
@@ -1,5 +1,4 @@
-import { ZodiosClass, ZodiosInstance } from '@zodios/core';
-import { ZodiosEndpointDefinitions } from '@zodios/core';
+import { ZodiosClass, ZodiosEndpointDefinitions, ZodiosInstance } from '@zodios/core';
 
 export default class Methods<T extends ZodiosEndpointDefinitions> {
   protected _apiClient: ZodiosInstance<T>;

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -34,6 +34,7 @@ describe('server', () => {
         tool.name,
         tool.description,
         tool.paramsSchema,
+        tool.annotations,
         tool.callback,
       );
     }
@@ -49,6 +50,7 @@ describe('server', () => {
         tool.name,
         tool.description,
         tool.paramsSchema,
+        tool.annotations,
         tool.callback,
       );
     }
@@ -65,6 +67,7 @@ describe('server', () => {
           tool.name,
           tool.description,
           tool.paramsSchema,
+          tool.annotations,
           tool.callback,
         );
       } else {
@@ -72,6 +75,7 @@ describe('server', () => {
           tool.name,
           tool.description,
           tool.paramsSchema,
+          tool.annotations,
           tool.callback,
         );
       }

--- a/src/server.ts
+++ b/src/server.ts
@@ -31,8 +31,8 @@ class Server extends McpServer {
   }
 
   registerTools = (): void => {
-    for (const { name, description, paramsSchema, callback } of getToolsToRegister()) {
-      this.tool(name, description, paramsSchema, callback);
+    for (const { name, description, paramsSchema, annotations, callback } of getToolsToRegister()) {
+      this.tool(name, description, paramsSchema, annotations, callback);
     }
   };
 

--- a/src/tools/listDatasources.ts
+++ b/src/tools/listDatasources.ts
@@ -24,6 +24,11 @@ Retrieves a list of published data sources from a specified Tableau site using t
   paramsSchema: {
     filter: z.string().optional(),
   },
+  annotations: {
+    title: 'List Datasources',
+    readOnlyHint: true,
+    openWorldHint: false,
+  },
   callback: async ({ filter }): Promise<CallToolResult> => {
     const config = getConfig();
     return await listDatasourcesTool.logAndExecute({

--- a/src/tools/listFields.ts
+++ b/src/tools/listFields.ts
@@ -22,6 +22,11 @@ export const listFieldsTool = new Tool({
   paramsSchema: {
     datasourceLuid: z.string(),
   },
+  annotations: {
+    title: 'List Fields',
+    readOnlyHint: true,
+    openWorldHint: false,
+  },
   callback: async ({ datasourceLuid }): Promise<CallToolResult> => {
     const config = getConfig();
     const query = getGraphqlQuery(datasourceLuid);

--- a/src/tools/queryDatasource/queryDatasource.ts
+++ b/src/tools/queryDatasource/queryDatasource.ts
@@ -14,6 +14,11 @@ export const queryDatasourceTool = new Tool({
     datasourceLuid: z.string(),
     datasourceQuery: DatasourceQuery,
   },
+  annotations: {
+    title: 'Query Datasource',
+    readOnlyHint: true,
+    openWorldHint: false,
+  },
   callback: async ({ datasourceLuid, datasourceQuery }): Promise<CallToolResult> => {
     const config = getConfig();
     return await queryDatasourceTool.logAndExecute({

--- a/src/tools/readMetadata.ts
+++ b/src/tools/readMetadata.ts
@@ -12,6 +12,11 @@ export const readMetadataTool = new Tool({
   paramsSchema: {
     datasourceLuid: z.string(),
   },
+  annotations: {
+    title: 'Read Metadata',
+    readOnlyHint: true,
+    openWorldHint: false,
+  },
   callback: async ({ datasourceLuid }): Promise<CallToolResult> => {
     const config = getConfig();
 

--- a/src/tools/tool.test.ts
+++ b/src/tools/tool.test.ts
@@ -15,6 +15,11 @@ describe('Tool', () => {
     paramsSchema: {
       param1: z.string(),
     },
+    annotations: {
+      title: 'List Fields',
+      readOnlyHint: true,
+      openWorldHint: false,
+    },
     callback: vi.fn(),
   } as const;
 

--- a/src/tools/tool.ts
+++ b/src/tools/tool.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from 'node:crypto';
 
 import { ToolCallback } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { CallToolResult, ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
 import { Err, Ok, Result } from 'ts-results-es';
 import { ZodRawShape } from 'zod';
 
@@ -13,6 +13,7 @@ export type ToolParams<Args extends ZodRawShape | undefined = undefined> = {
   name: ToolName;
   description: string;
   paramsSchema: Args;
+  annotations: ToolAnnotations;
   callback: ToolCallback<Args>;
 };
 
@@ -20,12 +21,14 @@ export class Tool<Args extends ZodRawShape | undefined = undefined> {
   name: ToolName;
   description: string;
   paramsSchema: Args;
+  annotations: ToolAnnotations;
   callback: ToolCallback<Args>;
 
-  constructor({ name, description, paramsSchema, callback }: ToolParams<Args>) {
+  constructor({ name, description, paramsSchema, annotations, callback }: ToolParams<Args>) {
     this.name = name;
     this.description = description;
     this.paramsSchema = paramsSchema;
+    this.annotations = annotations;
     this.callback = callback;
   }
 


### PR DESCRIPTION
From https://modelcontextprotocol.io/docs/concepts/tools#tool-annotations

> Tool annotations provide additional metadata about a tool’s behavior, helping clients understand how to present and manage tools. These annotations are hints that describe the nature and impact of a tool, but should not be relied upon for security decisions.

> Tool annotations serve several key purposes:
> 
> 1. Provide UX-specific information without affecting model context
> 2. Help clients categorize and present tools appropriately
> 3. Convey information about a tool’s potential side effects
> 4. Assist in developing intuitive interfaces for tool approval