### PR TITLE
Add concurrent PAT usage warning to docs

### DIFF
--- a/docs/docs/configuration/mcp-config/authentication/pat.md
+++ b/docs/docs/configuration/mcp-config/authentication/pat.md
@@ -33,8 +33,8 @@ client-side code where it could accidentally be revealed.
 
 Do not use a PAT when [`TRANSPORT`](../env-vars.md#transport) is `http` if you expect simultaneous
 requests from multiple clients since PATs cannot be used concurrently. Signing in multiple times
-with the same PAT at the same time, whether to the same site or a different site, will terminate any
-prior session and will result in an authentication error. See
+with the same PAT at the same time will terminate any prior session and will result in an
+authentication error. See
 [Understand personal access tokens](https://help.tableau.com/current/server/en-us/security_personal_access_tokens.htm#understand-personal-access-tokens)
 for more details.
 

--- a/docs/docs/configuration/mcp-config/http-server.md
+++ b/docs/docs/configuration/mcp-config/http-server.md
@@ -32,8 +32,8 @@ The method the MCP server uses to authenticate to the Tableau REST APIs.
 
 Do not use a PAT when [`TRANSPORT`](env-vars.md#transport) is `http` if you expect simultaneous
 requests from multiple clients since PATs cannot be used concurrently. Signing in multiple times
-with the same PAT at the same time, whether to the same site or a different site, will terminate any
-prior session and will result in an authentication error. See
+with the same PAT at the same time will terminate any prior session and will result in an
+authentication error. See
 [Understand personal access tokens](https://help.tableau.com/current/server/en-us/security_personal_access_tokens.htm#understand-personal-access-tokens)
 for more details.
 


### PR DESCRIPTION
These changes add warnings to the docs on Personal Access Tokens and enabling the HTTP server to avoid errors encountered while attempting to concurrently using a PAT.

<img width="1488" height="745" alt="image" src="https://github.com/user-attachments/assets/3bc4d618-edc8-4f6c-ba3d-b8b25fcc543f" />

<img width="1488" height="566" alt="image" src="https://github.com/user-attachments/assets/74a1176d-84b6-42a6-a055-58f104f52725" />
