### PR TITLE
Rename package to @tableau/mcp-server and publish to npmjs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,9 @@ jobs:
       - name: Build Claude MCP Bundle
         run: npm run build:mcpb
 
+      - name: Build NPM package
+        run: npm pack
+
       - name: Tests
         run: npm run coverage
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,5 +21,5 @@ jobs:
           npm ci
           npm run build
           npm publish --provenance --dry-run
-          env:
-            NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,8 @@
 name: Publish
 on:
-  release:
-    types: [published]
+  push:
+    branches:
+      - 'anyoung/npmjs'
 jobs:
   publish-npm:
     runs-on: ubuntu-latest
@@ -16,9 +17,9 @@ jobs:
           registry-url: https://registry.npmjs.org/
       - run: |
           git fetch --tags
-          git checkout ${{ github.event.release.tag_name }}
+          git checkout v1.8.0
           npm ci
           npm run build
-          npm publish --provenance
+          npm publish --provenance --dry-run
           env:
             NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,7 @@
 name: Publish
 on:
-  push:
-    branches:
-      - 'anyoung/npmjs'
+  release:
+    types: [published]
 jobs:
   publish-npm:
     runs-on: ubuntu-latest
@@ -17,9 +16,9 @@ jobs:
           registry-url: https://registry.npmjs.org/
       - run: |
           git fetch --tags
-          git checkout v1.8.0
+          git checkout -b publish ${{ github.event.release.tag_name }}
           npm ci
           npm run build
-          npm publish --provenance --dry-run
+          npm publish --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,21 @@
+name: Publish
+on:
+  release:
+    types: [published]
+jobs:
+  publish-npm:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # Needed for npm provenance
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org/
+      - run: npm ci
+      - run: npm run build
+      - run: npm publish --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,8 +14,11 @@ jobs:
         with:
           node-version: 20
           registry-url: https://registry.npmjs.org/
-      - run: npm ci
-      - run: npm run build
-      - run: npm publish --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - run: |
+          git fetch --tags
+          git checkout ${{ github.event.release.tag_name }}
+          npm ci
+          npm run build
+          npm publish --provenance
+          env:
+            NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ manifest.json
 tableau-mcp.dxt
 tableau-mcp.mcpb
 *.pem
+*.tgz

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,7 @@
+**/*
+!CODE_OF_CONDUCT.md
+!CONTRIBUTING.md
+!LICENSE.txt
+!README.md
+!SECURITY.md
+!build/**/*

--- a/README.md
+++ b/README.md
@@ -27,7 +27,13 @@ Standard config works in most MCP clients:
   "mcpServers": {
     "tableau": {
       "command": "npx",
-      "args": ["@tableau/mcp-server@latest"]
+      "args": ["@tableau/mcp-server@latest"],
+      "env": {
+        "SERVER": "https://my-tableau-server.com",
+        "SITE_NAME": "my_site",
+        "PAT_NAME": "my_pat",
+        "PAT_VALUE": "pat_value"
+      }
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -12,3 +12,23 @@ make it easier for developers to build AI-applications that integrate with Table
 ## Official Documentation
 
 https://tableau.github.io/tableau-mcp/
+
+## Quick Start
+
+### Requirements
+
+- Node.js 20 or newer
+- An MCP client e.g. Claude Desktop, Cursor, VS Code, MCP Inspector, etc.
+
+Standard config works in most MCP clients:
+
+```json
+{
+  "mcpServers": {
+    "tableau": {
+      "command": "npx",
+      "args": ["@tableau/mcp-server@latest"]
+    }
+  }
+}
+```

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -4,10 +4,34 @@ sidebar_position: 2
 
 # Getting Started
 
+## Quick Start
+
+### Requirements
+
+- Node.js 20 or newer
+- An MCP client e.g. Claude Desktop, Cursor, VS Code, MCP Inspector, etc.
+
+Standard config works in most MCP clients:
+
+```json
+{
+  "mcpServers": {
+    "tableau": {
+      "command": "npx",
+      "args": ["@tableau/mcp-server@latest"]
+    }
+  }
+}
+```
+
+## Working with the source code
+
 1. Clone the repository.
 2. Install [Node.js](https://nodejs.org/en/download) (tested with 22.15.0 LTS).
 3. `npm install`
 4. `npm run build`
+5. Configure your MCP client using the instructions in the
+   [Configuring AI Tools](./configuration/ai-tools-config/README.md) section.
 
 To keep up with repo changes:
 

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -18,7 +18,13 @@ Standard config works in most MCP clients:
   "mcpServers": {
     "tableau": {
       "command": "npx",
-      "args": ["@tableau/mcp-server@latest"]
+      "args": ["@tableau/mcp-server@latest"],
+      "env": {
+        "SERVER": "https://my-tableau-server.com",
+        "SITE_NAME": "my_site",
+        "PAT_NAME": "my_pat",
+        "PAT_VALUE": "pat_value"
+      }
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tableau-mcp",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tableau-mcp",
-      "version": "1.8.0",
+      "version": "1.8.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "tableau-mcp",
+  "name": "@tableau/mcp-server",
   "description": "An MCP server for Tableau, providing a suite of tools that will make it easier for developers to build AI-applications that integrate with Tableau.",
   "version": "1.8.0",
   "homepage": "https://github.com/tableau/tableau-mcp",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "An MCP server for Tableau, providing a suite of tools that will make it easier for developers to build AI-applications that integrate with Tableau.",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "homepage": "https://github.com/tableau/tableau-mcp",
   "bugs": "https://github.com/tableau/tableau-mcp/issues",
   "author": "Tableau",

--- a/src/server.ts
+++ b/src/server.ts
@@ -8,7 +8,7 @@ import { Tool } from './tools/tool.js';
 import { toolNames } from './tools/toolName.js';
 import { toolFactories } from './tools/tools.js';
 
-export const serverName = pkg.name;
+export const serverName = 'tableau-mcp';
 export const serverVersion = pkg.version;
 
 export class Server extends McpServer {


### PR DESCRIPTION
These changes will automatically publish to npmjs with any new GitHub release. I will create a new release after this PR merges. There may be a followup PR to work out any issues during the publishing process.

This will allow folks to configure their MCP clients to automatically grab the latest package from NPM any time they attempt to start up the MCP server.

```json
"mcpServers": {
  "tableau": {
    "command": "npx",
    "args": ["@tableau/mcp-server@latest"],
    "env": {
      "SERVER": "https://10ax.online.tableau.com/",
      "SITE_NAME": "mcp-test",
      "PAT_NAME": "mcp",
      "PAT_VALUE": "..."
    }
  }
},
```