### PR TITLE
Add the session management into the MCP Server Express. Add the GET a…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "1.11.1",
+  "version": "1.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "1.11.1",
+      "version": "1.12.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",
@@ -17,6 +17,7 @@
         "fast-levenshtein": "^3.0.0",
         "jose": "^6.0.12",
         "ts-results-es": "^5.0.1",
+        "uuid": "^13.0.0",
         "zod": "^3.24.3",
         "zod-validation-error": "^4.0.1"
       },
@@ -8891,6 +8892,19 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/uuid": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
+      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache-lib": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "An MCP server for Tableau, providing a suite of tools that will make it easier for developers to build AI applications that integrate with Tableau.",
-  "version": "1.11.1",
+  "version": "1.12.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"
@@ -56,6 +56,7 @@
     "fast-levenshtein": "^3.0.0",
     "jose": "^6.0.12",
     "ts-results-es": "^5.0.1",
+    "uuid": "^13.0.0",
     "zod": "^3.24.3",
     "zod-validation-error": "^4.0.1"
   },

--- a/src/config.ts
+++ b/src/config.ts
@@ -44,6 +44,7 @@ export class Config {
   enableServerLogging: boolean;
   serverLogDirectory: string;
   boundedContext: BoundedContext;
+  stateful: boolean;
 
   constructor() {
     const cleansedVars = removeClaudeMcpBundleUserConfigTemplates(process.env);
@@ -76,6 +77,7 @@ export class Config {
       INCLUDE_PROJECT_IDS: includeProjectIds,
       INCLUDE_DATASOURCE_IDS: includeDatasourceIds,
       INCLUDE_WORKBOOK_IDS: includeWorkbookIds,
+      STATEFUL: stateful,
     } = cleansedVars;
 
     const defaultPort = 3927;
@@ -101,6 +103,7 @@ export class Config {
       datasourceIds: createSetFromCommaSeparatedString(includeDatasourceIds),
       workbookIds: createSetFromCommaSeparatedString(includeWorkbookIds),
     };
+    this.stateful = stateful === 'true';
 
     if (this.boundedContext.projectIds?.size === 0) {
       throw new Error(

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,7 +36,7 @@ async function startServer(): Promise<void> {
 
       // eslint-disable-next-line no-console -- console.log is intentional here since the transport is not stdio.
       console.log(
-        `${serverName} v${serverVersion} stateless streamable HTTP server available at ${url}`,
+        `${serverName} v${serverVersion} ${config.stateful ? 'stateful' : 'stateless'} streamable HTTP server available at ${url}`,
       );
       break;
     }

--- a/src/server/express.ts
+++ b/src/server/express.ts
@@ -1,10 +1,11 @@
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
-import { LoggingLevel } from '@modelcontextprotocol/sdk/types.js';
+import { isInitializeRequest, LoggingLevel } from '@modelcontextprotocol/sdk/types.js';
 import cors from 'cors';
 import express, { Request, Response } from 'express';
 import fs, { existsSync } from 'fs';
 import http from 'http';
 import https from 'https';
+import { v7 as uuidv7 } from 'uuid';
 
 import { Config } from '../config.js';
 import { setLogLevel } from '../logging/log.js';
@@ -20,6 +21,11 @@ export async function startExpressServer({
   logLevel: LoggingLevel;
 }): Promise<{ url: string }> {
   const app = express();
+  const transports: { [sessionId: string]: StreamableHTTPServerTransport } = {};
+
+  const server = new Server();
+  server.registerTools();
+  server.registerRequestHandlers();
 
   app.use(express.json());
   app.use(express.urlencoded());
@@ -41,8 +47,8 @@ export async function startExpressServer({
 
   const path = `/${basePath}`;
   app.post(path, createMcpServer);
-  app.get(path, methodNotAllowed);
-  app.delete(path, methodNotAllowed);
+  app.get(path, config.stateful ? handleSessionRequest : methodNotAllowed);
+  app.delete(path, config.stateful ? handleSessionRequest : methodNotAllowed);
 
   const useSsl = !!(config.sslKey && config.sslCert);
   if (!useSsl) {
@@ -76,25 +82,52 @@ export async function startExpressServer({
       );
   });
 
+  function getStreamableHttp(sessionId?: string, body?: any): StreamableHTTPServerTransport {
+    if (config.stateful) {
+      if (sessionId && transports[sessionId]) {
+        return transports[sessionId];
+      }
+
+      if (!sessionId && isInitializeRequest(body)) {
+        const newTransport: StreamableHTTPServerTransport = new StreamableHTTPServerTransport({
+          sessionIdGenerator: () => uuidv7(),
+          onsessioninitialized: (newSessionId) => {
+            transports[newSessionId] = newTransport;
+          },
+        });
+
+        newTransport.onclose = () => {
+          if (newTransport.sessionId) {
+            delete transports[newTransport.sessionId];
+          }
+        };
+
+        return newTransport;
+      }
+    }
+
+    return new StreamableHTTPServerTransport({
+      sessionIdGenerator: undefined,
+    });
+  }
+
   async function createMcpServer(req: Request, res: Response): Promise<void> {
     try {
-      const server = new Server();
-      const transport: StreamableHTTPServerTransport = new StreamableHTTPServerTransport({
-        sessionIdGenerator: undefined,
-      });
+      const sessionId = req.headers['mcp-session-id'] as string | undefined;
 
-      res.on('close', () => {
-        transport.close();
-        server.close();
-      });
-
-      server.registerTools();
-      server.registerRequestHandlers();
-
-      await server.connect(transport);
-      setLogLevel(server, logLevel);
-
-      await transport.handleRequest(req, res, req.body);
+      const transport: StreamableHTTPServerTransport = getStreamableHttp(sessionId, req.body);
+      if (!config.stateful) {
+        res.on('close', () => {
+          transport.close();
+        });
+      }
+      if (sessionId && transports[sessionId]) {
+        await transport.handleRequest(req, res, req.body);
+      } else {
+        await server.connect(transport);
+        setLogLevel(server, logLevel);
+        await transport.handleRequest(req, res, req.body);
+      }
     } catch (error) {
       // eslint-disable-next-line no-console -- console.error is intentional here since the transport is not stdio.
       console.error('Error handling MCP request:', error);
@@ -109,6 +142,17 @@ export async function startExpressServer({
         });
       }
     }
+  }
+
+  async function handleSessionRequest(req: express.Request, res: express.Response): Promise<void> {
+    const sessionId = req.headers['mcp-session-id'] as string | undefined;
+    if (!sessionId || !transports[sessionId]) {
+      res.status(400).send('Invalid or missing session ID');
+      return;
+    }
+
+    const transport = transports[sessionId];
+    await transport.handleRequest(req, res);
   }
 }
 


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of
the pull request._

# Pull Request Template

<!-- Thank you for your contribution! Please fill out the following template to help us review your pull
request! -->

## Description
### Change
#### feat: Implement Stateful Session Management

This commit introduces session management to the MCP Server, enabling it to support multiple concurrent client connections. The server can now operate in either a stateful or stateless mode, configurable via the optional `STATEFUL` environment variable.

**Key Changes:**

*   **Stateful Session Management:** When `STATEFUL=true`, the server now:
    *   Assigns a unique session ID (using UUIDv7) to each new client.
    *   Implements `GET` and `DELETE` endpoint handlers for clients to manage their sessions, aligning with the MCP specification.
    *   Cleans up transport connections gracefully using the `onclose` event handler.
*   **Server Instantiation:** The MCP Server is now instantiated only once at startup, rather than on every incoming request. This ensures a persistent state and improves performance.
*   **Stateless Mode:** In the default stateless mode, the server maintains its original behavior, closing the transport immediately after each response.
*   **Improved Logging:** The server's startup message now indicates whether it is running in stateful or stateless mode.
*   **New Dependency:** Added the `uuid` library to generate unique session identifiers.

This enhancement allows the server to interoperate correctly with MCP clients that require persistent sessions, paving the way for more complex, multi-client interactions.
## Type of Change

- [] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## How Has This Been Tested?
I only run the npm test and made sure the test is passed but I try to connect to the mcp server with stateless and stateful mode and the result is connected (with sessionId and without sessionId)

## Related Issues
https://github.com/tableau/tableau-mcp/issues/153

## Checklist
- [x] I have updated the version in the package.json file by using `npm run version`.
      For example, use `npm run version:patch` for a patch version bump.
- [x] I have made any necessary changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Contributor Agreement

By submitting this pull request, I confirm that:

- [x] I have read the [CONTRIBUTING guidelines](../../CONTRIBUTING.md) for this project and followed
      its Contribution Checklist.
