### PR TITLE
@W-21451162 datasource descriptions now returned in getDatasourceMetadata response

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "1.17.8",
+  "version": "1.17.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "1.17.8",
+      "version": "1.17.9",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "1.17.8",
+  "version": "1.17.9",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/src/tools/getDatasourceMetadata/datasourceMetadataUtils.ts
+++ b/src/tools/getDatasourceMetadata/datasourceMetadataUtils.ts
@@ -51,6 +51,7 @@ export const parameterSchema = z
   .partial();
 
 export const fieldsResultSchema = z.object({
+  datasourceDescription: z.string(),
   fields: z.array(fieldSchema),
   parameters: z.array(parameterSchema),
 });
@@ -61,6 +62,7 @@ export type FieldsResult = z.infer<typeof fieldsResultSchema>;
 
 export function simplifyReadMetadataResult(readMetadataResult: MetadataResponse): FieldsResult {
   const simplifiedResponse: FieldsResult = {
+    datasourceDescription: '',
     fields: [],
     parameters: [],
   };
@@ -127,6 +129,7 @@ export function combineFields(
   // readMetadata (VizQL Data Service API) and listFields (GraphQL Metadata API) results
   // to optimize for LLM accuracy and reduce tokens in response.
   const combinedFields: FieldsResult = {
+    datasourceDescription: listFieldsResult.data.publishedDatasources[0]?.description ?? '',
     fields: [],
     parameters: [],
   };

--- a/src/tools/getDatasourceMetadata/getDatasourceMetadata.test.ts
+++ b/src/tools/getDatasourceMetadata/getDatasourceMetadata.test.ts
@@ -244,6 +244,7 @@ describe('getDatasourceMetadataTool', () => {
     const responseData = JSON.parse(result.content[0].text);
 
     expect(responseData).toMatchObject({
+      datasourceDescription: 'Test Description',
       fields: [
         {
           name: 'Profit Ratio',
@@ -334,6 +335,7 @@ describe('getDatasourceMetadataTool', () => {
     invariant(result.content[0].type === 'text');
     const responseData = JSON.parse(result.content[0].text);
     expect(responseData).toEqual({
+      datasourceDescription: 'Test Description',
       fields: [],
       parameters: [],
     });
@@ -349,6 +351,7 @@ describe('getDatasourceMetadataTool', () => {
     invariant(result.content[0].type === 'text');
     const responseData = JSON.parse(result.content[0].text);
     expect(responseData).toEqual({
+      datasourceDescription: 'Test Description',
       fields: [
         {
           dataCategory: 'QUANTITATIVE',


### PR DESCRIPTION
## Description

Added datasourceDescription: z.string() to fieldsResultSchema so the field is always present in the response.
In combineFields (the path taken when the Metadata API is enabled): populated from the GraphQL response's publishedDatasources[0].description, falling back to an empty string if absent. The GraphQL query already fetched this field, so no query changes were needed.

In simplifyReadMetadataResult (the path taken when the Metadata API is disabled): always returns an empty string, since the VizQL Data Service's readMetadata API does not expose datasource description.

Updated tests to assert datasourceDescription is present and correctly valued across all relevant scenarios.

## Motivation and Context
datasource descriptions weren't showing up in the response from the getDatasourceMetadata tool calls. 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## How Has This Been Tested?

all 15 tests passed when running npx vitest run src/tools/getDatasourceMetadata/getDatasourceMetadata.test.ts

## Related Issues
n/a 

## Checklist

- [x] I have updated the version in the package.json file by using `npm run version`. For example,
      use `npm run version:patch` for a patch version bump.
- [ ] I have made any necessary changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have documented any breaking changes in the PR description. For example, renaming a config
      environment variable or changing its default value.

## Contributor Agreement

By submitting this pull request, I confirm that:

- [x] I have read the [CONTRIBUTING guidelines](../../CONTRIBUTING.md) for this project and followed
      its Contribution Checklist.
