### PR TITLE
[draft] Add experimental build

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "exports": {
     ".": "./build/index.js",
+    "./experimental": "./build/index-experimental.js",
     "./tracing": "./build/telemetry/tracing.js"
   },
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import dotenv from 'dotenv';
 import { getConfig } from './config.js';
 import { isLoggingLevel, log, setLogLevel, setServerLogger, writeToStderr } from './logging/log.js';
 import { ServerLogger } from './logging/serverLogger.js';
+import { getMetaEnv } from './metaEnv.js';
 import { Server, serverName, serverVersion } from './server.js';
 import { startExpressServer } from './server/express.js';
 import { getExceptionMessage } from './utils/getExceptionMessage.js';
@@ -29,6 +30,7 @@ async function startServer(): Promise<void> {
 
       setLogLevel(server, logLevel);
       log.info(server, `${server.name} v${server.version} running on stdio`);
+      log.info(server, `Build configuration: ${getMetaEnv().buildConfiguration}`);
       break;
     }
     case 'http': {
@@ -44,6 +46,8 @@ async function startServer(): Promise<void> {
       console.log(
         `${serverName} v${serverVersion} ${config.disableSessionManagement ? 'stateless ' : ''}streamable HTTP server available at ${url}`,
       );
+      // eslint-disable-next-line no-console -- console.log is intentional here since the transport is not stdio.
+      console.log(`Build configuration: ${getMetaEnv().buildConfiguration}`);
       break;
     }
   }

--- a/src/metaEnv.ts
+++ b/src/metaEnv.ts
@@ -1,0 +1,13 @@
+import { BuildConfiguration, isBuildConfiguration } from './scripts/build';
+
+class MetaEnv {
+  buildConfiguration: BuildConfiguration;
+
+  constructor() {
+    this.buildConfiguration = isBuildConfiguration(import.meta.env.BUILD_CONFIGURATION)
+      ? import.meta.env.BUILD_CONFIGURATION
+      : 'default';
+  }
+}
+
+export const getMetaEnv = (): MetaEnv => new MetaEnv();

--- a/src/metaEnv.ts
+++ b/src/metaEnv.ts
@@ -1,4 +1,4 @@
-import { BuildConfiguration, isBuildConfiguration } from './scripts/build';
+import { BuildConfiguration, isBuildConfiguration } from './scripts/buildConfigurations';
 
 class MetaEnv {
   buildConfiguration: BuildConfiguration;

--- a/src/scripts/build.ts
+++ b/src/scripts/build.ts
@@ -3,15 +3,10 @@
 import { build, BuildOptions, BuildResult } from 'esbuild';
 import { chmod, mkdir, rm } from 'fs/promises';
 
+import { buildConfigurations } from './buildConfigurations';
 import { globalIdentifiers } from './globalIndentifiers';
 
 const dev = process.argv.includes('--dev');
-
-export const buildConfigurations = ['default', 'experimental'] as const;
-export type BuildConfiguration = (typeof buildConfigurations)[number];
-export function isBuildConfiguration(value: unknown): value is BuildConfiguration {
-  return buildConfigurations.some((c) => c === value);
-}
 
 (async () => {
   await rm('./build', { recursive: true, force: true });

--- a/src/scripts/build.ts
+++ b/src/scripts/build.ts
@@ -1,35 +1,35 @@
 /* eslint-disable no-console */
 
-import { build } from 'esbuild';
+import { build, BuildOptions, BuildResult } from 'esbuild';
 import { chmod, mkdir, rm } from 'fs/promises';
 
+import { globalIdentifiers } from './globalIndentifiers';
+
 const dev = process.argv.includes('--dev');
+
+export const buildConfigurations = ['default', 'experimental'] as const;
+export type BuildConfiguration = (typeof buildConfigurations)[number];
+export function isBuildConfiguration(value: unknown): value is BuildConfiguration {
+  return buildConfigurations.some((c) => c === value);
+}
 
 (async () => {
   await rm('./build', { recursive: true, force: true });
 
-  console.log('🏗️ Building...');
-  const result = await build({
-    entryPoints: ['./src/index.ts'],
-    bundle: true,
-    platform: 'node',
-    format: 'cjs',
-    minify: !dev,
-    packages: dev ? 'external' : 'bundle',
-    sourcemap: true,
-    logLevel: dev ? 'debug' : 'info',
-    logOverride: {
-      'empty-import-meta': 'silent',
-    },
-    outfile: './build/index.js',
-  });
+  console.log('🏗️ Building all configurations...');
+  for (const configuration of buildConfigurations) {
+    console.log(`🏗️ Building ${configuration}...`);
+    const { result, outfile } = await buildConfiguration(configuration);
 
-  for (const error of result.errors) {
-    console.log(`❌ ${error.text}`);
-  }
+    for (const error of result.errors) {
+      console.log(`❌ ${error.text}`);
+    }
 
-  for (const warning of result.warnings) {
-    console.log(`⚠️ ${warning.text}`);
+    for (const warning of result.warnings) {
+      console.log(`⚠️ ${warning.text}`);
+    }
+
+    await chmod(outfile, '755');
   }
 
   console.log('🏗️ Building telemetry/tracing.js...');
@@ -52,6 +52,41 @@ const dev = process.argv.includes('--dev');
   for (const warning of tracingResult.warnings) {
     console.log(`⚠️ ${warning.text}`);
   }
-
-  await chmod('./build/index.js', '755');
 })();
+
+async function buildConfiguration(
+  configuration: string,
+): Promise<{ result: BuildResult<BuildOptions>; outfile: string }> {
+  process.env.BUILD_CONFIGURATION = configuration;
+  const buildOptions: BuildOptions = {
+    entryPoints: ['./src/index.ts'],
+    bundle: true,
+    platform: 'node',
+    format: 'cjs',
+    minify: !dev,
+    packages: dev ? 'external' : 'bundle',
+    sourcemap: true,
+    logLevel: dev ? 'debug' : 'info',
+    logOverride: {
+      'empty-import-meta': 'silent',
+    },
+    outfile: './build/index.js',
+    define: {
+      // 'import.meta.env.BUILD_CONFIGURATION': JSON.stringify(process.env.BUILD_CONFIGURATION),
+      ...globalIdentifiers.reduce<Record<`import.meta.env.${string}`, string>>(
+        (acc, { name, defaultValue }) => {
+          acc[`import.meta.env.${name}`] = JSON.stringify(process.env[name] ?? defaultValue);
+          return acc;
+        },
+        {},
+      ),
+    },
+    // must be last so that the action can override previous build options
+    ...globalIdentifiers.reduce((acc, { name, defaultValue, action }) => {
+      return { ...acc, ...action(process.env[name] ?? defaultValue) };
+    }, {}),
+  };
+
+  const result = await build(buildOptions);
+  return { result, outfile: buildOptions.outfile ?? '' };
+}

--- a/src/scripts/buildConfigurations.ts
+++ b/src/scripts/buildConfigurations.ts
@@ -1,0 +1,5 @@
+export const buildConfigurations = ['default', 'experimental'] as const;
+export type BuildConfiguration = (typeof buildConfigurations)[number];
+export function isBuildConfiguration(value: unknown): value is BuildConfiguration {
+  return buildConfigurations.some((c) => c === value);
+}

--- a/src/scripts/createClaudeMcpBundleManifest.ts
+++ b/src/scripts/createClaudeMcpBundleManifest.ts
@@ -11,7 +11,6 @@ import packageJson from '../../package.json';
 import { ProcessEnvEx } from '../../types/process-env.js';
 import { toolNames } from '../tools/toolName.js';
 
-// @ts-expect-error - import.meta is not allowed in CommonJS output, but this file is built using esbuild as ESM
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 

--- a/src/scripts/globalIndentifiers.ts
+++ b/src/scripts/globalIndentifiers.ts
@@ -1,0 +1,27 @@
+import { BuildOptions } from 'esbuild';
+
+import { BuildConfiguration } from './build';
+
+type GlobalIdentifier = {
+  name: string;
+  defaultValue: string;
+  action: (value: string) => BuildOptions | undefined;
+};
+
+export const globalIdentifiers: ReadonlyArray<GlobalIdentifier> = [
+  {
+    name: 'BUILD_CONFIGURATION',
+    defaultValue: 'default' satisfies BuildConfiguration,
+    action: (value: string): BuildOptions | undefined => {
+      if (value === 'default') {
+        return {
+          outfile: './build/index.js',
+        };
+      }
+
+      return {
+        outfile: `./build/index-${value}.js`,
+      };
+    },
+  },
+];

--- a/src/scripts/globalIndentifiers.ts
+++ b/src/scripts/globalIndentifiers.ts
@@ -1,6 +1,6 @@
 import { BuildOptions } from 'esbuild';
 
-import { BuildConfiguration } from './build';
+import { BuildConfiguration } from './buildConfigurations';
 
 type GlobalIdentifier = {
   name: string;

--- a/tests/eval/base.ts
+++ b/tests/eval/base.ts
@@ -7,7 +7,7 @@ import {
   StreamedRunResult,
   withTrace,
 } from '@openai/agents';
-import { OpenAI } from 'openai/client.js';
+import OpenAI from 'openai';
 import { Err, Ok, Result } from 'ts-results-es';
 import z from 'zod';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,9 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true,
     "outDir": "./build",
     "rootDir": "./",
     "strict": true,

--- a/types/import-meta.d.ts
+++ b/types/import-meta.d.ts
@@ -1,0 +1,5 @@
+interface ImportMeta {
+  readonly env: {
+    readonly BUILD_CONFIGURATION: string;
+  };
+}


### PR DESCRIPTION
The build now emits TWO files.

The original index.js (with `import.meta.env.BUILD_CONFIGURATION` replaced with "default")
A new index-experimental.js file (with `import.meta.env.BUILD_CONFIGURATION` replaced with "experimental")