### PR TITLE
@W-22354451: make resource access checking cache-safe for per-site and per-session tool scopes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "1.18.9",
+  "version": "1.18.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "1.18.9",
+      "version": "1.18.10",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "1.18.9",
+  "version": "1.18.10",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/src/tools/resourceAccessChecker.test.ts
+++ b/src/tools/resourceAccessChecker.test.ts
@@ -1,6 +1,10 @@
+import { type BoundedContext, OverridableConfig } from '../overridableConfig.js';
 import { getCombinationsOfBoundedContextInputs } from '../utils/getCombinationsOfBoundedContextInputs.js';
 import { mockDatasources } from './listDatasources/mockDatasources.js';
-import { exportedForTesting } from './resourceAccessChecker.js';
+import {
+  exportedForTesting,
+  resourceAccessChecker as singletonResourceAccessChecker,
+} from './resourceAccessChecker.js';
 import { getMockRequestHandlerExtra } from './toolContext.mock.js';
 import { mockCustomView } from './views/mockCustomView.js';
 import { mockView } from './views/mockView.js';
@@ -13,6 +17,12 @@ const mocks = vi.hoisted(() => ({
   mockGetCustomView: vi.fn(),
   mockGetWorkbook: vi.fn(),
   mockQueryDatasource: vi.fn(),
+  boundedContext: {
+    projectIds: null,
+    datasourceIds: null,
+    workbookIds: null,
+    tags: null,
+  } as BoundedContext,
 }));
 
 vi.mock('../restApiInstance.js', () => ({
@@ -38,6 +48,202 @@ describe('ResourceAccessChecker', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    exportedForTesting.resetResourceAccessCheckerSingleton();
+    mocks.boundedContext = {
+      projectIds: null,
+      datasourceIds: null,
+      workbookIds: null,
+      tags: null,
+    };
+    vi.mocked(extra.getConfigWithOverrides).mockImplementation(async () => {
+      const config = new OverridableConfig({});
+      config.boundedContext = mocks.boundedContext;
+      return config;
+    });
+  });
+
+  describe('hasActiveBoundedContext', () => {
+    it('should treat null fields as unscoped', () => {
+      expect(
+        exportedForTesting.hasActiveBoundedContext({
+          projectIds: null,
+          datasourceIds: null,
+          workbookIds: null,
+          tags: null,
+        }),
+      ).toBe(false);
+    });
+
+    it.each([
+      { field: 'projectIds', boundedContext: { projectIds: new Set<string>() } },
+      { field: 'datasourceIds', boundedContext: { datasourceIds: new Set<string>() } },
+      { field: 'workbookIds', boundedContext: { workbookIds: new Set<string>() } },
+      { field: 'tags', boundedContext: { tags: new Set<string>() } },
+      { field: 'viewIds', boundedContext: { viewIds: new Set<string>() } },
+    ])('should treat non-null $field as scoped even when empty', ({ boundedContext }) => {
+      expect(
+        exportedForTesting.hasActiveBoundedContext({
+          projectIds: null,
+          datasourceIds: null,
+          workbookIds: null,
+          tags: null,
+          ...boundedContext,
+        }),
+      ).toBe(true);
+    });
+  });
+
+  describe('cache isolation across bounded contexts', () => {
+    it('should evaluate the same datasource LUID independently across datasource id scopes', async () => {
+      const mockDatasource = mockDatasources.datasources[0];
+      mocks.boundedContext = {
+        projectIds: null,
+        datasourceIds: new Set([mockDatasource.id]),
+        workbookIds: null,
+        tags: null,
+      };
+
+      expect(
+        await singletonResourceAccessChecker.isDatasourceAllowed({
+          datasourceLuid: mockDatasource.id,
+          extra,
+        }),
+      ).toEqual({ allowed: true });
+
+      mocks.boundedContext = {
+        projectIds: null,
+        datasourceIds: new Set(['some-other-datasource-id']),
+        workbookIds: null,
+        tags: null,
+      };
+
+      expect(
+        await singletonResourceAccessChecker.isDatasourceAllowed({
+          datasourceLuid: mockDatasource.id,
+          extra,
+        }),
+      ).toEqual({
+        allowed: false,
+        message: [
+          'The set of allowed data sources that can be queried is limited by the server configuration.',
+          `Querying the datasource with LUID ${mockDatasource.id} is not allowed.`,
+        ].join(' '),
+      });
+    });
+
+    it('should evaluate the same workbook LUID independently across workbook id scopes', async () => {
+      mocks.boundedContext = {
+        projectIds: null,
+        datasourceIds: null,
+        workbookIds: new Set([mockWorkbook.id]),
+        tags: null,
+      };
+
+      expect(
+        await singletonResourceAccessChecker.isWorkbookAllowed({
+          workbookId: mockWorkbook.id,
+          extra,
+        }),
+      ).toEqual({ allowed: true, content: undefined });
+
+      mocks.boundedContext = {
+        projectIds: null,
+        datasourceIds: null,
+        workbookIds: new Set(['some-other-workbook-id']),
+        tags: null,
+      };
+
+      expect(
+        await singletonResourceAccessChecker.isWorkbookAllowed({
+          workbookId: mockWorkbook.id,
+          extra,
+        }),
+      ).toEqual({
+        allowed: false,
+        message: [
+          'The set of allowed workbooks that can be queried is limited by the server configuration.',
+          `Querying the workbook with LUID ${mockWorkbook.id} is not allowed.`,
+        ].join(' '),
+      });
+    });
+
+    it('should evaluate the same view LUID independently across workbook id scopes', async () => {
+      mocks.mockGetView.mockResolvedValue(mockView);
+      mocks.boundedContext = {
+        projectIds: null,
+        datasourceIds: null,
+        workbookIds: new Set([mockView.workbook.id]),
+        tags: null,
+      };
+
+      expect(
+        await singletonResourceAccessChecker.isViewAllowed({
+          viewId: mockView.id,
+          extra,
+        }),
+      ).toEqual({ allowed: true });
+
+      mocks.boundedContext = {
+        projectIds: null,
+        datasourceIds: null,
+        workbookIds: new Set(['some-other-workbook-id']),
+        tags: null,
+      };
+
+      expect(
+        await singletonResourceAccessChecker.isViewAllowed({
+          viewId: mockView.id,
+          extra,
+        }),
+      ).toEqual({
+        allowed: false,
+        message: [
+          'The set of allowed views that can be queried is limited by the server configuration.',
+          `The view with LUID ${mockView.id} cannot be queried because it does not belong to an allowed workbook.`,
+        ].join(' '),
+      });
+      expect(mocks.mockGetView).toHaveBeenCalledTimes(2);
+    });
+
+    it('should evaluate the same custom view LUID independently across workbook id scopes', async () => {
+      mocks.mockGetCustomView.mockResolvedValue(mockCustomView);
+      mocks.mockGetView.mockResolvedValue(mockView);
+      mocks.boundedContext = {
+        projectIds: null,
+        datasourceIds: null,
+        workbookIds: new Set([mockView.workbook.id]),
+        tags: null,
+      };
+
+      expect(
+        await singletonResourceAccessChecker.isCustomViewAllowed({
+          customViewId: mockCustomView.id,
+          extra,
+        }),
+      ).toEqual({ allowed: true });
+
+      mocks.boundedContext = {
+        projectIds: null,
+        datasourceIds: null,
+        workbookIds: new Set(['some-other-workbook-id']),
+        tags: null,
+      };
+
+      expect(
+        await singletonResourceAccessChecker.isCustomViewAllowed({
+          customViewId: mockCustomView.id,
+          extra,
+        }),
+      ).toEqual({
+        allowed: false,
+        message: [
+          'The set of allowed views that can be queried is limited by the server configuration.',
+          `The view with LUID ${mockView.id} cannot be queried because it does not belong to an allowed workbook.`,
+        ].join(' '),
+      });
+      expect(mocks.mockGetCustomView).toHaveBeenCalledTimes(2);
+      expect(mocks.mockGetView).toHaveBeenCalledTimes(2);
+    });
   });
 
   describe('isDatasourceAllowed', () => {
@@ -309,12 +515,9 @@ describe('ResourceAccessChecker', () => {
           ).toEqual({ allowed: true });
 
           let expectedNumberOfCalls = 0;
-          if (projectIds || tags) {
-            // If project or tag filtering is enabled, we cannot cache the result so we need to call the "Get View" API each time.
+          if (projectIds || workbookIds || tags) {
+            // If any bounded context is enabled, we cannot cache the result so we need to call the "Get View" API each time.
             expectedNumberOfCalls = 2;
-          } else if (workbookIds) {
-            // If only workbook filtering is enabled, we can cache the result so we only need to call the "Get View" API once.
-            expectedNumberOfCalls = 1;
           }
 
           expect(mocks.mockGetView).toHaveBeenCalledTimes(expectedNumberOfCalls);
@@ -385,12 +588,9 @@ describe('ResourceAccessChecker', () => {
           });
 
           let expectedNumberOfCalls = 0;
-          if (projectIds || tags) {
-            // If project or tag filtering is enabled, we cannot cache the result so we need to call the "Get View" API each time.
+          if (projectIds || workbookIds || tags) {
+            // If any bounded context is enabled, we cannot cache the result so we need to call the "Get View" API each time.
             expectedNumberOfCalls = 2;
-          } else if (workbookIds) {
-            // If only workbook filtering is enabled, we can cache the result so we only need to call the "Get View" API once.
-            expectedNumberOfCalls = 1;
           }
 
           expect(mocks.mockGetView).toHaveBeenCalledTimes(expectedNumberOfCalls);

--- a/src/tools/resourceAccessChecker.ts
+++ b/src/tools/resourceAccessChecker.ts
@@ -1,3 +1,4 @@
+import { log } from '../logging/logger.js';
 import { BoundedContext } from '../overridableConfig.js';
 import { useRestApi } from '../restApiInstance.js';
 import { DataSource } from '../sdks/tableau/types/dataSource.js';
@@ -5,12 +6,45 @@ import { View } from '../sdks/tableau/types/view.js';
 import { Workbook } from '../sdks/tableau/types/workbook.js';
 import { RESOURCE_ACCESS_CHECKER_REQUIRED_API_SCOPES } from '../server/oauth/scopes.js';
 import { getExceptionMessage } from '../utils/getExceptionMessage.js';
-import { getConfigWithOverrides } from '../utils/mcpSiteSettings.js';
 import { TableauRequestHandlerExtra } from './toolContext.js';
 
 type AllowedResult<T = unknown> =
   | { allowed: true; content?: T }
   | { allowed: false; message: string };
+
+// Cache-eligibility view of the bounded context.
+// Required fields (`projectIds`, `datasourceIds`, `workbookIds`, `tags`) are
+// always `Set<string> | null`. `viewIds` is included as an optional
+// forward-compatible field so future view-scoped access cannot accidentally
+// reuse the unscoped cache; today it is typically `undefined`.
+type CacheBoundedContext = BoundedContext & { viewIds?: Set<string> | null };
+type ResourceType = 'datasource' | 'workbook' | 'view' | 'custom-view';
+type CacheDecision = 'hit' | 'miss' | 'write' | 'skipped-scoped';
+
+const boundedContextCacheKeys = [
+  'projectIds',
+  'datasourceIds',
+  'workbookIds',
+  'tags',
+  'viewIds',
+] as const;
+
+// Treat any non-null set as an active bound, even when empty.
+// An empty set can represent an intentionally restrictive deny-all scope,
+// so it must not be allowed to use the unscoped cache.
+// `undefined` is treated as inactive only because optional future fields
+// (currently `viewIds`) may simply not be present on the bounded context.
+function hasActiveBoundedContext(boundedContext: CacheBoundedContext): boolean {
+  return boundedContextCacheKeys.some(
+    (key) => boundedContext[key] !== null && boundedContext[key] !== undefined,
+  );
+}
+
+function getActiveBoundedContextKeys(boundedContext: CacheBoundedContext): Array<string> {
+  return boundedContextCacheKeys.filter(
+    (key) => boundedContext[key] !== null && boundedContext[key] !== undefined,
+  );
+}
 
 class ResourceAccessChecker {
   private _testOverrides: {
@@ -49,64 +83,116 @@ class ResourceAccessChecker {
     this._cachedCustomViewIds = new Map();
   }
 
-  private async getAllowedProjectIds({
-    extra,
-  }: {
-    extra: TableauRequestHandlerExtra;
-  }): Promise<Set<string> | null> {
-    return (
-      this._testOverrides.projectIds ??
-      (
-        await getConfigWithOverrides({
-          restApiArgs: { ...extra },
-        })
-      ).boundedContext.projectIds
-    );
+  private hasTestOverrides(): boolean {
+    return Object.values(this._testOverrides).some((value) => value !== undefined);
   }
 
-  private async getAllowedDatasourceIds({
+  private async getBoundedContext({
     extra,
   }: {
     extra: TableauRequestHandlerExtra;
-  }): Promise<Set<string> | null> {
-    return (
-      this._testOverrides.datasourceIds ??
-      (
-        await getConfigWithOverrides({
-          restApiArgs: { ...extra },
-        })
-      ).boundedContext.datasourceIds
-    );
+  }): Promise<BoundedContext> {
+    if (this.hasTestOverrides()) {
+      return {
+        projectIds: this._testOverrides.projectIds ?? null,
+        datasourceIds: this._testOverrides.datasourceIds ?? null,
+        workbookIds: this._testOverrides.workbookIds ?? null,
+        tags: this._testOverrides.tags ?? null,
+      };
+    }
+
+    return (await extra.getConfigWithOverrides()).boundedContext;
   }
 
-  private async getAllowedWorkbookIds({
+  private logCacheDecision({
+    resourceType,
+    resourceLuid,
+    decision,
+    boundedContext,
     extra,
   }: {
+    resourceType: ResourceType;
+    resourceLuid: string;
+    decision: CacheDecision;
+    boundedContext: CacheBoundedContext;
     extra: TableauRequestHandlerExtra;
-  }): Promise<Set<string> | null> {
-    return (
-      this._testOverrides.workbookIds ??
-      (
-        await getConfigWithOverrides({
-          restApiArgs: { ...extra },
-        })
-      ).boundedContext.workbookIds
-    );
+  }): void {
+    log({
+      level: 'debug',
+      logger: 'resource-access',
+      message: {
+        event: 'resource-access-cache',
+        resourceType,
+        resourceLuid,
+        decision,
+        activeBoundedContextKeys: getActiveBoundedContextKeys(boundedContext),
+        requestId: extra.requestId,
+      },
+    });
   }
 
-  private async getAllowedTags({
+  private getCachedResult<T>({
+    cache,
+    cacheKey,
+    resourceType,
+    boundedContext,
     extra,
   }: {
+    cache: Map<string, AllowedResult<T>>;
+    cacheKey: string;
+    resourceType: ResourceType;
+    boundedContext: CacheBoundedContext;
     extra: TableauRequestHandlerExtra;
-  }): Promise<Set<string> | null> {
-    return (
-      this._testOverrides.tags ??
-      (
-        await getConfigWithOverrides({
-          restApiArgs: { ...extra },
-        })
-      ).boundedContext.tags
-    );
+  }): AllowedResult<T> | undefined {
+    if (hasActiveBoundedContext(boundedContext)) {
+      this.logCacheDecision({
+        resourceType,
+        resourceLuid: cacheKey,
+        decision: 'skipped-scoped',
+        boundedContext,
+        extra,
+      });
+      return undefined;
+    }
+
+    const cachedResult = cache.get(cacheKey);
+    this.logCacheDecision({
+      resourceType,
+      resourceLuid: cacheKey,
+      decision: cachedResult ? 'hit' : 'miss',
+      boundedContext,
+      extra,
+    });
+    return cachedResult;
+  }
+
+  private setCachedResult<T>({
+    cache,
+    cacheKey,
+    resourceType,
+    boundedContext,
+    result,
+    extra,
+  }: {
+    cache: Map<string, AllowedResult<T>>;
+    cacheKey: string;
+    resourceType: ResourceType;
+    boundedContext: CacheBoundedContext;
+    result: AllowedResult<T>;
+    extra: TableauRequestHandlerExtra;
+  }): void {
+    if (hasActiveBoundedContext(boundedContext)) {
+      return;
+    }
+
+    cache.set(cacheKey, result);
+    this.logCacheDecision({
+      resourceType,
+      resourceLuid: cacheKey,
+      decision: 'write',
+      boundedContext,
+      extra,
+    });
   }
 
   async isDatasourceAllowed({
@@ -116,18 +202,32 @@ class ResourceAccessChecker {
     datasourceLuid: string;
     extra: TableauRequestHandlerExtra;
   }): Promise<AllowedResult> {
+    const boundedContext = await this.getBoundedContext({ extra });
+    const cachedResult = this.getCachedResult({
+      cache: this._cachedDatasourceIds,
+      cacheKey: datasourceLuid,
+      resourceType: 'datasource',
+      boundedContext,
+      extra,
+    });
+    if (cachedResult) {
+      return cachedResult;
+    }
+
     const result = await this._isDatasourceAllowed({
       datasourceLuid,
       extra,
+      boundedContext,
     });
 
-    const allowedProjectIds = await this.getAllowedProjectIds({ extra });
-    const allowedTags = await this.getAllowedTags({ extra });
-    if (!allowedProjectIds && !allowedTags) {
-      // If project filtering is enabled, we cannot cache the result since the datasource may be moved between projects.
-      // If tag filtering is enabled, we cannot cache the result since the datasource tags can change over time.
-      this._cachedDatasourceIds.set(datasourceLuid, result);
-    }
+    this.setCachedResult({
+      cache: this._cachedDatasourceIds,
+      cacheKey: datasourceLuid,
+      resourceType: 'datasource',
+      boundedContext,
+      result,
+      extra,
+    });
 
     return result;
   }
@@ -139,18 +239,32 @@ class ResourceAccessChecker {
     workbookId: string;
     extra: TableauRequestHandlerExtra;
   }): Promise<AllowedResult<Workbook>> {
+    const boundedContext = await this.getBoundedContext({ extra });
+    const cachedResult = this.getCachedResult({
+      cache: this._cachedWorkbookIds,
+      cacheKey: workbookId,
+      resourceType: 'workbook',
+      boundedContext,
+      extra,
+    });
+    if (cachedResult) {
+      return cachedResult;
+    }
+
     const result = await this._isWorkbookAllowed({
       workbookId,
       extra,
+      boundedContext,
     });
 
-    const allowedProjectIds = await this.getAllowedProjectIds({ extra });
-    const allowedTags = await this.getAllowedTags({ extra });
-    if (!allowedProjectIds && !allowedTags) {
-      // If project filtering is enabled, we cannot cache the result since the workbook may be moved between projects.
-      // If tag filtering is enabled, we cannot cache the result since the workbook tags can change over time.
-      this._cachedWorkbookIds.set(workbookId, result);
-    }
+    this.setCachedResult({
+      cache: this._cachedWorkbookIds,
+      cacheKey: workbookId,
+      resourceType: 'workbook',
+      boundedContext,
+      result,
+      extra,
+    });
 
     return result;
   }
@@ -162,18 +276,32 @@ class ResourceAccessChecker {
     viewId: string;
     extra: TableauRequestHandlerExtra;
   }): Promise<AllowedResult> {
+    const boundedContext = await this.getBoundedContext({ extra });
+    const cachedResult = this.getCachedResult({
+      cache: this._cachedViewIds,
+      cacheKey: viewId,
+      resourceType: 'view',
+      boundedContext,
+      extra,
+    });
+    if (cachedResult) {
+      return cachedResult;
+    }
+
     const result = await this._isViewAllowed({
       viewId,
       extra,
+      boundedContext,
     });
 
-    const allowedProjectIds = await this.getAllowedProjectIds({ extra });
-    const allowedTags = await this.getAllowedTags({ extra });
-    if (!allowedProjectIds && !allowedTags) {
-      // If project filtering is enabled, we cannot cache the result since the workbook containing the view may be moved between projects.
-      // If tag filtering is enabled, we cannot cache the result since the view tags can change over time.
-      this._cachedViewIds.set(viewId, result);
-    }
+    this.setCachedResult({
+      cache: this._cachedViewIds,
+      cacheKey: viewId,
+      resourceType: 'view',
+      boundedContext,
+      result,
+      extra,
+    });
 
     return result;
   }
@@ -188,20 +316,32 @@ class ResourceAccessChecker {
     customViewId: string;
     extra: TableauRequestHandlerExtra;
   }): Promise<AllowedResult> {
+    const boundedContext = await this.getBoundedContext({ extra });
+    const cachedResult = this.getCachedResult({
+      cache: this._cachedCustomViewIds,
+      cacheKey: customViewId,
+      resourceType: 'custom-view',
+      boundedContext,
+      extra,
+    });
+    if (cachedResult) {
+      return cachedResult;
+    }
+
     const result = await this._isCustomViewAllowed({
       customViewId,
       extra,
+      boundedContext,
     });
 
-    const allowedProjectIds = await this.getAllowedProjectIds({ extra });
-    const allowedTags = await this.getAllowedTags({ extra });
-    if (!allowedProjectIds && !allowedTags) {
-      // If project filtering is enabled, we cannot cache the result since the workbook containing the view
-      // that contains the custom view may be moved between projects.
-      // If tag filtering is enabled, we cannot cache the result since the tags on the view
-      // that contains the custom view can change over time.
-      this._cachedCustomViewIds.set(customViewId, result);
-    }
+    this.setCachedResult({
+      cache: this._cachedCustomViewIds,
+      cacheKey: customViewId,
+      resourceType: 'custom-view',
+      boundedContext,
+      result,
+      extra,
+    });
 
     return result;
   }
@@ -209,16 +349,13 @@ class ResourceAccessChecker {
   private async _isDatasourceAllowed({
     datasourceLuid,
     extra,
+    boundedContext,
   }: {
     datasourceLuid: string;
     extra: TableauRequestHandlerExtra;
+    boundedContext: BoundedContext;
   }): Promise<AllowedResult> {
-    const cachedResult = this._cachedDatasourceIds.get(datasourceLuid);
-    if (cachedResult) {
-      return cachedResult;
-    }
-
-    const allowedDatasourceIds = await this.getAllowedDatasourceIds({ extra });
+    const allowedDatasourceIds = boundedContext.datasourceIds;
     if (allowedDatasourceIds && !allowedDatasourceIds.has(datasourceLuid)) {
       return {
         allowed: false,
@@ -242,7 +379,7 @@ class ResourceAccessChecker {
       });
     }
 
-    const allowedProjectIds = await this.getAllowedProjectIds({ extra });
+    const allowedProjectIds = boundedContext.projectIds;
     if (allowedProjectIds) {
       try {
         datasource = await getDatasource();
@@ -268,7 +405,7 @@ class ResourceAccessChecker {
       }
     }
 
-    const allowedTags = await this.getAllowedTags({ extra });
+    const allowedTags = boundedContext.tags;
     if (allowedTags) {
       try {
         datasource = datasource ?? (await getDatasource());
@@ -300,16 +437,13 @@ class ResourceAccessChecker {
   private async _isWorkbookAllowed({
     workbookId,
     extra,
+    boundedContext,
   }: {
     workbookId: string;
     extra: TableauRequestHandlerExtra;
+    boundedContext: BoundedContext;
   }): Promise<AllowedResult<Workbook>> {
-    const cachedResult = this._cachedWorkbookIds.get(workbookId);
-    if (cachedResult) {
-      return cachedResult;
-    }
-
-    const allowedWorkbookIds = await this.getAllowedWorkbookIds({ extra });
+    const allowedWorkbookIds = boundedContext.workbookIds;
     if (allowedWorkbookIds && !allowedWorkbookIds.has(workbookId)) {
       return {
         allowed: false,
@@ -333,7 +467,7 @@ class ResourceAccessChecker {
       });
     }
 
-    const allowedProjectIds = await this.getAllowedProjectIds({ extra });
+    const allowedProjectIds = boundedContext.projectIds;
     if (allowedProjectIds) {
       try {
         workbook = await getWorkbook();
@@ -359,7 +493,7 @@ class ResourceAccessChecker {
       }
     }
 
-    const allowedTags = await this.getAllowedTags({ extra });
+    const allowedTags = boundedContext.tags;
     if (allowedTags) {
       try {
         workbook = workbook ?? (await getWorkbook());
@@ -391,15 +525,12 @@ class ResourceAccessChecker {
   private async _isViewAllowed({
     viewId,
     extra,
+    boundedContext,
   }: {
     viewId: string;
     extra: TableauRequestHandlerExtra;
+    boundedContext: BoundedContext;
   }): Promise<AllowedResult> {
-    const cachedResult = this._cachedViewIds.get(viewId);
-    if (cachedResult) {
-      return cachedResult;
-    }
-
     let view: View | undefined;
     async function getView(): Promise<View> {
       return await useRestApi({
@@ -414,7 +545,7 @@ class ResourceAccessChecker {
       });
     }
 
-    const allowedWorkbookIds = await this.getAllowedWorkbookIds({ extra });
+    const allowedWorkbookIds = boundedContext.workbookIds;
     if (allowedWorkbookIds) {
       try {
         view = await getView();
@@ -440,7 +571,7 @@ class ResourceAccessChecker {
       }
     }
 
-    const allowedProjectIds = await this.getAllowedProjectIds({ extra });
+    const allowedProjectIds = boundedContext.projectIds;
     if (allowedProjectIds) {
       try {
         view = view ?? (await getView());
@@ -466,7 +597,7 @@ class ResourceAccessChecker {
       }
     }
 
-    const allowedTags = await this.getAllowedTags({ extra });
+    const allowedTags = boundedContext.tags;
     if (allowedTags) {
       try {
         view = view ?? (await getView());
@@ -498,18 +629,15 @@ class ResourceAccessChecker {
   private async _isCustomViewAllowed({
     customViewId,
     extra,
+    boundedContext,
   }: {
     customViewId: string;
     extra: TableauRequestHandlerExtra;
+    boundedContext: BoundedContext;
   }): Promise<AllowedResult> {
-    const cachedResult = this._cachedCustomViewIds.get(customViewId);
-    if (cachedResult) {
-      return cachedResult;
-    }
-
-    const allowedWorkbookIds = await this.getAllowedWorkbookIds({ extra });
-    const allowedProjectIds = await this.getAllowedProjectIds({ extra });
-    const allowedTags = await this.getAllowedTags({ extra });
+    const allowedWorkbookIds = boundedContext.workbookIds;
+    const allowedProjectIds = boundedContext.projectIds;
+    const allowedTags = boundedContext.tags;
     if (!allowedWorkbookIds && !allowedProjectIds && !allowedTags) {
       // If no filtering is enabled, there's no need to resolve the view the custom view belongs to.
       return { allowed: true };
@@ -540,9 +668,10 @@ class ResourceAccessChecker {
     }
 
     // The custom view is allowed if the underlying view that contains it is allowed.
-    const isCustomViewAllowed = await this.isViewAllowed({
+    const isCustomViewAllowed = await this._isViewAllowed({
       viewId: underlyingViewId,
       extra,
+      boundedContext,
     });
 
     return isCustomViewAllowed;
@@ -552,6 +681,7 @@ class ResourceAccessChecker {
 let resourceAccessChecker = ResourceAccessChecker.create();
 const exportedForTesting = {
   createResourceAccessChecker: ResourceAccessChecker.createForTesting,
+  hasActiveBoundedContext,
   resetResourceAccessCheckerSingleton: () => {
     resourceAccessChecker = ResourceAccessChecker.create();
   },


### PR DESCRIPTION
## Description

Hardened `resourceAccessChecker` caching to prevent scope leakage across tenants/sites/sessions by making cache use conditional on effective bounded context. Cache lookups/writes now occur only in public checker methods after bounded context resolution, and are skipped whenever any bounded-context field is active (non-null), including empty sets. Added/updated tests to verify cross-scope isolation and preserved unscoped caching behavior.

## Motivation and Context

Resource access decisions were previously cached by resource LUID in a way that could allow decisions from one scope to be reused in another scope. That is unsafe for hosted multi-tenant and per-session/dynamic scoping. This change ensures scoped decisions are always evaluated independently and cannot contaminate other scope contexts.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Other (please describe): Security hardening / cache-safety cleanup

## How Has This Been Tested?

Executed:

- `npx vitest run src/tools/resourceAccessChecker.test.ts`
- `npm test`
- `npx tsc --noEmit`
- `npm run lint`

Coverage added/updated in `src/tools/resourceAccessChecker.test.ts` includes:

- Same resource LUID allowed under scope A and denied under scope B (datasource/workbook/view/custom-view)
- No cache contamination across changed bounded contexts
- Empty non-null sets treated as active bounds
- Unscoped behavior still uses cache as expected

## Related Issues

- Issue: _TBD (please link the created issue)_
- GUS: Make resource access checking cache-safe for per-site and per-session tool scopes

## Checklist

- [x] I have updated the version in the package.json file by using `npm run version`. For example,
      use `npm run version:patch` for a patch version bump.
- [ ] I have made any necessary changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have documented any breaking changes in the PR description. For example, renaming a config
      environment variable or changing its default value.

## Contributor Agreement

By submitting this pull request, I confirm that:

- [x] I have read the [CONTRIBUTING guidelines](../../CONTRIBUTING.md) for this project and followed
      its Contribution Checklist.