### PR TITLE
Fix url logging

### DIFF
--- a/src/restApiInstance.ts
+++ b/src/restApiInstance.ts
@@ -97,13 +97,12 @@ export const getResponseErrorInterceptor =
 function logRequest(request: RequestInterceptorConfig, requestId: RequestId): void {
   const config = getConfig();
   const maskedRequest = config.disableLogMasking ? request : maskRequest(request);
-  const { baseUrl, url } = maskedRequest;
-  const urlParts = [...baseUrl.split('/'), ...(url?.split('/') ?? [])].filter(Boolean);
+  const url = new URL(maskedRequest.url ?? '', maskedRequest.baseUrl);
   const messageObj = {
     type: 'request',
     requestId,
     method: maskedRequest.method,
-    url: urlParts.join('/'),
+    url: url.toString(),
     ...(shouldLogWhenLevelIsAtLeast('debug') && {
       headers: maskedRequest.headers,
       data: maskedRequest.data,
@@ -117,12 +116,11 @@ function logRequest(request: RequestInterceptorConfig, requestId: RequestId): vo
 function logResponse(response: ResponseInterceptorConfig, requestId: RequestId): void {
   const config = getConfig();
   const maskedResponse = config.disableLogMasking ? response : maskResponse(response);
-  const { baseUrl, url } = maskedResponse;
-  const urlParts = [...baseUrl.split('/'), ...(url?.split('/') ?? [])].filter(Boolean);
+  const url = new URL(maskedResponse.url ?? '', maskedResponse.baseUrl);
   const messageObj = {
     type: 'response',
     requestId,
-    url: urlParts.join('/'),
+    url: url.toString(),
     status: maskedResponse.status,
     ...(shouldLogWhenLevelIsAtLeast('debug') && {
       headers: maskedResponse.headers,


### PR DESCRIPTION
Notice the `https:/devplat.tableautest.com` in the `url` below. This change fixes the protocol to properly have 2 slashes.

```json
{
  "timestamp": "2025-06-18T23:29:39.985Z",
  "currentLogLevel": "debug",
  "message": {
    "type": "response",
    "requestId": 2,
    "url": "https:/devplat.tableautest.com/api/3.24/sites/527b24a8-64fb-412b-8300-6b72c3da1fbd/datasources",
    "status": 200
  }
}
```