### PR TITLE
docs: clarify that setting OAUTH_ISSUER enables OAuth

### DIFF
--- a/docs/docs/configuration/mcp-config/authentication/oauth.md
+++ b/docs/docs/configuration/mcp-config/authentication/oauth.md
@@ -15,7 +15,7 @@ is accessed using a local development URL e.g. `http://127.0.0.1:3927/tableau-mc
 When `AUTH` is `oauth`, the MCP server will use a Tableau session initiated by the Tableau OAuth
 flow to authenticate to the Tableau REST APIs.
 
-OAuth is enabled by setting the `OAUTH_ISSUER` environment variable to the URL of your MCP server.
+OAuth is enabled by setting the `OAUTH_ISSUER` environment variable to the origin of your MCP server.
 
 :::info
 

--- a/docs/docs/configuration/mcp-config/oauth.md
+++ b/docs/docs/configuration/mcp-config/oauth.md
@@ -14,7 +14,7 @@ is accessed using a local development URL e.g. `http://127.0.0.1:3927/tableau-mc
 
 ## How to Enable OAuth
 
-To enable OAuth, set the [`OAUTH_ISSUER`](#oauth_issuer) environment variable to the URL of your MCP server. When a URL for `OAUTH_ISSUER` is provided, the MCP server will act as an OAuth 2.1 resource server, capable of accepting and responding to protected resource requests using encrypted access tokens.
+To enable OAuth, set the [`OAUTH_ISSUER`](#oauth_issuer) environment variable to the origin of your MCP server. When a URL for `OAUTH_ISSUER` is provided, the MCP server will act as an OAuth 2.1 resource server, capable of accepting and responding to protected resource requests using encrypted access tokens.
 
 When OAuth is enabled:
 - MCP clients will be required to authenticate via Tableau OAuth before connecting to the MCP server
@@ -46,7 +46,7 @@ The method the MCP server uses to authenticate to the Tableau REST APIs.
 
 ### `OAUTH_ISSUER`
 
-**Setting this environment variable enables OAuth.** This should be the URL of your MCP server (the issuer of access tokens).
+**Setting this environment variable enables OAuth.** This should be the origin of your MCP server (the issuer of access tokens).
 
 - Example: `http://127.0.0.1:3927` (for local testing) or `https://tableau-mcp.example.com` (for production)
 - Required if `AUTH` is `oauth`


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of
the pull request._

# Pull Request Template

<!-- Thank you for your contribution! Please fill out the following template to help us review your pull
request! -->

## Description
This PR clarifies that setting the `OAUTH_ISSUER` environment variable is what enables OAuth in the MCP server.
Changes made:
  - Added a "How to Enable OAuth" section at the top of the OAuth documentation
  - Updated the `OAUTH_ISSUER` variable description with bold text stating it enables OAuth
  - Listed the automatic defaults when OAuth is enabled (TRANSPORT=http, AUTH=oauth)
  - Added clearer examples for local testing and production URLs
  - Updated the authentication/oauth.md reference file for consistency

## Motivation and Context
Users were confused because the documentation said "When OAuth is enabled..." but never explicitly explained HOW to enable it. This was reported in issue #185.

## Type of Change
  - [ ] Bug fix
  - [ ] New feature
  - [ ] Breaking change
  - [x] Documentation update
  - [ ] Other (please describe):

## How Has This Been Tested?

- Documentation builds successfully (`cd docs && npm run build`)
- All 786 unit tests pass (`npm test`)
- Lint passes (`npm run lint`)
- Project builds successfully (`npm run build`)

## Related Issues
Fixes #185

## Checklist

- [ ] I have updated the version in the package.json file by using `npm run version`. For example,
      use `npm run version:patch` for a patch version bump.
- [x] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have documented any breaking changes in the PR description. For example, renaming a config environment variable or changing its default value.

## Contributor Agreement

By submitting this pull request, I confirm that:

- [x] I have read the [CONTRIBUTING guidelines](../../CONTRIBUTING.md) for this project and followed
      its Contribution Checklist.
