### PR TITLE
@W-22034341: reset consent tool

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "1.18.3",
+  "version": "1.18.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "1.18.3",
+      "version": "1.18.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "1.18.4",
+  "version": "1.18.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "1.18.4",
+      "version": "1.18.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "1.18.3",
+  "version": "1.18.4",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "1.18.4",
+  "version": "1.18.5",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/src/server/oauth/scopes.ts
+++ b/src/server/oauth/scopes.ts
@@ -139,6 +139,12 @@ const toolScopeMap: Record<
     mcp: [],
     api: new Set<TableauApiScope>(),
   },
+  // Consent lifecycle: no Tableau REST API calls. Bearer-only (Tableau authZ server).
+  // Any authenticated user may reset their own consent regardless of granted scopes.
+  'reset-consent': {
+    mcp: [],
+    api: new Set<TableauApiScope>(),
+  },
 };
 
 const supportedMcpScopes = Array.from(

--- a/src/server/passthroughAuthMiddleware.test.ts
+++ b/src/server/passthroughAuthMiddleware.test.ts
@@ -16,7 +16,7 @@ const TOOLS_WITHOUT_API_SCOPES_WITH_PASSTHROUGH_GUARD: ReadonlyArray<ToolName> =
   // for Passthrough auth and undefined tableauAuthInfo, so passthrough callers are rejected.
   'revoke-access-token',
   // Consent lifecycle tool: no Tableau REST API call. The tool callback explicitly returns an error
-  // for Passthrough auth and non-Bearer auth types, so passthrough callers are rejected.
+  // for non-Bearer auth types, so passthrough callers are rejected.
   'reset-consent',
 ];
 

--- a/src/server/passthroughAuthMiddleware.test.ts
+++ b/src/server/passthroughAuthMiddleware.test.ts
@@ -15,6 +15,9 @@ const TOOLS_WITHOUT_API_SCOPES_WITH_PASSTHROUGH_GUARD: ReadonlyArray<ToolName> =
   // Token lifecycle tool: no Tableau REST API call. The tool callback explicitly returns an error
   // for Passthrough auth and undefined tableauAuthInfo, so passthrough callers are rejected.
   'revoke-access-token',
+  // Consent lifecycle tool: no Tableau REST API call. The tool callback explicitly returns an error
+  // for Passthrough auth and non-Bearer auth types, so passthrough callers are rejected.
+  'reset-consent',
 ];
 
 describe('passthroughAuthMiddleware', () => {

--- a/src/tools/resetConsent/resetConsent.test.ts
+++ b/src/tools/resetConsent/resetConsent.test.ts
@@ -34,26 +34,25 @@ describe('resetConsentTool', () => {
   });
 
   describe('disabled property', () => {
-    let savedEnv: NodeJS.ProcessEnv;
-
-    beforeEach(() => {
-      savedEnv = { ...process.env };
-    });
-
-    afterEach(() => {
-      process.env = savedEnv;
-    });
-
-    it('should be disabled when AUTH is not oauth (default PAT mode)', async () => {
-      delete process.env.OAUTH_ISSUER;
+    it('should be disabled when OAuth is not enabled (no OAUTH_ISSUER)', async () => {
+      vi.stubEnv('OAUTH_ISSUER', '');
       const tool = getResetConsentTool(new Server());
       expect(await Provider.from(tool.disabled)).toBe(true);
     });
 
-    it('should be enabled when AUTH=oauth', async () => {
-      process.env.AUTH = 'oauth';
-      process.env.OAUTH_ISSUER = MOCK_ISSUER;
-      process.env.OAUTH_EMBEDDED_AUTHZ_SERVER = 'false';
+    it('should be disabled when the embedded authorization server is active', async () => {
+      // TABLEAU_MCP_TEST=true (set by testSetup) bypasses the JWE key file existence check.
+      vi.stubEnv('OAUTH_ISSUER', MOCK_ISSUER);
+      vi.stubEnv('OAUTH_EMBEDDED_AUTHZ_SERVER', 'true');
+      vi.stubEnv('OAUTH_REDIRECT_URI', `${MOCK_ISSUER}/Callback`);
+      vi.stubEnv('OAUTH_JWE_PRIVATE_KEY_PATH', '/placeholder/key.pem');
+      const tool = getResetConsentTool(new Server());
+      expect(await Provider.from(tool.disabled)).toBe(true);
+    });
+
+    it('should be enabled when OAuth is enabled and the Tableau authorization server is active', async () => {
+      vi.stubEnv('OAUTH_ISSUER', MOCK_ISSUER);
+      vi.stubEnv('OAUTH_EMBEDDED_AUTHZ_SERVER', 'false');
       const tool = getResetConsentTool(new Server());
       expect(await Provider.from(tool.disabled)).toBe(false);
     });
@@ -133,27 +132,6 @@ describe('resetConsentTool', () => {
     });
   });
 
-  describe('X-Tableau-Auth (embedded authZ mode -- not supported)', () => {
-    it('should return an error and make no fetch call for X-Tableau-Auth', async () => {
-      const extra = getMockRequestHandlerExtra();
-      extra.config.oauth.issuer = MOCK_ISSUER;
-      extra.tableauAuthInfo = {
-        type: 'X-Tableau-Auth',
-        username: 'test-user',
-        server: MOCK_SERVER,
-        siteId: 'site-id',
-        accessToken: 'tableau-access-token',
-        refreshToken: 'tableau-refresh-token',
-      };
-      const result = await getToolResult(extra);
-
-      expect(result.isError).toBe(true);
-      expect(mockFetch).not.toHaveBeenCalled();
-      invariant(result.content[0].type === 'text');
-      expect(result.content[0].text).toContain('embedded');
-    });
-  });
-
   describe('Passthrough auth (not supported)', () => {
     it('should return an error and make no fetch call for Passthrough auth', async () => {
       const extra = getMockRequestHandlerExtra();
@@ -170,7 +148,7 @@ describe('resetConsentTool', () => {
       expect(result.isError).toBe(true);
       expect(mockFetch).not.toHaveBeenCalled();
       invariant(result.content[0].type === 'text');
-      expect(result.content[0].text).toContain('Passthrough');
+      expect(result.content[0].text).toContain('Bearer');
     });
   });
 });

--- a/src/tools/resetConsent/resetConsent.test.ts
+++ b/src/tools/resetConsent/resetConsent.test.ts
@@ -1,0 +1,184 @@
+import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+
+import { Server } from '../../server.js';
+import invariant from '../../utils/invariant.js';
+import { Provider } from '../../utils/provider.js';
+import { getMockRequestHandlerExtra } from '../toolContext.mock.js';
+import { getResetConsentTool } from './resetConsent.js';
+
+const MOCK_ISSUER = 'https://sso.online.tableau.com';
+const MOCK_TOKEN = 'eyJhbGciOiJIUzI1NiJ9.dGVzdC1wYXlsb2Fk.signature';
+const MOCK_SERVER = 'https://my-tableau-server.com';
+
+describe('resetConsentTool', () => {
+  let mockFetch: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    mockFetch = vi.fn();
+    vi.stubGlobal('fetch', mockFetch);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('should create a tool instance with correct properties', async () => {
+    const tool = getResetConsentTool(new Server());
+    const annotations = await Provider.from(tool.annotations);
+    expect(tool.name).toBe('reset-consent');
+    expect(tool.paramsSchema).toEqual({});
+    expect(annotations?.readOnlyHint).toBe(false);
+    expect(annotations?.destructiveHint).toBe(false);
+    expect(annotations?.idempotentHint).toBe(true);
+    expect(annotations?.openWorldHint).toBe(false);
+  });
+
+  describe('disabled property', () => {
+    let savedEnv: NodeJS.ProcessEnv;
+
+    beforeEach(() => {
+      savedEnv = { ...process.env };
+    });
+
+    afterEach(() => {
+      process.env = savedEnv;
+    });
+
+    it('should be disabled when AUTH is not oauth (default PAT mode)', async () => {
+      delete process.env.OAUTH_ISSUER;
+      const tool = getResetConsentTool(new Server());
+      expect(await Provider.from(tool.disabled)).toBe(true);
+    });
+
+    it('should be enabled when AUTH=oauth', async () => {
+      process.env.AUTH = 'oauth';
+      process.env.OAUTH_ISSUER = MOCK_ISSUER;
+      process.env.OAUTH_EMBEDDED_AUTHZ_SERVER = 'false';
+      const tool = getResetConsentTool(new Server());
+      expect(await Provider.from(tool.disabled)).toBe(false);
+    });
+  });
+
+  describe('Bearer auth (Tableau authZ server mode)', () => {
+    function makeBearerExtra(): ReturnType<typeof getMockRequestHandlerExtra> {
+      const extra = getMockRequestHandlerExtra();
+      extra.config.oauth.issuer = MOCK_ISSUER;
+      extra.tableauAuthInfo = {
+        type: 'Bearer',
+        raw: MOCK_TOKEN,
+        username: 'test@example.com',
+        server: MOCK_ISSUER,
+        siteId: 'test-site-id',
+      };
+      return extra;
+    }
+
+    it('should POST to the issuer resetConsent endpoint with Authorization Bearer header and no body', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+      await getToolResult(makeBearerExtra());
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        `${MOCK_ISSUER}/oauth2/resetConsent`,
+        expect.objectContaining({
+          method: 'POST',
+          headers: expect.objectContaining({
+            Authorization: `Bearer ${MOCK_TOKEN}`,
+          }),
+        }),
+      );
+    });
+
+    it('should not include a request body', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+      await getToolResult(makeBearerExtra());
+
+      const callArgs = mockFetch.mock.calls[0][1];
+      expect(callArgs.body).toBeUndefined();
+    });
+
+    it('should return a success result on HTTP 200', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+      const result = await getToolResult(makeBearerExtra());
+
+      expect(result.isError).toBe(false);
+      invariant(result.content[0].type === 'text');
+      expect(result.content[0].text).toContain('consent');
+    });
+
+    it('should return an error result when the endpoint returns non-200', async () => {
+      mockFetch.mockResolvedValue(new Response('unauthorized', { status: 401 }));
+      const result = await getToolResult(makeBearerExtra());
+
+      expect(result.isError).toBe(true);
+      invariant(result.content[0].type === 'text');
+      expect(result.content[0].text).toContain('401');
+    });
+
+    it('should return an error result on network failure', async () => {
+      mockFetch.mockRejectedValue(new Error('fetch failed: connection refused'));
+      const result = await getToolResult(makeBearerExtra());
+
+      expect(result.isError).toBe(true);
+      invariant(result.content[0].type === 'text');
+      expect(result.content[0].text).toContain('connection refused');
+    });
+
+    it('should not expose the raw token in the success response', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+      const result = await getToolResult(makeBearerExtra());
+
+      const fullText = result.content.map((c) => (c.type === 'text' ? c.text : '')).join('');
+      expect(fullText).not.toContain(MOCK_TOKEN);
+      expect(fullText).not.toContain('eyJ');
+    });
+  });
+
+  describe('X-Tableau-Auth (embedded authZ mode -- not supported)', () => {
+    it('should return an error and make no fetch call for X-Tableau-Auth', async () => {
+      const extra = getMockRequestHandlerExtra();
+      extra.config.oauth.issuer = MOCK_ISSUER;
+      extra.tableauAuthInfo = {
+        type: 'X-Tableau-Auth',
+        username: 'test-user',
+        server: MOCK_SERVER,
+        siteId: 'site-id',
+        accessToken: 'tableau-access-token',
+        refreshToken: 'tableau-refresh-token',
+      };
+      const result = await getToolResult(extra);
+
+      expect(result.isError).toBe(true);
+      expect(mockFetch).not.toHaveBeenCalled();
+      invariant(result.content[0].type === 'text');
+      expect(result.content[0].text).toContain('embedded');
+    });
+  });
+
+  describe('Passthrough auth (not supported)', () => {
+    it('should return an error and make no fetch call for Passthrough auth', async () => {
+      const extra = getMockRequestHandlerExtra();
+      extra.tableauAuthInfo = {
+        type: 'Passthrough',
+        username: 'test-user',
+        userId: 'user-id',
+        server: MOCK_SERVER,
+        siteId: 'site-id',
+        raw: 'x-tableau-auth-session-token',
+      };
+      const result = await getToolResult(extra);
+
+      expect(result.isError).toBe(true);
+      expect(mockFetch).not.toHaveBeenCalled();
+      invariant(result.content[0].type === 'text');
+      expect(result.content[0].text).toContain('Passthrough');
+    });
+  });
+});
+
+async function getToolResult(
+  extra: ReturnType<typeof getMockRequestHandlerExtra>,
+): Promise<CallToolResult> {
+  const tool = getResetConsentTool(new Server());
+  const callback = await Provider.from(tool.callback);
+  return await callback({}, extra);
+}

--- a/src/tools/resetConsent/resetConsent.ts
+++ b/src/tools/resetConsent/resetConsent.ts
@@ -34,14 +34,14 @@ export const getResetConsentTool = (server: Server): Tool<typeof paramsSchema> =
     name: 'reset-consent',
     description: `Resets saved OAuth consent for the current user on the Tableau authorization server.
 
-After resetting consent, the current MCP session remains valid. The next OAuth authorization flow will re-prompt the user for consent.
+After resetting consent, the current session remains valid. The next OAuth authorization flow will re-prompt the user for consent.
 
 This tool requires no input — it operates on the token already associated with the current session and never exposes the raw token value.
 
 **Important:** Call this tool before revoking the access token. Revocation invalidates the token required to authenticate the consent reset request.
 
 **When to use:**
-- Clearing previously granted consent as part of session teardown
+- Clearing previously granted OAuth consent as part of session teardown
 - Resetting consent state during testing or development
 - Cleaning up OAuth grants when a user's access should be fully removed`,
     paramsSchema,

--- a/src/tools/resetConsent/resetConsent.ts
+++ b/src/tools/resetConsent/resetConsent.ts
@@ -19,9 +19,10 @@ const paramsSchema = {};
  *   - Bearer (Tableau authZ server mode): posts to `${config.oauth.issuer}/oauth2/resetConsent`
  *     with the access token in the Authorization header. The current session remains valid.
  *
+ * Disabled when the embedded authorization server is active (no consent model).
+ *
  * Not supported (returns runtime error):
- *   - X-Tableau-Auth (embedded authZ): the embedded authorization server has no consent model.
- *   - Passthrough: session credentials are managed externally.
+ *   - Passthrough or other non-Bearer auth: session credentials are managed externally.
  *
  * Important: call this tool BEFORE revoking the access token, since revocation
  * invalidates the token required to authenticate the reset consent request.
@@ -52,7 +53,7 @@ This tool requires no input — it operates on the token already associated with
       idempotentHint: true,
       openWorldHint: false,
     },
-    disabled: config.auth !== 'oauth',
+    disabled: !config.oauth.enabled || config.oauth.embeddedAuthzServer,
     callback: async (_args, extra): Promise<CallToolResult> => {
       return resetConsentTool.logAndExecute<string>({
         extra,
@@ -88,24 +89,12 @@ This tool requires no input — it operates on the token already associated with
             );
           }
 
-          if (tableauAuthInfo.type === 'X-Tableau-Auth') {
-            return new Err(
-              new McpToolError({
-                type: 'not-supported',
-                message:
-                  'Consent reset is not available for the embedded authorization server. ' +
-                  'The embedded authorization server does not maintain a consent model.',
-                statusCode: 400,
-              }),
-            );
-          }
-
-          // Passthrough or any other auth type
+          // Passthrough or any other non-Bearer auth type
           return new Err(
             new McpToolError({
               type: 'not-supported',
               message:
-                'Consent reset is not available for Passthrough authentication. ' +
+                'Consent reset is only available for Bearer authentication. ' +
                 'Session credentials are managed externally.',
               statusCode: 400,
             }),

--- a/src/tools/resetConsent/resetConsent.ts
+++ b/src/tools/resetConsent/resetConsent.ts
@@ -1,0 +1,120 @@
+import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { Err, Ok } from 'ts-results-es';
+
+import { getConfig } from '../../config.js';
+import { McpToolError } from '../../errors/mcpToolError.js';
+import { Server } from '../../server.js';
+import invariant from '../../utils/invariant.js';
+import { Tool } from '../tool.js';
+
+const paramsSchema = {};
+
+/**
+ * Resets saved OAuth consent for the current user on the Tableau authorization server.
+ *
+ * The token is derived from request context — the model never sees or handles
+ * the raw token value.
+ *
+ * Supported auth modes:
+ *   - Bearer (Tableau authZ server mode): posts to `${config.oauth.issuer}/oauth2/resetConsent`
+ *     with the access token in the Authorization header. The current session remains valid.
+ *
+ * Not supported (returns runtime error):
+ *   - X-Tableau-Auth (embedded authZ): the embedded authorization server has no consent model.
+ *   - Passthrough: session credentials are managed externally.
+ *
+ * Important: call this tool BEFORE revoking the access token, since revocation
+ * invalidates the token required to authenticate the reset consent request.
+ */
+export const getResetConsentTool = (server: Server): Tool<typeof paramsSchema> => {
+  const config = getConfig();
+
+  const resetConsentTool = new Tool({
+    server,
+    name: 'reset-consent',
+    description: `Resets saved OAuth consent for the current user on the Tableau authorization server.
+
+After resetting consent, the current MCP session remains valid. The next OAuth authorization flow will re-prompt the user for consent.
+
+This tool requires no input — it operates on the token already associated with the current session and never exposes the raw token value.
+
+**Important:** Call this tool before revoking the access token. Revocation invalidates the token required to authenticate the consent reset request.
+
+**When to use:**
+- Clearing previously granted consent as part of session teardown
+- Resetting consent state during testing or development
+- Cleaning up OAuth grants when a user's access should be fully removed`,
+    paramsSchema,
+    annotations: {
+      title: 'Reset Consent',
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
+    disabled: config.auth !== 'oauth',
+    callback: async (_args, extra): Promise<CallToolResult> => {
+      return resetConsentTool.logAndExecute<string>({
+        extra,
+        args: {},
+        callback: async () => {
+          const { tableauAuthInfo, config: extraConfig, signal } = extra;
+          invariant(tableauAuthInfo, 'tableauAuthInfo must be set in OAuth mode');
+
+          if (tableauAuthInfo.type === 'Bearer') {
+            const token = tableauAuthInfo.raw;
+            const resetConsentUrl = `${extraConfig.oauth.issuer}/oauth2/resetConsent`;
+
+            const response = await fetch(resetConsentUrl, {
+              method: 'POST',
+              headers: {
+                Authorization: `Bearer ${token}`,
+              },
+              signal,
+            });
+
+            if (!response.ok) {
+              return new Err(
+                new McpToolError({
+                  type: 'reset-consent-failed',
+                  message: `The authorization server rejected the reset consent request (HTTP ${response.status}).`,
+                  statusCode: response.status,
+                }),
+              );
+            }
+
+            return Ok(
+              'Consent has been reset. The next authorization flow will re-prompt for consent.',
+            );
+          }
+
+          if (tableauAuthInfo.type === 'X-Tableau-Auth') {
+            return new Err(
+              new McpToolError({
+                type: 'not-supported',
+                message:
+                  'Consent reset is not available for the embedded authorization server. ' +
+                  'The embedded authorization server does not maintain a consent model.',
+                statusCode: 400,
+              }),
+            );
+          }
+
+          // Passthrough or any other auth type
+          return new Err(
+            new McpToolError({
+              type: 'not-supported',
+              message:
+                'Consent reset is not available for Passthrough authentication. ' +
+                'Session credentials are managed externally.',
+              statusCode: 400,
+            }),
+          );
+        },
+        constrainSuccessResult: (result) => ({ type: 'success', result }),
+      });
+    },
+  });
+
+  return resetConsentTool;
+};

--- a/src/tools/revokeAccessToken/revokeAccessToken.ts
+++ b/src/tools/revokeAccessToken/revokeAccessToken.ts
@@ -32,7 +32,7 @@ export const getRevokeAccessTokenTool = (server: Server): Tool<typeof paramsSche
   const revokeAccessTokenTool = new Tool({
     server,
     name: 'revoke-access-token',
-    description: `Revokes the access token used to authenticate the current MCP session.
+    description: `Revokes the access token used to authenticate the current session.
 
 After revocation the session is invalidated. Subsequent Tableau API calls within this session may fail. Clients should disconnect from the MCP server after calling this tool.
 

--- a/src/tools/toolName.ts
+++ b/src/tools/toolName.ts
@@ -16,6 +16,7 @@ export const toolNames = [
   'generate-pulse-insight-brief',
   'search-content',
   'revoke-access-token',
+  'reset-consent',
 ] as const;
 export type ToolName = (typeof toolNames)[number];
 
@@ -43,7 +44,7 @@ export const toolGroups = {
     'generate-pulse-insight-brief',
   ],
   'content-exploration': ['search-content'],
-  'token-management': ['revoke-access-token'],
+  'token-management': ['revoke-access-token', 'reset-consent'],
 } as const satisfies Record<ToolGroupName, Array<ToolName>>;
 
 export function isToolName(value: unknown): value is ToolName {

--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -9,6 +9,7 @@ import { getListPulseMetricsFromMetricDefinitionIdTool } from './pulse/listMetri
 import { getListPulseMetricsFromMetricIdsTool } from './pulse/listMetricsFromMetricIds/listPulseMetricsFromMetricIds.js';
 import { getListPulseMetricSubscriptionsTool } from './pulse/listMetricSubscriptions/listPulseMetricSubscriptions.js';
 import { getQueryDatasourceTool } from './queryDatasource/queryDatasource.js';
+import { getResetConsentTool } from './resetConsent/resetConsent.js';
 import { getRevokeAccessTokenTool } from './revokeAccessToken/revokeAccessToken.js';
 import { getGetViewDataTool } from './views/getViewData.js';
 import { getGetViewImageTool } from './views/getViewImage.js';
@@ -34,4 +35,5 @@ export const toolFactories = [
   getListViewsTool,
   getSearchContentTool,
   getRevokeAccessTokenTool,
+  getResetConsentTool,
 ];

--- a/tests/e2e/server.test.ts
+++ b/tests/e2e/server.test.ts
@@ -1,5 +1,5 @@
 import { serverName, serverVersion } from '../../src/server.js';
-import { toolNames } from '../../src/tools/toolName.js';
+import { ToolName, toolNames } from '../../src/tools/toolName.js';
 import { resetEnv, setEnv } from '../testEnv.js';
 import { getClient, listTools } from './client.js';
 
@@ -17,10 +17,7 @@ describe('server', () => {
 
   it('should list tools', async () => {
     const names = await listTools();
-    const oauthOnlyTools: ReadonlyArray<(typeof toolNames)[number]> = [
-      'revoke-access-token',
-      'reset-consent',
-    ];
+    const oauthOnlyTools: ReadonlyArray<ToolName> = ['revoke-access-token', 'reset-consent'];
     const expectedToolNames =
       process.env.AUTH === 'oauth'
         ? [...toolNames]

--- a/tests/e2e/server.test.ts
+++ b/tests/e2e/server.test.ts
@@ -17,10 +17,14 @@ describe('server', () => {
 
   it('should list tools', async () => {
     const names = await listTools();
+    const oauthOnlyTools: ReadonlyArray<(typeof toolNames)[number]> = [
+      'revoke-access-token',
+      'reset-consent',
+    ];
     const expectedToolNames =
       process.env.AUTH === 'oauth'
         ? [...toolNames]
-        : toolNames.filter((name) => name !== 'revoke-access-token');
+        : toolNames.filter((name) => !oauthOnlyTools.includes(name));
     expect(names).toEqual(expect.arrayContaining(expectedToolNames));
     expect(names).toHaveLength(expectedToolNames.length);
   });

--- a/tests/oauth/tableau-authz/fixtures/connectOAuthClient.ts
+++ b/tests/oauth/tableau-authz/fixtures/connectOAuthClient.ts
@@ -32,20 +32,20 @@ export const getOAuthClientFixture: WorkerFixture<OAuthClient, { browser: Browse
   // reset-consent is best-effort; revoking the token is asserted so failures are surfaced.
   try {
     const resetConsentResult = await client.callTool('reset-consent', {
-      schema: z.object({ message: z.string() }),
+      schema: z.string(),
       toolArgs: {},
     });
-    expect(resetConsentResult.message).toContain('consent');
+    expect(resetConsentResult).toContain('consent');
   } catch {
     // best-effort: do not prevent revocation if consent reset fails
   }
 
   try {
     const revokeResult = await client.callTool('revoke-access-token', {
-      schema: z.object({ message: z.string() }),
+      schema: z.string(),
       toolArgs: {},
     });
-    expect(revokeResult.message).toContain('revocation');
+    expect(revokeResult).toContain('revocation');
   } finally {
     await client.close();
   }

--- a/tests/oauth/tableau-authz/fixtures/connectOAuthClient.ts
+++ b/tests/oauth/tableau-authz/fixtures/connectOAuthClient.ts
@@ -26,10 +26,19 @@ export const getOAuthClientFixture: WorkerFixture<OAuthClient, { browser: Browse
 
   await use(client);
 
-  // Teardown: reset consent first (requires a valid token), then revoke via the MCP tool.
-  // Order matters: resetConsent() uses the access token, so it must run before revocation.
-  // resetConsent() is best-effort; revoking the token is asserted so failures are surfaced.
-  await client.resetConsent();
+  // Teardown: reset consent first (requires a valid token), then revoke.
+  // Order matters: reset-consent uses the access token, so it must run before revocation.
+  // Both calls go through the MCP tool path to exercise real tool coverage.
+  // reset-consent is best-effort; revoking the token is asserted so failures are surfaced.
+  try {
+    const resetConsentResult = await client.callTool('reset-consent', {
+      schema: z.object({ message: z.string() }),
+      toolArgs: {},
+    });
+    expect(resetConsentResult.message).toContain('consent');
+  } catch {
+    // best-effort: do not prevent revocation if consent reset fails
+  }
 
   try {
     const revokeResult = await client.callTool('revoke-access-token', {


### PR DESCRIPTION
### Description
Adds a new MCP tool, reset-consent, that clears saved OAuth consent on the Tableau authorization server for the current user. It follows the same wiring pattern as revoke-access-token: registered in toolNames / toolGroups, OAuth scope map, and toolFactories.

### Behavior:

Bearer (Tableau authZ server): POST to ${config.oauth.issuer}/oauth2/resetConsent with Authorization: Bearer <access token> and no body (aligned with the existing OAuth test client).
X-Tableau-Auth (embedded) and Passthrough: returns a clear “not supported” error and does not call the network.
Tool is disabled when config.auth !== 'oauth' (same as revoke).
Annotations: destructiveHint: false (consent reset vs token revocation), idempotentHint: true, etc.
Also updates passthrough guard list and e2e tool listing so OAuth-only tools are expected only when AUTH=oauth.

### Motivation and Context
OAuth flows can persist consent on the authorization server. Operators and clients need a first-class MCP action to reset that consent (e.g. teardown, testing, or forcing re-consent) without hand-rolling HTTP. This mirrors revoke-access-token at the MCP layer but targets /oauth2/resetConsent with the correct request shape (header auth, no body) and Bearer-only semantics so embedded auth is not mis-modeled.

### Type of Change



 New feature

### How Has This Been Tested?
Added unit tests in src/tools/resetConsent/resetConsent.test.ts (metadata, disabled/enabled under OAuth, Bearer happy path and errors, embedded + Passthrough rejection, no token leakage in success text, fetch shape).
Updated src/server/passthroughAuthMiddleware.test.ts guard list for the new no-scope tool.
Updated tests/e2e/server.test.ts so reset-consent is only listed when AUTH === 'oauth'.
Ran full unit suite, tsc --noEmit, and ESLint on touched paths (adjust to whatever you actually ran, e.g. npm test, npx tsc --noEmit, npx eslint …).
(Optional follow-up from the plan: npm run test:oauth:embedded if you run OAuth integration tests in CI or locally.)


 I have updated the version in the package.json file by using npm run version. For example, use npm run version:patch for a patch version bump.

 I have made any necessary changes to the documentation

 I have added tests that prove my fix is effective or that my feature works

 New and existing unit tests pass locally with my changes

 I have documented any breaking changes in the PR description. For example, renaming a config environment variable or changing its default value.
(No breaking changes expected: new tool only in OAuth mode; existing clients unchanged.)

Contributor Agreement
By submitting this pull request, I confirm that:


 I have read the [CONTRIBUTING guidelines](vscode-file://vscode-app/Applications/Cursor.app/Contents/Resources/app/out/vs/code/CONTRIBUTING.md) for this project and followed its Contribution Checklist.