### PR TITLE
Adjust docs build path location

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Upload Build Artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: docs/build
+          path: docs/build/tableau-mcp
 
   deploy:
     name: Deploy to GitHub Pages


### PR DESCRIPTION
After the update to Docusaurus 3.9.0 (#122), the built files are actually down one level, so that needs to be adjusted for publishing to GH pages.