### PR TITLE
@W-20600362: Add PR title check action

### DIFF
--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -15,9 +15,7 @@ jobs:
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          PR_TITLE_PATTERN='^@W-\d+'
-
-          if [[ ! "$PR_TITLE" =~ $PR_TITLE_PATTERN ]]; then
+          if [[ ! "$PR_TITLE" =~ ^@W-[0-9]+ ]]; then
             echo "❌ PR title must match the pattern '@W-<digits>' (e.g., @W-123456)"
             exit 1
           fi


### PR DESCRIPTION
This PR forces us to add a GUS work item ID to PR titles. PRs from forks and dependabot are exempt. Once merged, I'll make the action required to merge a PR.