### PR TITLE
Sign out from REST API when operations complete

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tableau-mcp",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tableau-mcp",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tableau-mcp",
   "description": "A MCP server for Tableau, providing a suite of tools that will make it easier for developers to build AI-applications that integrate with Tableau.",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "homepage": "https://github.com/tableau/tableau-mcp",
   "bugs": "https://github.com/tableau/tableau-mcp/issues",
   "author": "Tableau",

--- a/src/restApiInstance.test.ts
+++ b/src/restApiInstance.test.ts
@@ -2,11 +2,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { log } from './logging/log.js';
 import {
-  getNewRestApiInstanceAsync,
   getRequestErrorInterceptor,
   getRequestInterceptor,
   getResponseErrorInterceptor,
   getResponseInterceptor,
+  useRestApi,
 } from './restApiInstance.js';
 import { AuthConfig } from './sdks/tableau/authConfig.js';
 import RestApi from './sdks/tableau/restApi.js';
@@ -15,6 +15,7 @@ import { Server } from './server.js';
 vi.mock('./sdks/tableau/restApi.js', () => ({
   default: vi.fn().mockImplementation(() => ({
     signIn: vi.fn().mockResolvedValue(undefined),
+    signOut: vi.fn().mockResolvedValue(undefined),
   })),
 }));
 
@@ -40,13 +41,14 @@ describe('restApiInstance', () => {
     vi.clearAllMocks();
   });
 
-  describe('getNewRestApiInstanceAsync', () => {
+  describe('useRestApi', () => {
     it('should create a new RestApi instance and sign in', async () => {
-      const restApi = await getNewRestApiInstanceAsync(
+      const restApi = await useRestApi(
         mockHost,
         mockAuthConfig,
         mockRequestId,
         new Server(),
+        (restApi) => Promise.resolve(restApi),
       );
 
       expect(RestApi).toHaveBeenCalledWith(mockHost, expect.any(Object));

--- a/src/restApiInstance.ts
+++ b/src/restApiInstance.ts
@@ -19,7 +19,7 @@ import RestApi from './sdks/tableau/restApi.js';
 import { Server } from './server.js';
 import { getExceptionMessage } from './utils/getExceptionMessage.js';
 
-export const getNewRestApiInstanceAsync = async (
+const getNewRestApiInstanceAsync = async (
   host: string,
   authConfig: AuthConfig,
   requestId: RequestId,
@@ -38,6 +38,21 @@ export const getNewRestApiInstanceAsync = async (
 
   await restApi.signIn(authConfig);
   return restApi;
+};
+
+export const useRestApi = async <T>(
+  host: string,
+  authConfig: AuthConfig,
+  requestId: RequestId,
+  server: Server,
+  callback: (restApi: RestApi) => Promise<T>,
+): Promise<T> => {
+  const restApi = await getNewRestApiInstanceAsync(host, authConfig, requestId, server);
+  try {
+    return await callback(restApi);
+  } finally {
+    await restApi.signOut();
+  }
 };
 
 export const getRequestInterceptor =

--- a/src/sdks/tableau/apis/authenticationApi.ts
+++ b/src/sdks/tableau/apis/authenticationApi.ts
@@ -28,7 +28,16 @@ const signInEndpoint = makeEndpoint({
   ],
 });
 
-const authenticationApi = makeApi([signInEndpoint]);
+const signOutEndpoint = makeEndpoint({
+  method: 'post',
+  path: '/auth/signout',
+  alias: 'signOut',
+  description:
+    'Signs you out of the current session. This call invalidates the authentication token that is created by a call to Sign In.',
+  response: z.void(),
+});
+
+const authenticationApi = makeApi([signInEndpoint, signOutEndpoint]);
 export const authenticationApis = [
   ...authenticationApi,
 ] as const satisfies ZodiosEndpointDefinitions;

--- a/src/sdks/tableau/methods/authenticationMethods.ts
+++ b/src/sdks/tableau/methods/authenticationMethods.ts
@@ -3,6 +3,7 @@ import { Zodios } from '@zodios/core';
 import { authenticationApis } from '../apis/authenticationApi.js';
 import { AuthConfig } from '../authConfig.js';
 import { Credentials } from '../types/credentials.js';
+import AuthenticatedMethods from './authenticatedMethods.js';
 import Methods from './methods.js';
 
 /**
@@ -10,13 +11,19 @@ import Methods from './methods.js';
  *
  * @export
  * @class AuthenticationMethods
- * @link https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref_authentication.htm#sign_in
+ * @link https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref_authentication.htm
  */
 export default class AuthenticationMethods extends Methods<typeof authenticationApis> {
   constructor(baseUrl: string) {
     super(new Zodios(baseUrl, authenticationApis));
   }
 
+  /**
+   * Signs you in as a user on the specified site on Tableau Server or Tableau Cloud.
+   *
+   * @param {AuthConfig} authConfig - The authentication configuration
+   * @link https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref_authentication.htm#sign_in
+   */
   signIn = async (authConfig: AuthConfig): Promise<Credentials> => {
     return (
       await this._apiClient.signIn({
@@ -36,5 +43,31 @@ export default class AuthenticationMethods extends Methods<typeof authentication
         },
       })
     ).credentials;
+  };
+}
+
+/**
+ * Authentication methods of the Tableau Server REST API that assume the user is already authenticated
+ *
+ * @export
+ * @class AuthenticatedAuthenticationMethods
+ * @link https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref_authentication.htm
+ */
+export class AuthenticatedAuthenticationMethods extends AuthenticatedMethods<
+  typeof authenticationApis
+> {
+  constructor(baseUrl: string, creds: Credentials) {
+    super(new Zodios(baseUrl, authenticationApis), creds);
+  }
+
+  /**
+   * Signs you out of the current session. This call invalidates the authentication token that is created by a call to Sign In.
+   * @link https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref_authentication.htm#sign_out
+   *
+   */
+  signOut = async (): Promise<void> => {
+    await this._apiClient.signOut(undefined, {
+      ...this.authHeader,
+    });
   };
 }

--- a/src/tools/listDatasources/listDatasources.test.ts
+++ b/src/tools/listDatasources/listDatasources.test.ts
@@ -20,12 +20,16 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock('../../restApiInstance.js', () => ({
-  getNewRestApiInstanceAsync: vi.fn().mockResolvedValue({
-    datasourcesMethods: {
-      listDatasources: mocks.mockListDatasources,
-    },
-    siteId: 'test-site-id',
-  }),
+  useRestApi: vi
+    .fn()
+    .mockImplementation(async (_host, _authConfig, _requestId, _server, callback) =>
+      callback({
+        datasourcesMethods: {
+          listDatasources: mocks.mockListDatasources,
+        },
+        siteId: 'test-site-id',
+      }),
+    ),
 }));
 
 describe('listDatasourcesTool', () => {

--- a/src/tools/listDatasources/listDatasources.ts
+++ b/src/tools/listDatasources/listDatasources.ts
@@ -3,7 +3,7 @@ import { Ok } from 'ts-results-es';
 import { z } from 'zod';
 
 import { getConfig } from '../../config.js';
-import { getNewRestApiInstanceAsync } from '../../restApiInstance.js';
+import { useRestApi } from '../../restApiInstance.js';
 import { Server } from '../../server.js';
 import { paginate } from '../../utils/paginate.js';
 import { Tool } from '../tool.js';
@@ -101,34 +101,37 @@ export const getListDatasourcesTool = (server: Server): Tool<typeof paramsSchema
         requestId,
         args: { filter, pageSize, limit },
         callback: async () => {
-          const restApi = await getNewRestApiInstanceAsync(
-            config.server,
-            config.authConfig,
-            requestId,
-            server,
-          );
+          return new Ok(
+            await useRestApi(
+              config.server,
+              config.authConfig,
+              requestId,
+              server,
+              async (restApi) => {
+                const datasources = await paginate({
+                  pageConfig: {
+                    pageSize,
+                    limit: config.maxResultLimit
+                      ? Math.min(config.maxResultLimit, limit ?? Number.MAX_SAFE_INTEGER)
+                      : limit,
+                  },
+                  getDataFn: async (pageConfig) => {
+                    const { pagination, datasources: data } =
+                      await restApi.datasourcesMethods.listDatasources({
+                        siteId: restApi.siteId,
+                        filter: validatedFilter ?? '',
+                        pageSize: pageConfig.pageSize,
+                        pageNumber: pageConfig.pageNumber,
+                      });
 
-          const datasources = await paginate({
-            pageConfig: {
-              pageSize,
-              limit: config.maxResultLimit
-                ? Math.min(config.maxResultLimit, limit ?? Number.MAX_SAFE_INTEGER)
-                : limit,
-            },
-            getDataFn: async (pageConfig) => {
-              const { pagination, datasources: data } =
-                await restApi.datasourcesMethods.listDatasources({
-                  siteId: restApi.siteId,
-                  filter: validatedFilter ?? '',
-                  pageSize: pageConfig.pageSize,
-                  pageNumber: pageConfig.pageNumber,
+                    return { pagination, data };
+                  },
                 });
 
-              return { pagination, data };
-            },
-          });
-
-          return new Ok(datasources);
+                return datasources;
+              },
+            ),
+          );
         },
       });
     },

--- a/src/tools/listFields.test.ts
+++ b/src/tools/listFields.test.ts
@@ -69,11 +69,15 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock('../restApiInstance.js', () => ({
-  getNewRestApiInstanceAsync: vi.fn().mockResolvedValue({
-    metadataMethods: {
-      graphql: mocks.mockGraphql,
-    },
-  }),
+  useRestApi: vi
+    .fn()
+    .mockImplementation(async (_host, _authConfig, _requestId, _server, callback) =>
+      callback({
+        metadataMethods: {
+          graphql: mocks.mockGraphql,
+        },
+      }),
+    ),
 }));
 
 describe('listFieldsTool', () => {

--- a/src/tools/listFields.ts
+++ b/src/tools/listFields.ts
@@ -3,7 +3,7 @@ import { Ok } from 'ts-results-es';
 import { z } from 'zod';
 
 import { getConfig } from '../config.js';
-import { getNewRestApiInstanceAsync } from '../restApiInstance.js';
+import { useRestApi } from '../restApiInstance.js';
 import { Server } from '../server.js';
 import { Tool } from './tool.js';
 import { validateDatasourceLuid } from './validateDatasourceLuid.js';
@@ -99,13 +99,17 @@ export const getListFieldsTool = (server: Server): Tool<typeof paramsSchema> => 
         requestId,
         args: { datasourceLuid },
         callback: async () => {
-          const restApi = await getNewRestApiInstanceAsync(
-            config.server,
-            config.authConfig,
-            requestId,
-            server,
+          return new Ok(
+            await useRestApi(
+              config.server,
+              config.authConfig,
+              requestId,
+              server,
+              async (restApi) => {
+                return await restApi.metadataMethods.graphql(query);
+              },
+            ),
           );
-          return new Ok(await restApi.metadataMethods.graphql(query));
         },
       });
     },

--- a/src/tools/pulse/listAllMetricDefinitions/listAllPulseMetricDefinitions.test.ts
+++ b/src/tools/pulse/listAllMetricDefinitions/listAllPulseMetricDefinitions.test.ts
@@ -30,11 +30,15 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock('../../../restApiInstance.js', () => ({
-  getNewRestApiInstanceAsync: vi.fn().mockResolvedValue({
-    pulseMethods: {
-      listAllPulseMetricDefinitions: mocks.mockListAllPulseMetricDefinitions,
-    },
-  }),
+  useRestApi: vi
+    .fn()
+    .mockImplementation(async (_host, _authConfig, _requestId, _server, callback) =>
+      callback({
+        pulseMethods: {
+          listAllPulseMetricDefinitions: mocks.mockListAllPulseMetricDefinitions,
+        },
+      }),
+    ),
 }));
 
 describe('listAllPulseMetricDefinitionsTool', () => {

--- a/src/tools/pulse/listAllMetricDefinitions/listAllPulseMetricDefinitions.ts
+++ b/src/tools/pulse/listAllMetricDefinitions/listAllPulseMetricDefinitions.ts
@@ -3,7 +3,7 @@ import { Ok } from 'ts-results-es';
 import { z } from 'zod';
 
 import { getConfig } from '../../../config.js';
-import { getNewRestApiInstanceAsync } from '../../../restApiInstance.js';
+import { useRestApi } from '../../../restApiInstance.js';
 import { pulseMetricDefinitionViewEnum } from '../../../sdks/tableau/types/pulse.js';
 import { Server } from '../../../server.js';
 import { Tool } from '../../tool.js';
@@ -50,13 +50,17 @@ Retrieves a list of all published Pulse Metric Definitions using the Tableau RES
         requestId,
         args: { view },
         callback: async () => {
-          const restApi = await getNewRestApiInstanceAsync(
-            config.server,
-            config.authConfig,
-            requestId,
-            server,
+          return new Ok(
+            await useRestApi(
+              config.server,
+              config.authConfig,
+              requestId,
+              server,
+              async (restApi) => {
+                return await restApi.pulseMethods.listAllPulseMetricDefinitions(view);
+              },
+            ),
           );
-          return new Ok(await restApi.pulseMethods.listAllPulseMetricDefinitions(view));
         },
       });
     },

--- a/src/tools/pulse/listMetricDefinitionsFromDefinitionIds/listPulseMetricDefinitionsFromDefinitionIds.test.ts
+++ b/src/tools/pulse/listMetricDefinitionsFromDefinitionIds/listPulseMetricDefinitionsFromDefinitionIds.test.ts
@@ -30,12 +30,16 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock('../../../restApiInstance.js', () => ({
-  getNewRestApiInstanceAsync: vi.fn().mockResolvedValue({
-    pulseMethods: {
-      listPulseMetricDefinitionsFromMetricDefinitionIds:
-        mocks.mockListPulseMetricDefinitionsFromMetricDefinitionIds,
-    },
-  }),
+  useRestApi: vi
+    .fn()
+    .mockImplementation(async (_host, _authConfig, _requestId, _server, callback) =>
+      callback({
+        pulseMethods: {
+          listPulseMetricDefinitionsFromMetricDefinitionIds:
+            mocks.mockListPulseMetricDefinitionsFromMetricDefinitionIds,
+        },
+      }),
+    ),
 }));
 
 describe('listPulseMetricDefinitionsFromDefinitionIdsTool', () => {

--- a/src/tools/pulse/listMetricDefinitionsFromDefinitionIds/listPulseMetricDefinitionsFromDefinitionIds.ts
+++ b/src/tools/pulse/listMetricDefinitionsFromDefinitionIds/listPulseMetricDefinitionsFromDefinitionIds.ts
@@ -3,7 +3,7 @@ import { Ok } from 'ts-results-es';
 import { z } from 'zod';
 
 import { getConfig } from '../../../config.js';
-import { getNewRestApiInstanceAsync } from '../../../restApiInstance.js';
+import { useRestApi } from '../../../restApiInstance.js';
 import { pulseMetricDefinitionViewEnum } from '../../../sdks/tableau/types/pulse.js';
 import { Server } from '../../../server.js';
 import { Tool } from '../../tool.js';
@@ -61,16 +61,18 @@ Retrieves a list of specific Pulse Metric Definitions using the Tableau REST API
         requestId,
         args: { metricDefinitionIds, view },
         callback: async () => {
-          const restApi = await getNewRestApiInstanceAsync(
-            config.server,
-            config.authConfig,
-            requestId,
-            server,
-          );
           return new Ok(
-            await restApi.pulseMethods.listPulseMetricDefinitionsFromMetricDefinitionIds(
-              metricDefinitionIds,
-              view,
+            await useRestApi(
+              config.server,
+              config.authConfig,
+              requestId,
+              server,
+              async (restApi) => {
+                return await restApi.pulseMethods.listPulseMetricDefinitionsFromMetricDefinitionIds(
+                  metricDefinitionIds,
+                  view,
+                );
+              },
             ),
           );
         },

--- a/src/tools/pulse/listMetricSubscriptions/listPulseMetricSubscriptions.test.ts
+++ b/src/tools/pulse/listMetricSubscriptions/listPulseMetricSubscriptions.test.ts
@@ -14,12 +14,16 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock('../../../restApiInstance.js', () => ({
-  getNewRestApiInstanceAsync: vi.fn().mockResolvedValue({
-    pulseMethods: {
-      listPulseMetricSubscriptionsForCurrentUser:
-        mocks.mockListPulseMetricSubscriptionsForCurrentUser,
-    },
-  }),
+  useRestApi: vi
+    .fn()
+    .mockImplementation(async (_host, _authConfig, _requestId, _server, callback) =>
+      callback({
+        pulseMethods: {
+          listPulseMetricSubscriptionsForCurrentUser:
+            mocks.mockListPulseMetricSubscriptionsForCurrentUser,
+        },
+      }),
+    ),
 }));
 
 describe('listPulseMetricSubscriptionsTool', () => {

--- a/src/tools/pulse/listMetricSubscriptions/listPulseMetricSubscriptions.ts
+++ b/src/tools/pulse/listMetricSubscriptions/listPulseMetricSubscriptions.ts
@@ -2,7 +2,7 @@ import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { Ok } from 'ts-results-es';
 
 import { getConfig } from '../../../config.js';
-import { getNewRestApiInstanceAsync } from '../../../restApiInstance.js';
+import { useRestApi } from '../../../restApiInstance.js';
 import { Server } from '../../../server.js';
 import { Tool } from '../../tool.js';
 
@@ -36,13 +36,17 @@ Retrieves a list of published Pulse Metric Subscriptions for the current user us
         requestId,
         args: {},
         callback: async () => {
-          const restApi = await getNewRestApiInstanceAsync(
-            config.server,
-            config.authConfig,
-            requestId,
-            server,
+          return new Ok(
+            await useRestApi(
+              config.server,
+              config.authConfig,
+              requestId,
+              server,
+              async (restApi) => {
+                return await restApi.pulseMethods.listPulseMetricSubscriptionsForCurrentUser();
+              },
+            ),
           );
-          return new Ok(await restApi.pulseMethods.listPulseMetricSubscriptionsForCurrentUser());
         },
       });
     },

--- a/src/tools/pulse/listMetricsFromMetricDefinitionId/listPulseMetricsFromMetricDefinitionId.test.ts
+++ b/src/tools/pulse/listMetricsFromMetricDefinitionId/listPulseMetricsFromMetricDefinitionId.test.ts
@@ -22,11 +22,15 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock('../../../restApiInstance.js', () => ({
-  getNewRestApiInstanceAsync: vi.fn().mockResolvedValue({
-    pulseMethods: {
-      listPulseMetricsFromMetricDefinitionId: mocks.mockListPulseMetricsFromMetricDefinitionId,
-    },
-  }),
+  useRestApi: vi
+    .fn()
+    .mockImplementation(async (_host, _authConfig, _requestId, _server, callback) =>
+      callback({
+        pulseMethods: {
+          listPulseMetricsFromMetricDefinitionId: mocks.mockListPulseMetricsFromMetricDefinitionId,
+        },
+      }),
+    ),
 }));
 
 describe('listPulseMetricsFromMetricDefinitionIdTool', () => {

--- a/src/tools/pulse/listMetricsFromMetricDefinitionId/listPulseMetricsFromMetricDefinitionId.ts
+++ b/src/tools/pulse/listMetricsFromMetricDefinitionId/listPulseMetricsFromMetricDefinitionId.ts
@@ -3,7 +3,7 @@ import { Ok } from 'ts-results-es';
 import { z } from 'zod';
 
 import { getConfig } from '../../../config.js';
-import { getNewRestApiInstanceAsync } from '../../../restApiInstance.js';
+import { useRestApi } from '../../../restApiInstance.js';
 import { Server } from '../../../server.js';
 import { Tool } from '../../tool.js';
 
@@ -38,15 +38,17 @@ Retrieves a list of published Pulse Metrics from a Pulse Metric Definition using
         requestId,
         args: { pulseMetricDefinitionID },
         callback: async () => {
-          const restApi = await getNewRestApiInstanceAsync(
-            config.server,
-            config.authConfig,
-            requestId,
-            server,
-          );
           return new Ok(
-            await restApi.pulseMethods.listPulseMetricsFromMetricDefinitionId(
-              pulseMetricDefinitionID,
+            await useRestApi(
+              config.server,
+              config.authConfig,
+              requestId,
+              server,
+              async (restApi) => {
+                return await restApi.pulseMethods.listPulseMetricsFromMetricDefinitionId(
+                  pulseMetricDefinitionID,
+                );
+              },
             ),
           );
         },

--- a/src/tools/pulse/listMetricsFromMetricIds/listPulseMetricsFromMetricIds.test.ts
+++ b/src/tools/pulse/listMetricsFromMetricIds/listPulseMetricsFromMetricIds.test.ts
@@ -22,11 +22,15 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock('../../../restApiInstance.js', () => ({
-  getNewRestApiInstanceAsync: vi.fn().mockResolvedValue({
-    pulseMethods: {
-      listPulseMetricsFromMetricIds: mocks.mockListPulseMetricsFromMetricIds,
-    },
-  }),
+  useRestApi: vi
+    .fn()
+    .mockImplementation(async (_host, _authConfig, _requestId, _server, callback) =>
+      callback({
+        pulseMethods: {
+          listPulseMetricsFromMetricIds: mocks.mockListPulseMetricsFromMetricIds,
+        },
+      }),
+    ),
 }));
 
 describe('listPulseMetricsFromMetricIdsTool', () => {

--- a/src/tools/pulse/listMetricsFromMetricIds/listPulseMetricsFromMetricIds.ts
+++ b/src/tools/pulse/listMetricsFromMetricIds/listPulseMetricsFromMetricIds.ts
@@ -3,7 +3,7 @@ import { Ok } from 'ts-results-es';
 import { z } from 'zod';
 
 import { getConfig } from '../../../config.js';
-import { getNewRestApiInstanceAsync } from '../../../restApiInstance.js';
+import { useRestApi } from '../../../restApiInstance.js';
 import { Server } from '../../../server.js';
 import { Tool } from '../../tool.js';
 
@@ -42,13 +42,17 @@ Retrieves a list of published Pulse Metrics from a list of metric IDs using the 
         requestId,
         args: { metricIds },
         callback: async () => {
-          const restApi = await getNewRestApiInstanceAsync(
-            config.server,
-            config.authConfig,
-            requestId,
-            server,
+          return new Ok(
+            await useRestApi(
+              config.server,
+              config.authConfig,
+              requestId,
+              server,
+              async (restApi) => {
+                return await restApi.pulseMethods.listPulseMetricsFromMetricIds(metricIds);
+              },
+            ),
           );
-          return new Ok(await restApi.pulseMethods.listPulseMetricsFromMetricIds(metricIds));
         },
       });
     },

--- a/src/tools/queryDatasource/queryDatasource.test.ts
+++ b/src/tools/queryDatasource/queryDatasource.test.ts
@@ -41,11 +41,17 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock('../../restApiInstance.js', () => ({
-  getNewRestApiInstanceAsync: vi.fn().mockResolvedValue({
-    vizqlDataServiceMethods: {
-      queryDatasource: mocks.mockQueryDatasource,
-    },
-  }),
+  useRestApi: vi
+    .fn()
+    .mockImplementation(async (_host, _authConfig, _requestId, _server, callback) =>
+      callback({
+        signIn: vi.fn(),
+        signOut: vi.fn(),
+        vizqlDataServiceMethods: {
+          queryDatasource: mocks.mockQueryDatasource,
+        },
+      }),
+    ),
 }));
 
 describe('queryDatasourceTool', () => {

--- a/src/tools/queryDatasource/queryDatasource.ts
+++ b/src/tools/queryDatasource/queryDatasource.ts
@@ -2,7 +2,7 @@ import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
 
 import { getConfig } from '../../config.js';
-import { getNewRestApiInstanceAsync } from '../../restApiInstance.js';
+import { useRestApi } from '../../restApiInstance.js';
 import { Datasource, Query, TableauError } from '../../sdks/tableau/apis/vizqlDataServiceApi.js';
 import { Server } from '../../server.js';
 import { Tool } from '../tool.js';
@@ -54,14 +54,15 @@ export const getQueryDatasourceTool = (server: Server): Tool<typeof paramsSchema
             options,
           };
 
-          const restApi = await getNewRestApiInstanceAsync(
+          return await useRestApi(
             config.server,
             config.authConfig,
             requestId,
             server,
+            async (restApi) => {
+              return await restApi.vizqlDataServiceMethods.queryDatasource(queryRequest);
+            },
           );
-
-          return await restApi.vizqlDataServiceMethods.queryDatasource(queryRequest);
         },
         getErrorText: (error: z.infer<typeof TableauError>) => {
           return JSON.stringify({ requestId, ...handleQueryDatasourceError(error) });

--- a/src/tools/readMetadata.test.ts
+++ b/src/tools/readMetadata.test.ts
@@ -36,11 +36,15 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock('../restApiInstance.js', () => ({
-  getNewRestApiInstanceAsync: vi.fn().mockResolvedValue({
-    vizqlDataServiceMethods: {
-      readMetadata: mocks.mockReadMetadata,
-    },
-  }),
+  useRestApi: vi
+    .fn()
+    .mockImplementation(async (_host, _authConfig, _requestId, _server, callback) =>
+      callback({
+        vizqlDataServiceMethods: {
+          readMetadata: mocks.mockReadMetadata,
+        },
+      }),
+    ),
 }));
 
 describe('readMetadataTool', () => {

--- a/src/tools/readMetadata.ts
+++ b/src/tools/readMetadata.ts
@@ -3,7 +3,7 @@ import { Ok } from 'ts-results-es';
 import { z } from 'zod';
 
 import { getConfig } from '../config.js';
-import { getNewRestApiInstanceAsync } from '../restApiInstance.js';
+import { useRestApi } from '../restApiInstance.js';
 import { Server } from '../server.js';
 import { Tool } from './tool.js';
 import { validateDatasourceLuid } from './validateDatasourceLuid.js';
@@ -41,18 +41,20 @@ export const getReadMetadataTool = (server: Server): Tool<typeof paramsSchema> =
         requestId,
         args: { datasourceLuid },
         callback: async () => {
-          const restApi = await getNewRestApiInstanceAsync(
-            config.server,
-            config.authConfig,
-            requestId,
-            server,
-          );
           return new Ok(
-            await restApi.vizqlDataServiceMethods.readMetadata({
-              datasource: {
-                datasourceLuid,
+            await useRestApi(
+              config.server,
+              config.authConfig,
+              requestId,
+              server,
+              async (restApi) => {
+                return await restApi.vizqlDataServiceMethods.readMetadata({
+                  datasource: {
+                    datasourceLuid,
+                  },
+                });
               },
-            }),
+            ),
           );
         },
       });


### PR DESCRIPTION
I've pulled these commits out of the [anyoung/transport](https://github.com/tableau/tableau-mcp/tree/anyoung/transport) branch to simplify its diff.

These change introduce a `useRestApi` function that:

1. Creates a new instance of the `RestApi` client.
2. Passes that instance to a callback method
3. Signs out from the REST API, immediately killing that Tableau session.