### PR TITLE
Generate JWT from admin-provided endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,32 @@ username. The following is an example:
 { "username": "{OAUTH_USERNAME}", "region": "West" }
 ```
 
+#### External JWT Configuration
+
+When `AUTH` is `jwt`, before the MCP server authenticates to the Tableau REST API, it will make a
+POST request to the endpoint provided in `JWT_PROVIDER_URL`.
+
+POST request body:
+
+```js
+{
+  username: "user@tableau.com", // The value of JWT_SUB_CLAIM
+  scopes: ["tableau:scope:1"], // The list of scopes the JWT should have
+  source: "tableau-mcp",
+  resource: 'mcp-tool-name', // The name of the tool being called e.g. query-datasource
+  server: "https://tableau.example.com", // The value of SERVER
+  siteName: "siteName", // The value of SITE_NAME
+}
+```
+
+Expected response:
+
+```json
+{
+  "jwt": "eyJhbGciOiJI..."
+}
+```
+
 #### OAuth Configuration
 
 ⚠️ Tableau Server 2025.3+ only. Tableau Cloud is not supported. ⚠️

--- a/README.md
+++ b/README.md
@@ -261,7 +261,8 @@ username. The following is an example:
 #### External JWT Configuration
 
 When `AUTH` is `jwt`, before the MCP server authenticates to the Tableau REST API, it will make a
-POST request to the endpoint provided in `JWT_PROVIDER_URL`.
+POST request to the endpoint provided in `JWT_PROVIDER_URL`. This endpoint must return the JSON web
+token to then be used to authenticate to the REST API.
 
 POST request body:
 

--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ POST request body:
 ```js
 {
   username: "user@tableau.com", // The value of JWT_SUB_CLAIM
-  scopes: ["tableau:scope:1"], // The list of scopes the JWT should have
+  scopes: ["tableau:example:scope"], // The list of scopes the JWT should have
   source: "tableau-mcp",
   resource: 'mcp-tool-name', // The name of the tool being called e.g. query-datasource
   server: "https://tableau.example.com", // The value of SERVER

--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ username. The following is an example:
 
 When `AUTH` is `jwt`, before the MCP server authenticates to the Tableau REST API, it will make a
 POST request to the endpoint provided in `JWT_PROVIDER_URL`. This endpoint must return the JSON web
-token to then be used to authenticate to the REST API.
+token to then be used to authenticate to the REST API. It must only accept and return JSON.
 
 POST request body:
 

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -33,6 +33,7 @@ describe('Config', () => {
       CONNECTED_APP_SECRET_ID: undefined,
       CONNECTED_APP_SECRET_VALUE: undefined,
       JWT_ADDITIONAL_PAYLOAD: undefined,
+      JWT_PROVIDER_URL: undefined,
       DATASOURCE_CREDENTIALS: undefined,
       DEFAULT_LOG_LEVEL: undefined,
       DISABLE_LOG_MASKING: undefined,
@@ -642,6 +643,46 @@ describe('Config', () => {
       expect(config.connectedAppSecretId).toBe('');
       expect(config.connectedAppSecretValue).toBe('');
       expect(config.jwtAdditionalPayload).toBe('{}');
+    });
+  });
+
+  describe('JWT auth configuration', () => {
+    it('should parse jwt auth configuration when all required variables are provided', () => {
+      process.env = {
+        ...process.env,
+        ...defaultEnvVars,
+        AUTH: 'jwt',
+        JWT_PROVIDER_URL: 'https://example.com/jwt',
+        JWT_SUB_CLAIM: 'user@example.com',
+      };
+
+      const config = new Config();
+      expect(config.auth).toBe('jwt');
+      expect(config.jwtProviderUrl).toBe('https://example.com/jwt');
+      expect(config.jwtSubClaim).toBe('user@example.com');
+    });
+
+    it('should throw error when JWT_PROVIDER_URL is missing for jwt auth', () => {
+      process.env = {
+        ...process.env,
+        ...defaultEnvVars,
+        AUTH: 'jwt',
+        JWT_PROVIDER_URL: undefined,
+      };
+
+      expect(() => new Config()).toThrow('The environment variable JWT_PROVIDER_URL is not set');
+    });
+
+    it('should throw error when JWT_SUB_CLAIM is missing for jwt auth', () => {
+      process.env = {
+        ...process.env,
+        ...defaultEnvVars,
+        AUTH: 'jwt',
+        JWT_PROVIDER_URL: 'https://example.com',
+        JWT_SUB_CLAIM: undefined,
+      };
+
+      expect(() => new Config()).toThrow('The environment variable JWT_SUB_CLAIM is not set');
     });
   });
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -178,6 +178,9 @@ export class Config {
       invariant(clientId, 'The environment variable CONNECTED_APP_CLIENT_ID is not set');
       invariant(secretId, 'The environment variable CONNECTED_APP_SECRET_ID is not set');
       invariant(secretValue, 'The environment variable CONNECTED_APP_SECRET_VALUE is not set');
+    } else if (this.auth === 'jwt') {
+      invariant(jwtProviderUrl, 'The environment variable JWT_PROVIDER_URL is not set');
+      invariant(jwtSubClaim, 'The environment variable JWT_SUB_CLAIM is not set');
     }
 
     this.server = server;

--- a/src/config.ts
+++ b/src/config.ts
@@ -11,7 +11,7 @@ const TWENTY_FOUR_HOURS_IN_MS = 24 * 60 * 60 * 1000;
 const THIRTY_DAYS_IN_MS = 30 * 24 * 60 * 60 * 1000;
 const ONE_YEAR_IN_MS = 365.25 * 24 * 60 * 60 * 1000;
 
-const authTypes = ['pat', 'direct-trust', 'oauth'] as const;
+const authTypes = ['pat', 'direct-trust', 'oauth', 'jwt'] as const;
 type AuthType = (typeof authTypes)[number];
 
 export class Config {
@@ -30,6 +30,7 @@ export class Config {
   connectedAppSecretId: string;
   connectedAppSecretValue: string;
   jwtAdditionalPayload: string;
+  jwtProviderUrl: string;
   datasourceCredentials: string;
   defaultLogLevel: string;
   disableLogMasking: boolean;
@@ -66,6 +67,7 @@ export class Config {
       CONNECTED_APP_SECRET_ID: secretId,
       CONNECTED_APP_SECRET_VALUE: secretValue,
       JWT_ADDITIONAL_PAYLOAD: jwtAdditionalPayload,
+      JWT_PROVIDER_URL: jwtProviderUrl,
       DATASOURCE_CREDENTIALS: datasourceCredentials,
       DEFAULT_LOG_LEVEL: defaultLogLevel,
       DISABLE_LOG_MASKING: disableLogMasking,
@@ -186,6 +188,7 @@ export class Config {
     this.connectedAppSecretId = secretId ?? '';
     this.connectedAppSecretValue = secretValue ?? '';
     this.jwtAdditionalPayload = jwtAdditionalPayload || '{}';
+    this.jwtProviderUrl = jwtProviderUrl ?? '';
   }
 }
 

--- a/src/restApiInstance.test.ts
+++ b/src/restApiInstance.test.ts
@@ -51,6 +51,7 @@ describe('restApiInstance', () => {
         requestId: mockRequestId,
         server: new Server(),
         jwtScopes: [],
+        context: 'none',
         callback: (restApi) => Promise.resolve(restApi),
       });
 

--- a/src/restApiInstance.ts
+++ b/src/restApiInstance.ts
@@ -20,6 +20,7 @@ import { TableauAuthInfo } from './server/oauth/schemas.js';
 import { userAgent } from './server/userAgent.js';
 import { ToolName } from './tools/toolName.js';
 import { getExceptionMessage } from './utils/getExceptionMessage.js';
+import { getJwtFromProvider } from './utils/getJwtFromProvider.js';
 
 type JwtScopes =
   | 'tableau:viz_data_service:read'
@@ -75,23 +76,15 @@ const getNewRestApiInstanceAsync = async ({
       additionalPayload: getJwtAdditionalPayload(config, authInfo),
     });
   } else if (config.auth === 'jwt') {
-    const response = await fetch(config.jwtProviderUrl, {
-      method: 'POST',
-      headers: {
-        Accept: 'application/json',
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        username: getJwtSubClaim(config, authInfo),
-        scopes: [...jwtScopes],
-        source: server.name,
-        resource: context,
-        server: config.server,
-        siteName: config.siteName,
-      }),
+    const jwt = await getJwtFromProvider(config.jwtProviderUrl, {
+      username: getJwtSubClaim(config, authInfo),
+      scopes: [...jwtScopes],
+      source: server.name,
+      resource: context,
+      server: config.server,
+      siteName: config.siteName,
     });
 
-    const { jwt } = await response.json();
     await restApi.signIn({
       type: 'jwt',
       siteName: config.siteName,

--- a/src/restApiInstance.ts
+++ b/src/restApiInstance.ts
@@ -65,6 +65,29 @@ const getNewRestApiInstanceAsync = async (
       scopes: jwtScopes,
       additionalPayload: getJwtAdditionalPayload(config, authInfo),
     });
+  } else if (config.auth === 'jwt') {
+    const response = await fetch(config.jwtProviderUrl, {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        username: getJwtSubClaim(config, authInfo),
+        scopes: [...jwtScopes],
+        source: server.name,
+        resource: 'query-datasource', // TODO: parameterize
+        server: config.server,
+        siteName: config.siteName,
+      }),
+    });
+
+    const { jwt } = await response.json();
+    await restApi.signIn({
+      type: 'jwt',
+      siteName: config.siteName,
+      jwt,
+    });
   } else {
     if (!authInfo?.accessToken || !authInfo?.userId) {
       throw new Error('Auth info is required when not signing in first.');

--- a/src/scripts/createClaudeDesktopExtensionManifest.ts
+++ b/src/scripts/createClaudeDesktopExtensionManifest.ts
@@ -107,6 +107,14 @@ const envVars = {
     required: false,
     sensitive: false,
   },
+  JWT_PROVIDER_URL: {
+    includeInUserConfig: false,
+    type: 'string',
+    title: 'JWT Provider URL',
+    description: 'The URL of the JWT provider.',
+    required: false,
+    sensitive: false,
+  },
   TRANSPORT: {
     includeInUserConfig: false,
     type: 'string',

--- a/src/sdks/tableau/authConfig.ts
+++ b/src/sdks/tableau/authConfig.ts
@@ -15,4 +15,8 @@ export type AuthConfig = {
       scopes: Set<string>;
       additionalPayload?: Record<string, unknown>;
     }
+  | {
+      type: 'jwt';
+      jwt: string;
+    }
 );

--- a/src/sdks/tableau/methods/authenticationMethods.ts
+++ b/src/sdks/tableau/methods/authenticationMethods.ts
@@ -52,6 +52,10 @@ export default class AuthenticationMethods extends Methods<typeof authentication
                     additionalPayload: authConfig.additionalPayload,
                   }),
                 };
+              case 'jwt':
+                return {
+                  jwt: authConfig.jwt,
+                };
             }
           })()),
         },

--- a/src/server/express.ts
+++ b/src/server/express.ts
@@ -6,9 +6,10 @@ import fs, { existsSync } from 'fs';
 import http from 'http';
 import https from 'https';
 
-import { Config } from '../config.js';
+import { Config, getConfig } from '../config.js';
 import { setLogLevel } from '../logging/log.js';
 import { Server } from '../server.js';
+import { getJwt } from '../utils/getJwt.js';
 import { validateProtocolVersion } from './middleware.js';
 import { OAuthProvider } from './oauth/provider.js';
 
@@ -53,6 +54,7 @@ export async function startExpressServer({
   app.post(path, ...middleware, createMcpServer);
   app.get(path, ...middleware, methodNotAllowed);
   app.delete(path, ...middleware, methodNotAllowed);
+  app.post('/jwt', generateJwt);
 
   const useSsl = !!(config.sslKey && config.sslCert);
   if (!useSsl) {
@@ -132,4 +134,36 @@ async function methodNotAllowed(_req: Request, res: Response): Promise<void> {
       id: null,
     }),
   );
+}
+
+async function generateJwt(req: Request, res: Response): Promise<void> {
+  const { connectedAppClientId, connectedAppSecretId, connectedAppSecretValue } = getConfig();
+
+  const { username, scopes, source, resource, server, siteName } = req.body;
+  if (!username || !scopes || !source || !resource || !server || !siteName) {
+    res.status(400).json({
+      error: 'username, scopes, source, resource, server, and siteName are required',
+    });
+    return;
+  }
+
+  const additionalPayload: Record<string, unknown> = {};
+  if (resource === 'query-datasource') {
+    additionalPayload.region = 'West';
+  }
+
+  const jwt = await getJwt({
+    username: username as string,
+    connectedApp: {
+      clientId: connectedAppClientId,
+      secretId: connectedAppSecretId,
+      secretValue: connectedAppSecretValue,
+    },
+    scopes: new Set(scopes as string[]),
+    additionalPayload,
+  });
+
+  res.json({
+    jwt,
+  });
 }

--- a/src/tools/listDatasources/listDatasources.ts
+++ b/src/tools/listDatasources/listDatasources.ts
@@ -93,6 +93,7 @@ export const getListDatasourcesTool = (server: Server): Tool<typeof paramsSchema
             requestId,
             server,
             jwtScopes: ['tableau:content:read'],
+            context: listDatasourcesTool.name,
             authInfo: getTableauAuthInfo(authInfo),
             callback: async (restApi) => {
               const datasources = await paginate({

--- a/src/tools/listFields.ts
+++ b/src/tools/listFields.ts
@@ -107,6 +107,7 @@ export const getListFieldsTool = (server: Server): Tool<typeof paramsSchema> => 
               requestId,
               server,
               jwtScopes: ['tableau:content:read'],
+              context: listFieldsTool.name,
               authInfo: getTableauAuthInfo(authInfo),
               callback: async (restApi) => {
                 return await restApi.metadataMethods.graphql(query);

--- a/src/tools/pulse/generateMetricValueInsightBundle/generatePulseMetricValueInsightBundleTool.ts
+++ b/src/tools/pulse/generateMetricValueInsightBundle/generatePulseMetricValueInsightBundleTool.ts
@@ -153,6 +153,7 @@ Generate an insight bundle for the current aggregated value for Pulse Metric usi
               requestId,
               server,
               jwtScopes: ['tableau:insights:read'],
+              context: generatePulseMetricValueInsightBundleTool.name,
               authInfo: getTableauAuthInfo(authInfo),
               callback: async (restApi) =>
                 await restApi.pulseMethods.generatePulseMetricValueInsightBundle(

--- a/src/tools/pulse/listAllMetricDefinitions/listAllPulseMetricDefinitions.ts
+++ b/src/tools/pulse/listAllMetricDefinitions/listAllPulseMetricDefinitions.ts
@@ -58,6 +58,7 @@ Retrieves a list of all published Pulse Metric Definitions using the Tableau RES
               requestId,
               server,
               jwtScopes: ['tableau:insight_definitions_metrics:read'],
+              context: listAllPulseMetricDefinitionsTool.name,
               authInfo: getTableauAuthInfo(authInfo),
               callback: async (restApi) => {
                 return await restApi.pulseMethods.listAllPulseMetricDefinitions(view);

--- a/src/tools/pulse/listMetricDefinitionsFromDefinitionIds/listPulseMetricDefinitionsFromDefinitionIds.ts
+++ b/src/tools/pulse/listMetricDefinitionsFromDefinitionIds/listPulseMetricDefinitionsFromDefinitionIds.ts
@@ -72,6 +72,7 @@ Retrieves a list of specific Pulse Metric Definitions using the Tableau REST API
               requestId,
               server,
               jwtScopes: ['tableau:insight_definitions_metrics:read'],
+              context: listPulseMetricDefinitionsFromDefinitionIdsTool.name,
               authInfo: getTableauAuthInfo(authInfo),
               callback: async (restApi) => {
                 return await restApi.pulseMethods.listPulseMetricDefinitionsFromMetricDefinitionIds(

--- a/src/tools/pulse/listMetricSubscriptions/listPulseMetricSubscriptions.ts
+++ b/src/tools/pulse/listMetricSubscriptions/listPulseMetricSubscriptions.ts
@@ -44,6 +44,7 @@ Retrieves a list of published Pulse Metric Subscriptions for the current user us
               requestId,
               server,
               jwtScopes: ['tableau:metric_subscriptions:read'],
+              context: listPulseMetricSubscriptionsTool.name,
               authInfo: getTableauAuthInfo(authInfo),
               callback: async (restApi) => {
                 return await restApi.pulseMethods.listPulseMetricSubscriptionsForCurrentUser();

--- a/src/tools/pulse/listMetricsFromMetricDefinitionId/listPulseMetricsFromMetricDefinitionId.ts
+++ b/src/tools/pulse/listMetricsFromMetricDefinitionId/listPulseMetricsFromMetricDefinitionId.ts
@@ -49,6 +49,7 @@ Retrieves a list of published Pulse Metrics from a Pulse Metric Definition using
               requestId,
               server,
               jwtScopes: ['tableau:insight_definitions_metrics:read'],
+              context: listPulseMetricsFromMetricDefinitionIdTool.name,
               authInfo: getTableauAuthInfo(authInfo),
               callback: async (restApi) => {
                 return await restApi.pulseMethods.listPulseMetricsFromMetricDefinitionId(

--- a/src/tools/pulse/listMetricsFromMetricIds/listPulseMetricsFromMetricIds.ts
+++ b/src/tools/pulse/listMetricsFromMetricIds/listPulseMetricsFromMetricIds.ts
@@ -50,6 +50,7 @@ Retrieves a list of published Pulse Metrics from a list of metric IDs using the 
               requestId,
               server,
               jwtScopes: ['tableau:insight_metrics:read'],
+              context: listPulseMetricsFromMetricIdsTool.name,
               authInfo: getTableauAuthInfo(authInfo),
               callback: async (restApi) => {
                 return await restApi.pulseMethods.listPulseMetricsFromMetricIds(metricIds);

--- a/src/tools/queryDatasource/queryDatasource.ts
+++ b/src/tools/queryDatasource/queryDatasource.ts
@@ -81,6 +81,7 @@ export const getQueryDatasourceTool = (server: Server): Tool<typeof paramsSchema
             requestId,
             server,
             jwtScopes: ['tableau:viz_data_service:read'],
+            context: queryDatasourceTool.name,
             authInfo: getTableauAuthInfo(authInfo),
             callback: async (restApi) => {
               if (!config.disableQueryDatasourceFilterValidation) {

--- a/src/tools/readMetadata.ts
+++ b/src/tools/readMetadata.ts
@@ -49,6 +49,7 @@ export const getReadMetadataTool = (server: Server): Tool<typeof paramsSchema> =
               requestId,
               server,
               jwtScopes: ['tableau:viz_data_service:read'],
+              context: readMetadataTool.name,
               authInfo: getTableauAuthInfo(authInfo),
               callback: async (restApi) => {
                 return await restApi.vizqlDataServiceMethods.readMetadata({

--- a/src/tools/views/getViewData.ts
+++ b/src/tools/views/getViewData.ts
@@ -38,6 +38,7 @@ export const getGetViewDataTool = (server: Server): Tool<typeof paramsSchema> =>
               requestId,
               server,
               jwtScopes: ['tableau:views:download'],
+              context: getViewDataTool.name,
               authInfo: getTableauAuthInfo(authInfo),
               callback: async (restApi) => {
                 return await restApi.viewsMethods.queryViewData({

--- a/src/tools/views/getViewImage.ts
+++ b/src/tools/views/getViewImage.ts
@@ -44,6 +44,7 @@ export const getGetViewImageTool = (server: Server): Tool<typeof paramsSchema> =
               requestId,
               server,
               jwtScopes: ['tableau:views:download'],
+              context: getViewImageTool.name,
               authInfo: getTableauAuthInfo(authInfo),
               callback: async (restApi) => {
                 return await restApi.viewsMethods.queryViewImage({

--- a/src/tools/views/listViews.ts
+++ b/src/tools/views/listViews.ts
@@ -83,6 +83,7 @@ export const getListViewsTool = (server: Server): Tool<typeof paramsSchema> => {
               requestId,
               server,
               jwtScopes: ['tableau:content:read'],
+              context: listViewsTool.name,
               authInfo: getTableauAuthInfo(authInfo),
               callback: async (restApi) => {
                 const workbooks = await paginate({

--- a/src/tools/workbooks/getWorkbook.ts
+++ b/src/tools/workbooks/getWorkbook.ts
@@ -38,6 +38,7 @@ export const getGetWorkbookTool = (server: Server): Tool<typeof paramsSchema> =>
               requestId,
               server,
               jwtScopes: ['tableau:content:read'],
+              context: getWorkbookTool.name,
               authInfo: getTableauAuthInfo(authInfo),
               callback: async (restApi) => {
                 const workbook = await restApi.workbooksMethods.getWorkbook({

--- a/src/tools/workbooks/listWorkbooks.ts
+++ b/src/tools/workbooks/listWorkbooks.ts
@@ -80,6 +80,7 @@ export const getListWorkbooksTool = (server: Server): Tool<typeof paramsSchema> 
               requestId,
               server,
               jwtScopes: ['tableau:content:read'],
+              context: listWorkbooksTool.name,
               authInfo: getTableauAuthInfo(authInfo),
               callback: async (restApi) => {
                 const workbooks = await paginate({

--- a/src/utils/getJwtFromProvider.ts
+++ b/src/utils/getJwtFromProvider.ts
@@ -1,0 +1,16 @@
+export async function getJwtFromProvider(
+  jwtProviderUrl: string,
+  body: Record<string, unknown>,
+): Promise<string> {
+  const response = await fetch(jwtProviderUrl, {
+    method: 'POST',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+
+  const { jwt } = await response.json();
+  return jwt;
+}

--- a/src/utils/getJwtFromProvider.ts
+++ b/src/utils/getJwtFromProvider.ts
@@ -1,3 +1,9 @@
+import { z } from 'zod';
+
+const jwtResponseSchema = z.object({
+  jwt: z.string(),
+});
+
 export async function getJwtFromProvider(
   jwtProviderUrl: string,
   body: Record<string, unknown>,
@@ -11,6 +17,12 @@ export async function getJwtFromProvider(
     body: JSON.stringify(body),
   });
 
-  const { jwt } = await response.json();
-  return jwt;
+  const json = await response.json();
+  const result = jwtResponseSchema.safeParse(json);
+
+  if (!result.success) {
+    throw new Error('Invalid JWT response, expected: { "jwt": "..." }');
+  }
+
+  return result.data.jwt;
 }

--- a/types/process-env.d.ts
+++ b/types/process-env.d.ts
@@ -28,6 +28,7 @@ export interface ProcessEnvEx {
   OAUTH_AUTHORIZATION_CODE_TIMEOUT_MS: string | undefined;
   OAUTH_ACCESS_TOKEN_TIMEOUT_MS: string | undefined;
   OAUTH_REFRESH_TOKEN_TIMEOUT_MS: string | undefined;
+  JWT_PROVIDER_URL: string | undefined;
 }
 
 declare global {

--- a/types/process-env.d.ts
+++ b/types/process-env.d.ts
@@ -14,6 +14,7 @@ export interface ProcessEnvEx {
   CONNECTED_APP_SECRET_ID: string | undefined;
   CONNECTED_APP_SECRET_VALUE: string | undefined;
   JWT_ADDITIONAL_PAYLOAD: string | undefined;
+  JWT_PROVIDER_URL: string | undefined;
   DATASOURCE_CREDENTIALS: string | undefined;
   DEFAULT_LOG_LEVEL: string | undefined;
   DISABLE_LOG_MASKING: string | undefined;
@@ -28,7 +29,6 @@ export interface ProcessEnvEx {
   OAUTH_AUTHORIZATION_CODE_TIMEOUT_MS: string | undefined;
   OAUTH_ACCESS_TOKEN_TIMEOUT_MS: string | undefined;
   OAUTH_REFRESH_TOKEN_TIMEOUT_MS: string | undefined;
-  JWT_PROVIDER_URL: string | undefined;
 }
 
 declare global {


### PR DESCRIPTION
These changes allow server administrators to specify a `JWT_PROVIDER_URL` environment variable such that when `AUTH` is `jwt`, before the MCP server authenticates to the Tableau REST API, it will make a POST request to the endpoint provided in `JWT_PROVIDER_URL`. This endpoint must return the JSON web token to then be used to authenticate to the REST API.

POST request body:

```js
{
  username: "user@tableau.com", // The value of JWT_SUB_CLAIM
  scopes: ["tableau:example:scope"], // The list of scopes the JWT should have
  source: "tableau-mcp",
  resource: 'mcp-tool-name', // The name of the tool being called e.g. query-datasource
  server: "https://tableau.example.com", // The value of SERVER
  siteName: "siteName", // The value of SITE_NAME
}
```

Expected response:

```json
{
  "jwt": "eyJhbGciOiJI..."
}
```