### PR TITLE
@W-21748754: Add list-custom-views tools

### DIFF
--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -4,8 +4,7 @@ sidebar_position: 1
 
 # Introduction
 
-Tableau MCP is a suite of developer primitives, including tools, resources and prompts, that will
-make it easier for developers to build AI applications that integrate with Tableau.
+Tableau's official MCP Server. Helping Agents see and understand data.
 
 ## Key Features
 
@@ -24,6 +23,7 @@ make it easier for developers to build AI applications that integrate with Table
 | [list-datasources](tools/data-qna/list-datasources.md)                                                                | Retrieves a list of published data sources from a specified Tableau site ([REST API][query])          |
 | [list-workbooks](tools/workbooks/list-workbooks.md)                                                                   | Retrieves a list of workbooks from a specified Tableau site ([REST API][list-workbooks])              |
 | [list-views](tools/views/list-views.md)                                                                               | Retrieves a list of views from a specified Tableau site ([REST API][list-views])                      |
+| [list-custom-views](tools/views/list-custom-views.md)                                                                 | Retrieves a list of custom views for a specified Tableau workbook ([REST API][list-custom-views])     |
 | [get-datasource-metadata](tools/data-qna/get-datasource-metadata.md)                                                  | Fetches field metadata for the specified datasource ([Metadata API][meta] & [VDS API][vds])           |
 | [get-workbook](tools/workbooks/get-workbook.md)                                                                       | Retrieves information on a workbook from a specified Tableau site ([REST API][get-workbook])          |
 | [get-view-data](tools/views/get-view-data.md)                                                                         | Retrieves data in CSV format for the specified view in a Tableau workbook ([REST API][get-view-data]) |
@@ -35,7 +35,7 @@ make it easier for developers to build AI applications that integrate with Table
 | [list-pulse-metrics-from-metric-ids](tools/pulse/list-pulse-metrics-from-metric-ids.md)                               | List Pulse Metrics from Metric IDs ([Pulse API][pulse])                                               |
 | [list-pulse-metric-subscriptions](tools/pulse/list-pulse-metric-subscriptions.md)                                     | List Pulse Metric Subscriptions for Current User ([Pulse API][pulse])                                 |
 | [generate-pulse-metric-value-insight-bundle](tools/pulse/generate-pulse-metric-value-insight-bundle.md)               | Generate Pulse Metric Value Insight Bundle ([Pulse API][pulse])                                       |
-| [generate-pulse-insight-brief](tools/pulse/generate-pulse-insight-brief.md)                                           | Generate AI-powered Pulse Insight Brief (Discover) ([Pulse API][pulse])                                          |
+| [generate-pulse-insight-brief](tools/pulse/generate-pulse-insight-brief.md)                                           | Generate AI-powered Pulse Insight Brief (Discover) ([Pulse API][pulse])                               |
 | [search-content](tools/content-exploration/search-content.md)                                                         | Searches for content in a Tableau site ([Content Exploration API][content-exploration])               |
 
 [query]:
@@ -44,6 +44,8 @@ make it easier for developers to build AI applications that integrate with Table
   https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref_workbooks_and_views.htm#query_workbooks_for_site
 [list-views]:
   https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref_workbooks_and_views.htm#query_views_for_site
+[list-custom-views]:
+  https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref_workbooks_and_views.htm#list_custom_views
 [get-workbook]:
   https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref_workbooks_and_views.htm#query_workbook
 [get-view-data]:
@@ -53,4 +55,5 @@ make it easier for developers to build AI applications that integrate with Table
 [meta]: https://help.tableau.com/current/api/metadata_api/en-us/index.html
 [vds]: https://help.tableau.com/current/api/vizql-data-service/en-us/index.html
 [pulse]: https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref_pulse.htm
-[content-exploration]: https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref_content_exploration.htm
+[content-exploration]:
+  https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref_content_exploration.htm

--- a/docs/docs/tools/views/list-custom-views.md
+++ b/docs/docs/tools/views/list-custom-views.md
@@ -26,10 +26,20 @@ Example: `222ea993-9391-4910-a167-56b3d19b4e3b`
 
 A
 [filter expression](https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_concepts_filtering_and_sorting.htm)
-as defined in the
-[Tableau REST API Custom Views filter fields](https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_concepts_filtering_and_sorting.htm#custom-views).
+using only these supported Tableau REST API Custom Views filter fields:
+
+- `viewId:eq:<viewId>`
+- `ownerId:eq:<ownerId>`
 
 Example: `viewId:eq:9460abfe-a6b2-49d1-b998-39e1ebcc55ce`
+
+:::warning
+
+The tool always includes `workbookId` in the filter expression based on the required
+[`workbookId`](#workbookid) argument. Including the `workbookId` field in the filter will be
+ignored.
+
+:::
 
 <hr />
 

--- a/docs/docs/tools/views/list-custom-views.md
+++ b/docs/docs/tools/views/list-custom-views.md
@@ -1,0 +1,82 @@
+---
+sidebar_position: 4
+---
+
+# List Custom Views
+
+Retrieves a list of custom views for a specified Tableau workbook.
+
+## APIs called
+
+- [Get Workbook](https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref_workbooks_and_views.htm#query_workbook)
+- [List Custom Views](https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref_workbooks_and_views.htm#list_custom_views)
+
+## Required arguments
+
+### `workbookId`
+
+The ID of the workbook containing the custom view, potentially retrieved by the
+[List Workbooks](../workbooks/list-workbooks.md) tool.
+
+Example: `222ea993-9391-4910-a167-56b3d19b4e3b`
+
+## Optional arguments
+
+### `filter`
+
+A
+[filter expression](https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_concepts_filtering_and_sorting.htm)
+as defined in the
+[Tableau REST API Custom Views filter fields](https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_concepts_filtering_and_sorting.htm#custom-views).
+
+Example: `viewId:eq:9460abfe-a6b2-49d1-b998-39e1ebcc55ce`
+
+<hr />
+
+### `pageSize`
+
+The value of the `page-size` argument provided to the
+[List Custom Views](https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref_workbooks_and_views.htm#list_custom_views)
+REST API. The tool automatically performs pagination and will repeatedly call the REST API until
+either all custom views are retrieved or the `limit` argument has been reached. The `pageSize`
+argument will determine how many custom views to return in each call. You may want to provide a
+larger value if you know in advance that you have more than 100 custom views to retrieve.
+
+Example: `1000`
+
+<hr />
+
+### `limit`
+
+The maximum number of custom views to return. The tool will return at most this many custom views.
+
+Example: `2000`
+
+See also: [`MAX_RESULT_LIMIT`](../../configuration/mcp-config/env-vars.md#max_result_limit)
+
+## Example result
+
+```json
+[
+  {
+    "id": "1db3a121-51ac-4435-b533-3053e698dfc8",
+    "name": "My Custom View",
+    "createdAt": "2026-03-26T17:34:21Z",
+    "updatedAt": "2026-03-31T22:06:29Z",
+    "lastAccessedAt": "2026-03-31T22:06:29Z",
+    "shared": false,
+    "view": {
+      "id": "9460abfe-a6b2-49d1-b998-39e1ebcc55ce",
+      "name": "Overview"
+    },
+    "workbook": {
+      "id": "222ea993-9391-4910-a167-56b3d19b4e3b",
+      "name": "Superstore"
+    },
+    "owner": {
+      "id": "bbdee366-4a50-4c2c-a5c8-746da5b64483",
+      "name": "andrew.young@tableau.com"
+    }
+  }
+]
+```

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -4,8 +4,7 @@ import { themes as prismThemes } from 'prism-react-renderer';
 
 const config: Config = {
   title: 'Tableau MCP',
-  tagline:
-    'Tableau MCP is a suite of developer primitives, including tools, resources and prompts, that will make it easier for developers to build AI applications that integrate with Tableau.',
+  tagline: "Tableau's official MCP Server. Helping Agents see and understand data.",
   favicon: 'img/favicon.ico',
   trailingSlash: false,
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "1.18.3",
+  "version": "1.18.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "1.18.3",
+      "version": "1.18.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "1.18.2",
+  "version": "1.18.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "1.18.2",
+      "version": "1.18.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "1.18.2",
+  "version": "1.18.3",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "1.18.3",
+  "version": "1.18.4",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/src/errors/mcpToolError.ts
+++ b/src/errors/mcpToolError.ts
@@ -96,9 +96,21 @@ export class ViewNotAllowedError extends McpToolError {
   }
 }
 
+export class CustomViewNotAllowedError extends McpToolError {
+  constructor(message: string) {
+    super({ type: 'custom-view-not-allowed', message, statusCode: 403 });
+  }
+}
+
 export class WorkbookNotAllowedError extends McpToolError {
   constructor(message: string) {
     super({ type: 'workbook-not-allowed', message, statusCode: 403 });
+  }
+}
+
+export class WorkbookNotFoundError extends McpToolError {
+  constructor(message: string) {
+    super({ type: 'workbook-not-found', message, statusCode: 404 });
   }
 }
 

--- a/src/sdks/tableau/apis/viewsApi.ts
+++ b/src/sdks/tableau/apis/viewsApi.ts
@@ -27,7 +27,7 @@ const listCustomViewsEndpoint = makeEndpoint({
       type: 'Query',
       schema: z.string().optional(),
       description:
-        'An expression that lets you specify a subset of views to return. You can filter on predefined fields such as name, tags, and createdAt. You can include multiple filter expressions.',
+        'An expression that lets you specify a subset of custom views to return. You can filter on viewId, ownerId, and workbookId. You can include multiple filter expressions.',
     },
   ],
   response: z.object({

--- a/src/sdks/tableau/apis/viewsApi.ts
+++ b/src/sdks/tableau/apis/viewsApi.ts
@@ -1,6 +1,7 @@
 import { makeApi, makeEndpoint, ZodiosEndpointDefinitions } from '@zodios/core';
 import { z } from 'zod';
 
+import { customViewSchema } from '../types/customView.js';
 import { paginationSchema } from '../types/pagination.js';
 import { viewSchema } from '../types/view.js';
 import { paginationParameters } from './paginationParameters.js';
@@ -11,6 +12,28 @@ const getViewEndpoint = makeEndpoint({
   alias: 'getView',
   description: 'Gets the details of a specific view.',
   response: z.object({ view: viewSchema }),
+});
+
+const listCustomViewsEndpoint = makeEndpoint({
+  method: 'get',
+  path: '/sites/:siteId/customviews',
+  alias: 'listCustomViews',
+  description:
+    'Gets a list of custom views on a site. The list includes details of each custom view.',
+  parameters: [
+    ...paginationParameters,
+    {
+      name: 'filter',
+      type: 'Query',
+      schema: z.string().optional(),
+      description:
+        'An expression that lets you specify a subset of views to return. You can filter on predefined fields such as name, tags, and createdAt. You can include multiple filter expressions.',
+    },
+  ],
+  response: z.object({
+    pagination: paginationSchema,
+    customViews: z.object({ customView: z.array(customViewSchema).optional() }),
+  }),
 });
 
 const queryViewDataEndpoint = makeEndpoint({
@@ -117,6 +140,7 @@ const queryViewsForSiteEndpoint = makeEndpoint({
 
 const viewsApi = makeApi([
   getViewEndpoint,
+  listCustomViewsEndpoint,
   queryViewDataEndpoint,
   queryViewImageEndpoint,
   queryViewsForWorkbookEndpoint,

--- a/src/sdks/tableau/methods/viewsMethods.ts
+++ b/src/sdks/tableau/methods/viewsMethods.ts
@@ -5,6 +5,7 @@ import { AxiosRequestConfig, isAxiosError } from '../../../utils/axios.js';
 import { getExceptionMessage } from '../../../utils/getExceptionMessage.js';
 import { viewsApis } from '../apis/viewsApi.js';
 import { RestApiCredentials } from '../restApi.js';
+import { CustomView } from '../types/customView.js';
 import { Pagination } from '../types/pagination.js';
 import { View } from '../types/view.js';
 import AuthenticatedMethods from './authenticatedMethods.js';
@@ -32,6 +33,40 @@ export default class ViewsMethods extends AuthenticatedMethods<typeof viewsApis>
    */
   getView = async ({ viewId, siteId }: { viewId: string; siteId: string }): Promise<View> => {
     return (await this._apiClient.getView({ params: { siteId, viewId }, ...this.authHeader })).view;
+  };
+
+  /**
+   * Gets a list of custom views on a site. The list includes details of each custom view.
+   *
+   * Required scopes: `tableau:content:read`
+   *
+   * @param {string} siteId - The Tableau site ID
+   * @param {string} filter - (Optional) Fields and operators that you can use to filter results
+   * @param {number} pageSize - (Optional) The number of items to return in one response. The minimum is 1. The maximum is 1000. The default is 100.
+   * @param {number} pageNumber - (Optional) The offset for paging. The default is 1.
+   * @link https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref_workbooks_and_views.htm#list_custom_views
+   */
+  listCustomViews = async ({
+    siteId,
+    filter,
+    pageSize,
+    pageNumber,
+  }: {
+    siteId: string;
+    filter?: string;
+    pageSize?: number;
+    pageNumber?: number;
+  }): Promise<{ pagination: Pagination; customViews: CustomView[] }> => {
+    const response = await this._apiClient.listCustomViews({
+      params: { siteId },
+      queries: { filter, pageSize, pageNumber },
+      ...this.authHeader,
+    });
+
+    return {
+      pagination: response.pagination,
+      customViews: response.customViews.customView ?? [],
+    };
   };
 
   /**

--- a/src/sdks/tableau/types/customView.ts
+++ b/src/sdks/tableau/types/customView.ts
@@ -1,0 +1,32 @@
+import { z } from 'zod';
+
+/**
+ * Subset of Tableau REST API custom view resource (Get Custom View).
+ * @see https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref_workbooks_and_views.htm#get_custom_view
+ */
+export const customViewSchema = z.object({
+  id: z.string(),
+  name: z.string().optional(),
+  createdAt: z.string().optional(),
+  updatedAt: z.string().optional(),
+  lastAccessedAt: z.string().optional(),
+  shared: z.union([z.boolean(), z.string()]).optional(),
+  view: z.object({
+    id: z.string(),
+    name: z.string().optional(),
+  }),
+  workbook: z
+    .object({
+      id: z.string(),
+      name: z.string().optional(),
+    })
+    .optional(),
+  owner: z
+    .object({
+      id: z.string(),
+      name: z.string().optional(),
+    })
+    .optional(),
+});
+
+export type CustomView = z.infer<typeof customViewSchema>;

--- a/src/server/oauth/scopes.ts
+++ b/src/server/oauth/scopes.ts
@@ -75,6 +75,10 @@ const toolScopeMap: Record<
     mcp: ['tableau:mcp:view:read'],
     api: new Set(['tableau:content:read']),
   },
+  'list-custom-views': {
+    mcp: ['tableau:mcp:view:read'],
+    api: new Set(['tableau:content:read']),
+  },
   'query-datasource': {
     mcp: ['tableau:mcp:datasource:read'],
     api: new Set(['tableau:viz_data_service:read', ...RESOURCE_ACCESS_CHECKER_REQUIRED_API_SCOPES]),

--- a/src/tools/toolName.ts
+++ b/src/tools/toolName.ts
@@ -2,6 +2,7 @@ export const toolNames = [
   'list-datasources',
   'list-workbooks',
   'list-views',
+  'list-custom-views',
   'query-datasource',
   'get-datasource-metadata',
   'get-workbook',
@@ -32,7 +33,7 @@ export type ToolGroupName = (typeof toolGroupNames)[number];
 export const toolGroups = {
   datasource: ['list-datasources', 'get-datasource-metadata', 'query-datasource'],
   workbook: ['list-workbooks', 'get-workbook'],
-  view: ['list-views', 'get-view-data', 'get-view-image'],
+  view: ['list-views', 'list-custom-views', 'get-view-data', 'get-view-image'],
   pulse: [
     'list-all-pulse-metric-definitions',
     'list-pulse-metric-definitions-from-definition-ids',

--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -12,6 +12,7 @@ import { getQueryDatasourceTool } from './queryDatasource/queryDatasource.js';
 import { getRevokeAccessTokenTool } from './revokeAccessToken/revokeAccessToken.js';
 import { getGetViewDataTool } from './views/getViewData.js';
 import { getGetViewImageTool } from './views/getViewImage.js';
+import { getListCustomViewsTool } from './views/listCustomViews.js';
 import { getListViewsTool } from './views/listViews.js';
 import { getGetWorkbookTool } from './workbooks/getWorkbook.js';
 import { getListWorkbooksTool } from './workbooks/listWorkbooks.js';
@@ -32,6 +33,7 @@ export const toolFactories = [
   getGetViewImageTool,
   getListWorkbooksTool,
   getListViewsTool,
+  getListCustomViewsTool,
   getSearchContentTool,
   getRevokeAccessTokenTool,
 ];

--- a/src/tools/views/customViewsFilterUtils.ts
+++ b/src/tools/views/customViewsFilterUtils.ts
@@ -1,0 +1,51 @@
+import { z } from 'zod';
+
+import {
+  FilterOperator,
+  FilterOperatorSchema,
+  parseAndValidateFilterString,
+} from '../../utils/parseAndValidateFilterString.js';
+
+const FilterFieldSchema = z.enum([
+  'createdAt',
+  'id',
+  'name',
+  'ownerId',
+  'shared',
+  'updatedAt',
+  'viewId',
+  'workbookId',
+]);
+
+type FilterField = z.infer<typeof FilterFieldSchema>;
+
+const allowedOperatorsByField: Record<FilterField, FilterOperator[]> = {
+  createdAt: ['eq', 'gt', 'gte', 'lt', 'lte'],
+  id: ['eq', 'in'],
+  name: ['eq', 'in'],
+  ownerId: ['eq'],
+  shared: ['eq'],
+  updatedAt: ['eq', 'gt', 'gte', 'lt', 'lte'],
+  viewId: ['eq'],
+  workbookId: ['eq'],
+};
+
+const _FilterExpressionSchema = z.object({
+  field: FilterFieldSchema,
+  operator: FilterOperatorSchema,
+  value: z.string(),
+});
+
+type FilterExpression = z.infer<typeof _FilterExpressionSchema>;
+
+export function parseAndValidateCustomViewsFilterString(filterString: string): string {
+  return parseAndValidateFilterString<FilterField, FilterExpression>({
+    filterString,
+    allowedOperatorsByField,
+    filterFieldSchema: FilterFieldSchema,
+  });
+}
+
+export const exportedForTesting = {
+  FilterFieldSchema,
+};

--- a/src/tools/views/customViewsFilterUtils.ts
+++ b/src/tools/views/customViewsFilterUtils.ts
@@ -6,26 +6,15 @@ import {
   parseAndValidateFilterString,
 } from '../../utils/parseAndValidateFilterString.js';
 
-const FilterFieldSchema = z.enum([
-  'createdAt',
-  'id',
-  'name',
-  'ownerId',
-  'shared',
-  'updatedAt',
-  'viewId',
-  'workbookId',
-]);
+const FilterFieldSchema = z.enum(['ownerId', 'viewId', 'workbookId']);
 
 type FilterField = z.infer<typeof FilterFieldSchema>;
 
+// Note that this set is based off the requirement of the List Custom Views REST API, which states:
+// "The supported filters for custom views use the eq (equals) operator, with the resources: viewId, ownerId, and workbookId."
+// This is a subset of the custom view filter fields listed in the table at https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_concepts_filtering_and_sorting.htm#custom-views
 const allowedOperatorsByField: Record<FilterField, FilterOperator[]> = {
-  createdAt: ['eq', 'gt', 'gte', 'lt', 'lte'],
-  id: ['eq', 'in'],
-  name: ['eq', 'in'],
   ownerId: ['eq'],
-  shared: ['eq'],
-  updatedAt: ['eq', 'gt', 'gte', 'lt', 'lte'],
   viewId: ['eq'],
   workbookId: ['eq'],
 };

--- a/src/tools/views/customViewsFilterUtils.ts
+++ b/src/tools/views/customViewsFilterUtils.ts
@@ -13,19 +13,20 @@ type FilterField = z.infer<typeof FilterFieldSchema>;
 // Note that this set is based off the requirement of the List Custom Views REST API, which states:
 // "The supported filters for custom views use the eq (equals) operator, with the resources: viewId, ownerId, and workbookId."
 // This is a subset of the custom view filter fields listed in the table at https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_concepts_filtering_and_sorting.htm#custom-views
+// which is likely a docs bug.
 const allowedOperatorsByField: Record<FilterField, FilterOperator[]> = {
   ownerId: ['eq'],
   viewId: ['eq'],
   workbookId: ['eq'],
 };
 
-const _FilterExpressionSchema = z.object({
+const _filterExpressionSchema = z.object({
   field: FilterFieldSchema,
   operator: FilterOperatorSchema,
   value: z.string(),
 });
 
-type FilterExpression = z.infer<typeof _FilterExpressionSchema>;
+type FilterExpression = z.infer<typeof _filterExpressionSchema>;
 
 export function parseAndValidateCustomViewsFilterString(filterString: string): string {
   return parseAndValidateFilterString<FilterField, FilterExpression>({
@@ -34,7 +35,3 @@ export function parseAndValidateCustomViewsFilterString(filterString: string): s
     filterFieldSchema: FilterFieldSchema,
   });
 }
-
-export const exportedForTesting = {
-  FilterFieldSchema,
-};

--- a/src/tools/views/listCustomViews.test.ts
+++ b/src/tools/views/listCustomViews.test.ts
@@ -111,6 +111,25 @@ describe('listCustomViewsTool', () => {
     );
   });
 
+  it('should ignore the workbookId filter if it is provided', async () => {
+    mocks.mockListCustomViews.mockResolvedValue(mockCustomViews);
+    mocks.mockGetWorkbook.mockResolvedValue(mockWorkbook);
+    const result = await getToolResult({
+      workbookId: mockWorkbook.id,
+      filter: `workbookId:eq:some-other-workbook-id,viewId:eq:${mockCustomView.view.id}`,
+    });
+
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+    expect(JSON.parse(`${result.content[0].text}`)).toMatchObject(mockCustomViews.customViews);
+    expect(mocks.mockListCustomViews).toHaveBeenCalledWith({
+      siteId: 'test-site-id',
+      filter: `workbookId:eq:${mockWorkbook.id},viewId:eq:${mockCustomView.view.id}`,
+      pageNumber: undefined,
+      pageSize: undefined,
+    });
+  });
+
   it('should return a custom view not allowed error if its workbook is not allowed due to tool scoping', async () => {
     vi.stubEnv('INCLUDE_WORKBOOK_IDS', 'some-other-workbook-id');
 

--- a/src/tools/views/listCustomViews.test.ts
+++ b/src/tools/views/listCustomViews.test.ts
@@ -1,0 +1,145 @@
+import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+
+import { Server } from '../../server.js';
+import { stubDefaultEnvVars } from '../../testShared.js';
+import invariant from '../../utils/invariant.js';
+import { Provider } from '../../utils/provider.js';
+import { exportedForTesting as resourceAccessCheckerExportedForTesting } from '../resourceAccessChecker.js';
+import { getMockRequestHandlerExtra } from '../toolContext.mock.js';
+import { mockWorkbook } from '../workbooks/mockWorkbook.js';
+import { getListCustomViewsTool } from './listCustomViews.js';
+import { mockCustomView } from './mockCustomView.js';
+
+const { resetResourceAccessCheckerSingleton } = resourceAccessCheckerExportedForTesting;
+
+const mockCustomViews = {
+  pagination: {
+    pageNumber: 1,
+    pageSize: 10,
+    totalAvailable: 1,
+  },
+  customViews: [mockCustomView],
+};
+
+const mocks = vi.hoisted(() => ({
+  mockListCustomViews: vi.fn(),
+  mockGetWorkbook: vi.fn(),
+}));
+
+vi.mock('../../restApiInstance.js', () => ({
+  useRestApi: vi.fn().mockImplementation(async ({ callback }) =>
+    callback({
+      workbooksMethods: {
+        getWorkbook: mocks.mockGetWorkbook,
+      },
+      viewsMethods: {
+        listCustomViews: mocks.mockListCustomViews,
+      },
+      siteId: 'test-site-id',
+    }),
+  ),
+}));
+
+describe('listCustomViewsTool', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    stubDefaultEnvVars();
+    resetResourceAccessCheckerSingleton();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('should create a tool instance with correct properties', () => {
+    const listCustomViewsTool = getListCustomViewsTool(new Server());
+    expect(listCustomViewsTool.name).toBe('list-custom-views');
+    expect(listCustomViewsTool.description).toContain(
+      'Retrieves a list of custom views for a Tableau workbook including their metadata such as name, owner, and the view they are found in.',
+    );
+    expect(listCustomViewsTool.paramsSchema).toMatchObject({
+      workbookId: expect.any(Object),
+      filter: expect.any(Object),
+      pageSize: expect.any(Object),
+      limit: expect.any(Object),
+    });
+  });
+
+  it('should successfully get custom views', async () => {
+    mocks.mockListCustomViews.mockResolvedValue(mockCustomViews);
+    mocks.mockGetWorkbook.mockResolvedValue(mockWorkbook);
+    const result = await getToolResult({
+      workbookId: mockWorkbook.id,
+      filter: `name:eq:${mockCustomView.name}`,
+    });
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+    expect(JSON.parse(`${result.content[0].text}`)).toMatchObject(mockCustomViews.customViews);
+    expect(mocks.mockListCustomViews).toHaveBeenCalledWith({
+      siteId: 'test-site-id',
+      filter: `workbookId:eq:${mockWorkbook.id},name:eq:${mockCustomView.name}`,
+      pageNumber: undefined,
+      pageSize: undefined,
+    });
+  });
+
+  it('should handle API errors gracefully', async () => {
+    const errorMessage = 'API Error';
+    mocks.mockListCustomViews.mockRejectedValue(new Error(errorMessage));
+    mocks.mockGetWorkbook.mockResolvedValue(mockWorkbook);
+    const result = await getToolResult({
+      workbookId: mockWorkbook.id,
+      filter: `name:eq:${mockCustomView.name}`,
+    });
+    expect(result.isError).toBe(true);
+    invariant(result.content[0].type === 'text');
+    expect(result.content[0].text).toContain(errorMessage);
+  });
+
+  it('should return a workbook not found error if the workbook is not found', async () => {
+    mocks.mockGetWorkbook.mockRejectedValue(
+      new Error(`The workbook with LUID ${mockWorkbook.id} was not found.`),
+    );
+    const result = await getToolResult({
+      workbookId: mockWorkbook.id,
+      filter: `name:eq:${mockCustomView.name}`,
+    });
+    expect(result.isError).toBe(true);
+    invariant(result.content[0].type === 'text');
+    expect(result.content[0].text).toContain(
+      `The workbook with LUID ${mockWorkbook.id} was not found.`,
+    );
+  });
+
+  it('should return a custom view not allowed error if its workbook is not allowed due to tool scoping', async () => {
+    vi.stubEnv('INCLUDE_WORKBOOK_IDS', 'some-other-workbook-id');
+
+    mocks.mockListCustomViews.mockResolvedValue(mockCustomViews);
+    mocks.mockGetWorkbook.mockResolvedValue(mockWorkbook);
+    const result = await getToolResult({
+      workbookId: mockWorkbook.id,
+      filter: `name:eq:${mockCustomView.name}`,
+    });
+    expect(result.isError).toBe(true);
+    invariant(result.content[0].type === 'text');
+    expect(result.content[0].text).toContain(
+      [
+        `The custom views from the workbook with LUID ${mockWorkbook.id} are not allowed to be queried.`,
+        'The set of allowed workbooks that can be queried is limited by the server configuration.',
+        `Querying the workbook with LUID ${mockWorkbook.id} is not allowed.`,
+      ].join(' '),
+    );
+  });
+});
+
+async function getToolResult(params: {
+  workbookId: string;
+  filter: string;
+}): Promise<CallToolResult> {
+  const listCustomViewsTool = getListCustomViewsTool(new Server());
+  const callback = await Provider.from(listCustomViewsTool.callback);
+  return await callback(
+    { workbookId: params.workbookId, filter: params.filter, pageSize: undefined, limit: undefined },
+    getMockRequestHandlerExtra(),
+  );
+}

--- a/src/tools/views/listCustomViews.test.ts
+++ b/src/tools/views/listCustomViews.test.ts
@@ -70,14 +70,14 @@ describe('listCustomViewsTool', () => {
     mocks.mockGetWorkbook.mockResolvedValue(mockWorkbook);
     const result = await getToolResult({
       workbookId: mockWorkbook.id,
-      filter: `name:eq:${mockCustomView.name}`,
+      filter: `viewId:eq:${mockCustomView.view.id}`,
     });
     expect(result.isError).toBe(false);
     invariant(result.content[0].type === 'text');
     expect(JSON.parse(`${result.content[0].text}`)).toMatchObject(mockCustomViews.customViews);
     expect(mocks.mockListCustomViews).toHaveBeenCalledWith({
       siteId: 'test-site-id',
-      filter: `workbookId:eq:${mockWorkbook.id},name:eq:${mockCustomView.name}`,
+      filter: `workbookId:eq:${mockWorkbook.id},viewId:eq:${mockCustomView.view.id}`,
       pageNumber: undefined,
       pageSize: undefined,
     });
@@ -89,7 +89,7 @@ describe('listCustomViewsTool', () => {
     mocks.mockGetWorkbook.mockResolvedValue(mockWorkbook);
     const result = await getToolResult({
       workbookId: mockWorkbook.id,
-      filter: `name:eq:${mockCustomView.name}`,
+      filter: `viewId:eq:${mockCustomView.view.id}`,
     });
     expect(result.isError).toBe(true);
     invariant(result.content[0].type === 'text');
@@ -102,7 +102,7 @@ describe('listCustomViewsTool', () => {
     );
     const result = await getToolResult({
       workbookId: mockWorkbook.id,
-      filter: `name:eq:${mockCustomView.name}`,
+      filter: `viewId:eq:${mockCustomView.view.id}`,
     });
     expect(result.isError).toBe(true);
     invariant(result.content[0].type === 'text');
@@ -118,7 +118,7 @@ describe('listCustomViewsTool', () => {
     mocks.mockGetWorkbook.mockResolvedValue(mockWorkbook);
     const result = await getToolResult({
       workbookId: mockWorkbook.id,
-      filter: `name:eq:${mockCustomView.name}`,
+      filter: `viewId:eq:${mockCustomView.view.id}`,
     });
     expect(result.isError).toBe(true);
     invariant(result.content[0].type === 'text');

--- a/src/tools/views/listCustomViews.ts
+++ b/src/tools/views/listCustomViews.ts
@@ -78,7 +78,7 @@ export const getListCustomViewsTool = (server: Server): Tool<typeof paramsSchema
               [
                 `The custom views from the workbook with LUID ${workbookId} are not allowed to be queried.`,
                 isWorkbookAllowedResult.message,
-              ].join('. '),
+              ].join(' '),
             ).toErr();
           }
 

--- a/src/tools/views/listCustomViews.ts
+++ b/src/tools/views/listCustomViews.ts
@@ -53,7 +53,7 @@ export const getListCustomViewsTool = (server: Server): Tool<typeof paramsSchema
     callback: async ({ workbookId, filter, pageSize, limit }, extra): Promise<CallToolResult> => {
       const configWithOverrides = await extra.getConfigWithOverrides();
 
-      if (filter?.includes('workbookId:eq:')) {
+      if (filter?.includes('workbookId:')) {
         // Remove any workbookId filter since the source of truth comes from the workbookId argument.
         filter = filter
           .split(',')

--- a/src/tools/views/listCustomViews.ts
+++ b/src/tools/views/listCustomViews.ts
@@ -1,0 +1,154 @@
+import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { Ok } from 'ts-results-es';
+import { z } from 'zod';
+
+import { CustomViewNotAllowedError, WorkbookNotFoundError } from '../../errors/mcpToolError.js';
+import { useRestApi } from '../../restApiInstance.js';
+import { Server } from '../../server.js';
+import { getExceptionMessage } from '../../utils/getExceptionMessage.js';
+import { paginate } from '../../utils/paginate.js';
+import { genericFilterDescription } from '../genericFilterDescription.js';
+import { resourceAccessChecker } from '../resourceAccessChecker.js';
+import { Tool } from '../tool.js';
+import { parseAndValidateCustomViewsFilterString } from './customViewsFilterUtils.js';
+
+const paramsSchema = {
+  workbookId: z.string().min(1),
+  filter: z.string().optional(),
+  pageSize: z.number().gt(0).optional(),
+  limit: z.number().gt(0).optional(),
+};
+
+export const getListCustomViewsTool = (server: Server): Tool<typeof paramsSchema> => {
+  const listCustomViewsTool = new Tool({
+    server,
+    name: 'list-custom-views',
+    // workbookId intentionally omitted from the filter field table since it originates from the workbookId parameter
+    description: `
+  Retrieves a list of custom views for a Tableau workbook including their metadata such as name, owner, and the view they are found in. Supports optional filtering via field:operator:value expressions (e.g., name:eq:Overview) for precise and flexible view discovery. Use this tool when a user requests to list, search, or filter Tableau custom views for a workbook.
+
+  **Supported Filter Fields and Operators**
+  | Field               | Operators            |
+  |---------------------|----------------------|
+  | createdAt           | eq, gt, gte, lt, lte |
+  | id                  | eq, in               |
+  | name                | eq, in               |
+  | ownerId             | eq                   |
+  | shared              | eq                   |
+  | updatedAt           | eq, gt, gte, lt, lte |
+  | viewId              | eq                   |
+
+  ${genericFilterDescription}
+
+  **Example Usage:**
+  - List all custom views on a site
+  - List custom views with the name "Overview":
+      filter: "name:eq:Overview"
+  - List custom views in the view with a specific ID:
+      filter: "viewId:eq:4d18c547-bbb1-4187-ae5a-7f78b35adf2d"
+  - List custom views created after January 1, 2023:
+      filter: "createdAt:gt:2023-01-01T00:00:00Z"
+  - List custom views with the name "Overview" and created after January 1, 2023:
+      filter: "name:eq:Overview,createdAt:gt:2023-01-01T00:00:00Z"`,
+    paramsSchema,
+    annotations: {
+      title: 'List Custom Views',
+      readOnlyHint: true,
+      openWorldHint: false,
+    },
+    callback: async ({ workbookId, filter, pageSize, limit }, extra): Promise<CallToolResult> => {
+      const configWithOverrides = await extra.getConfigWithOverrides();
+
+      const filters = [`workbookId:eq:${workbookId}`, ...(filter ? [filter] : [])].join(',');
+      const validatedFilter = parseAndValidateCustomViewsFilterString(filters);
+
+      return await listCustomViewsTool.logAndExecute({
+        extra,
+        args: { workbookId },
+        callback: async () => {
+          const isWorkbookAllowedResult = await resourceAccessChecker.isWorkbookAllowed({
+            workbookId,
+            extra,
+          });
+
+          if (!isWorkbookAllowedResult.allowed) {
+            // The workbook is not allowed to be queried,
+            // so the custom views for that workbook are not allowed to be queried either.
+            return new CustomViewNotAllowedError(
+              [
+                `The custom views from the workbook with LUID ${workbookId} are not allowed to be queried.`,
+                isWorkbookAllowedResult.message,
+              ].join('. '),
+            ).toErr();
+          }
+
+          let workbook = isWorkbookAllowedResult.content;
+
+          return await useRestApi({
+            ...extra,
+            jwtScopes: listCustomViewsTool.requiredApiScopes,
+            callback: async (restApi) => {
+              if (!workbook) {
+                try {
+                  workbook = await restApi.workbooksMethods.getWorkbook({
+                    workbookId,
+                    siteId: restApi.siteId,
+                  });
+                } catch (error) {
+                  return new WorkbookNotFoundError(
+                    [
+                      `The workbook with LUID ${workbookId} was not found.`,
+                      getExceptionMessage(error),
+                    ].join(' '),
+                  ).toErr();
+                }
+              }
+
+              if (!workbook) {
+                return new WorkbookNotFoundError(
+                  `The workbook with LUID ${workbookId} was not found.`,
+                ).toErr();
+              }
+
+              const maxResultLimit = configWithOverrides.getMaxResultLimit(
+                listCustomViewsTool.name,
+              );
+
+              const customViews = await paginate({
+                pageConfig: {
+                  pageSize,
+                  limit: maxResultLimit
+                    ? Math.min(maxResultLimit, limit ?? Number.MAX_SAFE_INTEGER)
+                    : limit,
+                },
+                getDataFn: async (pageConfig) => {
+                  const { pagination, customViews: data } =
+                    await restApi.viewsMethods.listCustomViews({
+                      siteId: restApi.siteId,
+                      filter: validatedFilter ?? '',
+                      pageSize: pageConfig.pageSize,
+                      pageNumber: pageConfig.pageNumber,
+                    });
+
+                  return { pagination, data };
+                },
+              });
+
+              return Ok(customViews);
+            },
+          });
+        },
+        constrainSuccessResult: async (customViews) => {
+          // The custom views do not need to be further constrained since they are already constrained by the workbook.
+          // Workbook filtering was already handled by the tool itself.
+          return {
+            type: 'success',
+            result: customViews,
+          };
+        },
+      });
+    },
+  });
+
+  return listCustomViewsTool;
+};

--- a/src/tools/views/listCustomViews.ts
+++ b/src/tools/views/listCustomViews.ts
@@ -30,26 +30,17 @@ export const getListCustomViewsTool = (server: Server): Tool<typeof paramsSchema
   **Supported Filter Fields and Operators**
   | Field               | Operators            |
   |---------------------|----------------------|
-  | createdAt           | eq, gt, gte, lt, lte |
-  | id                  | eq, in               |
-  | name                | eq, in               |
   | ownerId             | eq                   |
-  | shared              | eq                   |
-  | updatedAt           | eq, gt, gte, lt, lte |
   | viewId              | eq                   |
 
   ${genericFilterDescription}
 
   **Example Usage:**
   - List all custom views on a site
-  - List custom views with the name "Overview":
-      filter: "name:eq:Overview"
-  - List custom views in the view with a specific ID:
-      filter: "viewId:eq:4d18c547-bbb1-4187-ae5a-7f78b35adf2d"
-  - List custom views created after January 1, 2023:
-      filter: "createdAt:gt:2023-01-01T00:00:00Z"
-  - List custom views with the name "Overview" and created after January 1, 2023:
-      filter: "name:eq:Overview,createdAt:gt:2023-01-01T00:00:00Z"`,
+  - List custom views from the view with viewId "9460abfe-a6b2-49d1-b998-39e1ebcc55ce":
+      filter: "viewId:eq:9460abfe-a6b2-49d1-b998-39e1ebcc55ce"
+  - List custom views for the owner with ownerId "bbdee366-4a50-4c2c-a5c8-746da5b64483":
+      filter: "ownerId:eq:bbdee366-4a50-4c2c-a5c8-746da5b64483"`,
     paramsSchema,
     annotations: {
       title: 'List Custom Views',

--- a/src/tools/views/listCustomViews.ts
+++ b/src/tools/views/listCustomViews.ts
@@ -25,7 +25,7 @@ export const getListCustomViewsTool = (server: Server): Tool<typeof paramsSchema
     name: 'list-custom-views',
     // workbookId intentionally omitted from the filter field table since it originates from the workbookId parameter
     description: `
-  Retrieves a list of custom views for a Tableau workbook including their metadata such as name, owner, and the view they are found in. Supports optional filtering via field:operator:value expressions (e.g., name:eq:Overview) for precise and flexible view discovery. Use this tool when a user requests to list, search, or filter Tableau custom views for a workbook.
+  Retrieves a list of custom views for a Tableau workbook including their metadata such as name, owner, and the view they are found in. Supports optional filtering via field:operator:value expressions (e.g., viewId:eq:<view_id>) for precise and flexible custom view discovery. The tool always includes the workbookId in the final filter expression based on the required workbookId argument. Including the workbookId field in the filter will be ignored. Use this tool when a user requests to list, search, or filter Tableau custom views for a workbook.
 
   **Supported Filter Fields and Operators**
   | Field               | Operators            |
@@ -36,10 +36,13 @@ export const getListCustomViewsTool = (server: Server): Tool<typeof paramsSchema
   ${genericFilterDescription}
 
   **Example Usage:**
-  - List all custom views on a site
+  - List all custom views for a given workbook:
+      workbookId: "222ea993-9391-4910-a167-56b3d19b4e3b"
   - List custom views from the view with viewId "9460abfe-a6b2-49d1-b998-39e1ebcc55ce":
+      workbookId: "222ea993-9391-4910-a167-56b3d19b4e3b"
       filter: "viewId:eq:9460abfe-a6b2-49d1-b998-39e1ebcc55ce"
   - List custom views for the owner with ownerId "bbdee366-4a50-4c2c-a5c8-746da5b64483":
+      workbookId: "222ea993-9391-4910-a167-56b3d19b4e3b"
       filter: "ownerId:eq:bbdee366-4a50-4c2c-a5c8-746da5b64483"`,
     paramsSchema,
     annotations: {
@@ -49,6 +52,14 @@ export const getListCustomViewsTool = (server: Server): Tool<typeof paramsSchema
     },
     callback: async ({ workbookId, filter, pageSize, limit }, extra): Promise<CallToolResult> => {
       const configWithOverrides = await extra.getConfigWithOverrides();
+
+      if (filter?.includes('workbookId:eq:')) {
+        // Remove any workbookId filter since the source of truth comes from the workbookId argument.
+        filter = filter
+          .split(',')
+          .filter((f) => !f.startsWith('workbookId:'))
+          .join(',');
+      }
 
       const filters = [`workbookId:eq:${workbookId}`, ...(filter ? [filter] : [])].join(',');
       const validatedFilter = parseAndValidateCustomViewsFilterString(filters);

--- a/src/tools/views/listCustomViews.ts
+++ b/src/tools/views/listCustomViews.ts
@@ -95,12 +95,6 @@ export const getListCustomViewsTool = (server: Server): Tool<typeof paramsSchema
                 }
               }
 
-              if (!workbook) {
-                return new WorkbookNotFoundError(
-                  `The workbook with LUID ${workbookId} was not found.`,
-                ).toErr();
-              }
-
               const maxResultLimit = configWithOverrides.getMaxResultLimit(
                 listCustomViewsTool.name,
               );

--- a/src/tools/views/mockCustomView.ts
+++ b/src/tools/views/mockCustomView.ts
@@ -1,0 +1,10 @@
+import type { CustomView } from '../../sdks/tableau/types/customView.js';
+import { mockWorkbook } from '../workbooks/mockWorkbook.js';
+import { mockView } from './mockView.js';
+
+export const mockCustomView = {
+  id: 'f69e71d6-8a91-4f46-bea7-dc7d2e124ab7',
+  name: 'my-custom-view',
+  view: mockView,
+  workbook: mockWorkbook,
+} satisfies CustomView;

--- a/src/tools/views/viewsFilterUtils.ts
+++ b/src/tools/views/viewsFilterUtils.ts
@@ -67,7 +67,3 @@ export function parseAndValidateViewsFilterString(filterString: string): string 
     filterFieldSchema: FilterFieldSchema,
   });
 }
-
-export const exportedForTesting = {
-  FilterFieldSchema,
-};

--- a/tests/constants.ts
+++ b/tests/constants.ts
@@ -1,7 +1,7 @@
 import invariant from '../src/utils/invariant.js';
 
 export type Datasource = { id: string };
-export type Workbook = { id: string; defaultViewId: string };
+export type Workbook = { id: string; defaultView: { id: string; customViewId: string } };
 
 export type PulseDefinition = { id: string; metrics: Array<PulseMetric> };
 export type PulseMetric = { id: string };
@@ -39,7 +39,10 @@ const environmentData: EnvironmentData = {
           workbooks: {
             Superstore: {
               id: '222ea993-9391-4910-a167-56b3d19b4e3b',
-              defaultViewId: '9460abfe-a6b2-49d1-b998-39e1ebcc55ce',
+              defaultView: {
+                id: '9460abfe-a6b2-49d1-b998-39e1ebcc55ce',
+                customViewId: '1db3a121-51ac-4435-b533-3053e698dfc8',
+              },
             },
           },
           pulse: {
@@ -62,7 +65,10 @@ const environmentData: EnvironmentData = {
           workbooks: {
             Superstore: {
               id: 'c1beaa20-0b98-43d8-a5de-0bff82bf6a8f',
-              defaultViewId: '6e341026-2d87-4a80-b238-86dafa75c2f6',
+              defaultView: {
+                id: '6e341026-2d87-4a80-b238-86dafa75c2f6',
+                customViewId: '33052443-3d7e-458b-a725-52b0e5ee6ef0',
+              },
             },
           },
           pulse: {
@@ -85,7 +91,10 @@ const environmentData: EnvironmentData = {
           workbooks: {
             Superstore: {
               id: '44bb9110-456f-4b26-a82f-4d9d9271f1af',
-              defaultViewId: 'f19c1ed1-7294-45e8-818e-dbc6814bb19c',
+              defaultView: {
+                id: 'f19c1ed1-7294-45e8-818e-dbc6814bb19c',
+                customViewId: 'e55e08c2-72d1-4627-be48-614d02f17bd8',
+              },
             },
           },
           pulse: {

--- a/tests/e2e/views/getViewData.test.ts
+++ b/tests/e2e/views/getViewData.test.ts
@@ -14,7 +14,7 @@ describe('get-view-data', () => {
     const data = await callTool('get-view-data', {
       env,
       schema: z.string(),
-      toolArgs: { viewId: superstore.defaultViewId },
+      toolArgs: { viewId: superstore.defaultView.id },
     });
 
     const lines = data.split('\n');

--- a/tests/e2e/views/getViewImage.test.ts
+++ b/tests/e2e/views/getViewImage.test.ts
@@ -13,7 +13,7 @@ describe('get-view-image', () => {
     const pngData = await callTool('get-view-image', {
       env,
       schema: z.string(),
-      toolArgs: { viewId: superstore.defaultViewId },
+      toolArgs: { viewId: superstore.defaultView.id },
       contentType: 'image',
     });
 

--- a/tests/e2e/views/listCustomViews.test.ts
+++ b/tests/e2e/views/listCustomViews.test.ts
@@ -1,0 +1,84 @@
+import z from 'zod';
+
+import { customViewSchema } from '../../../src/sdks/tableau/types/customView.js';
+import invariant from '../../../src/utils/invariant.js';
+import { getDefaultEnv, getSuperstoreWorkbook, resetEnv, setEnv } from '../../testEnv.js';
+import { callTool } from '../client.js';
+
+describe('list-custom-views', () => {
+  beforeAll(setEnv);
+  afterAll(resetEnv);
+
+  it('should list custom views for a workbook', async () => {
+    const env = getDefaultEnv();
+    const superstore = getSuperstoreWorkbook(env);
+
+    const customViews = await callTool('list-custom-views', {
+      env,
+      schema: z.array(customViewSchema),
+      toolArgs: { workbookId: superstore.id },
+    });
+
+    expect(customViews.length).greaterThan(0);
+    const customView = customViews.find(
+      (customView) => customView.id === superstore.defaultView.customViewId,
+    );
+    invariant(customView, 'Custom view for Superstore workbook not found');
+
+    expect(customView).toMatchObject({
+      id: superstore.defaultView.customViewId,
+      workbook: {
+        id: superstore.id,
+      },
+      view: {
+        id: superstore.defaultView.id,
+      },
+    });
+  });
+
+  it('should list custom views with filter', async () => {
+    const env = getDefaultEnv();
+    const superstore = getSuperstoreWorkbook(env);
+
+    const customViews = await callTool('list-custom-views', {
+      env,
+      schema: z.array(customViewSchema),
+      toolArgs: {
+        workbookId: superstore.id,
+        filter: `viewId:eq:${superstore.defaultView.id}`,
+      },
+    });
+
+    expect(customViews).toHaveLength(1);
+    expect(customViews[0]).toMatchObject({
+      id: superstore.defaultView.customViewId,
+      workbook: {
+        id: superstore.id,
+      },
+      view: {
+        id: superstore.defaultView.id,
+      },
+    });
+  });
+
+  it('should list custom views with pageSize and limit', async () => {
+    const env = getDefaultEnv();
+    const superstore = getSuperstoreWorkbook(env);
+
+    const customViews = await callTool('list-custom-views', {
+      schema: z.array(customViewSchema),
+      toolArgs: { workbookId: superstore.id, pageSize: 5, limit: 10 },
+    });
+
+    expect(customViews).toHaveLength(1);
+    expect(customViews[0]).toMatchObject({
+      id: superstore.defaultView.customViewId,
+      workbook: {
+        id: superstore.id,
+      },
+      view: {
+        id: superstore.defaultView.id,
+      },
+    });
+  });
+});

--- a/tests/e2e/views/listViews.test.ts
+++ b/tests/e2e/views/listViews.test.ts
@@ -19,11 +19,11 @@ describe('list-views', () => {
     });
 
     expect(views.length).greaterThan(0);
-    const view = views.find((view) => view.id === superstore.defaultViewId);
+    const view = views.find((view) => view.id === superstore.defaultView.id);
     invariant(view, 'Default view for Superstore workbook not found');
 
     expect(view).toMatchObject({
-      id: superstore.defaultViewId,
+      id: superstore.defaultView.id,
       name: 'Overview',
       workbook: {
         id: superstore.id,
@@ -43,7 +43,7 @@ describe('list-views', () => {
 
     expect(views).toHaveLength(1);
     expect(views[0]).toMatchObject({
-      id: superstore.defaultViewId,
+      id: superstore.defaultView.id,
       name: 'Overview',
       workbook: {
         id: superstore.id,

--- a/tests/e2e/workbooks/getWorkbook.test.ts
+++ b/tests/e2e/workbooks/getWorkbook.test.ts
@@ -19,7 +19,7 @@ describe('get-workbook', () => {
     expect(workbook).toMatchObject({
       id: superstore.id,
       name: 'Superstore',
-      defaultViewId: superstore.defaultViewId,
+      defaultViewId: superstore.defaultView.id,
     });
   });
 });

--- a/tests/e2e/workbooks/listWorkbooks.test.ts
+++ b/tests/e2e/workbooks/listWorkbooks.test.ts
@@ -23,7 +23,7 @@ describe('list-workbooks', () => {
     expect(workbook).toMatchObject({
       id: superstore.id,
       name: 'Superstore',
-      defaultViewId: superstore.defaultViewId,
+      defaultViewId: superstore.defaultView.id,
     });
   });
 
@@ -43,7 +43,7 @@ describe('list-workbooks', () => {
     expect(workbook).toMatchObject({
       id: superstore.id,
       name: 'Superstore',
-      defaultViewId: superstore.defaultViewId,
+      defaultViewId: superstore.defaultView.id,
     });
   });
 });

--- a/tests/oauth/tableau-authz/fixtures/connectOAuthClient.ts
+++ b/tests/oauth/tableau-authz/fixtures/connectOAuthClient.ts
@@ -33,10 +33,10 @@ export const getOAuthClientFixture: WorkerFixture<OAuthClient, { browser: Browse
 
   try {
     const revokeResult = await client.callTool('revoke-access-token', {
-      schema: z.object({ message: z.string() }),
+      schema: z.string(),
       toolArgs: {},
     });
-    expect(revokeResult.message).toContain('revocation');
+    expect(revokeResult).toContain('revocation');
   } finally {
     await client.close();
   }

--- a/tests/oauth/tableau-authz/tests/getViewData.test.ts
+++ b/tests/oauth/tableau-authz/tests/getViewData.test.ts
@@ -10,7 +10,7 @@ test.describe('get-view-data', () => {
     const viewData = await client.callTool('get-view-data', {
       schema: z.string(),
       toolArgs: {
-        viewId: superstore.defaultViewId,
+        viewId: superstore.defaultView.id,
       },
     });
 

--- a/tests/oauth/tableau-authz/tests/getViewImage.test.ts
+++ b/tests/oauth/tableau-authz/tests/getViewImage.test.ts
@@ -11,7 +11,7 @@ test.describe('get-view-image', () => {
       schema: z.string(),
       contentType: 'image',
       toolArgs: {
-        viewId: superstore.defaultViewId,
+        viewId: superstore.defaultView.id,
       },
     });
 

--- a/tests/oauth/tableau-authz/tests/listCustomViews.test.ts
+++ b/tests/oauth/tableau-authz/tests/listCustomViews.test.ts
@@ -1,0 +1,35 @@
+import { z } from 'zod';
+
+import { customViewSchema } from '../../../../src/sdks/tableau/types/customView.js';
+import invariant from '../../../../src/utils/invariant.js';
+import { expect, test } from './base.js';
+import { getSuperstoreWorkbook } from './testEnv.js';
+
+test.describe('list-custom-views', () => {
+  test('list custom views', async ({ client }) => {
+    const superstore = getSuperstoreWorkbook();
+
+    const customViews = await client.callTool('list-custom-views', {
+      schema: z.array(customViewSchema),
+      toolArgs: {
+        workbookId: superstore.id,
+      },
+    });
+
+    expect(customViews.length).toBeGreaterThan(0);
+    const customView = customViews.find(
+      (customView) => customView.id === superstore.defaultView.customViewId,
+    );
+    invariant(customView, 'Custom view for Superstore workbook not found');
+
+    expect(customView).toMatchObject({
+      id: superstore.defaultView.customViewId,
+      workbook: {
+        id: superstore.id,
+      },
+      view: {
+        id: superstore.defaultView.id,
+      },
+    });
+  });
+});


### PR DESCRIPTION
These changes introduce a new `list-custom-views` tool which allows for finding all the custom views for a given workbook that the user has permissions to find. This tool opens the door for creating additional tools for custom views, like `get-custom-view-data` and `get-custom-view-image` which require knowing the ID of the custom view beforehand.

The reason why the tool is limited to a single workbook is because otherwise tool scoping becomes problematic:

Without a `workbookId:eq:{workbookId}` filter, the [List Custom Views REST API](https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref_workbooks_and_views.htm#list_custom_views) could return, say, details of 1000 custom views.

A single custom view returned by the API looks like this:

```json
{
  "id": "37d015c6-bc28-4c88-989c-72c0a171f7aa",
  "name": "New name 2",
  "createdAt": "2016-02-03T23:35:09Z",
  "updatedAt": "2022-09-28T23:56:01Z",
  "lastAccessedAt": "2022-09-28T23:58:25Z",
  "shared": "false",
  "view": {
	  "id": "8e33ff19-a7a4-4aa5-9dd8-a171e2b9c29f",
	  "name": "circle"
  },
  "workbook": {
	  "id": "2fbe87c9-a7d8-45bf-b2b3-877a26ec9af5",
	  "name": "marks and viz types 2"
  },
  "owner": {
	  "id": "cdfe8548-84c8-418e-9b33-2c0728b2398a",
	  "name": "workgroupuser"
  }
}
```

If project or tag filtering is enabled in tool scoping, we would need to look up *every* workbook to determine its corresponding project and tags, which could be 1000 workbooks. Restricting the tool to single workbook mitigates this problem and is more in line with the use case where a user is asking questions about a single workbook and its custom views.
