### PR TITLE
@W-22373417: Rename LogEntry.error to LogEntry.data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/src/index.combined.ts
+++ b/src/index.combined.ts
@@ -37,7 +37,7 @@ async function startServer(): Promise<void> {
       message: 'Fatal error initializing server info',
       level: 'error',
       logger: 'startup',
-      error,
+      data: error,
     });
     process.exit(1);
   });
@@ -91,7 +91,7 @@ startServer().catch((error) => {
     message: 'Fatal error when starting the server',
     level: 'error',
     logger: 'startup',
-    error,
+    data: error,
   });
   process.exit(1);
 });

--- a/src/index.desktop.ts
+++ b/src/index.desktop.ts
@@ -40,7 +40,7 @@ startServer().catch((error) => {
     message: 'Fatal error when starting the server',
     level: 'error',
     logger: 'startup',
-    error,
+    data: error,
   });
   process.exit(1);
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,7 @@ async function startServer(): Promise<void> {
       message: 'Fatal error initializing server info',
       level: 'error',
       logger: 'startup',
-      error,
+      data: error,
     });
     process.exit(1);
   });
@@ -114,7 +114,7 @@ startServer().catch((error) => {
     message: 'Fatal error when starting the server',
     level: 'error',
     logger: 'startup',
-    error,
+    data: error,
   });
   process.exit(1);
 });

--- a/src/logging/logger.test.ts
+++ b/src/logging/logger.test.ts
@@ -61,6 +61,35 @@ describe('log', () => {
     stderrSpy.mockRestore();
   });
 
+  it('should write JSON and data object to stderr when transport is stdio and appLogger is enabled', () => {
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+    log({ ...entry, data: { test: 'test' } });
+
+    expect(stderrSpy).toHaveBeenCalledWith(JSON.stringify({ ...entry }) + '\n');
+    expect(stderrSpy).toHaveBeenCalledWith(JSON.stringify({ test: 'test' }) + '\n');
+    stderrSpy.mockRestore();
+  });
+
+  it('should write JSON and an error when the data object cannot be stringified', () => {
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+    // Create a circular reference to test the error handling.
+    const data: Record<string, any> = {};
+    data.data = data;
+    log({ ...entry, data });
+
+    expect(stderrSpy).toHaveBeenCalledWith(JSON.stringify({ ...entry }) + '\n');
+    expect(stderrSpy).toHaveBeenCalledWith(
+      [
+        'Failed to write data to stderr: Converting circular structure to JSON',
+        "    --> starting at object with constructor 'Object'",
+        "    --- property 'data' closes the circle\n",
+      ].join('\n'),
+    );
+    stderrSpy.mockRestore();
+  });
+
   it('should write JSON to console.log when transport is http and appLogger is enabled', () => {
     vi.stubEnv('TRANSPORT', 'http');
     vi.stubEnv('DANGEROUSLY_DISABLE_OAUTH', 'true');
@@ -73,7 +102,7 @@ describe('log', () => {
     consoleSpy.mockRestore();
   });
 
-  it('should write JSON and error to console.log when transport is http and appLogger is enabled', () => {
+  it('should write JSON and data object to console.log when transport is http and appLogger is enabled', () => {
     vi.stubEnv('TRANSPORT', 'http');
     vi.stubEnv('DANGEROUSLY_DISABLE_OAUTH', 'true');
 

--- a/src/logging/logger.test.ts
+++ b/src/logging/logger.test.ts
@@ -80,12 +80,9 @@ describe('log', () => {
     const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     const error = new Error('boom');
 
-    log({ ...entry, level: 'error', error });
+    log({ ...entry, level: 'error', data: error });
 
-    expect(consoleSpy).toHaveBeenCalledWith(
-      JSON.stringify({ ...entry, level: 'error', error }),
-      error,
-    );
+    expect(consoleSpy).toHaveBeenCalledWith(JSON.stringify({ ...entry, level: 'error' }), error);
     consoleSpy.mockRestore();
   });
 

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -44,7 +44,7 @@ export function log(entry: LogEntry): void {
     const { data, ...rest } = entry;
     const message = JSON.stringify(rest);
     if (config.transport === 'http') {
-      if (entry.data) {
+      if (data) {
         // eslint-disable-next-line no-console -- console.log is intentional here since the transport is not stdio.
         console.log(message, data);
       } else {
@@ -53,6 +53,9 @@ export function log(entry: LogEntry): void {
       }
     } else {
       process.stderr.write(message.endsWith('\n') ? message : `${message}\n`);
+      if (data) {
+        process.stderr.write(JSON.stringify(data) + '\n');
+      }
     }
   }
   if (config.loggers.has('fileLogger')) {

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -1,4 +1,5 @@
 import { getConfig } from '../config.js';
+import { getExceptionMessage } from '../utils/getExceptionMessage.js';
 import { getFileLogger } from './fileLogger.js';
 import { LogEntry, LogLevel, logLevelSeverity } from './types.js';
 
@@ -44,7 +45,7 @@ export function log(entry: LogEntry): void {
     const { data, ...rest } = entry;
     const message = JSON.stringify(rest);
     if (config.transport === 'http') {
-      if (data) {
+      if (data !== undefined) {
         // eslint-disable-next-line no-console -- console.log is intentional here since the transport is not stdio.
         console.log(message, data);
       } else {
@@ -53,8 +54,12 @@ export function log(entry: LogEntry): void {
       }
     } else {
       process.stderr.write(message.endsWith('\n') ? message : `${message}\n`);
-      if (data) {
-        process.stderr.write(JSON.stringify(data) + '\n');
+      if (data !== undefined) {
+        try {
+          process.stderr.write(JSON.stringify(data) + '\n');
+        } catch (error) {
+          process.stderr.write(`Failed to write data to stderr: ${getExceptionMessage(error)}\n`);
+        }
       }
     }
   }

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -40,11 +40,13 @@ export function log(entry: LogEntry): void {
     return;
   }
   if (config.loggers.has('appLogger')) {
-    const message = JSON.stringify(entry);
+    // Remove data from the entry to avoid double logging.
+    const { data, ...rest } = entry;
+    const message = JSON.stringify(rest);
     if (config.transport === 'http') {
-      if (entry.error) {
+      if (entry.data) {
         // eslint-disable-next-line no-console -- console.log is intentional here since the transport is not stdio.
-        console.log(message, entry.error);
+        console.log(message, data);
       } else {
         // eslint-disable-next-line no-console -- console.log is intentional here since the transport is not stdio.
         console.log(message);

--- a/src/logging/secretMask.ts
+++ b/src/logging/secretMask.ts
@@ -89,7 +89,7 @@ function clone<T>(obj: T): Result<T, Error> {
       message: 'Could not clone object, notification may not be sanitized!',
       level: 'error',
       logger: 'secretMask',
-      error: error,
+      data: error,
     });
     return Err(new Error(getExceptionMessage(error)));
   }

--- a/src/logging/types.ts
+++ b/src/logging/types.ts
@@ -18,7 +18,7 @@ export const logLevelSeverity = Object.fromEntries(
 
 export type LogEntry = {
   message: string;
-  error?: unknown;
+  data?: unknown;
   level: LogLevel;
   logger: string | undefined;
 };

--- a/src/restApiInstance.ts
+++ b/src/restApiInstance.ts
@@ -209,7 +209,7 @@ export const getRequestErrorInterceptor =
         message: `Request ${requestId} failed`,
         level: 'error',
         logger: 'rest-api',
-        error: error,
+        data: error,
       });
       notifier.error(
         server.mcpServer,
@@ -248,7 +248,7 @@ export const getResponseErrorInterceptor =
         message: `Response from request ${requestId} failed`,
         level: 'error',
         logger: 'rest-api',
-        error: error,
+        data: error,
       });
       notifier.error(
         server.mcpServer,

--- a/src/scripts/createClaudeMcpBundleManifest.ts
+++ b/src/scripts/createClaudeMcpBundleManifest.ts
@@ -215,6 +215,14 @@ const envVars = {
     required: false,
     sensitive: false,
   },
+  LOG_LEVEL: {
+    includeInUserConfig: false,
+    type: 'string',
+    title: 'Log Level',
+    description: 'The minimum severity level for server log output.',
+    required: false,
+    sensitive: false,
+  },
   DATASOURCE_CREDENTIALS: {
     includeInUserConfig: true,
     type: 'string',

--- a/src/server/express.ts
+++ b/src/server/express.ts
@@ -175,7 +175,7 @@ export async function startExpressServer({
         message: 'Error handling MCP request',
         level: 'error',
         logger: 'server',
-        error: error,
+        data: error,
       });
       if (!res.headersSent) {
         res.status(500).json({

--- a/src/server/oauth/accessTokenValidator.ts
+++ b/src/server/oauth/accessTokenValidator.ts
@@ -107,7 +107,7 @@ export class EmbeddedAccessTokenValidator extends AccessTokenValidator {
         message: 'Embedded access token validation error',
         level: 'debug',
         logger: 'oauth',
-        error,
+        data: error,
       });
       return new Err('Invalid or expired access token');
     }
@@ -172,7 +172,7 @@ export class TableauAccessTokenValidator extends AccessTokenValidator {
         message: 'Tableau access token validation error',
         level: 'debug',
         logger: 'oauth',
-        error,
+        data: error,
       });
       return new Err('Invalid or expired access token');
     }

--- a/src/server/oauth/authorize.ts
+++ b/src/server/oauth/authorize.ts
@@ -213,7 +213,7 @@ async function getOAuthRedirectUrl(
       message: 'Failed to follow Tableau OAuth redirect for site picker',
       level: 'error',
       logger: 'oauth',
-      error: error,
+      data: error,
     });
     return initialOAuthUrl;
   }
@@ -255,7 +255,7 @@ async function getClientFromMetadataDoc(
         message: `DNS resolution failed for client metadata URL ${clientMetadataUrl.hostname}`,
         level: 'info',
         logger: 'oauth',
-        error,
+        data: error,
       });
       return Err({
         error: 'invalid_request',
@@ -310,7 +310,7 @@ async function getClientFromMetadataDoc(
       message: `Failed to fetch client metadata from ${originalUrl}`,
       level: 'error',
       logger: 'oauth',
-      error,
+      data: error,
     });
     return Err({
       error: 'invalid_request',

--- a/src/server/oauth/callback.ts
+++ b/src/server/oauth/callback.ts
@@ -181,7 +181,7 @@ export function callback(
         message: 'OAuth callback error',
         level: 'error',
         logger: 'oauth',
-        error: error,
+        data: error,
       });
       res.status(500).json({
         error: 'server_error',
@@ -236,7 +236,7 @@ async function exchangeAuthorizationCode({
       message: 'Failed to exchange authorization code',
       level: 'error',
       logger: 'oauth',
-      error: error,
+      data: error,
     });
     return Err('Failed to exchange authorization code');
   }

--- a/src/server/oauth/provider.ts
+++ b/src/server/oauth/provider.ts
@@ -102,7 +102,7 @@ export class EmbeddedOAuthProvider extends OAuthProvider {
           message: 'Failed to read JWE private key file',
           level: 'error',
           logger: 'oauth',
-          error: error,
+          data: error,
         });
         throw new Error('Failed to read private key file');
       }
@@ -119,7 +119,7 @@ export class EmbeddedOAuthProvider extends OAuthProvider {
         message: 'Failed to create JWE private key',
         level: 'error',
         logger: 'oauth',
-        error,
+        data: error,
       });
       throw new Error('Failed to create private key');
     }

--- a/src/server/oauth/revoke.ts
+++ b/src/server/oauth/revoke.ts
@@ -154,7 +154,7 @@ async function tryRevokeAccessToken(
           message: 'Best-effort Tableau signout failed during token revocation',
           level: 'error',
           logger: 'oauth',
-          error,
+          data: error,
         });
       }
     }

--- a/src/server/oauth/token.ts
+++ b/src/server/oauth/token.ts
@@ -281,7 +281,7 @@ export function token(
         }
       }
     } catch (error) {
-      log({ message: 'Token endpoint error', level: 'error', logger: 'oauth', error: error });
+      log({ message: 'Token endpoint error', level: 'error', logger: 'oauth', data: error });
       res.status(500).json({
         error: 'server_error',
         error_description: 'Internal server error',
@@ -378,7 +378,7 @@ async function exchangeRefreshToken(
       message: 'Failed to exchange refresh token',
       level: 'error',
       logger: 'oauth',
-      error,
+      data: error,
     });
     return Err('Failed to exchange refresh token');
   }

--- a/src/telemetry/init.ts
+++ b/src/telemetry/init.ts
@@ -101,7 +101,7 @@ export function initializeTelemetry(): TelemetryProvider {
       message: 'Failed to initialize telemetry provider',
       level: 'error',
       logger: 'telemetry',
-      error,
+      data: error,
     });
     log({ message: 'Falling back to NoOp telemetry provider', level: 'info', logger: 'telemetry' });
 

--- a/src/telemetry/productTelemetry/telemetryForwarder.ts
+++ b/src/telemetry/productTelemetry/telemetryForwarder.ts
@@ -101,7 +101,7 @@ async function sendTelemetryRequest(req: Request): Promise<void> {
       message: 'Telemetry request failed',
       level: 'error',
       logger: 'telemetry',
-      error,
+      data: error,
     });
   }
 }

--- a/src/tools/desktop/tool.ts
+++ b/src/tools/desktop/tool.ts
@@ -61,7 +61,7 @@ export class DesktopTool<Args extends ZodRawShape | undefined = undefined> exten
         message: 'Tool execution failed',
         level: 'error',
         logger: 'tool',
-        error,
+        data: error,
       });
       toolResult = getErrorResult(requestId, error);
       return toolResult;

--- a/src/tools/web/resourceAccessChecker.ts
+++ b/src/tools/web/resourceAccessChecker.ts
@@ -193,7 +193,7 @@ class ResourceAccessChecker {
           message: `Resource access check failed for datasource ${datasourceLuid}`,
           level: 'error',
           logger: 'resource-access',
-          error,
+          data: error,
         });
         return {
           allowed: false,
@@ -225,7 +225,7 @@ class ResourceAccessChecker {
           message: `Resource access check failed for datasource ${datasourceLuid} tags`,
           level: 'error',
           logger: 'resource-access',
-          error,
+          data: error,
         });
         return {
           allowed: false,
@@ -291,7 +291,7 @@ class ResourceAccessChecker {
           message: `Resource access check failed for workbook ${workbookId}`,
           level: 'error',
           logger: 'resource-access',
-          error,
+          data: error,
         });
         return {
           allowed: false,
@@ -323,7 +323,7 @@ class ResourceAccessChecker {
           message: `Resource access check failed for workbook ${workbookId} tags`,
           level: 'error',
           logger: 'resource-access',
-          error,
+          data: error,
         });
         return {
           allowed: false,
@@ -379,7 +379,7 @@ class ResourceAccessChecker {
           message: `Resource access check failed for view ${viewId} workbook`,
           level: 'error',
           logger: 'resource-access',
-          error,
+          data: error,
         });
         return {
           allowed: false,
@@ -411,7 +411,7 @@ class ResourceAccessChecker {
           message: `Resource access check failed for view ${viewId} project`,
           level: 'error',
           logger: 'resource-access',
-          error,
+          data: error,
         });
         return {
           allowed: false,
@@ -443,7 +443,7 @@ class ResourceAccessChecker {
           message: `Resource access check failed for view ${viewId} tags`,
           level: 'error',
           logger: 'resource-access',
-          error,
+          data: error,
         });
         return {
           allowed: false,
@@ -491,7 +491,7 @@ class ResourceAccessChecker {
         message: `Resource access check failed for custom view ${customViewId}`,
         level: 'error',
         logger: 'resource-access',
-        error,
+        data: error,
       });
       return {
         allowed: false,

--- a/src/tools/web/tool.ts
+++ b/src/tools/web/tool.ts
@@ -154,7 +154,7 @@ export class WebTool<Args extends ZodRawShape | undefined = undefined> extends T
         message: 'Tool execution failed',
         level: 'error',
         logger: 'tool',
-        error,
+        data: error,
       });
       toolResult = getErrorResult(requestId, error);
       return toolResult;

--- a/types/process-env.d.ts
+++ b/types/process-env.d.ts
@@ -23,6 +23,7 @@ export interface ProcessEnvEx {
   JWT_ADDITIONAL_PAYLOAD: string | undefined;
   DATASOURCE_CREDENTIALS: string | undefined;
   DEFAULT_NOTIFICATION_LEVEL: string | undefined;
+  LOG_LEVEL: string | undefined;
   DISABLE_LOG_MASKING: string | undefined;
   INCLUDE_TOOLS: string | undefined;
   EXCLUDE_TOOLS: string | undefined;


### PR DESCRIPTION
While I was working on #340 , it became apparent that logging data for non-error scenarios was going to be necessary. These changes:

1. Rename `error` to `data` in `LogEntry`
2. Remove `data` from the serialized message string since it will be logged by itself
3. Add some error handling for data that cannot be stringified