### PR TITLE
Remove cieq and has filter operators

### DIFF
--- a/src/tools/listDatasources/listDatasources.ts
+++ b/src/tools/listDatasources/listDatasources.ts
@@ -47,17 +47,15 @@ Retrieves a list of published data sources from a specified Tableau site using t
 | updatedAt              | eq, gt, gte, lt, lte                      |
 
 **Supported Operators**
-- \`cieq\`: case-insensitive equals
 - \`eq\`: equals
 - \`gt\`: greater than
 - \`gte\`: greater than or equal
-- \`has\`: includes the specified string (substring search, only for Query Jobs)
 - \`in\`: any of [list] (for searching tags)
 - \`lt\`: less than
 - \`lte\`: less than or equal
 
 **Filter Expression Notes**
-- Filter expressions can’t contain ampersand (&) or comma (,) characters even if those characters are encoded.
+- Filter expressions can't contain ampersand (&) or comma (,) characters even if those characters are encoded.
 - Operators are delimited with colons (:). For example: \`filter=name:eq:Project Views\`
 - Field names, operator names, and values are case-sensitive.
 - To filter on multiple fields, combine expressions using a comma:  \`filter=lastLogin:gte:2016-01-01T00:00:00Z,siteRole:eq:Publisher\`


### PR DESCRIPTION
Filter fields does not support the cieq and has operators. Remove them so agents don't get confused and try to use them.