### PR TITLE
fix: use crypto.randomInt for secure code verifier length (#169)

### DIFF
--- a/src/server/oauth/authorize.ts
+++ b/src/server/oauth/authorize.ts
@@ -1,5 +1,5 @@
 import axiosRetry from 'axios-retry';
-import { randomBytes, randomUUID } from 'crypto';
+import { randomBytes, randomInt, randomUUID } from 'crypto';
 import express from 'express';
 import { isIP } from 'net';
 import { isSSRFSafeURL } from 'ssrfcheck';
@@ -103,7 +103,7 @@ export function authorize(
 
     const tableauClientId = randomUUID();
     // 22-64 bytes (44-128 chars) is the recommended length for code verifiers
-    const numCodeVerifierBytes = Math.floor(Math.random() * (64 - 22 + 1)) + 22;
+    const numCodeVerifierBytes = randomInt(22, 65);
     const tableauCodeVerifier = randomBytes(numCodeVerifierBytes).toString('hex');
     const tableauCodeChallenge = generateCodeChallenge(tableauCodeVerifier);
     pendingAuthorizations.set(authKey, {


### PR DESCRIPTION

<!-- Thank you for your contribution! Please fill out the following template to help us review your pull
request! -->

## Description
Replace `Math.random()` with `crypto.randomInt()` for determining the code verifier byte length in the OAuth authorization flow.
**Changes:**
  - Added `randomInt` to the crypto import
  - Replaced `Math.floor(Math.random() * (64 - 22 + 1)) + 22` with `randomInt(22, 65)`
  
## Motivation and Context
A security scan flagged the use of `Math.random()` for security-sensitive randomness. `Math.random()` is not cryptographically secure. Node.js's `crypto.randomInt()` provides cryptographically secure random integers and is the recommended approach for security-sensitive operations.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## How Has This Been Tested?
- All 792 existing unit tests pass
- Verified that `randomInt(22, 65)` produces the same range (22-64 inclusive) as the original formula
- Build and lint pass successfully

## Related Issues
Fixes #169

## Checklist

- [ ] I have updated the version in the package.json file by using `npm run version`. For example,
      use `npm run version:patch` for a patch version bump.
- [x] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have documented any breaking changes in the PR description. For example, renaming a config environment variable or changing its default value.

## Contributor Agreement

By submitting this pull request, I confirm that:

- [x] I have read the [CONTRIBUTING guidelines](../../CONTRIBUTING.md) for this project and followed its Contribution Checklist.
