### PR TITLE
@W-22550685: Redact or truncate large binary/image payloads from MCP notifications

### DIFF
--- a/docs/docs/configuration/mcp-config/env-vars.md
+++ b/docs/docs/configuration/mcp-config/env-vars.md
@@ -146,6 +146,19 @@ Disable masking of credentials in MCP client notifications and server logs. For 
 
 <hr />
 
+## `NOTIFICATION_PAYLOAD_MAX_BYTES`
+
+The maximum string length included in MCP client notifications and server logs before large payloads
+are redacted or truncated.
+
+- Default: `8192`
+- Must be a positive number.
+
+Binary payloads, large SVG/XML payloads, and large base64 image payloads are redacted. Other strings
+larger than this value are truncated.
+
+<hr />
+
 ## `DATASOURCE_CREDENTIALS`
 
 A JSON string that includes usernames and passwords for any datasources that require them.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "2.2.4",
+      "version": "2.2.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/src/config.shared.test.ts
+++ b/src/config.shared.test.ts
@@ -1,0 +1,25 @@
+import { BaseConfig } from './config.shared.js';
+
+describe('BaseConfig', () => {
+  beforeEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('should default notification payload max bytes to 8192', () => {
+    const config = new BaseConfig();
+
+    expect(config.notificationPayloadMaxBytes).toBe(8192);
+  });
+
+  it('should set notification payload max bytes when specified', () => {
+    vi.stubEnv('NOTIFICATION_PAYLOAD_MAX_BYTES', '4096');
+
+    const config = new BaseConfig();
+
+    expect(config.notificationPayloadMaxBytes).toBe(4096);
+  });
+});

--- a/src/config.shared.ts
+++ b/src/config.shared.ts
@@ -17,6 +17,7 @@ export class BaseConfig {
   loggers: Set<LoggerType>;
   fileLoggerDirectory: string;
   maxRequestTimeoutMs: number;
+  notificationPayloadMaxBytes: number;
 
   constructor() {
     const cleansedVars = removeClaudeMcpBundleUserConfigTemplates(process.env);
@@ -27,6 +28,7 @@ export class BaseConfig {
       ENABLED_LOGGERS: logging,
       FILE_LOGGER_DIRECTORY: fileLoggerDirectory,
       MAX_REQUEST_TIMEOUT_MS: maxRequestTimeoutMs,
+      NOTIFICATION_PAYLOAD_MAX_BYTES: notificationPayloadMaxBytes,
     } = cleansedVars;
 
     this.transport = isTransport(transport) ? transport : 'stdio';
@@ -38,6 +40,10 @@ export class BaseConfig {
       defaultValue: milliseconds.fromMinutes(10),
       minValue: 5000,
       maxValue: milliseconds.fromHours(1),
+    });
+    this.notificationPayloadMaxBytes = parseNumber(notificationPayloadMaxBytes, {
+      defaultValue: 8192,
+      minValue: 1,
     });
   }
 }

--- a/src/logging/notification.test.ts
+++ b/src/logging/notification.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { WebMcpServer } from '../server.web.js';
+import { getFileLogger } from './fileLogger.js';
 import {
   getNotificationMessageForTool,
   isNotificationLevel,
@@ -9,9 +10,20 @@ import {
   shouldNotifyWhenLevelIsAtLeast,
 } from './notification.js';
 
+vi.mock('./fileLogger.js', () => ({
+  getFileLogger: vi.fn(),
+}));
+
+type NotificationPayloadWithData = {
+  params: {
+    data: string;
+  };
+};
+
 describe('notification', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(getFileLogger).mockReturnValue(undefined);
   });
 
   describe('isLoggingLevel', () => {
@@ -164,6 +176,66 @@ describe('notification', () => {
           relatedRequestId: undefined,
         },
       );
+    });
+
+    it('should use sanitized messages for file logging and MCP notifications', async () => {
+      const server = new WebMcpServer();
+      const fileLogger = { log: vi.fn() };
+      vi.mocked(getFileLogger).mockReturnValue(fileLogger as never);
+      setNotificationLevel(server.mcpServer, 'info', { silent: true });
+      const message = {
+        type: 'response',
+        data: Buffer.from([137, 80, 78, 71]),
+      } as const;
+
+      await notifier.info(server.mcpServer, message, { notifier: 'rest-api' });
+
+      expect(fileLogger.log).toHaveBeenCalledWith({
+        message: JSON.stringify({
+          type: 'response',
+          data: {
+            redacted: true,
+            reason: 'binary-payload',
+            message: '[redacted binary payload]',
+            kind: 'Buffer',
+            byteLength: 4,
+          },
+        }),
+        level: 'info',
+        logger: 'rest-api',
+      });
+
+      const notificationPayload = vi.mocked(server.mcpServer.server.notification).mock
+        .calls[0][0] as NotificationPayloadWithData;
+      const notificationData = JSON.parse(notificationPayload.params.data);
+      expect(notificationData.message).toEqual({
+        type: 'response',
+        data: {
+          redacted: true,
+          reason: 'binary-payload',
+          message: '[redacted binary payload]',
+          kind: 'Buffer',
+          byteLength: 4,
+        },
+      });
+      expect(notificationPayload.params.data).not.toContain('"0":137');
+    });
+
+    it('should preserve small normal notification messages', async () => {
+      const server = new WebMcpServer();
+      setNotificationLevel(server.mcpServer, 'info', { silent: true });
+      const message = {
+        type: 'response',
+        status: 200,
+        data: { message: 'ok' },
+      } as const;
+
+      await notifier.info(server.mcpServer, message, { notifier: 'rest-api' });
+
+      const notificationPayload = vi.mocked(server.mcpServer.server.notification).mock
+        .calls[0][0] as NotificationPayloadWithData;
+      const notificationData = JSON.parse(notificationPayload.params.data);
+      expect(notificationData.message).toEqual(message);
     });
   });
 });

--- a/src/logging/notification.test.ts
+++ b/src/logging/notification.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { WebMcpServer } from '../server.web.js';
 import { getFileLogger } from './fileLogger.js';
@@ -24,6 +24,10 @@ describe('notification', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(getFileLogger).mockReturnValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
   });
 
   describe('isLoggingLevel', () => {
@@ -236,6 +240,36 @@ describe('notification', () => {
         .calls[0][0] as NotificationPayloadWithData;
       const notificationData = JSON.parse(notificationPayload.params.data);
       expect(notificationData.message).toEqual(message);
+    });
+
+    it('should use the configured notification payload max bytes', async () => {
+      vi.stubEnv('NOTIFICATION_PAYLOAD_MAX_BYTES', '12');
+      const server = new WebMcpServer();
+      setNotificationLevel(server.mcpServer, 'info', { silent: true });
+
+      await notifier.info(
+        server.mcpServer,
+        {
+          type: 'response',
+          data: 'notification payload',
+        },
+        { notifier: 'rest-api' },
+      );
+
+      const notificationPayload = vi.mocked(server.mcpServer.server.notification).mock
+        .calls[0][0] as NotificationPayloadWithData;
+      const notificationData = JSON.parse(notificationPayload.params.data);
+      expect(notificationData.message).toEqual({
+        type: 'response',
+        data: {
+          truncated: true,
+          reason: 'oversized-string',
+          message: '[truncated oversized string]',
+          value: 'notification',
+          originalLength: 20,
+          threshold: 12,
+        },
+      });
     });
   });
 });

--- a/src/logging/notification.ts
+++ b/src/logging/notification.ts
@@ -3,6 +3,7 @@ import { LoggingLevel, RequestId } from '@modelcontextprotocol/sdk/types.js';
 
 import { ToolName } from '../tools/toolName.js';
 import { getFileLogger } from './fileLogger.js';
+import { sanitizeForNotification } from './sanitizeNotification.js';
 import { orderedLogLevels } from './types.js';
 
 type NotificationName = 'rest-api' | (string & {});
@@ -87,8 +88,11 @@ function getSendNotificationMessageFn(level: LoggingLevel) {
     message: string | NotificationMessage,
     { notifier, requestId }: NotificationMethodOptions = { notifier: 'tableau-mcp' },
   ) => {
+    const sanitizedMessage = sanitizeForNotification(message);
     const fileLogMessage =
-      typeof message === 'string' ? message : safeStringifyNotificationMessage(message);
+      typeof sanitizedMessage === 'string'
+        ? sanitizedMessage
+        : safeStringifyNotificationMessage(sanitizedMessage);
     getFileLogger()?.log({
       message: fileLogMessage,
       level,
@@ -112,7 +116,7 @@ function getSendNotificationMessageFn(level: LoggingLevel) {
               timestamp: new Date().toISOString(),
               currentNotificationLevel,
               notifier,
-              message,
+              message: sanitizedMessage,
             },
             null,
             2,
@@ -126,7 +130,7 @@ function getSendNotificationMessageFn(level: LoggingLevel) {
   };
 }
 
-function safeStringifyNotificationMessage(message: NotificationMessage): string {
+function safeStringifyNotificationMessage(message: unknown): string {
   try {
     return JSON.stringify(message);
   } catch {

--- a/src/logging/notification.ts
+++ b/src/logging/notification.ts
@@ -1,6 +1,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { LoggingLevel, RequestId } from '@modelcontextprotocol/sdk/types.js';
 
+import { getBaseConfig } from '../config.shared.js';
 import { ToolName } from '../tools/toolName.js';
 import { getFileLogger } from './fileLogger.js';
 import { sanitizeForNotification } from './sanitizeNotification.js';
@@ -88,7 +89,9 @@ function getSendNotificationMessageFn(level: LoggingLevel) {
     message: string | NotificationMessage,
     { notifier, requestId }: NotificationMethodOptions = { notifier: 'tableau-mcp' },
   ) => {
-    const sanitizedMessage = sanitizeForNotification(message);
+    const sanitizedMessage = sanitizeForNotification(message, {
+      maxStringLength: getBaseConfig().notificationPayloadMaxBytes,
+    });
     const fileLogMessage =
       typeof sanitizedMessage === 'string'
         ? sanitizedMessage

--- a/src/logging/sanitizeNotification.test.ts
+++ b/src/logging/sanitizeNotification.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from 'vitest';
+
+import { sanitizeForNotification } from './sanitizeNotification.js';
+
+describe('sanitizeForNotification', () => {
+  it('redacts Buffer payloads before JSON serialization can expand byte indexes', () => {
+    const sanitized = sanitizeForNotification({
+      type: 'response',
+      data: Buffer.from([137, 80, 78, 71]),
+    });
+
+    expect(sanitized).toEqual({
+      type: 'response',
+      data: {
+        redacted: true,
+        reason: 'binary-payload',
+        message: '[redacted binary payload]',
+        kind: 'Buffer',
+        byteLength: 4,
+      },
+    });
+    expect(JSON.stringify(sanitized)).not.toContain('"0":137');
+  });
+
+  it('redacts Uint8Array payloads before JSON serialization can expand byte indexes', () => {
+    const sanitized = sanitizeForNotification({
+      type: 'response',
+      data: new Uint8Array([1, 2, 3]),
+    });
+
+    expect(sanitized).toEqual({
+      type: 'response',
+      data: {
+        redacted: true,
+        reason: 'binary-payload',
+        message: '[redacted binary payload]',
+        kind: 'Uint8Array',
+        byteLength: 3,
+      },
+    });
+    expect(JSON.stringify(sanitized)).not.toContain('"0":1');
+  });
+
+  it('redacts large SVG strings', () => {
+    const svg = `<svg xmlns="http://www.w3.org/2000/svg">${'<rect />'.repeat(20)}</svg>`;
+
+    const sanitized = sanitizeForNotification(
+      { type: 'response', data: svg },
+      { maxStringLength: 32 },
+    );
+
+    expect(sanitized).toEqual({
+      type: 'response',
+      data: {
+        redacted: true,
+        reason: 'svg-xml-payload',
+        message: '[redacted large SVG/XML payload]',
+        mimeTypeGuess: 'image/svg+xml',
+        originalLength: svg.length,
+        threshold: 32,
+      },
+    });
+  });
+
+  it('redacts large base64 image strings', () => {
+    const pngBase64 = Buffer.concat([
+      Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+      Buffer.from('image-bytes'.repeat(20)),
+    ]).toString('base64');
+
+    const sanitized = sanitizeForNotification(
+      { type: 'response', data: pngBase64 },
+      { maxStringLength: 32 },
+    );
+
+    expect(sanitized).toEqual({
+      type: 'response',
+      data: {
+        redacted: true,
+        reason: 'base64-image-payload',
+        message: '[redacted large base64 image payload]',
+        mimeTypeGuess: 'image/png',
+        originalLength: pngBase64.length,
+        threshold: 32,
+      },
+    });
+  });
+
+  it('bounds ordinary oversized strings', () => {
+    const text = 'ordinary text '.repeat(20);
+
+    const sanitized = sanitizeForNotification(
+      { type: 'response', data: text },
+      { maxStringLength: 32 },
+    );
+
+    expect(sanitized).toEqual({
+      type: 'response',
+      data: {
+        truncated: true,
+        reason: 'oversized-string',
+        message: '[truncated oversized string]',
+        value: text.slice(0, 32),
+        originalLength: text.length,
+        threshold: 32,
+      },
+    });
+  });
+
+  it('leaves small normal notification messages unchanged', () => {
+    const message = {
+      type: 'response',
+      status: 200,
+      data: { message: 'ok' },
+    };
+
+    expect(sanitizeForNotification(message)).toEqual(message);
+  });
+
+  it('does not mutate original message objects', () => {
+    const message = {
+      type: 'response',
+      data: {
+        image: Buffer.from([1, 2, 3]),
+        text: 'ordinary text '.repeat(20),
+      },
+    };
+    const originalImage = message.data.image;
+    const originalText = message.data.text;
+
+    sanitizeForNotification(message, { maxStringLength: 32 });
+
+    expect(message.data.image).toBe(originalImage);
+    expect(message.data.text).toBe(originalText);
+  });
+});

--- a/src/logging/sanitizeNotification.ts
+++ b/src/logging/sanitizeNotification.ts
@@ -1,0 +1,141 @@
+const DEFAULT_MAX_STRING_LENGTH = 8192;
+const MAX_DEPTH = 8;
+
+type SanitizeOptions = {
+  maxStringLength?: number;
+};
+
+type BinaryLike = ArrayBuffer | ArrayBufferView;
+
+export function sanitizeForNotification(value: unknown, options: SanitizeOptions = {}): unknown {
+  return sanitizeValue(value, {
+    maxStringLength: options.maxStringLength ?? DEFAULT_MAX_STRING_LENGTH,
+    seen: new WeakSet<object>(),
+    depth: 0,
+  });
+}
+
+function sanitizeValue(
+  value: unknown,
+  context: { maxStringLength: number; seen: WeakSet<object>; depth: number },
+): unknown {
+  if (typeof value === 'string') {
+    return sanitizeString(value, context.maxStringLength);
+  }
+
+  if (isBinaryLike(value)) {
+    return getBinaryRedaction(value);
+  }
+
+  if (!value || typeof value !== 'object') {
+    return value;
+  }
+
+  if (context.seen.has(value)) {
+    return '[Circular notification value]';
+  }
+
+  if (context.depth >= MAX_DEPTH) {
+    return '[Notification value exceeds maximum depth]';
+  }
+
+  context.seen.add(value);
+
+  if (Array.isArray(value)) {
+    return value.map((item) => sanitizeValue(item, { ...context, depth: context.depth + 1 }));
+  }
+
+  const sanitized: Record<string, unknown> = {};
+  for (const [key, nestedValue] of Object.entries(value)) {
+    sanitized[key] = sanitizeValue(nestedValue, {
+      ...context,
+      depth: context.depth + 1,
+    });
+  }
+
+  return sanitized;
+}
+
+function sanitizeString(value: string, maxStringLength: number): unknown {
+  if (value.length <= maxStringLength) {
+    return value;
+  }
+
+  if (isSvgOrXml(value)) {
+    return {
+      redacted: true,
+      reason: 'svg-xml-payload',
+      message: '[redacted large SVG/XML payload]',
+      mimeTypeGuess: 'image/svg+xml',
+      originalLength: value.length,
+      threshold: maxStringLength,
+    };
+  }
+
+  const imageMimeType = getBase64ImageMimeType(value);
+  if (imageMimeType) {
+    return {
+      redacted: true,
+      reason: 'base64-image-payload',
+      message: '[redacted large base64 image payload]',
+      mimeTypeGuess: imageMimeType,
+      originalLength: value.length,
+      threshold: maxStringLength,
+    };
+  }
+
+  return {
+    truncated: true,
+    reason: 'oversized-string',
+    message: '[truncated oversized string]',
+    value: value.slice(0, maxStringLength),
+    originalLength: value.length,
+    threshold: maxStringLength,
+  };
+}
+
+function isBinaryLike(value: unknown): value is BinaryLike {
+  return value instanceof ArrayBuffer || ArrayBuffer.isView(value);
+}
+
+function getBinaryRedaction(value: BinaryLike): Record<string, unknown> {
+  return {
+    redacted: true,
+    reason: 'binary-payload',
+    message: '[redacted binary payload]',
+    kind: Buffer.isBuffer(value) ? 'Buffer' : value.constructor.name,
+    byteLength: value.byteLength,
+  };
+}
+
+function isSvgOrXml(value: string): boolean {
+  return /^\s*(<\?xml|<svg\b)/i.test(value);
+}
+
+function getBase64ImageMimeType(value: string): string | undefined {
+  if (!isBase64Like(value)) {
+    return undefined;
+  }
+
+  if (value.startsWith('iVBOR')) {
+    return 'image/png';
+  }
+
+  if (value.startsWith('/9j/')) {
+    return 'image/jpeg';
+  }
+
+  if (value.startsWith('R0lGOD')) {
+    return 'image/gif';
+  }
+
+  if (value.startsWith('UklGR')) {
+    return 'image/webp';
+  }
+
+  return undefined;
+}
+
+function isBase64Like(value: string): boolean {
+  return value.length % 4 === 0 && /^[A-Za-z0-9+/]+={0,2}$/.test(value);
+}


### PR DESCRIPTION
## Description

Redacts large notification payloads before they are written to file logs or emitted as MCP `notifications/message` events.

This adds a centralized, non-mutating notification sanitizer that handles binary/typed-array payloads, large SVG/XML image strings, large base64 image strings, and ordinary oversized strings. Tool results themselves are unchanged.

## Motivation and Context

Fixes #312.

Tools such as `get-view-image` can receive large PNG/SVG REST API responses. At debug notification levels, those REST responses were included in MCP notifications and file logs, causing clients to write huge binary/image payloads to log files.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## How Has This Been Tested?

Validated locally with:

- `npx tsc --noEmit`
- `npm run lint`
- `npm test`

Added unit coverage for:

- Buffer and Uint8Array payload redaction before JSON serialization expands byte-indexed objects
- Large SVG/XML payload redaction
- Large base64 image payload redaction
- Ordinary oversized string truncation
- Small normal notification messages remaining unchanged
- Original notification message objects not being mutated
- Sanitized messages being used for both file logging and MCP notification emission

## Related Issues

Fixes #312

## Checklist

- [x] I have updated the version in the package.json file by using `npm run version`. For example,
      use `npm run version:patch` for a patch version bump.
- [x] I have made any necessary changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have documented any breaking changes in the PR description. For example, renaming a config
      environment variable or changing its default value.

## Contributor Agreement

By submitting this pull request, I confirm that:

- [x] I have read the [CONTRIBUTING guidelines](../../CONTRIBUTING.md) for this project and followed
      its Contribution Checklist.