### PR TITLE
fix: LIST parameter members schema to match VDS response format

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "1.15.3",
+  "version": "1.15.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "1.15.3",
+      "version": "1.15.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "An MCP server for Tableau, providing a suite of tools that will make it easier for developers to build AI applications that integrate with Tableau.",
-  "version": "1.15.3",
+  "version": "1.15.4",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/src/sdks/tableau/apis/vizqlDataServiceApi.ts
+++ b/src/sdks/tableau/apis/vizqlDataServiceApi.ts
@@ -78,7 +78,7 @@ const parameterSchema = z.discriminatedUnion('parameterType', [
   parameterBaseSchema
     .extend({
       parameterType: z.literal('LIST'),
-      members: z.array(parameterValueSchema),
+      members: z.array(z.object({ value: parameterValueSchema })),
     })
     .strict(),
   parameterBaseSchema

--- a/src/tools/getDatasourceMetadata/datasourceMetadataUtils.ts
+++ b/src/tools/getDatasourceMetadata/datasourceMetadataUtils.ts
@@ -93,7 +93,7 @@ export function simplifyReadMetadataResult(readMetadataResult: MetadataResponse)
       };
 
       if (parameter.parameterType === 'LIST' && parameter.members) {
-        toPush.members = parameter.members;
+        toPush.members = parameter.members.map((m) => m.value);
       } else if (parameter.parameterType === 'QUANTITATIVE_DATE') {
         toPush.minDate = parameter.minDate;
         toPush.maxDate = parameter.maxDate;
@@ -174,7 +174,7 @@ export function combineFields(
       };
 
       if (parameter.parameterType === 'LIST' && parameter.members) {
-        toPush.members = parameter.members;
+        toPush.members = parameter.members.map((m) => m.value);
       } else if (parameter.parameterType === 'QUANTITATIVE_DATE') {
         toPush.minDate = parameter.minDate;
         toPush.maxDate = parameter.maxDate;

--- a/src/tools/getDatasourceMetadata/getDatasourceMetadata.test.ts
+++ b/src/tools/getDatasourceMetadata/getDatasourceMetadata.test.ts
@@ -70,7 +70,7 @@ const mockReadMetadataResponses = vi.hoisted(() => ({
           parameterCaption: 'Test Int',
           dataType: 'INTEGER',
           value: 1,
-          members: [1, 2, 3],
+          members: [{ value: 1 }, { value: 2 }, { value: 3 }],
         },
         {
           parameterType: 'ANY_VALUE',

--- a/src/tools/queryDatasource/validators/validateQueryAgainstDatasourceMetadata.test.ts
+++ b/src/tools/queryDatasource/validators/validateQueryAgainstDatasourceMetadata.test.ts
@@ -280,7 +280,7 @@ const sampleMetadataResponse: MetadataResponse = {
         parameterCaption: 'Test Boolean',
         dataType: 'BOOLEAN',
         value: false,
-        members: [true, false],
+        members: [{ value: true }, { value: false }],
       },
       {
         parameterType: 'QUANTITATIVE_RANGE',
@@ -298,7 +298,7 @@ const sampleMetadataResponse: MetadataResponse = {
         parameterCaption: 'Test Int',
         dataType: 'INTEGER',
         value: 1,
-        members: [1, 2, 3],
+        members: [{ value: 1 }, { value: 2 }, { value: 3 }],
       },
       {
         parameterType: 'QUANTITATIVE_RANGE',

--- a/src/tools/queryDatasource/validators/validateQueryAgainstDatasourceMetadata.ts
+++ b/src/tools/queryDatasource/validators/validateQueryAgainstDatasourceMetadata.ts
@@ -219,10 +219,10 @@ export function validateParametersAgainstDatasourceMetadata(
         }
         continue;
       case 'LIST':
-        if (!matchingParameter.members.includes(parameter.value)) {
+        if (!matchingParameter.members.some((m) => m.value === parameter.value)) {
           validationErrors.push({
             parameter: parameter.parameterCaption,
-            message: `Parameter '${parameter.parameterCaption}' has a value that is not in the list of allowed values for the parameter. The list of allowed values is [${matchingParameter.members.join(', ')}].`,
+            message: `Parameter '${parameter.parameterCaption}' has a value that is not in the list of allowed values for the parameter. The list of allowed values is [${matchingParameter.members.map((m) => m.value).join(', ')}].`,
           });
         }
         continue;


### PR DESCRIPTION
**IMPORTANT: Issue created first — see #228.**

## Description

Fix `get-datasource-metadata` crashing with `Cannot read properties of undefined (reading 'map')` for any datasource containing LIST parameters.

The VDS `read-metadata` endpoint returns LIST parameter `members` as an array of objects (`[{value: "Daily"}, ...]`) but the Zod schema expected an array of primitives (`["Daily", ...]`). The `.strict()` modifier on the discriminated union causes Zod validation to fail when parsing the response.

## Motivation and Context

Any published datasource with LIST parameters (e.g., dynamic dimension selectors, date granularity pickers) is completely unusable with `get-datasource-metadata`. This blocks schema discovery for datasources that use parameters.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## How Has This Been Tested?

Tested against Tableau Cloud datasources before and after the fix:

| Datasource | Parameters | Before | After |
|---|---|---|---|
| Published DS (28 fields, 0 params) | None | ✅ | ✅ |
| Same DS after adding 1 LIST param (28 fields, 1 param) | `Choose Date Granularity`: Daily, Monthly, Quarterly, Yearly | ❌ Crashes | ✅ 28 fields, 1 parameter returned correctly |
| Published DS with 2 LIST params | `Choose Dimension`, `Choose Date Granularity` | ❌ Crashes | ✅ All fields and parameters returned correctly |

## Related Issues

Fixes #228

## Checklist

- [x] I have updated the version in the package.json file by using `npm run version`. For example, use `npm run version:patch` for a patch version bump.
- [x] I have made any necessary changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have documented any breaking changes in the PR description. For example, renaming a config environment variable or changing its default value.

## Contributor Agreement

- [x] I have read the [CONTRIBUTING guidelines](../../CONTRIBUTING.md) for this project and followed its Contribution Checklist.

## Changes

3 files, 5 lines changed:

- **`src/sdks/tableau/apis/vizqlDataServiceApi.ts`** — Update LIST parameter schema to expect `{value: x}` objects
- **`src/tools/getDatasourceMetadata/datasourceMetadataUtils.ts`** — Unwrap member values (`m.value`) when building simplified output (both `simplifyReadMetadataResult` and `combineFields`)
- **`src/tools/queryDatasource/validators/validateQueryAgainstDatasourceMetadata.ts`** — Fix validation to use `.some(m => m.value === x)` and `.map(m => m.value).join()`
