### PR TITLE
@W-22373417: Remove common config duplication in desktop Config class

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "2.2.2",
+      "version": "2.2.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/src/config.desktop.test.ts
+++ b/src/config.desktop.test.ts
@@ -1,0 +1,19 @@
+import { Config } from './config.desktop.js';
+
+describe('DesktopConfig', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.unstubAllEnvs();
+    vi.stubEnv('TABLEAU_MCP_TEST', 'true');
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('should throw error when TRANSPORT is not stdio', () => {
+    vi.stubEnv('TRANSPORT', 'http');
+
+    expect(() => new Config()).toThrow('TRANSPORT must be "stdio" for Tableau Desktop authoring');
+  });
+});

--- a/src/config.desktop.ts
+++ b/src/config.desktop.ts
@@ -1,26 +1,12 @@
-import { join } from 'path';
+import { BaseConfig } from './config.shared.js';
 
-import { removeClaudeMcpBundleUserConfigTemplates } from './config.shared.js';
-import { LoggerType, parseLoggerTypes } from './logging/logger.js';
-
-export class Config {
-  transport: 'stdio';
-  defaultLogLevel: string;
-  loggers: Set<LoggerType>;
-  fileLoggerDirectory: string;
-
+export class Config extends BaseConfig {
   constructor() {
-    const cleansedVars = removeClaudeMcpBundleUserConfigTemplates(process.env);
-    const {
-      DEFAULT_LOG_LEVEL: defaultLogLevel,
-      ENABLED_LOGGERS: logging,
-      FILE_LOGGER_DIRECTORY: fileLoggerDirectory,
-    } = cleansedVars;
+    super();
 
-    this.transport = 'stdio';
-    this.defaultLogLevel = defaultLogLevel ?? 'debug';
-    this.loggers = parseLoggerTypes(logging);
-    this.fileLoggerDirectory = fileLoggerDirectory || join(__dirname, 'logs');
+    if (this.transport !== 'stdio') {
+      throw new Error('TRANSPORT must be "stdio" for Tableau Desktop authoring');
+    }
   }
 }
 

--- a/src/config.shared.ts
+++ b/src/config.shared.ts
@@ -1,3 +1,44 @@
+import { join } from 'path';
+
+import { parseLogLevel } from './logging/logger';
+import { LoggerType, parseLoggerTypes } from './logging/loggerType';
+import { LogLevel } from './logging/types';
+import { isTransport, TransportName } from './transports';
+import { milliseconds } from './utils/milliseconds';
+import { parseNumber } from './utils/parseNumber';
+
+export class BaseConfig {
+  transport: TransportName;
+  defaultNotificationLevel: string;
+  logLevel: LogLevel;
+  loggers: Set<LoggerType>;
+  fileLoggerDirectory: string;
+  maxRequestTimeoutMs: number;
+
+  constructor() {
+    const cleansedVars = removeClaudeMcpBundleUserConfigTemplates(process.env);
+    const {
+      TRANSPORT: transport,
+      DEFAULT_NOTIFICATION_LEVEL: defaultNotificationLevel,
+      LOG_LEVEL: logLevel,
+      ENABLED_LOGGERS: logging,
+      FILE_LOGGER_DIRECTORY: fileLoggerDirectory,
+      MAX_REQUEST_TIMEOUT_MS: maxRequestTimeoutMs,
+    } = cleansedVars;
+
+    this.transport = isTransport(transport) ? transport : 'stdio';
+    this.defaultNotificationLevel = defaultNotificationLevel ?? 'debug';
+    this.logLevel = parseLogLevel(logLevel);
+    this.loggers = parseLoggerTypes(logging);
+    this.fileLoggerDirectory = fileLoggerDirectory || join(__dirname, 'logs');
+    this.maxRequestTimeoutMs = parseNumber(maxRequestTimeoutMs, {
+      defaultValue: milliseconds.fromMinutes(10),
+      minValue: 5000,
+      maxValue: milliseconds.fromHours(1),
+    });
+  }
+}
+
 // When the user does not provide a site name in the Claude MCP Bundle configuration,
 // Claude doesn't replace its value and sets the site name to "${user_config.site_name}".
 export function removeClaudeMcpBundleUserConfigTemplates(
@@ -12,3 +53,5 @@ export function removeClaudeMcpBundleUserConfigTemplates(
     return acc;
   }, {});
 }
+
+export const getBaseConfig = (): BaseConfig => new BaseConfig();

--- a/src/config.shared.ts
+++ b/src/config.shared.ts
@@ -1,11 +1,11 @@
 import { join } from 'path';
 
-import { parseLogLevel } from './logging/logger';
-import { LoggerType, parseLoggerTypes } from './logging/loggerType';
-import { LogLevel } from './logging/types';
-import { isTransport, TransportName } from './transports';
-import { milliseconds } from './utils/milliseconds';
-import { parseNumber } from './utils/parseNumber';
+import { parseLogLevel } from './logging/logger.js';
+import { LoggerType, parseLoggerTypes } from './logging/loggerType.js';
+import { LogLevel } from './logging/types.js';
+import { isTransport, TransportName } from './transports.js';
+import { milliseconds } from './utils/milliseconds.js';
+import { parseNumber } from './utils/parseNumber.js';
 
 export class BaseConfig {
   transport: TransportName;

--- a/src/config.shared.ts
+++ b/src/config.shared.ts
@@ -4,8 +4,11 @@ import { parseLogLevel } from './logging/logger.js';
 import { LoggerType, parseLoggerTypes } from './logging/loggerType.js';
 import { LogLevel } from './logging/types.js';
 import { isTransport, TransportName } from './transports.js';
+import { getDirname } from './utils/getDirname.js';
 import { milliseconds } from './utils/milliseconds.js';
 import { parseNumber } from './utils/parseNumber.js';
+
+const __dirname = getDirname();
 
 export class BaseConfig {
   transport: TransportName;

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,10 +1,8 @@
-import { exportedForTesting } from './config.js';
+import { Config } from './config.js';
 import { stubDefaultEnvVars } from './testShared.js';
 import { milliseconds } from './utils/milliseconds.js';
 
 describe('Config', () => {
-  const { Config } = exportedForTesting;
-
   beforeEach(() => {
     vi.resetModules();
     vi.unstubAllEnvs();

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,18 +1,12 @@
 import { CorsOptions } from 'cors';
 import { existsSync, readFileSync } from 'fs';
-import { join } from 'path';
 
-import { removeClaudeMcpBundleUserConfigTemplates } from './config.shared.js';
-import { LoggerType, parseLoggerTypes, parseLogLevel } from './logging/logger.js';
-import type { LogLevel } from './logging/types.js';
+import { BaseConfig, removeClaudeMcpBundleUserConfigTemplates } from './config.shared.js';
 import { isTelemetryProvider, providerConfigSchema, TelemetryConfig } from './telemetry/types.js';
 import { isTransport, TransportName } from './transports.js';
-import { getDirname } from './utils/getDirname.js';
 import invariant from './utils/invariant.js';
 import { milliseconds } from './utils/milliseconds.js';
 import { parseNumber } from './utils/parseNumber.js';
-
-const __dirname = getDirname();
 
 const authTypes = ['pat', 'uat', 'direct-trust', 'oauth'] as const;
 type AuthType = (typeof authTypes)[number];
@@ -21,7 +15,7 @@ function isAuthType(auth: unknown): auth is AuthType {
   return authTypes.some((type) => type === auth);
 }
 
-export class Config {
+export class Config extends BaseConfig {
   auth: AuthType;
   server: string;
   transport: TransportName;
@@ -43,13 +37,8 @@ export class Config {
   uatKeyId: string;
   jwtAdditionalPayload: string;
   datasourceCredentials: string;
-  defaultNotificationLevel: string;
-  logLevel: LogLevel;
   disableLogMasking: boolean;
-  maxRequestTimeoutMs: number;
   disableSessionManagement: boolean;
-  loggers: Set<LoggerType>;
-  fileLoggerDirectory: string;
   tableauServerVersionCheckIntervalInHours: number;
   passthroughAuthUserSessionCheckIntervalInMinutes: number;
   mcpSiteSettingsCheckIntervalInMinutes: number;
@@ -82,6 +71,8 @@ export class Config {
   breakGlassDisableGlobally: boolean;
 
   constructor() {
+    super();
+
     const cleansedVars = removeClaudeMcpBundleUserConfigTemplates(process.env);
     const {
       AUTH: auth,
@@ -107,13 +98,8 @@ export class Config {
       UAT_KEY_ID: uatKeyId,
       JWT_ADDITIONAL_PAYLOAD: jwtAdditionalPayload,
       DATASOURCE_CREDENTIALS: datasourceCredentials,
-      DEFAULT_NOTIFICATION_LEVEL: defaultNotificationLevel,
-      LOG_LEVEL: logLevel,
       DISABLE_LOG_MASKING: disableLogMasking,
-      MAX_REQUEST_TIMEOUT_MS: maxRequestTimeoutMs,
       DISABLE_SESSION_MANAGEMENT: disableSessionManagement,
-      ENABLED_LOGGERS: logging,
-      FILE_LOGGER_DIRECTORY: fileLoggerDirectory,
       TABLEAU_SERVER_VERSION_CHECK_INTERVAL_IN_HOURS: tableauServerVersionCheckIntervalInHours,
       PASSTHROUGH_AUTH_USER_SESSION_CHECK_INTERVAL_IN_MINUTES:
         passthroughAuthUserSessionCheckIntervalInMinutes,
@@ -159,12 +145,8 @@ export class Config {
     });
     this.corsOriginConfig = getCorsOriginConfig(corsOriginConfig?.trim() ?? '');
     this.datasourceCredentials = datasourceCredentials ?? '';
-    this.defaultNotificationLevel = defaultNotificationLevel ?? 'debug';
-    this.logLevel = parseLogLevel(logLevel);
     this.disableLogMasking = disableLogMasking === 'true';
     this.disableSessionManagement = disableSessionManagement === 'true';
-    this.loggers = parseLoggerTypes(logging);
-    this.fileLoggerDirectory = fileLoggerDirectory || join(__dirname, 'logs');
 
     this.tableauServerVersionCheckIntervalInHours = parseNumber(
       tableauServerVersionCheckIntervalInHours,
@@ -335,12 +317,6 @@ export class Config {
       }
     }
 
-    this.maxRequestTimeoutMs = parseNumber(maxRequestTimeoutMs, {
-      defaultValue: milliseconds.fromMinutes(10),
-      minValue: 5000,
-      maxValue: milliseconds.fromHours(1),
-    });
-
     if (this.auth === 'pat') {
       invariant(patName, 'The environment variable PAT_NAME is not set');
       invariant(patValue, 'The environment variable PAT_VALUE is not set');
@@ -452,7 +428,3 @@ function getCorsOriginConfig(corsOriginConfig: string): CorsOptions['origin'] {
 }
 
 export const getConfig = (): Config => new Config();
-
-export const exportedForTesting = {
-  Config,
-};

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,7 +3,7 @@ import { existsSync, readFileSync } from 'fs';
 
 import { BaseConfig, removeClaudeMcpBundleUserConfigTemplates } from './config.shared.js';
 import { isTelemetryProvider, providerConfigSchema, TelemetryConfig } from './telemetry/types.js';
-import { isTransport, TransportName } from './transports.js';
+import { isTransport } from './transports.js';
 import invariant from './utils/invariant.js';
 import { milliseconds } from './utils/milliseconds.js';
 import { parseNumber } from './utils/parseNumber.js';
@@ -18,7 +18,6 @@ function isAuthType(auth: unknown): auth is AuthType {
 export class Config extends BaseConfig {
   auth: AuthType;
   server: string;
-  transport: TransportName;
   sslKey: string;
   sslCert: string;
   httpPort: number;

--- a/src/index.desktop.ts
+++ b/src/index.desktop.ts
@@ -12,7 +12,9 @@ async function startServer(): Promise<void> {
   dotenv.config();
   const config = getDesktopConfig();
 
-  const logLevel = isNotificationLevel(config.defaultLogLevel) ? config.defaultLogLevel : 'debug';
+  const notificationLevel = isNotificationLevel(config.defaultNotificationLevel)
+    ? config.defaultNotificationLevel
+    : 'debug';
   if (config.loggers.has('fileLogger')) {
     setFileLogger(new FileLogger({ logDirectory: config.fileLoggerDirectory }));
   }
@@ -31,7 +33,7 @@ async function startServer(): Promise<void> {
   const transport = new StdioServerTransport();
   await server.mcpServer.connect(transport);
 
-  setNotificationLevel(server.mcpServer, logLevel);
+  setNotificationLevel(server.mcpServer, notificationLevel);
   notifier.info(server.mcpServer, `${server.name} v${server.version} running on stdio`);
 }
 

--- a/src/logging/logger.test.ts
+++ b/src/logging/logger.test.ts
@@ -1,7 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { getFileLogger } from './fileLogger.js';
-import { log, parseLoggerTypes, parseLogLevel, shouldLog } from './logger.js';
+import { log, parseLogLevel, shouldLog } from './logger.js';
+import { parseLoggerTypes } from './loggerType.js';
 
 vi.mock('./fileLogger.js', () => ({
   getFileLogger: vi.fn(),

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -1,11 +1,7 @@
-import { getConfig } from '../config.js';
+import { getBaseConfig } from '../config.shared.js';
 import { getExceptionMessage } from '../utils/getExceptionMessage.js';
 import { getFileLogger } from './fileLogger.js';
 import { LogEntry, LogLevel, logLevelSeverity } from './types.js';
-
-export const loggerTypes = ['fileLogger', 'appLogger'] as const;
-export type LoggerType = (typeof loggerTypes)[number];
-const validLoggerTypes = new Set(loggerTypes);
 
 export function shouldLog(entryLevel: LogLevel, minLevel: LogLevel): boolean {
   return logLevelSeverity[entryLevel] >= logLevelSeverity[minLevel];
@@ -23,20 +19,8 @@ export function parseLogLevel(value: string | undefined): LogLevel {
   return 'info';
 }
 
-export function parseLoggerTypes(value: string | undefined): Set<LoggerType> {
-  if (!value) {
-    return new Set<LoggerType>(['appLogger']);
-  }
-  return new Set(
-    value
-      .split(',')
-      .map((s) => s.trim())
-      .filter((s): s is LoggerType => validLoggerTypes.has(s as LoggerType)),
-  );
-}
-
 export function log(entry: LogEntry): void {
-  const config = getConfig();
+  const config = getBaseConfig();
   if (!shouldLog(entry.level, config.logLevel)) {
     return;
   }

--- a/src/logging/loggerType.ts
+++ b/src/logging/loggerType.ts
@@ -1,0 +1,15 @@
+export const loggerTypes = ['fileLogger', 'appLogger'] as const;
+export type LoggerType = (typeof loggerTypes)[number];
+const validLoggerTypes = new Set(loggerTypes);
+
+export function parseLoggerTypes(value: string | undefined): Set<LoggerType> {
+  if (!value) {
+    return new Set<LoggerType>(['appLogger']);
+  }
+  return new Set(
+    value
+      .split(',')
+      .map((s) => s.trim())
+      .filter((s): s is LoggerType => validLoggerTypes.has(s as LoggerType)),
+  );
+}

--- a/src/overridableConfig.ts
+++ b/src/overridableConfig.ts
@@ -1,4 +1,4 @@
-import { ProcessEnvEx } from '../types/process-env.js';
+import { ProcessEnvWeb } from '../types/process-env.js';
 import { removeClaudeMcpBundleUserConfigTemplates } from './config.shared.js';
 import {
   isWebToolGroupName,
@@ -19,7 +19,7 @@ export const overridableVariables = [
   'MAX_RESULT_LIMITS',
   'DISABLE_QUERY_DATASOURCE_VALIDATION_REQUESTS',
   'DISABLE_METADATA_API_REQUESTS',
-] as const satisfies ReadonlyArray<keyof ProcessEnvEx>;
+] as const satisfies ReadonlyArray<keyof ProcessEnvWeb>;
 
 export const requestOverridableVariables = overridableVariables.filter(
   (v) => v !== 'ALLOWED_REQUEST_OVERRIDES' && v !== 'INCLUDE_TOOLS' && v !== 'EXCLUDE_TOOLS',

--- a/src/scripts/createClaudeMcpBundleManifest.ts
+++ b/src/scripts/createClaudeMcpBundleManifest.ts
@@ -8,7 +8,7 @@ import { fileURLToPath } from 'url';
 import { z } from 'zod';
 
 import packageJson from '../../package.json';
-import { ProcessEnvEx } from '../../types/process-env.js';
+import { ProcessEnvWeb } from '../../types/process-env.js';
 import { webToolNames } from '../tools/web/toolName.js';
 
 // @ts-expect-error - import.meta is not allowed in CommonJS output, this script is run with tsx as ESM
@@ -19,7 +19,7 @@ type McpbUserConfigurationOption = z.infer<typeof McpbUserConfigurationOptionSch
 type McpbManifest = z.infer<typeof McpbManifestSchema>;
 
 type EnvVars = {
-  [TKey in keyof ProcessEnvEx]: McpbUserConfigurationOption & {
+  [TKey in keyof ProcessEnvWeb]: McpbUserConfigurationOption & {
     includeInUserConfig: boolean;
   };
 };

--- a/tests/testEnv.ts
+++ b/tests/testEnv.ts
@@ -1,10 +1,10 @@
 import dotenv from 'dotenv';
 import { existsSync } from 'fs';
 
-import { ProcessEnvEx } from '../types/process-env.js';
+import { ProcessEnvWeb } from '../types/process-env.js';
 import { Datasource, getDatasource, getWorkbook, Workbook } from './constants.js';
 
-type EnvValues = Record<keyof ProcessEnvEx, string>;
+type EnvValues = Record<keyof ProcessEnvWeb, string>;
 
 export function setEnv(): void {
   if (existsSync('.env')) {
@@ -23,13 +23,13 @@ export function resetEnv(): void {
   dotenv.config({ path: 'tests/.env.reset', override: true });
 }
 
-export function getEnv(envKeys: Array<keyof ProcessEnvEx>): EnvValues {
+export function getEnv(envKeys: Array<keyof ProcessEnvWeb>): EnvValues {
   return envKeys.reduce(
     (acc, key) => {
       acc[key] = process.env[key] ?? '';
       return acc;
     },
-    {} as Record<keyof ProcessEnvEx, string>,
+    {} as Record<keyof ProcessEnvWeb, string>,
   );
 }
 

--- a/types/process-env.d.ts
+++ b/types/process-env.d.ts
@@ -1,6 +1,14 @@
-export interface ProcessEnvEx {
-  AUTH: string | undefined;
+interface ProcessEnvBase {
   TRANSPORT: string | undefined;
+  DEFAULT_NOTIFICATION_LEVEL: string | undefined;
+  LOG_LEVEL: string | undefined;
+  ENABLED_LOGGERS: string | undefined;
+  FILE_LOGGER_DIRECTORY: string | undefined;
+  MAX_REQUEST_TIMEOUT_MS: string | undefined;
+}
+
+export interface ProcessEnvWeb extends ProcessEnvBase {
+  AUTH: string | undefined;
   SSL_KEY: string | undefined;
   SSL_CERT: string | undefined;
   HTTP_PORT_ENV_VAR_NAME: string | undefined;
@@ -22,19 +30,15 @@ export interface ProcessEnvEx {
   UAT_KEY_ID: string | undefined;
   JWT_ADDITIONAL_PAYLOAD: string | undefined;
   DATASOURCE_CREDENTIALS: string | undefined;
-  DEFAULT_NOTIFICATION_LEVEL: string | undefined;
   LOG_LEVEL: string | undefined;
   DISABLE_LOG_MASKING: string | undefined;
   INCLUDE_TOOLS: string | undefined;
   EXCLUDE_TOOLS: string | undefined;
-  MAX_REQUEST_TIMEOUT_MS: string | undefined;
   MAX_RESULT_LIMIT: string | undefined;
   MAX_RESULT_LIMITS: string | undefined;
   DISABLE_QUERY_DATASOURCE_VALIDATION_REQUESTS: string | undefined;
   DISABLE_METADATA_API_REQUESTS: string | undefined;
   DISABLE_SESSION_MANAGEMENT: string | undefined;
-  ENABLED_LOGGERS: string | undefined;
-  FILE_LOGGER_DIRECTORY: string | undefined;
   INCLUDE_PROJECT_IDS: string | undefined;
   INCLUDE_DATASOURCE_IDS: string | undefined;
   INCLUDE_WORKBOOK_IDS: string | undefined;
@@ -71,9 +75,12 @@ export interface ProcessEnvEx {
   BREAK_GLASS_DISABLE_GLOBALLY: string | undefined;
 }
 
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type -- no-empty-object-type rule will complain once we start adding members in the next PR
+export interface ProcessEnvDesktop extends ProcessEnvBase {}
+
 declare global {
   namespace NodeJS {
-    interface ProcessEnv extends ProcessEnvEx {
+    interface ProcessEnv extends ProcessEnvWeb, ProcessEnvDesktop {
       [key: string]: string | undefined;
     }
   }

--- a/types/process-env.d.ts
+++ b/types/process-env.d.ts
@@ -75,12 +75,9 @@ export interface ProcessEnvWeb extends ProcessEnvBase {
   BREAK_GLASS_DISABLE_GLOBALLY: string | undefined;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type -- no-empty-object-type rule will complain once we start adding members in the next PR
-export interface ProcessEnvDesktop extends ProcessEnvBase {}
-
 declare global {
   namespace NodeJS {
-    interface ProcessEnv extends ProcessEnvWeb, ProcessEnvDesktop {
+    interface ProcessEnv extends ProcessEnvWeb {
       [key: string]: string | undefined;
     }
   }


### PR DESCRIPTION
While working on #340, I realized there was one more followup I wanted to do from the previous refactoring to enable the desktop variant. These changes remove the code duplication in the desktop Config class by introducing a shared base Config class that includes common config entries like logging and transport.