### PR TITLE
@W-22067441: allow any port for loopback redirect URIs in CIMD matching (#290)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "1.18.5",
+  "version": "1.18.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "1.18.5",
+      "version": "1.18.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "1.18.5",
+  "version": "1.18.6",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/src/server/oauth/authorize.ts
+++ b/src/server/oauth/authorize.ts
@@ -14,6 +14,7 @@ import { clientMetadataCache } from './clientMetadataCache.js';
 import { getDnsResolver } from './dnsResolver.js';
 import { generateCodeChallenge } from './generateCodeChallenge.js';
 import { isValidRedirectUri } from './isValidRedirectUri.js';
+import { matchesRegisteredRedirectUri } from './matchesRegisteredRedirectUri.js';
 import { TABLEAU_CLOUD_SERVER_URL } from './provider.js';
 import { cimdMetadataSchema, ClientMetadata, mcpAuthorizeSchema } from './schemas.js';
 import { getSupportedScopes, parseScopes, validateScopes } from './scopes.js';
@@ -74,7 +75,10 @@ export function authorize(
         return;
       }
 
-      if (redirect_uris && !redirect_uris.includes(redirect_uri)) {
+      if (
+        redirect_uris &&
+        !redirect_uris.some((uri) => matchesRegisteredRedirectUri(redirect_uri, uri))
+      ) {
         res.status(400).json({
           error: 'invalid_request',
           error_description: `Invalid redirect URI: ${redirect_uri}`,

--- a/src/server/oauth/isValidRedirectUri.ts
+++ b/src/server/oauth/isValidRedirectUri.ts
@@ -11,9 +11,12 @@ export function isValidRedirectUri(redirectUri: unknown): boolean {
       return true;
     }
 
-    // Allow HTTP only for localhost
+    // Allow HTTP only for loopback hosts (RFC 8252 §7.3).
+    // Note: Node's URL parser keeps IPv6 hostnames bracketed (e.g. '[::1]').
     if (url.protocol === 'http:') {
-      return url.hostname === 'localhost' || url.hostname === '127.0.0.1';
+      return (
+        url.hostname === 'localhost' || url.hostname === '127.0.0.1' || url.hostname === '[::1]'
+      );
     }
 
     // Allow custom schemes (like systemprompt://)

--- a/src/server/oauth/matchesRegisteredRedirectUri.test.ts
+++ b/src/server/oauth/matchesRegisteredRedirectUri.test.ts
@@ -1,0 +1,137 @@
+import { matchesRegisteredRedirectUri } from './matchesRegisteredRedirectUri.js';
+
+describe('matchesRegisteredRedirectUri', () => {
+  describe('exact matches', () => {
+    it('matches identical URIs', () => {
+      expect(matchesRegisteredRedirectUri('http://127.0.0.1/cb', 'http://127.0.0.1/cb')).toBe(true);
+    });
+
+    it('matches identical custom-scheme URIs', () => {
+      expect(matchesRegisteredRedirectUri('cursor://cb', 'cursor://cb')).toBe(true);
+    });
+
+    it('matches identical https URIs', () => {
+      expect(matchesRegisteredRedirectUri('https://example.com/cb', 'https://example.com/cb')).toBe(
+        true,
+      );
+    });
+  });
+
+  describe('loopback port relaxation (RFC 8252 §7.3)', () => {
+    it('allows any port for IPv4 loopback (127.0.0.1)', () => {
+      expect(
+        matchesRegisteredRedirectUri(
+          'http://127.0.0.1:54321/callback',
+          'http://127.0.0.1/callback',
+        ),
+      ).toBe(true);
+    });
+
+    it('allows any port for IPv6 loopback ([::1])', () => {
+      expect(
+        matchesRegisteredRedirectUri('http://[::1]:54321/callback', 'http://[::1]/callback'),
+      ).toBe(true);
+    });
+
+    it('allows any port for localhost', () => {
+      expect(
+        matchesRegisteredRedirectUri(
+          'http://localhost:54321/callback',
+          'http://localhost/callback',
+        ),
+      ).toBe(true);
+    });
+
+    it('allows port differences when registered URI also has a port', () => {
+      expect(
+        matchesRegisteredRedirectUri(
+          'http://127.0.0.1:54321/callback',
+          'http://127.0.0.1:6274/callback',
+        ),
+      ).toBe(true);
+    });
+
+    it('preserves query and fragment when they match', () => {
+      expect(
+        matchesRegisteredRedirectUri('http://127.0.0.1:9/cb?x=1#y', 'http://127.0.0.1/cb?x=1#y'),
+      ).toBe(true);
+    });
+  });
+
+  describe('loopback mismatches', () => {
+    it('rejects path mismatch', () => {
+      expect(matchesRegisteredRedirectUri('http://127.0.0.1:9/a', 'http://127.0.0.1/b')).toBe(
+        false,
+      );
+    });
+
+    it('rejects query mismatch', () => {
+      expect(
+        matchesRegisteredRedirectUri('http://127.0.0.1:9/cb?x=1', 'http://127.0.0.1/cb?x=2'),
+      ).toBe(false);
+    });
+
+    it('rejects fragment mismatch', () => {
+      expect(matchesRegisteredRedirectUri('http://127.0.0.1:9/cb#a', 'http://127.0.0.1/cb#b')).toBe(
+        false,
+      );
+    });
+
+    it('rejects scheme mismatch (https request vs http registered)', () => {
+      expect(matchesRegisteredRedirectUri('https://127.0.0.1:9/cb', 'http://127.0.0.1/cb')).toBe(
+        false,
+      );
+    });
+
+    it('rejects cross-host loopback: localhost vs 127.0.0.1', () => {
+      expect(matchesRegisteredRedirectUri('http://localhost:9/cb', 'http://127.0.0.1/cb')).toBe(
+        false,
+      );
+      expect(matchesRegisteredRedirectUri('http://127.0.0.1:9/cb', 'http://localhost/cb')).toBe(
+        false,
+      );
+    });
+
+    it('rejects cross-host loopback: ::1 vs 127.0.0.1', () => {
+      expect(matchesRegisteredRedirectUri('http://[::1]:9/cb', 'http://127.0.0.1/cb')).toBe(false);
+    });
+
+    it('rejects userinfo mismatch', () => {
+      expect(matchesRegisteredRedirectUri('http://u:p@127.0.0.1:9/cb', 'http://127.0.0.1/cb')).toBe(
+        false,
+      );
+    });
+  });
+
+  describe('non-loopback strictness', () => {
+    it('rejects port difference on non-loopback http host', () => {
+      expect(matchesRegisteredRedirectUri('http://example.com:9/cb', 'http://example.com/cb')).toBe(
+        false,
+      );
+    });
+
+    it('rejects port difference on https host', () => {
+      expect(
+        matchesRegisteredRedirectUri('https://example.com:8443/cb', 'https://example.com/cb'),
+      ).toBe(false);
+    });
+
+    it('rejects custom scheme mismatch', () => {
+      expect(matchesRegisteredRedirectUri('cursor://cb', 'fakemcpclient://cb')).toBe(false);
+    });
+  });
+
+  describe('invalid input', () => {
+    it('returns false for unparseable request URI', () => {
+      expect(matchesRegisteredRedirectUri('not a url', 'http://127.0.0.1/cb')).toBe(false);
+    });
+
+    it('returns false for unparseable registered URI', () => {
+      expect(matchesRegisteredRedirectUri('http://127.0.0.1:9/cb', 'not a url')).toBe(false);
+    });
+
+    it('returns false for empty strings that do not match', () => {
+      expect(matchesRegisteredRedirectUri('', 'http://127.0.0.1/cb')).toBe(false);
+    });
+  });
+});

--- a/src/server/oauth/matchesRegisteredRedirectUri.ts
+++ b/src/server/oauth/matchesRegisteredRedirectUri.ts
@@ -1,0 +1,48 @@
+// Node's URL parser keeps IPv6 hostnames bracketed (e.g. '[::1]').
+const LOOPBACK_HOSTS = new Set(['127.0.0.1', '[::1]', 'localhost']);
+
+/**
+ * Returns true iff `requestUri` should be considered equal to `registeredUri`
+ * for the purposes of OAuth redirect URI matching.
+ *
+ * Default behavior is exact string match. As a narrow exception, RFC 8252
+ * section 7.3 requires authorization servers to allow any port for loopback
+ * IP redirect URIs, so that native clients can bind to an ephemeral port at
+ * request time. We honor that by relaxing the port comparison when both URIs
+ * are `http:` and share the exact same loopback host. Every other component
+ * (scheme, host, path, query, fragment, userinfo) must still match exactly.
+ *
+ * Host equivalence is intentionally exact (`127.0.0.1` != `localhost` != `[::1]`)
+ * to avoid DNS-resolution surprises and to keep the relaxation narrow.
+ */
+export function matchesRegisteredRedirectUri(requestUri: string, registeredUri: string): boolean {
+  if (requestUri === registeredUri) {
+    return true;
+  }
+
+  let req: URL;
+  let reg: URL;
+  try {
+    req = new URL(requestUri);
+    reg = new URL(registeredUri);
+  } catch {
+    return false;
+  }
+
+  if (
+    req.protocol === 'http:' &&
+    reg.protocol === 'http:' &&
+    LOOPBACK_HOSTS.has(req.hostname) &&
+    LOOPBACK_HOSTS.has(reg.hostname) &&
+    req.hostname === reg.hostname &&
+    req.pathname === reg.pathname &&
+    req.search === reg.search &&
+    req.hash === reg.hash &&
+    req.username === reg.username &&
+    req.password === reg.password
+  ) {
+    return true;
+  }
+
+  return false;
+}

--- a/tests/oauth/embedded-authz/clientIdMetadataDocuments.test.ts
+++ b/tests/oauth/embedded-authz/clientIdMetadataDocuments.test.ts
@@ -395,6 +395,168 @@ describe('clientIdMetadataDocuments', () => {
     });
   });
 
+  it('should accept loopback IPv4 redirect URI with a different port (RFC 8252 §7.3)', async () => {
+    const { app } = await startServer();
+
+    mocks.dnsResolver.mockReturnValue({ resolve4: () => ['1.2.3.4'] });
+    mockAxios.get.mockResolvedValue({
+      ...mocks.MOCK_AXIOS_GET_RESPONSE,
+      data: {
+        ...mocks.MOCK_AXIOS_GET_RESPONSE.data,
+        redirect_uris: ['http://127.0.0.1/callback'],
+      },
+    });
+
+    const response = await request(app).get('/oauth2/authorize').query({
+      response_type: 'code',
+      client_id: constants.FAKE_CLIENT_METADATA_URL,
+      redirect_uri: 'http://127.0.0.1:54321/callback',
+      code_challenge: 'fake-code-challenge',
+      code_challenge_method: 'S256',
+      state: 'fake-state',
+      resource: 'http://127.0.0.1:3927/tableau-mcp',
+    });
+
+    expect(response.status).toBe(302);
+  });
+
+  it('should accept loopback localhost redirect URI with a different port (RFC 8252 §7.3)', async () => {
+    const { app } = await startServer();
+
+    mocks.dnsResolver.mockReturnValue({ resolve4: () => ['1.2.3.4'] });
+    mockAxios.get.mockResolvedValue({
+      ...mocks.MOCK_AXIOS_GET_RESPONSE,
+      data: {
+        ...mocks.MOCK_AXIOS_GET_RESPONSE.data,
+        redirect_uris: ['http://localhost/callback'],
+      },
+    });
+
+    const response = await request(app).get('/oauth2/authorize').query({
+      response_type: 'code',
+      client_id: constants.FAKE_CLIENT_METADATA_URL,
+      redirect_uri: 'http://localhost:54321/callback',
+      code_challenge: 'fake-code-challenge',
+      code_challenge_method: 'S256',
+      state: 'fake-state',
+      resource: 'http://127.0.0.1:3927/tableau-mcp',
+    });
+
+    expect(response.status).toBe(302);
+  });
+
+  it('should accept loopback IPv6 redirect URI with a different port (RFC 8252 §7.3)', async () => {
+    const { app } = await startServer();
+
+    mocks.dnsResolver.mockReturnValue({ resolve4: () => ['1.2.3.4'] });
+    mockAxios.get.mockResolvedValue({
+      ...mocks.MOCK_AXIOS_GET_RESPONSE,
+      data: {
+        ...mocks.MOCK_AXIOS_GET_RESPONSE.data,
+        redirect_uris: ['http://[::1]/callback'],
+      },
+    });
+
+    const response = await request(app).get('/oauth2/authorize').query({
+      response_type: 'code',
+      client_id: constants.FAKE_CLIENT_METADATA_URL,
+      redirect_uri: 'http://[::1]:54321/callback',
+      code_challenge: 'fake-code-challenge',
+      code_challenge_method: 'S256',
+      state: 'fake-state',
+      resource: 'http://127.0.0.1:3927/tableau-mcp',
+    });
+
+    expect(response.status).toBe(302);
+  });
+
+  it('should reject a loopback path mismatch even when ports differ', async () => {
+    const { app } = await startServer();
+
+    mocks.dnsResolver.mockReturnValue({ resolve4: () => ['1.2.3.4'] });
+    mockAxios.get.mockResolvedValue({
+      ...mocks.MOCK_AXIOS_GET_RESPONSE,
+      data: {
+        ...mocks.MOCK_AXIOS_GET_RESPONSE.data,
+        redirect_uris: ['http://127.0.0.1/callback'],
+      },
+    });
+
+    const response = await request(app).get('/oauth2/authorize').query({
+      response_type: 'code',
+      client_id: constants.FAKE_CLIENT_METADATA_URL,
+      redirect_uri: 'http://127.0.0.1:54321/evil',
+      code_challenge: 'fake-code-challenge',
+      code_challenge_method: 'S256',
+      state: 'fake-state',
+      resource: 'http://127.0.0.1:3927/tableau-mcp',
+    });
+
+    expect(response.status).toBe(400);
+    expect(response.body).toEqual({
+      error: 'invalid_request',
+      error_description: 'Invalid redirect URI: http://127.0.0.1:54321/evil',
+    });
+  });
+
+  it('should reject cross-host loopback: request localhost against registered 127.0.0.1', async () => {
+    const { app } = await startServer();
+
+    mocks.dnsResolver.mockReturnValue({ resolve4: () => ['1.2.3.4'] });
+    mockAxios.get.mockResolvedValue({
+      ...mocks.MOCK_AXIOS_GET_RESPONSE,
+      data: {
+        ...mocks.MOCK_AXIOS_GET_RESPONSE.data,
+        redirect_uris: ['http://127.0.0.1/callback'],
+      },
+    });
+
+    const response = await request(app).get('/oauth2/authorize').query({
+      response_type: 'code',
+      client_id: constants.FAKE_CLIENT_METADATA_URL,
+      redirect_uri: 'http://localhost:54321/callback',
+      code_challenge: 'fake-code-challenge',
+      code_challenge_method: 'S256',
+      state: 'fake-state',
+      resource: 'http://127.0.0.1:3927/tableau-mcp',
+    });
+
+    expect(response.status).toBe(400);
+    expect(response.body).toEqual({
+      error: 'invalid_request',
+      error_description: 'Invalid redirect URI: http://localhost:54321/callback',
+    });
+  });
+
+  it('should reject non-loopback port mismatch (https)', async () => {
+    const { app } = await startServer();
+
+    mocks.dnsResolver.mockReturnValue({ resolve4: () => ['1.2.3.4'] });
+    mockAxios.get.mockResolvedValue({
+      ...mocks.MOCK_AXIOS_GET_RESPONSE,
+      data: {
+        ...mocks.MOCK_AXIOS_GET_RESPONSE.data,
+        redirect_uris: ['https://example.com/cb'],
+      },
+    });
+
+    const response = await request(app).get('/oauth2/authorize').query({
+      response_type: 'code',
+      client_id: constants.FAKE_CLIENT_METADATA_URL,
+      redirect_uri: 'https://example.com:8443/cb',
+      code_challenge: 'fake-code-challenge',
+      code_challenge_method: 'S256',
+      state: 'fake-state',
+      resource: 'http://127.0.0.1:3927/tableau-mcp',
+    });
+
+    expect(response.status).toBe(400);
+    expect(response.body).toEqual({
+      error: 'invalid_request',
+      error_description: 'Invalid redirect URI: https://example.com:8443/cb',
+    });
+  });
+
   it('should reject authorize requests if the CIMD request fails', async () => {
     const { app } = await startServer();
 


### PR DESCRIPTION
## Description

Fix CIMD (Client ID Metadata Document) redirect_uri validation so that a registered loopback URI matches a request-time URI that only differs in port, per [RFC 8252 §7.3](https://datatracker.ietf.org/doc/html/rfc8252#section-7.3). Previously the authorize endpoint used a raw Array.includes() string match against the CIMD's redirect_uris, which rejected native clients that bind to an OS-assigned ephemeral port at request time.

Implementation is intentionally surgical:

New matchesRegisteredRedirectUri(requestUri, registeredUri) helper in src/server/oauth/matchesRegisteredRedirectUri.ts — exact string match by default, with a narrow exception that ignores port when both URIs are http: and share the same loopback host (127.0.0.1, [::1], or localhost). Scheme, host, pathname, search, hash, and userinfo must still match exactly.
Host equivalence is exact: 127.0.0.1, [::1], and localhost each match only themselves (no cross-mapping), avoiding DNS-resolution surprises and keeping the relaxation narrow.
src/server/oauth/authorize.ts now calls redirect_uris.some((uri) => matchesRegisteredRedirectUri(redirect_uri, uri)) in the CIMD path.
src/server/oauth/isValidRedirectUri.ts extended by one check to also accept [::1] (alongside localhost/127.0.0.1) so IPv6 loopback isn't rejected by the general validity gate.
Token endpoint (src/server/oauth/token.ts) unchanged — it already compares against the authorize-time stored redirectUri, so it remains self-consistent and OAuth 2.1 §4.1.3 compliant.
DCR endpoint (src/server/oauth/register.ts) unchanged — no matching happens there.
## Motivation and Context

Closes #290.

Native MCP clients that follow RFC 8252 — including Claude Code — register loopback redirect URIs like http://127.0.0.1/callback or http://localhost/callback in their client metadata, then issue authorize requests with an ephemeral port such as http://127.0.0.1:54321/callback. The previous strict includes() comparison rejected these requests, breaking OAuth entirely for such clients. RFC 8252 §7.3 explicitly requires: "the authorization server MUST allow any port to be specified at the time of the request for loopback IP redirect URIs".
## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Other (please describe):

## How Has This Been Tested?

New unit suite — src/server/oauth/matchesRegisteredRedirectUri.test.ts (21 cases):

Exact matches: identical http/https/custom-scheme URIs.
Loopback port relaxation: IPv4 (127.0.0.1), IPv6 ([::1]), and localhost; with and without a port on the registered URI; preserving query and fragment.
Loopback mismatches still rejected: path, query, fragment, scheme, cross-host loopback (both directions), userinfo.
Non-loopback strictness: http and https port differences on public hosts; custom-scheme mismatches.
Invalid input: unparseable URIs and empty strings return false.
New CIMD integration cases in tests/oauth/embedded-authz/clientIdMetadataDocuments.test.ts:

Accepts http://127.0.0.1:54321/callback against registered http://127.0.0.1/callback → 302.
Accepts http://localhost:54321/callback against registered http://localhost/callback → 302.
Accepts http://[::1]:54321/callback against registered http://[::1]/callback → 302.
Rejects loopback path mismatch (http://127.0.0.1:54321/evil) → 400.
Rejects cross-host loopback (http://localhost:54321/callback against registered http://127.0.0.1/callback) → 400.
Rejects non-loopback https port mismatch (https://example.com:8443/cb against registered https://example.com/cb) → 400.
Verification run locally:

npm test — 1012 / 1012 pass
npm run test:oauth:embedded — 86 / 86 pass (including 17 in clientIdMetadataDocuments)
npx tsc --noEmit — clean
npx eslint on all touched files — clean

## Related Issues

Fixes #290

## Checklist

- [x] I have updated the version in the package.json file by using `npm run version`. For example,
      use `npm run version:patch` for a patch version bump.
- [x] I have made any necessary changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have documented any breaking changes in the PR description. For example, renaming a config
      environment variable or changing its default value.

## Contributor Agreement

By submitting this pull request, I confirm that:

- [x] I have read the [CONTRIBUTING guidelines](../../CONTRIBUTING.md) for this project and followed
      its Contribution Checklist.
