### PR TITLE
Add PR write permission to GITHUB_TOKEN

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    permissions:
+      pull-requests: write
+
     strategy:
       matrix:
         node-version: [20.x]


### PR DESCRIPTION
Have a look at https://github.com/tableau/tableau-mcp/pull/57/checks

Notice that the `Add PR Coverage comment` stage is failing. The [sticky-pull-request-comment](https://github.com/marocchino/sticky-pull-request-comment) action mentions the [Resource not accessible by integration](https://github.com/marocchino/sticky-pull-request-comment?tab=readme-ov-file#error-resource-not-accessible-by-integration) error and to fix it you need to [control the permissions for the github token](https://docs.github.com/en/actions/how-tos/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token). These changes will hopefully address that.