### PR TITLE
Stop returning error results for schema validation errors

### DIFF
--- a/docs/docs/developers/e2e-tests.md
+++ b/docs/docs/developers/e2e-tests.md
@@ -17,7 +17,8 @@ The E2E tests can only be run:
 
 To run them locally:
 
-1. Create a `e2e/.env` file with contents:
+1. Ensure you do not have a `.env` file in the root of the project.
+2. Create a `e2e/.env` file with contents:
 
 ```
 SERVER=https://10ax.online.tableau.com
@@ -29,9 +30,9 @@ CONNECTED_APP_SECRET_ID=<redacted>
 CONNECTED_APP_SECRET_VALUE=<redacted>
 ```
 
-2. Create a `e2e/.env.reset` file with the same contents except all the env var values as empty.
+3. Create a `e2e/.env.reset` file with the same contents except all the env var values as empty.
    Environment variables get set at the beginning of each test and cleared at the end of each test.
-3. Run `npm run test:e2e` or select the `vitest.config.e2e.ts` config in the [Vitest
+4. Run `npm run test:e2e` or select the `vitest.config.e2e.ts` config in the [Vitest
    extension][vitest.explorer] and run them from your IDE.
 
 ## Running the E2E tests against a different site

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "1.8.1",
+      "version": "1.8.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,8 @@
         "fast-levenshtein": "^3.0.0",
         "jose": "^6.0.12",
         "ts-results-es": "^5.0.1",
-        "zod": "^3.24.3"
+        "zod": "^3.24.3",
+        "zod-validation-error": "^4.0.1"
       },
       "bin": {
         "tableau-mcp-server": "build/index.js"
@@ -9417,6 +9418,18 @@
       "integrity": "sha512-/AuWwMP+YqiPbsJx5D6TfgRTc4kTLjsh5SOcd4bLsfUg2RcEXrFMJl1DGgdHy2aCfsIA/cr/1JM0xcB2GZji8g==",
       "peerDependencies": {
         "zod": "^3.24.1"
+      }
+    },
+    "node_modules/zod-validation-error": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-4.0.1.tgz",
+      "integrity": "sha512-F3rdaCOHs5ViJ5YTz5zzRtfkQdMdIeKudJAoxy7yB/2ZMEHw73lmCAcQw11r7++20MyGl4WV59EVh7A9rNAyog==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
     "fast-levenshtein": "^3.0.0",
     "jose": "^6.0.12",
     "ts-results-es": "^5.0.1",
-    "zod": "^3.24.3"
+    "zod": "^3.24.3",
+    "zod-validation-error": "^4.0.1"
   },
   "devDependencies": {
     "@anthropic-ai/mcpb": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "An MCP server for Tableau, providing a suite of tools that will make it easier for developers to build AI-applications that integrate with Tableau.",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/src/sdks/tableau/apis/vizqlDataServiceApi.ts
+++ b/src/sdks/tableau/apis/vizqlDataServiceApi.ts
@@ -270,7 +270,7 @@ export const QueryRequest = z
 
 export const QueryOutput = z
   .object({
-    dataz: z.array(z.unknown()),
+    data: z.array(z.unknown()),
   })
   .partial()
   .passthrough();

--- a/src/sdks/tableau/apis/vizqlDataServiceApi.ts
+++ b/src/sdks/tableau/apis/vizqlDataServiceApi.ts
@@ -270,7 +270,7 @@ export const QueryRequest = z
 
 export const QueryOutput = z
   .object({
-    data: z.array(z.unknown()),
+    dataz: z.array(z.unknown()),
   })
   .partial()
   .passthrough();

--- a/src/sdks/tableau/methods/vizqlDataServiceMethods.ts
+++ b/src/sdks/tableau/methods/vizqlDataServiceMethods.ts
@@ -1,4 +1,4 @@
-import { isErrorFromAlias, Zodios } from '@zodios/core';
+import { isErrorFromAlias, Zodios, ZodiosError } from '@zodios/core';
 import { Err, Ok, Result } from 'ts-results-es';
 import { z } from 'zod';
 
@@ -38,12 +38,16 @@ export default class VizqlDataServiceMethods extends AuthenticatedMethods<
    */
   queryDatasource = async (
     queryRequest: z.infer<typeof QueryRequest>,
-  ): Promise<Result<QueryOutput, TableauError>> => {
+  ): Promise<Result<QueryOutput, TableauError | ZodiosError>> => {
     try {
       return Ok(await this._apiClient.queryDatasource(queryRequest, { ...this.authHeader }));
     } catch (error) {
       if (isErrorFromAlias(this._apiClient.api, 'queryDatasource', error)) {
         return Err(error.response.data);
+      }
+
+      if (error instanceof ZodiosError) {
+        return Err(error);
       }
 
       throw error;

--- a/src/tools/queryDatasource/queryDatasource.ts
+++ b/src/tools/queryDatasource/queryDatasource.ts
@@ -1,4 +1,5 @@
 import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { ZodiosError } from '@zodios/core';
 import { Err } from 'ts-results-es';
 import { z } from 'zod';
 
@@ -98,10 +99,14 @@ export const getQueryDatasourceTool = (server: Server): Tool<typeof paramsSchema
 
               const result = await restApi.vizqlDataServiceMethods.queryDatasource(queryRequest);
               if (result.isErr()) {
-                return new Err({
-                  type: 'tableau-error',
-                  error: result.error,
-                });
+                return new Err(
+                  result.error instanceof ZodiosError
+                    ? result.error
+                    : {
+                        type: 'tableau-error',
+                        error: result.error,
+                      },
+                );
               }
               return result;
             },

--- a/src/tools/tool.ts
+++ b/src/tools/tool.ts
@@ -1,7 +1,9 @@
 import { ToolCallback } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { CallToolResult, RequestId, ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
+import { ZodiosError } from '@zodios/core';
 import { Result } from 'ts-results-es';
 import { z, ZodRawShape, ZodTypeAny } from 'zod';
+import { fromError, isZodErrorLike } from 'zod-validation-error';
 
 import { getToolLogMessage, log } from '../logging/log.js';
 import { Server } from '../server.js';
@@ -13,19 +15,32 @@ type ArgsValidator<Args extends ZodRawShape | undefined = undefined> = Args exte
   : never;
 
 export type ToolParams<Args extends ZodRawShape | undefined = undefined> = {
+  // The MCP server instance
   server: Server;
+
+  // The name of the tool
   name: ToolName;
+
+  // The description of the tool
   description: string;
+
+  // The schema of the tool's parameters
   paramsSchema: Args;
+
+  // The annotations of the tool
   annotations: ToolAnnotations;
+
+  // A function that validates the tool's arguments provided by the client
   argsValidator?: ArgsValidator<Args>;
+
+  // The implementation of the tool itself
   callback: ToolCallback<Args>;
 };
 
 type LogAndExecuteParams<T, E, Args extends ZodRawShape | undefined = undefined> = {
   requestId: RequestId;
   args: Args extends ZodRawShape ? z.objectOutputType<Args, ZodTypeAny> : undefined;
-  callback: () => Promise<Result<T, E>>;
+  callback: () => Promise<Result<T, E | ZodiosError>>;
   getSuccessResult?: (result: T) => CallToolResult;
   getErrorText?: (error: E) => string;
 };
@@ -113,6 +128,10 @@ export class Tool<Args extends ZodRawShape | undefined = undefined> {
         };
       }
 
+      if (result.error instanceof ZodiosError) {
+        return getErrorResult(requestId, result.error);
+      }
+
       if (getErrorText) {
         return {
           isError: true,
@@ -133,6 +152,28 @@ export class Tool<Args extends ZodRawShape | undefined = undefined> {
 }
 
 function getErrorResult(requestId: RequestId, error: unknown): CallToolResult {
+  if (error instanceof ZodiosError && isZodErrorLike(error.cause)) {
+    const validationError = fromError(error.cause);
+    return {
+      // Schema validation errors on otherwise successful API calls will not return an "error" result to the MCP client.
+      // We instead return the full response from the API with a data quality warning message
+      // that mentions why the schema validation failed.
+      // This should make it so users don't get "stuck" in the event our schemas are too strict or wrong.
+      // The only con is that the full response from the API might be larger than normal
+      // since a successful schema validation "trims" the response down to the shape of the schema.
+      isError: false,
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify({
+            data: error.data,
+            warning: validationError.toString(),
+          }),
+        },
+      ],
+    };
+  }
+
   return {
     isError: true,
     content: [


### PR DESCRIPTION
The Tableau REST API client used by the MCP server uses Zodios for type safety and validating the responses of these APIs. Currently, when an API call succeeds but its response does not match the schema we've defined, we return an error result from the tool.

I've witnessed, at least with Claude Desktop, that the tool result will appear in red and the LLM notes to the user that the tool encountered an error, but because Zodios by default includes the full API in the error message it continues as if the tool hadn't failed at all.

These changes:

1. Identify successful API responses with schema validation errors.
2. Convert the Zod issues into a user-friendly error message using [zod-validation-error](https://www.npmjs.com/package/zod-validation-error)
3. Return a *successful* tool result instead that contains the full API response but with a data quality warning using the error message from 2.