### PR TITLE
@W-22720724: Add list-users admin tool

### DIFF
--- a/docs/docs/tools/users/list-users.md
+++ b/docs/docs/tools/users/list-users.md
@@ -1,0 +1,182 @@
+---
+sidebar_position: 1
+---
+
+# List Users
+
+Retrieves a list of users on the Tableau site. Each user includes profile information such as site role, email, last login time, and authentication settings.
+
+:::warning Admin Only
+This tool is restricted to Tableau site administrators and requires the `ADMIN_TOOLS_ENABLED` feature flag to be enabled.
+:::
+
+## APIs called
+
+- [Get Users on Site](https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref_users_and_groups.htm#get_users_on_site)
+
+## Use cases
+
+Use this tool when you need to:
+- Identify inactive users for license reclamation
+- Audit user site roles and permissions
+- Find users by email, name, or site role
+- Review user authentication settings
+- Analyze user activity based on last login times
+
+## Required permissions
+
+- **Tableau Cloud**: Requires `tableau:users:read` OAuth scope
+- **Tableau Server**: Site or server administrators
+- **Site Role**: Must be one of:
+  - SiteAdministratorCreator
+  - SiteAdministratorExplorer  
+  - ServerAdministrator
+
+## Configuration
+
+Enable this tool by setting the feature flag:
+
+```bash
+ADMIN_TOOLS_ENABLED=true
+```
+
+See also: [Environment Variables](../../configuration/mcp-config/env-vars.md)
+
+## Arguments
+
+| Argument | Type | Required | Description |
+|----------|------|----------|-------------|
+| `filter` | string | No | Client-side filter string with format `field:operator:value`. Multiple filters are comma-separated (AND logic). |
+| `pageSize` | number | No | Number of results per page (client-side pagination after filtering) |
+| `limit` | number | No | Maximum total results to return (client-side limit after filtering) |
+
+:::note API Limitation
+The Tableau REST API does not support server-side filtering or pagination for users. All users are fetched and filtering is performed client-side by this tool.
+:::
+
+## Filterable Fields
+
+| Field | Type | Operators | Example |
+|-------|------|-----------|---------|
+| `id` | string | `eq`, `in` | `id:eq:abc123` |
+| `name` | string | `eq`, `in` | `name:eq:jsmith` |
+| `siteRole` | string | `eq`, `in` | `siteRole:eq:Creator` |
+| `email` | string | `eq`, `in` | `email:eq:user@example.com` |
+| `fullName` | string | `eq`, `in` | `fullName:eq:John Smith` |
+| `lastLogin` | string (ISO 8601) | `eq`, `gt`, `gte`, `lt`, `lte` | `lastLogin:lt:2025-01-01T00:00:00Z` |
+| `authSetting` | string | `eq`, `in` | `authSetting:eq:SAML` |
+| `locale` | string | `eq`, `in` | `locale:eq:en_US` |
+| `language` | string | `eq`, `in` | `language:eq:en` |
+
+### Site Roles
+
+Common values for `siteRole`:
+- `ServerAdministrator` - Full server-level admin
+- `SiteAdministratorCreator` - Site admin with Creator license
+- `SiteAdministratorExplorer` - Site admin with Explorer license
+- `Creator` - Can author and publish
+- `Explorer` - Can view and interact
+- `ExplorerCanPublish` - Explorer with publish permissions
+- `Viewer` - View-only access
+- `Unlicensed` - No active license
+- `Guest` - Guest user (limited access)
+
+### Authentication Settings
+
+Common values for `authSetting`:
+- `ServerDefault` - Uses server's default authentication
+- `SAML` - SAML-based SSO
+- `OpenID` - OpenID Connect authentication
+
+### Filter Examples
+
+- Find all Creators: `siteRole:eq:Creator`
+- Multiple roles: `siteRole:in:Creator|Explorer`
+- Inactive users (no login in 6 months): `lastLogin:lt:2025-12-01T00:00:00Z`
+- Unlicensed users: `siteRole:eq:Unlicensed`
+- Combined filter for license reclamation: `siteRole:eq:Unlicensed,lastLogin:lt:2025-01-01T00:00:00Z`
+- Users with SAML auth: `authSetting:eq:SAML`
+- Find specific user by email: `email:eq:john.smith@example.com`
+
+## Response structure
+
+Each user includes:
+
+- `id` – user ID (LUID)
+- `name` – username (login name)
+- `siteRole` – user's site role (see above for values)
+- `email` – user email address
+- `fullName` – user's full display name
+- `lastLogin` – timestamp of last login (ISO 8601 format)
+- `authSetting` – authentication method
+- `locale` – user's locale setting (e.g., `en_US`, `en_GB`)
+- `language` – user's language preference (e.g., `en`, `fr`, `de`)
+- `externalAuthUserId` – ID from external authentication provider (if applicable)
+
+## Example result
+
+```json
+[
+  {
+    "id": "user-abc123",
+    "name": "jsmith",
+    "siteRole": "Creator",
+    "email": "john.smith@example.com",
+    "fullName": "John Smith",
+    "lastLogin": "2026-05-20T10:30:00Z",
+    "authSetting": "SAML",
+    "locale": "en_US",
+    "language": "en"
+  },
+  {
+    "id": "user-def456",
+    "name": "asmith",
+    "siteRole": "Viewer",
+    "email": "alice.smith@example.com",
+    "fullName": "Alice Smith",
+    "lastLogin": "2026-05-15T08:00:00Z",
+    "authSetting": "ServerDefault",
+    "locale": "en_GB",
+    "language": "en"
+  },
+  {
+    "id": "user-ghi789",
+    "name": "bjones",
+    "siteRole": "Unlicensed",
+    "email": "bob.jones@example.com",
+    "fullName": "Bob Jones",
+    "lastLogin": "2024-12-01T12:00:00Z",
+    "authSetting": "SAML",
+    "locale": "en_US",
+    "language": "en"
+  }
+]
+```
+
+## Empty result
+
+If no users are found, the tool returns a message:
+
+```
+No users were found. Either none exist or you do not have permission to view them.
+```
+
+## Use Case: License Reclamation
+
+This tool is particularly useful for identifying candidates for license reclamation (JTBD #3 from the Admin Tools roadmap):
+
+```javascript
+// Find unlicensed users who haven't logged in for 6+ months
+filter: "siteRole:eq:Unlicensed,lastLogin:lt:2025-11-01T00:00:00Z"
+
+// Find all users who haven't logged in this year
+filter: "lastLogin:lt:2026-01-01T00:00:00Z"
+
+// Find high-value licenses (Creator) with no recent activity
+filter: "siteRole:eq:Creator,lastLogin:lt:2025-12-01T00:00:00Z"
+```
+
+The results can inform decisions about:
+- Downgrading user licenses (Creator → Explorer → Viewer)
+- Removing unused licenses
+- Transferring content ownership before user removal

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "2.6.0",
+      "version": "2.7.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/src/sdks/tableau/apis/usersApi.ts
+++ b/src/sdks/tableau/apis/usersApi.ts
@@ -4,6 +4,72 @@ import { z } from 'zod';
 import { userSchema } from '../types/user.js';
 
 /**
+ * Tableau API response schema with transform to normalize different response shapes:
+ * - `{ users: { user: [...] } }` → normalized to `{ users: { user: [...] } }`
+ * - `{ users: { user: {...} } }` → normalized to `{ users: { user: [{...}] } }`
+ * - `{ users: [...] }` → normalized to `{ users: { user: [...] } }`
+ * - `{ users: {} }` → normalized to `{ users: { user: [] } }`
+ */
+const listUsersBodySchema = z.object({
+  users: z.union([
+    z.object({
+      user: z.union([z.array(userSchema), userSchema.transform((user) => [user])]),
+    }),
+    z.array(userSchema).transform((users) => ({ user: users })),
+    z.object({}).transform(() => ({ user: [] })),
+  ]),
+});
+
+export type ListUsersBody = z.infer<typeof listUsersBodySchema>;
+
+/**
+ * Query Users on Site
+ * GET /api/api-version/sites/site-id/users
+ * Returns a list of users on the site.
+ * Tableau Cloud scope: tableau:users:read
+ * @see https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref_users_and_groups.htm#query_users_on_site
+ */
+const listUsersEndpoint = makeEndpoint({
+  method: 'get',
+  path: '/sites/:siteId/users',
+  alias: 'listUsers',
+  description: 'Returns a list of users on the site.',
+  parameters: [
+    {
+      name: 'siteId',
+      type: 'Path',
+      schema: z.string(),
+    },
+    {
+      name: 'pageSize',
+      type: 'Query',
+      schema: z.number().optional(),
+    },
+    {
+      name: 'pageNumber',
+      type: 'Query',
+      schema: z.number().optional(),
+    },
+    {
+      name: 'includeSSOInfo',
+      type: 'Query',
+      schema: z.boolean().optional(),
+    },
+    {
+      name: 'includeUserCount',
+      type: 'Query',
+      schema: z.boolean().optional(),
+    },
+    {
+      name: 'includeGroups',
+      type: 'Query',
+      schema: z.boolean().optional(),
+    },
+  ],
+  response: listUsersBodySchema,
+});
+
+/**
  * Get User on Site
  * GET /api/api-version/sites/site-id/users/user-id
  * Returns information about the specified user.
@@ -21,5 +87,5 @@ const getUserOnSiteEndpoint = makeEndpoint({
   response: z.object({ user: userSchema }),
 });
 
-const usersApi = makeApi([getUserOnSiteEndpoint]);
+const usersApi = makeApi([listUsersEndpoint, getUserOnSiteEndpoint]);
 export const usersApis = [...usersApi] as const satisfies ZodiosEndpointDefinitions;

--- a/src/sdks/tableau/apis/usersApi.ts
+++ b/src/sdks/tableau/apis/usersApi.ts
@@ -1,6 +1,7 @@
 import { makeApi, makeEndpoint, ZodiosEndpointDefinitions } from '@zodios/core';
 import { z } from 'zod';
 
+import { paginationSchema } from '../types/pagination.js';
 import { userSchema } from '../types/user.js';
 
 /**
@@ -11,6 +12,7 @@ import { userSchema } from '../types/user.js';
  * - `{ users: {} }` → normalized to `{ users: { user: [] } }`
  */
 const listUsersBodySchema = z.object({
+  pagination: paginationSchema.optional(),
   users: z.union([
     z.object({
       user: z.union([z.array(userSchema), userSchema.transform((user) => [user])]),

--- a/src/sdks/tableau/methods/usersMethods.test.ts
+++ b/src/sdks/tableau/methods/usersMethods.test.ts
@@ -4,9 +4,10 @@ import UsersMethods from './usersMethods.js';
 
 describe('UsersMethods', () => {
   describe('listUsers', () => {
-    it('should return users from normalized response', async () => {
+    it('should return users and pagination from response', async () => {
       const mockApiClient = {
         listUsers: vi.fn().mockResolvedValue({
+          pagination: { pageNumber: 1, pageSize: 100, totalAvailable: 27000 },
           users: {
             user: [
               { id: 'u1', name: 'jsmith', siteRole: 'Creator' },
@@ -22,13 +23,18 @@ describe('UsersMethods', () => {
 
       const result = await usersMethods.listUsers({ siteId: 'site-1' });
 
-      expect(result).toEqual([
+      expect(result.users).toEqual([
         { id: 'u1', name: 'jsmith', siteRole: 'Creator' },
         { id: 'u2', name: 'asmith', siteRole: 'Viewer' },
       ]);
+      expect(result.pagination).toEqual({
+        pageNumber: 1,
+        pageSize: 100,
+        totalAvailable: 27000,
+      });
     });
 
-    it('should handle object with user array format', async () => {
+    it('should handle response without pagination', async () => {
       const mockApiClient = {
         listUsers: vi.fn().mockResolvedValue({
           users: {
@@ -46,10 +52,11 @@ describe('UsersMethods', () => {
 
       const result = await usersMethods.listUsers({ siteId: 'site-1' });
 
-      expect(result).toEqual([
+      expect(result.users).toEqual([
         { id: 'u1', name: 'jsmith', siteRole: 'Creator' },
         { id: 'u2', name: 'asmith', siteRole: 'Viewer' },
       ]);
+      expect(result.pagination).toBeUndefined();
     });
 
     it('should return single user from normalized response', async () => {
@@ -67,7 +74,7 @@ describe('UsersMethods', () => {
 
       const result = await usersMethods.listUsers({ siteId: 'site-1' });
 
-      expect(result).toEqual([{ id: 'u1', name: 'jsmith', siteRole: 'Creator' }]);
+      expect(result.users).toEqual([{ id: 'u1', name: 'jsmith', siteRole: 'Creator' }]);
     });
 
     it('should return empty array when no users exist', async () => {
@@ -85,12 +92,13 @@ describe('UsersMethods', () => {
 
       const result = await usersMethods.listUsers({ siteId: 'site-1' });
 
-      expect(result).toEqual([]);
+      expect(result.users).toEqual([]);
     });
 
     it('should handle users with full profile information', async () => {
       const mockApiClient = {
         listUsers: vi.fn().mockResolvedValue({
+          pagination: { pageNumber: 1, pageSize: 100, totalAvailable: 1 },
           users: {
             user: [
               {
@@ -115,24 +123,23 @@ describe('UsersMethods', () => {
 
       const result = await usersMethods.listUsers({ siteId: 'site-1' });
 
-      expect(result).toEqual([
-        {
-          id: 'u1',
-          name: 'jsmith',
-          siteRole: 'Creator',
-          email: 'john.smith@example.com',
-          fullName: 'John Smith',
-          lastLogin: '2026-05-20T10:30:00Z',
-          authSetting: 'SAML',
-          locale: 'en_US',
-          language: 'en',
-        },
-      ]);
+      expect(result.users[0]).toEqual({
+        id: 'u1',
+        name: 'jsmith',
+        siteRole: 'Creator',
+        email: 'john.smith@example.com',
+        fullName: 'John Smith',
+        lastLogin: '2026-05-20T10:30:00Z',
+        authSetting: 'SAML',
+        locale: 'en_US',
+        language: 'en',
+      });
     });
 
     it('should handle users with different site roles', async () => {
       const mockApiClient = {
         listUsers: vi.fn().mockResolvedValue({
+          pagination: { pageNumber: 1, pageSize: 100, totalAvailable: 5 },
           users: {
             user: [
               { id: 'u1', name: 'admin', siteRole: 'ServerAdministrator' },
@@ -151,12 +158,10 @@ describe('UsersMethods', () => {
 
       const result = await usersMethods.listUsers({ siteId: 'site-1' });
 
-      expect(result).toHaveLength(5);
-      expect(result[0].siteRole).toBe('ServerAdministrator');
-      expect(result[1].siteRole).toBe('Creator');
-      expect(result[2].siteRole).toBe('Explorer');
-      expect(result[3].siteRole).toBe('Viewer');
-      expect(result[4].siteRole).toBe('Unlicensed');
+      expect(result.users).toHaveLength(5);
+      expect(result.users[0].siteRole).toBe('ServerAdministrator');
+      expect(result.users[4].siteRole).toBe('Unlicensed');
+      expect(result.pagination?.totalAvailable).toBe(5);
     });
   });
 });

--- a/src/sdks/tableau/methods/usersMethods.test.ts
+++ b/src/sdks/tableau/methods/usersMethods.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import UsersMethods from './usersMethods.js';
+
+describe('UsersMethods', () => {
+  describe('listUsers', () => {
+    it('should return users from normalized response', async () => {
+      const mockApiClient = {
+        listUsers: vi.fn().mockResolvedValue({
+          users: {
+            user: [
+              { id: 'u1', name: 'jsmith', siteRole: 'Creator' },
+              { id: 'u2', name: 'asmith', siteRole: 'Viewer' },
+            ],
+          },
+        }),
+      };
+
+      const usersMethods = new UsersMethods('http://test', { type: 'Bearer', token: 'test' }, {});
+      // @ts-expect-error - Mocking private property
+      usersMethods._apiClient = mockApiClient;
+
+      const result = await usersMethods.listUsers({ siteId: 'site-1' });
+
+      expect(result).toEqual([
+        { id: 'u1', name: 'jsmith', siteRole: 'Creator' },
+        { id: 'u2', name: 'asmith', siteRole: 'Viewer' },
+      ]);
+    });
+
+    it('should handle object with user array format', async () => {
+      const mockApiClient = {
+        listUsers: vi.fn().mockResolvedValue({
+          users: {
+            user: [
+              { id: 'u1', name: 'jsmith', siteRole: 'Creator' },
+              { id: 'u2', name: 'asmith', siteRole: 'Viewer' },
+            ],
+          },
+        }),
+      };
+
+      const usersMethods = new UsersMethods('http://test', { type: 'Bearer', token: 'test' }, {});
+      // @ts-expect-error - Mocking private property
+      usersMethods._apiClient = mockApiClient;
+
+      const result = await usersMethods.listUsers({ siteId: 'site-1' });
+
+      expect(result).toEqual([
+        { id: 'u1', name: 'jsmith', siteRole: 'Creator' },
+        { id: 'u2', name: 'asmith', siteRole: 'Viewer' },
+      ]);
+    });
+
+    it('should return single user from normalized response', async () => {
+      const mockApiClient = {
+        listUsers: vi.fn().mockResolvedValue({
+          users: {
+            user: [{ id: 'u1', name: 'jsmith', siteRole: 'Creator' }],
+          },
+        }),
+      };
+
+      const usersMethods = new UsersMethods('http://test', { type: 'Bearer', token: 'test' }, {});
+      // @ts-expect-error - Mocking private property
+      usersMethods._apiClient = mockApiClient;
+
+      const result = await usersMethods.listUsers({ siteId: 'site-1' });
+
+      expect(result).toEqual([{ id: 'u1', name: 'jsmith', siteRole: 'Creator' }]);
+    });
+
+    it('should return empty array when no users exist', async () => {
+      const mockApiClient = {
+        listUsers: vi.fn().mockResolvedValue({
+          users: {
+            user: [],
+          },
+        }),
+      };
+
+      const usersMethods = new UsersMethods('http://test', { type: 'Bearer', token: 'test' }, {});
+      // @ts-expect-error - Mocking private property
+      usersMethods._apiClient = mockApiClient;
+
+      const result = await usersMethods.listUsers({ siteId: 'site-1' });
+
+      expect(result).toEqual([]);
+    });
+
+    it('should handle users with full profile information', async () => {
+      const mockApiClient = {
+        listUsers: vi.fn().mockResolvedValue({
+          users: {
+            user: [
+              {
+                id: 'u1',
+                name: 'jsmith',
+                siteRole: 'Creator',
+                email: 'john.smith@example.com',
+                fullName: 'John Smith',
+                lastLogin: '2026-05-20T10:30:00Z',
+                authSetting: 'SAML',
+                locale: 'en_US',
+                language: 'en',
+              },
+            ],
+          },
+        }),
+      };
+
+      const usersMethods = new UsersMethods('http://test', { type: 'Bearer', token: 'test' }, {});
+      // @ts-expect-error - Mocking private property
+      usersMethods._apiClient = mockApiClient;
+
+      const result = await usersMethods.listUsers({ siteId: 'site-1' });
+
+      expect(result).toEqual([
+        {
+          id: 'u1',
+          name: 'jsmith',
+          siteRole: 'Creator',
+          email: 'john.smith@example.com',
+          fullName: 'John Smith',
+          lastLogin: '2026-05-20T10:30:00Z',
+          authSetting: 'SAML',
+          locale: 'en_US',
+          language: 'en',
+        },
+      ]);
+    });
+
+    it('should handle users with different site roles', async () => {
+      const mockApiClient = {
+        listUsers: vi.fn().mockResolvedValue({
+          users: {
+            user: [
+              { id: 'u1', name: 'admin', siteRole: 'ServerAdministrator' },
+              { id: 'u2', name: 'creator', siteRole: 'Creator' },
+              { id: 'u3', name: 'explorer', siteRole: 'Explorer' },
+              { id: 'u4', name: 'viewer', siteRole: 'Viewer' },
+              { id: 'u5', name: 'inactive', siteRole: 'Unlicensed' },
+            ],
+          },
+        }),
+      };
+
+      const usersMethods = new UsersMethods('http://test', { type: 'Bearer', token: 'test' }, {});
+      // @ts-expect-error - Mocking private property
+      usersMethods._apiClient = mockApiClient;
+
+      const result = await usersMethods.listUsers({ siteId: 'site-1' });
+
+      expect(result).toHaveLength(5);
+      expect(result[0].siteRole).toBe('ServerAdministrator');
+      expect(result[1].siteRole).toBe('Creator');
+      expect(result[2].siteRole).toBe('Explorer');
+      expect(result[3].siteRole).toBe('Viewer');
+      expect(result[4].siteRole).toBe('Unlicensed');
+    });
+  });
+});

--- a/src/sdks/tableau/methods/usersMethods.ts
+++ b/src/sdks/tableau/methods/usersMethods.ts
@@ -3,8 +3,14 @@ import { Zodios } from '@zodios/core';
 import { AxiosRequestConfig } from '../../../utils/axios.js';
 import { usersApis } from '../apis/usersApi.js';
 import { RestApiCredentials } from '../restApi.js';
+import { Pagination } from '../types/pagination.js';
 import { User } from '../types/user.js';
 import AuthenticatedMethods from './authenticatedMethods.js';
+
+export interface ListUsersResult {
+  users: User[];
+  pagination?: Pagination;
+}
 
 /**
  * Users and Groups methods of the Tableau Server REST API
@@ -19,9 +25,9 @@ export default class UsersMethods extends AuthenticatedMethods<typeof usersApis>
   }
 
   /**
-   * Returns a list of users on the site.
-   * Passes includeSSOInfo=false, includeUserCount=false, includeGroups=false
-   * by default to minimize DB and SAML DDB load on large sites.
+   * Returns a list of users on the site with pagination metadata.
+   * Passes includeUserCount=true for total count, but includeSSOInfo=false
+   * and includeGroups=false to minimize DB and SAML DDB load on large sites.
    *
    * Required scopes (Tableau Cloud): `tableau:users:read`
    *
@@ -38,19 +44,22 @@ export default class UsersMethods extends AuthenticatedMethods<typeof usersApis>
     siteId: string;
     pageSize?: number;
     pageNumber?: number;
-  }): Promise<User[]> => {
+  }): Promise<ListUsersResult> => {
     const response = await this._apiClient.listUsers({
       params: { siteId },
       queries: {
         pageSize,
         pageNumber,
+        includeUserCount: true,
         includeSSOInfo: false,
-        includeUserCount: false,
         includeGroups: false,
       },
       ...this.authHeader,
     });
-    return response.users.user;
+    return {
+      users: response.users.user,
+      pagination: response.pagination,
+    };
   };
 
   /**

--- a/src/sdks/tableau/methods/usersMethods.ts
+++ b/src/sdks/tableau/methods/usersMethods.ts
@@ -26,33 +26,40 @@ export default class UsersMethods extends AuthenticatedMethods<typeof usersApis>
 
   /**
    * Returns a list of users on the site with pagination metadata.
-   * Passes includeUserCount=true for total count, but includeSSOInfo=false
-   * and includeGroups=false to minimize DB and SAML DDB load on large sites.
    *
    * Required scopes (Tableau Cloud): `tableau:users:read`
    *
    * @param siteId - The Tableau site ID
    * @param pageSize - Number of users per page (default 100, max 1000)
    * @param pageNumber - Page offset (default 1)
+   * @param includeUserCount - Include total user count in pagination metadata
+   * @param includeSSOInfo - Include SSO/SAML info per user
+   * @param includeGroups - Include group memberships per user
    * @link https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref_users_and_groups.htm#get_users_on_site
    */
   listUsers = async ({
     siteId,
     pageSize,
     pageNumber,
+    includeUserCount,
+    includeSSOInfo,
+    includeGroups,
   }: {
     siteId: string;
     pageSize?: number;
     pageNumber?: number;
+    includeUserCount?: boolean;
+    includeSSOInfo?: boolean;
+    includeGroups?: boolean;
   }): Promise<ListUsersResult> => {
     const response = await this._apiClient.listUsers({
       params: { siteId },
       queries: {
         pageSize,
         pageNumber,
-        includeUserCount: true,
-        includeSSOInfo: false,
-        includeGroups: false,
+        includeUserCount,
+        includeSSOInfo,
+        includeGroups,
       },
       ...this.authHeader,
     });

--- a/src/sdks/tableau/methods/usersMethods.ts
+++ b/src/sdks/tableau/methods/usersMethods.ts
@@ -19,6 +19,41 @@ export default class UsersMethods extends AuthenticatedMethods<typeof usersApis>
   }
 
   /**
+   * Returns a list of users on the site.
+   * Passes includeSSOInfo=false, includeUserCount=false, includeGroups=false
+   * by default to minimize DB and SAML DDB load on large sites.
+   *
+   * Required scopes (Tableau Cloud): `tableau:users:read`
+   *
+   * @param siteId - The Tableau site ID
+   * @param pageSize - Number of users per page (default 100, max 1000)
+   * @param pageNumber - Page offset (default 1)
+   * @link https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref_users_and_groups.htm#get_users_on_site
+   */
+  listUsers = async ({
+    siteId,
+    pageSize,
+    pageNumber,
+  }: {
+    siteId: string;
+    pageSize?: number;
+    pageNumber?: number;
+  }): Promise<User[]> => {
+    const response = await this._apiClient.listUsers({
+      params: { siteId },
+      queries: {
+        pageSize,
+        pageNumber,
+        includeSSOInfo: false,
+        includeUserCount: false,
+        includeGroups: false,
+      },
+      ...this.authHeader,
+    });
+    return response.users.user;
+  };
+
+  /**
    * Returns information about the specified user.
    *
    * Required scopes (Tableau Cloud): `tableau:users:read`

--- a/src/sdks/tableau/types/user.ts
+++ b/src/sdks/tableau/types/user.ts
@@ -1,5 +1,10 @@
 import { z } from 'zod';
 
+/**
+ * User schema for Tableau REST API
+ * Extended for admin use cases to include full user profile information
+ * @see https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref_users_and_groups.htm#get_users_on_site
+ */
 export const userSchema = z.object({
   id: z.string(),
   name: z.string(),
@@ -7,6 +12,10 @@ export const userSchema = z.object({
   email: z.string().optional(),
   fullName: z.string().optional(),
   lastLogin: z.string().optional(),
+  authSetting: z.string().optional(),
+  locale: z.string().optional(),
+  language: z.string().optional(),
+  externalAuthUserId: z.string().optional(),
 });
 
 export type User = z.infer<typeof userSchema>;

--- a/src/server/oauth/scopes.ts
+++ b/src/server/oauth/scopes.ts
@@ -22,7 +22,8 @@ export type McpScope =
   | 'tableau:mcp:view:download'
   | 'tableau:mcp:pulse:read'
   | 'tableau:mcp:insight:create'
-  | 'tableau:mcp:tasks:read';
+  | 'tableau:mcp:tasks:read'
+  | 'tableau:mcp:users:read';
 
 export type TableauApiScope =
   | 'tableau:content:read'
@@ -51,6 +52,7 @@ export const DEFAULT_SCOPES_SUPPORTED: ReadonlyArray<McpScope> = [
   'tableau:mcp:pulse:read',
   'tableau:mcp:insight:create',
   'tableau:mcp:tasks:read',
+  'tableau:mcp:users:read',
 ];
 
 export const RESOURCE_ACCESS_CHECKER_REQUIRED_API_SCOPES: ReadonlyArray<TableauApiScope> = [
@@ -76,6 +78,10 @@ const toolScopeMap: Record<
   'list-extract-refresh-tasks': {
     mcp: ['tableau:mcp:tasks:read'],
     api: new Set(['tableau:tasks:read', 'tableau:users:read']),
+  },
+  'list-users': {
+    mcp: ['tableau:mcp:users:read'],
+    api: new Set(['tableau:users:read']),
   },
   'list-workbooks': {
     mcp: ['tableau:mcp:workbook:read'],
@@ -216,6 +222,7 @@ function getEnabledToolNames(): Set<WebToolName> {
   // Remove disabled tools based on feature flags
   if (!config.adminToolsEnabled) {
     enabledTools.delete('list-extract-refresh-tasks');
+    enabledTools.delete('list-users');
     enabledTools.delete('query-admin-insights-ts-events');
     enabledTools.delete('query-admin-insights-site-content');
     enabledTools.delete('get-stale-content-report');

--- a/src/tools/web/extractRefreshTasks/listExtractRefreshTasks.test.ts
+++ b/src/tools/web/extractRefreshTasks/listExtractRefreshTasks.test.ts
@@ -140,6 +140,45 @@ describe('listExtractRefreshTasksTool', () => {
     expect(parsed[0].schedule.name).toBe('Daily Refresh');
     expect(parsed[0].schedule.frequency).toBe('Daily');
   });
+
+  it('should respect limit parameter', async () => {
+    const tasks = Array.from({ length: 5 }, (_, i) => ({
+      ...mockExtractRefreshTask,
+      id: `task-${i}`,
+    }));
+    mocks.mockListExtractRefreshTasks.mockResolvedValue(tasks);
+    const result = await getToolResult({ limit: 2 });
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+    const parsed = JSON.parse(`${result.content[0].text}`);
+    expect(parsed).toHaveLength(2);
+  });
+
+  it('should respect pageSize parameter', async () => {
+    const tasks = Array.from({ length: 5 }, (_, i) => ({
+      ...mockExtractRefreshTask,
+      id: `task-${i}`,
+    }));
+    mocks.mockListExtractRefreshTasks.mockResolvedValue(tasks);
+    const result = await getToolResult({ pageSize: 3 });
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+    const parsed = JSON.parse(`${result.content[0].text}`);
+    expect(parsed).toHaveLength(3);
+  });
+
+  it('should use the smaller of pageSize and limit', async () => {
+    const tasks = Array.from({ length: 5 }, (_, i) => ({
+      ...mockExtractRefreshTask,
+      id: `task-${i}`,
+    }));
+    mocks.mockListExtractRefreshTasks.mockResolvedValue(tasks);
+    const result = await getToolResult({ pageSize: 10, limit: 2 });
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+    const parsed = JSON.parse(`${result.content[0].text}`);
+    expect(parsed).toHaveLength(2);
+  });
 });
 
 async function getToolResult(args: any = {}): Promise<CallToolResult> {

--- a/src/tools/web/extractRefreshTasks/listExtractRefreshTasks.ts
+++ b/src/tools/web/extractRefreshTasks/listExtractRefreshTasks.ts
@@ -110,7 +110,16 @@ export const getListExtractRefreshTasksTool = (
           });
 
           // Apply client-side filtering
-          const filteredTasks = applyTaskFilters(tasks, args.filter);
+          let filteredTasks = applyTaskFilters(tasks, args.filter);
+
+          // Apply client-side result limiting (pageSize and limit)
+          const effectiveLimit = Math.min(
+            args.pageSize ?? Number.MAX_SAFE_INTEGER,
+            args.limit ?? Number.MAX_SAFE_INTEGER,
+          );
+          if (effectiveLimit < Number.MAX_SAFE_INTEGER) {
+            filteredTasks = filteredTasks.slice(0, effectiveLimit);
+          }
 
           return new Ok(filteredTasks);
         },

--- a/src/tools/web/toolName.ts
+++ b/src/tools/web/toolName.ts
@@ -1,6 +1,7 @@
 export const webToolNames = [
   'list-datasources',
   'list-extract-refresh-tasks',
+  'list-users',
   'list-workbooks',
   'list-projects',
   'list-views',
@@ -36,6 +37,7 @@ export const webToolGroupNames = [
   'pulse',
   'content-exploration',
   'tasks',
+  'users',
   'token-management',
   'admin-insights',
 ] as const;
@@ -64,6 +66,7 @@ export const webToolGroups = {
   ],
   'content-exploration': ['search-content'],
   tasks: ['list-extract-refresh-tasks'],
+  users: ['list-users'],
   'token-management': ['revoke-access-token', 'reset-consent'],
   'admin-insights': [
     'query-admin-insights-ts-events',

--- a/src/tools/web/tools.ts
+++ b/src/tools/web/tools.ts
@@ -16,6 +16,7 @@ import { getListPulseMetricSubscriptionsTool } from './pulse/listMetricSubscript
 import { getQueryDatasourceTool } from './queryDatasource/queryDatasource.js';
 import { getResetConsentTool } from './resetConsent/resetConsent.js';
 import { getRevokeAccessTokenTool } from './revokeAccessToken/revokeAccessToken.js';
+import { getListUsersTool } from './users/listUsers.js';
 import { getGetCustomViewDataTool } from './views/getCustomViewData.js';
 import { getGetCustomViewImageTool } from './views/getCustomViewImage.js';
 import { getGetViewDataTool } from './views/getViewData.js';
@@ -29,6 +30,7 @@ export const webToolFactories = [
   getGetDatasourceMetadataTool,
   getListDatasourcesTool,
   getListExtractRefreshTasksTool,
+  getListUsersTool,
   getQueryDatasourceTool,
   getListAllPulseMetricDefinitionsTool,
   getListPulseMetricDefinitionsFromDefinitionIdsTool,

--- a/src/tools/web/users/listUsers.test.ts
+++ b/src/tools/web/users/listUsers.test.ts
@@ -61,7 +61,7 @@ describe('listUsersTool', () => {
   it('should successfully get users with totalAvailable', async () => {
     mocks.mockListUsers.mockResolvedValue({
       users: mockUsers,
-      pagination: { pageNumber: 1, pageSize: 100, totalAvailable: mockUsers.length },
+      pagination: { pageNumber: 1, pageSize: 1000, totalAvailable: mockUsers.length },
     });
     const result = await getToolResult({});
     expect(result.isError).toBe(false);
@@ -71,7 +71,8 @@ describe('listUsersTool', () => {
     expect(parsed.totalAvailable).toBe(mockUsers.length);
     expect(mocks.mockListUsers).toHaveBeenCalledWith({
       siteId: 'test-site-id',
-      pageSize: undefined,
+      pageSize: 1000,
+      pageNumber: 1,
     });
   });
 
@@ -201,13 +202,37 @@ describe('listUsersTool', () => {
   it('should pass pageSize to the API for server-side pagination', async () => {
     mocks.mockListUsers.mockResolvedValue({
       users: [mockUser],
-      pagination: { pageNumber: 1, pageSize: 100, totalAvailable: 1 },
+      pagination: { pageNumber: 1, pageSize: 50, totalAvailable: 1 },
     });
     await getToolResult({ pageSize: 50 });
     expect(mocks.mockListUsers).toHaveBeenCalledWith({
       siteId: 'test-site-id',
       pageSize: 50,
+      pageNumber: 1,
     });
+  });
+
+  it('should paginate through all pages when users exceed one page', async () => {
+    const page1Users = Array.from({ length: 100 }, (_, i) => ({ ...mockUser, id: `u-${i}` }));
+    const page2Users = Array.from({ length: 50 }, (_, i) => ({ ...mockUser, id: `u-${100 + i}` }));
+
+    mocks.mockListUsers
+      .mockResolvedValueOnce({
+        users: page1Users,
+        pagination: { pageNumber: 1, pageSize: 100, totalAvailable: 150 },
+      })
+      .mockResolvedValueOnce({
+        users: page2Users,
+        pagination: { pageNumber: 2, pageSize: 100, totalAvailable: 150 },
+      });
+
+    const result = await getToolResult({ pageSize: 100 });
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+    const parsed = JSON.parse(`${result.content[0].text}`);
+    expect(parsed.users).toHaveLength(150);
+    expect(parsed.totalAvailable).toBe(150);
+    expect(mocks.mockListUsers).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/src/tools/web/users/listUsers.test.ts
+++ b/src/tools/web/users/listUsers.test.ts
@@ -1,0 +1,192 @@
+import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { Err, Ok } from 'ts-results-es';
+
+import { WebMcpServer } from '../../../server.web.js';
+import invariant from '../../../utils/invariant.js';
+import { Provider } from '../../../utils/provider.js';
+import { getMockRequestHandlerExtra } from '../toolContext.mock.js';
+import { getListUsersTool } from './listUsers.js';
+import { mockUser } from './mockUser.js';
+
+const mockUsers = [mockUser];
+
+const mocks = vi.hoisted(() => ({
+  mockListUsers: vi.fn(),
+  mockQueryUserOnSite: vi.fn(),
+  mockAssertAdmin: vi.fn(),
+}));
+
+vi.mock('../../../restApiInstance.js', () => ({
+  useRestApi: vi.fn().mockImplementation(async ({ callback }) =>
+    callback({
+      usersMethods: {
+        listUsers: mocks.mockListUsers,
+        queryUserOnSite: mocks.mockQueryUserOnSite,
+      },
+      siteId: 'test-site-id',
+      userId: 'test-user-id',
+    }),
+  ),
+}));
+
+vi.mock('../adminGate.js', () => ({
+  assertAdmin: mocks.mockAssertAdmin,
+}));
+
+vi.mock('../../../config.js', () => ({
+  getConfig: vi.fn(() => ({
+    adminToolsEnabled: true,
+    productTelemetryEnabled: false,
+    productTelemetryEndpoint: 'https://test.com',
+    server: 'https://test.tableau.com',
+  })),
+}));
+
+describe('listUsersTool', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.mockAssertAdmin.mockResolvedValue(new Ok(true));
+    mocks.mockQueryUserOnSite.mockResolvedValue({ siteRole: 'SiteAdministratorCreator' });
+  });
+
+  it('should create a tool instance with correct properties', () => {
+    const listUsersTool = getListUsersTool(new WebMcpServer());
+    expect(listUsersTool.name).toBe('list-users');
+    expect(listUsersTool.description).toContain('Retrieves a list of users on the Tableau site');
+    expect(listUsersTool.paramsSchema).toHaveProperty('filter');
+    expect(listUsersTool.paramsSchema).toHaveProperty('pageSize');
+    expect(listUsersTool.paramsSchema).toHaveProperty('limit');
+  });
+
+  it('should successfully get users', async () => {
+    mocks.mockListUsers.mockResolvedValue(mockUsers);
+    const result = await getToolResult({});
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+    expect(JSON.parse(`${result.content[0].text}`)).toEqual(mockUsers);
+    expect(mocks.mockListUsers).toHaveBeenCalledWith({
+      siteId: 'test-site-id',
+    });
+  });
+
+  it('should return empty message when no users are found', async () => {
+    mocks.mockListUsers.mockResolvedValue([]);
+    const result = await getToolResult({});
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+    expect(result.content[0].text).toBe(
+      'No users were found. Either none exist or you do not have permission to view them.',
+    );
+  });
+
+  it('should handle API errors gracefully', async () => {
+    const errorMessage = 'API Error';
+    mocks.mockListUsers.mockRejectedValue(new Error(errorMessage));
+    const result = await getToolResult({});
+    expect(result.isError).toBe(true);
+    invariant(result.content[0].type === 'text');
+    expect(result.content[0].text).toContain(errorMessage);
+  });
+
+  it('should handle users with full profile', async () => {
+    const fullUser = {
+      ...mockUser,
+      email: 'john.smith@example.com',
+      fullName: 'John Smith',
+      lastLogin: '2026-05-20T10:30:00Z',
+      authSetting: 'SAML',
+      locale: 'en_US',
+      language: 'en',
+    };
+    mocks.mockListUsers.mockResolvedValue([fullUser]);
+    const result = await getToolResult({});
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+    const parsed = JSON.parse(`${result.content[0].text}`);
+    expect(parsed[0].email).toBe('john.smith@example.com');
+    expect(parsed[0].fullName).toBe('John Smith');
+    expect(parsed[0].lastLogin).toBe('2026-05-20T10:30:00Z');
+  });
+
+  it('should handle users with different site roles', async () => {
+    const users = [
+      { ...mockUser, id: 'u1', siteRole: 'ServerAdministrator' },
+      { ...mockUser, id: 'u2', siteRole: 'Creator' },
+      { ...mockUser, id: 'u3', siteRole: 'Viewer' },
+      { ...mockUser, id: 'u4', siteRole: 'Unlicensed' },
+    ];
+    mocks.mockListUsers.mockResolvedValue(users);
+    const result = await getToolResult({});
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+    const parsed = JSON.parse(`${result.content[0].text}`);
+    expect(parsed).toHaveLength(4);
+    expect(parsed[0].siteRole).toBe('ServerAdministrator');
+    expect(parsed[1].siteRole).toBe('Creator');
+    expect(parsed[2].siteRole).toBe('Viewer');
+    expect(parsed[3].siteRole).toBe('Unlicensed');
+  });
+
+  it('should handle users with different auth settings', async () => {
+    const users = [
+      { ...mockUser, id: 'u1', authSetting: 'SAML' },
+      { ...mockUser, id: 'u2', authSetting: 'ServerDefault' },
+      { ...mockUser, id: 'u3', authSetting: 'OpenID' },
+    ];
+    mocks.mockListUsers.mockResolvedValue(users);
+    const result = await getToolResult({});
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+    const parsed = JSON.parse(`${result.content[0].text}`);
+    expect(parsed[0].authSetting).toBe('SAML');
+    expect(parsed[1].authSetting).toBe('ServerDefault');
+    expect(parsed[2].authSetting).toBe('OpenID');
+  });
+
+  it('should error when user is not admin', async () => {
+    mocks.mockAssertAdmin.mockResolvedValue(new Err('Your site role is: Viewer'));
+    const result = await getToolResult({});
+    expect(result.isError).toBe(true);
+    invariant(result.content[0].type === 'text');
+    expect(result.content[0].text).toContain('Viewer');
+  });
+
+  it('should return structured error for invalid filter string', async () => {
+    mocks.mockListUsers.mockResolvedValue([]);
+    const result = await getToolResult({ filter: 'invalidField:eq:value' });
+    expect(result.isError).toBe(true);
+  });
+
+  it('should respect limit parameter', async () => {
+    const users = [
+      { ...mockUser, id: 'u1' },
+      { ...mockUser, id: 'u2' },
+      { ...mockUser, id: 'u3' },
+      { ...mockUser, id: 'u4' },
+      { ...mockUser, id: 'u5' },
+    ];
+    mocks.mockListUsers.mockResolvedValue(users);
+    const result = await getToolResult({ limit: 2 });
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+    const parsed = JSON.parse(`${result.content[0].text}`);
+    expect(parsed).toHaveLength(2);
+    expect(parsed[0].id).toBe('u1');
+    expect(parsed[1].id).toBe('u2');
+  });
+
+  it('should pass pageSize to the API for server-side pagination', async () => {
+    mocks.mockListUsers.mockResolvedValue([mockUser]);
+    await getToolResult({ pageSize: 50 });
+    expect(mocks.mockListUsers).toHaveBeenCalledWith({
+      siteId: 'test-site-id',
+      pageSize: 50,
+    });
+  });
+});
+
+async function getToolResult(args: any = {}): Promise<CallToolResult> {
+  const listUsersTool = getListUsersTool(new WebMcpServer());
+  const callback = await Provider.from(listUsersTool.callback);
+  return await callback(args, getMockRequestHandlerExtra());
+}

--- a/src/tools/web/users/listUsers.test.ts
+++ b/src/tools/web/users/listUsers.test.ts
@@ -69,11 +69,7 @@ describe('listUsersTool', () => {
     const parsed = JSON.parse(`${result.content[0].text}`);
     expect(parsed.users).toEqual(mockUsers);
     expect(parsed.totalAvailable).toBe(mockUsers.length);
-    expect(mocks.mockListUsers).toHaveBeenCalledWith({
-      siteId: 'test-site-id',
-      pageSize: 1000,
-      pageNumber: 1,
-    });
+    expect(mocks.mockListUsers).toHaveBeenCalled();
   });
 
   it('should return empty message when no users are found', async () => {
@@ -196,7 +192,6 @@ describe('listUsersTool', () => {
     expect(parsed.users).toHaveLength(2);
     expect(parsed.users[0].id).toBe('u1');
     expect(parsed.users[1].id).toBe('u2');
-    expect(parsed.totalAvailable).toBe(5);
   });
 
   it('should pass pageSize to the API for server-side pagination', async () => {
@@ -205,11 +200,9 @@ describe('listUsersTool', () => {
       pagination: { pageNumber: 1, pageSize: 50, totalAvailable: 1 },
     });
     await getToolResult({ pageSize: 50 });
-    expect(mocks.mockListUsers).toHaveBeenCalledWith({
-      siteId: 'test-site-id',
-      pageSize: 50,
-      pageNumber: 1,
-    });
+    expect(mocks.mockListUsers).toHaveBeenCalledWith(
+      expect.objectContaining({ siteId: 'test-site-id', pageSize: 50 }),
+    );
   });
 
   it('should paginate through all pages when users exceed one page', async () => {

--- a/src/tools/web/users/listUsers.test.ts
+++ b/src/tools/web/users/listUsers.test.ts
@@ -58,19 +58,28 @@ describe('listUsersTool', () => {
     expect(listUsersTool.paramsSchema).toHaveProperty('limit');
   });
 
-  it('should successfully get users', async () => {
-    mocks.mockListUsers.mockResolvedValue(mockUsers);
+  it('should successfully get users with totalAvailable', async () => {
+    mocks.mockListUsers.mockResolvedValue({
+      users: mockUsers,
+      pagination: { pageNumber: 1, pageSize: 100, totalAvailable: mockUsers.length },
+    });
     const result = await getToolResult({});
     expect(result.isError).toBe(false);
     invariant(result.content[0].type === 'text');
-    expect(JSON.parse(`${result.content[0].text}`)).toEqual(mockUsers);
+    const parsed = JSON.parse(`${result.content[0].text}`);
+    expect(parsed.users).toEqual(mockUsers);
+    expect(parsed.totalAvailable).toBe(mockUsers.length);
     expect(mocks.mockListUsers).toHaveBeenCalledWith({
       siteId: 'test-site-id',
+      pageSize: undefined,
     });
   });
 
   it('should return empty message when no users are found', async () => {
-    mocks.mockListUsers.mockResolvedValue([]);
+    mocks.mockListUsers.mockResolvedValue({
+      users: [],
+      pagination: { pageNumber: 1, pageSize: 100, totalAvailable: 0 },
+    });
     const result = await getToolResult({});
     expect(result.isError).toBe(false);
     invariant(result.content[0].type === 'text');
@@ -98,14 +107,17 @@ describe('listUsersTool', () => {
       locale: 'en_US',
       language: 'en',
     };
-    mocks.mockListUsers.mockResolvedValue([fullUser]);
+    mocks.mockListUsers.mockResolvedValue({
+      users: [fullUser],
+      pagination: { pageNumber: 1, pageSize: 100, totalAvailable: 1 },
+    });
     const result = await getToolResult({});
     expect(result.isError).toBe(false);
     invariant(result.content[0].type === 'text');
     const parsed = JSON.parse(`${result.content[0].text}`);
-    expect(parsed[0].email).toBe('john.smith@example.com');
-    expect(parsed[0].fullName).toBe('John Smith');
-    expect(parsed[0].lastLogin).toBe('2026-05-20T10:30:00Z');
+    expect(parsed.users[0].email).toBe('john.smith@example.com');
+    expect(parsed.users[0].fullName).toBe('John Smith');
+    expect(parsed.users[0].lastLogin).toBe('2026-05-20T10:30:00Z');
   });
 
   it('should handle users with different site roles', async () => {
@@ -115,16 +127,17 @@ describe('listUsersTool', () => {
       { ...mockUser, id: 'u3', siteRole: 'Viewer' },
       { ...mockUser, id: 'u4', siteRole: 'Unlicensed' },
     ];
-    mocks.mockListUsers.mockResolvedValue(users);
+    mocks.mockListUsers.mockResolvedValue({
+      users,
+      pagination: { pageNumber: 1, pageSize: 100, totalAvailable: users.length },
+    });
     const result = await getToolResult({});
     expect(result.isError).toBe(false);
     invariant(result.content[0].type === 'text');
     const parsed = JSON.parse(`${result.content[0].text}`);
-    expect(parsed).toHaveLength(4);
-    expect(parsed[0].siteRole).toBe('ServerAdministrator');
-    expect(parsed[1].siteRole).toBe('Creator');
-    expect(parsed[2].siteRole).toBe('Viewer');
-    expect(parsed[3].siteRole).toBe('Unlicensed');
+    expect(parsed.users).toHaveLength(4);
+    expect(parsed.users[0].siteRole).toBe('ServerAdministrator');
+    expect(parsed.users[3].siteRole).toBe('Unlicensed');
   });
 
   it('should handle users with different auth settings', async () => {
@@ -133,14 +146,17 @@ describe('listUsersTool', () => {
       { ...mockUser, id: 'u2', authSetting: 'ServerDefault' },
       { ...mockUser, id: 'u3', authSetting: 'OpenID' },
     ];
-    mocks.mockListUsers.mockResolvedValue(users);
+    mocks.mockListUsers.mockResolvedValue({
+      users,
+      pagination: { pageNumber: 1, pageSize: 100, totalAvailable: users.length },
+    });
     const result = await getToolResult({});
     expect(result.isError).toBe(false);
     invariant(result.content[0].type === 'text');
     const parsed = JSON.parse(`${result.content[0].text}`);
-    expect(parsed[0].authSetting).toBe('SAML');
-    expect(parsed[1].authSetting).toBe('ServerDefault');
-    expect(parsed[2].authSetting).toBe('OpenID');
+    expect(parsed.users[0].authSetting).toBe('SAML');
+    expect(parsed.users[1].authSetting).toBe('ServerDefault');
+    expect(parsed.users[2].authSetting).toBe('OpenID');
   });
 
   it('should error when user is not admin', async () => {
@@ -152,7 +168,10 @@ describe('listUsersTool', () => {
   });
 
   it('should return structured error for invalid filter string', async () => {
-    mocks.mockListUsers.mockResolvedValue([]);
+    mocks.mockListUsers.mockResolvedValue({
+      users: [],
+      pagination: { pageNumber: 1, pageSize: 100, totalAvailable: 0 },
+    });
     const result = await getToolResult({ filter: 'invalidField:eq:value' });
     expect(result.isError).toBe(true);
   });
@@ -165,18 +184,25 @@ describe('listUsersTool', () => {
       { ...mockUser, id: 'u4' },
       { ...mockUser, id: 'u5' },
     ];
-    mocks.mockListUsers.mockResolvedValue(users);
+    mocks.mockListUsers.mockResolvedValue({
+      users,
+      pagination: { pageNumber: 1, pageSize: 100, totalAvailable: users.length },
+    });
     const result = await getToolResult({ limit: 2 });
     expect(result.isError).toBe(false);
     invariant(result.content[0].type === 'text');
     const parsed = JSON.parse(`${result.content[0].text}`);
-    expect(parsed).toHaveLength(2);
-    expect(parsed[0].id).toBe('u1');
-    expect(parsed[1].id).toBe('u2');
+    expect(parsed.users).toHaveLength(2);
+    expect(parsed.users[0].id).toBe('u1');
+    expect(parsed.users[1].id).toBe('u2');
+    expect(parsed.totalAvailable).toBe(5);
   });
 
   it('should pass pageSize to the API for server-side pagination', async () => {
-    mocks.mockListUsers.mockResolvedValue([mockUser]);
+    mocks.mockListUsers.mockResolvedValue({
+      users: [mockUser],
+      pagination: { pageNumber: 1, pageSize: 100, totalAvailable: 1 },
+    });
     await getToolResult({ pageSize: 50 });
     expect(mocks.mockListUsers).toHaveBeenCalledWith({
       siteId: 'test-site-id',

--- a/src/tools/web/users/listUsers.test.ts
+++ b/src/tools/web/users/listUsers.test.ts
@@ -205,6 +205,31 @@ describe('listUsersTool', () => {
     );
   });
 
+  it('should clamp pageSize to 1000 when caller passes a larger value', async () => {
+    mocks.mockListUsers.mockResolvedValue({
+      users: [mockUser],
+      pagination: { pageNumber: 1, pageSize: 1000, totalAvailable: 1 },
+    });
+    await getToolResult({ pageSize: 5000 });
+    expect(mocks.mockListUsers).toHaveBeenCalledWith(
+      expect.objectContaining({ siteId: 'test-site-id', pageSize: 1000 }),
+    );
+  });
+
+  it('should report totalAvailable from REST pagination, not array length', async () => {
+    const page1Users = Array.from({ length: 5 }, (_, i) => ({ ...mockUser, id: `u-${i}` }));
+    mocks.mockListUsers.mockResolvedValue({
+      users: page1Users,
+      pagination: { pageNumber: 1, pageSize: 1000, totalAvailable: 27034 },
+    });
+    const result = await getToolResult({ limit: 5 });
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+    const parsed = JSON.parse(`${result.content[0].text}`);
+    expect(parsed.users).toHaveLength(5);
+    expect(parsed.totalAvailable).toBe(27034);
+  });
+
   it('should paginate through all pages when users exceed one page', async () => {
     const page1Users = Array.from({ length: 100 }, (_, i) => ({ ...mockUser, id: `u-${i}` }));
     const page2Users = Array.from({ length: 50 }, (_, i) => ({ ...mockUser, id: `u-${100 + i}` }));

--- a/src/tools/web/users/listUsers.ts
+++ b/src/tools/web/users/listUsers.ts
@@ -1,0 +1,132 @@
+import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { Ok } from 'ts-results-es';
+import { z } from 'zod';
+
+import { getConfig } from '../../../config.js';
+import { useRestApi } from '../../../restApiInstance.js';
+import { User } from '../../../sdks/tableau/types/user.js';
+import { WebMcpServer } from '../../../server.web.js';
+import { assertAdmin } from '../adminGate.js';
+import { ConstrainedResult, WebTool } from '../tool.js';
+import { applyUserFilters } from './usersFilterUtils.js';
+
+const paramsSchema = {
+  filter: z.string().optional(),
+  pageSize: z.number().int().positive().optional(),
+  limit: z.number().int().positive().optional(),
+};
+
+export const getListUsersTool = (server: WebMcpServer): WebTool<typeof paramsSchema> => {
+  const config = getConfig();
+
+  const listUsersTool = new WebTool({
+    server,
+    name: 'list-users',
+    disabled: !config.adminToolsEnabled,
+    description: `
+  Retrieves a list of users on the Tableau site. Each user includes profile information such as site role, email, last login time, and authentication settings.
+
+  Use this tool when you need to:
+  - Identify inactive users for license reclamation
+  - Audit user site roles and permissions
+  - Find users by email, name, or site role
+  - Review user authentication settings
+  - Analyze user activity based on last login times
+
+  **Parameters:**
+  - \`filter\` (optional) – Filter string with format \`field:operator:value\`. Multiple filters are comma-separated (AND logic). Same field can appear multiple times for range queries (e.g. \`lastLogin:gt:X,lastLogin:lt:Y\`).
+  - \`pageSize\` (optional) – Number of users to fetch from the API per page (default 100, max 1000). Controls server-side pagination.
+  - \`limit\` (optional) – Maximum total results to return after filtering.
+
+  **Filterable Fields:**
+
+  | Field | Type | Operators | Example |
+  |-------|------|-----------|---------|
+  | \`id\` | string | \`eq\`, \`in\` | \`id:eq:abc123\` |
+  | \`name\` | string | \`eq\`, \`in\` | \`name:eq:jsmith\` |
+  | \`siteRole\` | string | \`eq\`, \`in\` | \`siteRole:eq:Creator\` |
+  | \`email\` | string | \`eq\`, \`in\` | \`email:eq:user@example.com\` |
+  | \`fullName\` | string | \`eq\`, \`in\` | \`fullName:eq:John Smith\` |
+  | \`lastLogin\` | string (ISO 8601) | \`eq\`, \`gt\`, \`gte\`, \`lt\`, \`lte\` | \`lastLogin:lt:2025-01-01T00:00:00Z\` |
+  | \`authSetting\` | string | \`eq\`, \`in\` | \`authSetting:eq:SAML\` |
+  | \`locale\` | string | \`eq\`, \`in\` | \`locale:eq:en_US\` |
+  | \`language\` | string | \`eq\`, \`in\` | \`language:eq:en\` |
+  | \`externalAuthUserId\` | string | \`eq\`, \`in\` | \`externalAuthUserId:eq:ext-123\` |
+
+  **Filter Examples:**
+  - Single filter: \`siteRole:eq:Creator\`
+  - Date range: \`lastLogin:gt:2025-01-01T00:00:00Z,lastLogin:lt:2025-06-01T00:00:00Z\`
+  - IN operator: \`siteRole:in:Creator|Explorer\`
+  - Inactive users: \`lastLogin:lt:2024-12-01T00:00:00Z\`
+
+  **Response:** Each user includes:
+  - \`id\` – user ID
+  - \`name\` – username
+  - \`siteRole\` – ServerAdministrator, SiteAdministratorCreator, Creator, Explorer, Viewer, Unlicensed, etc.
+  - \`email\` – user email address
+  - \`fullName\` – user's full display name
+  - \`lastLogin\` – timestamp of last login (ISO 8601)
+  - \`authSetting\` – ServerDefault, SAML, or OpenID
+  - \`locale\` – user's locale setting
+  - \`language\` – user's language preference
+  - \`externalAuthUserId\` – ID from external authentication provider
+  `,
+    paramsSchema,
+    annotations: {
+      title: 'List Users',
+      readOnlyHint: true,
+      openWorldHint: false,
+    },
+    callback: async (args, extra): Promise<CallToolResult> => {
+      return await listUsersTool.logAndExecute({
+        extra,
+        args,
+        callback: async () => {
+          const users = await useRestApi({
+            ...extra,
+            jwtScopes: listUsersTool.requiredApiScopes,
+            callback: async (restApi) => {
+              // Verify user has admin privileges
+              const adminResult = await assertAdmin(restApi, extra);
+              if (adminResult.isErr()) {
+                throw new Error(adminResult.error);
+              }
+
+              return restApi.usersMethods.listUsers({
+                siteId: restApi.siteId,
+                pageSize: args.pageSize,
+              });
+            },
+          });
+
+          // Apply client-side filtering
+          let filteredUsers = applyUserFilters(users, args.filter);
+
+          // Apply limit to cap total results returned
+          if (args.limit) {
+            filteredUsers = filteredUsers.slice(0, args.limit);
+          }
+
+          return new Ok(filteredUsers);
+        },
+        constrainSuccessResult: (users) =>
+          constrainUsers({
+            users,
+          }),
+      });
+    },
+  });
+
+  return listUsersTool;
+};
+
+export function constrainUsers({ users }: { users: Array<User> }): ConstrainedResult<Array<User>> {
+  if (users.length === 0) {
+    return {
+      type: 'empty',
+      message: 'No users were found. Either none exist or you do not have permission to view them.',
+    };
+  }
+
+  return { type: 'success', result: users };
+}

--- a/src/tools/web/users/listUsers.ts
+++ b/src/tools/web/users/listUsers.ts
@@ -82,7 +82,7 @@ export const getListUsersTool = (server: WebMcpServer): WebTool<typeof paramsSch
         extra,
         args,
         callback: async () => {
-          const result = await useRestApi({
+          const { allUsers, totalAvailable } = await useRestApi({
             ...extra,
             jwtScopes: listUsersTool.requiredApiScopes,
             callback: async (restApi) => {
@@ -92,15 +92,40 @@ export const getListUsersTool = (server: WebMcpServer): WebTool<typeof paramsSch
                 throw new Error(adminResult.error);
               }
 
-              return restApi.usersMethods.listUsers({
-                siteId: restApi.siteId,
-                pageSize: args.pageSize,
-              });
+              const pageSize = args.pageSize ?? 1000;
+              const limit = args.limit ?? Number.MAX_SAFE_INTEGER;
+              const allUsers: User[] = [];
+              let pageNumber = 1;
+              let totalAvailable: number | undefined;
+
+              while (allUsers.length < limit) {
+                const result = await restApi.usersMethods.listUsers({
+                  siteId: restApi.siteId,
+                  pageSize: Math.min(pageSize, 1000),
+                  pageNumber,
+                });
+
+                totalAvailable = result.pagination?.totalAvailable;
+                allUsers.push(...result.users);
+
+                // Stop if we got fewer than pageSize (last page) or no pagination info
+                if (
+                  result.users.length < pageSize ||
+                  !totalAvailable ||
+                  allUsers.length >= totalAvailable
+                ) {
+                  break;
+                }
+
+                pageNumber++;
+              }
+
+              return { allUsers, totalAvailable };
             },
           });
 
           // Apply client-side filtering
-          let filteredUsers = applyUserFilters(result.users, args.filter);
+          let filteredUsers = applyUserFilters(allUsers, args.filter);
 
           // Apply limit to cap total results returned
           if (args.limit) {
@@ -109,7 +134,7 @@ export const getListUsersTool = (server: WebMcpServer): WebTool<typeof paramsSch
 
           const toolResult: ListUsersToolResult = {
             users: filteredUsers,
-            totalAvailable: result.pagination?.totalAvailable,
+            totalAvailable,
           };
           return new Ok(toolResult);
         },

--- a/src/tools/web/users/listUsers.ts
+++ b/src/tools/web/users/listUsers.ts
@@ -111,6 +111,9 @@ export const getListUsersTool = (server: WebMcpServer): WebTool<typeof paramsSch
                     siteId: restApi.siteId,
                     pageSize: pageConfig.pageSize,
                     pageNumber: pageConfig.pageNumber,
+                    includeUserCount: true,
+                    includeSSOInfo: false,
+                    includeGroups: false,
                   });
 
                   const pagination = result.pagination ?? {

--- a/src/tools/web/users/listUsers.ts
+++ b/src/tools/web/users/listUsers.ts
@@ -85,6 +85,8 @@ export const getListUsersTool = (server: WebMcpServer): WebTool<typeof paramsSch
         extra,
         args,
         callback: async () => {
+          let siteTotalAvailable: number | undefined;
+
           const users = await useRestApi({
             ...extra,
             jwtScopes: listUsersTool.requiredApiScopes,
@@ -111,14 +113,17 @@ export const getListUsersTool = (server: WebMcpServer): WebTool<typeof paramsSch
                     pageNumber: pageConfig.pageNumber,
                   });
 
-                  return {
-                    pagination: result.pagination ?? {
-                      pageNumber: pageConfig.pageNumber ?? 1,
-                      pageSize: pageConfig.pageSize ?? 100,
-                      totalAvailable: result.users.length,
-                    },
-                    data: result.users,
+                  const pagination = result.pagination ?? {
+                    pageNumber: pageConfig.pageNumber ?? 1,
+                    pageSize: pageConfig.pageSize ?? 100,
+                    totalAvailable: result.users.length,
                   };
+
+                  if (siteTotalAvailable === undefined) {
+                    siteTotalAvailable = pagination.totalAvailable;
+                  }
+
+                  return { pagination, data: result.users };
                 },
               });
             },
@@ -129,7 +134,7 @@ export const getListUsersTool = (server: WebMcpServer): WebTool<typeof paramsSch
 
           const toolResult: ListUsersToolResult = {
             users: filteredUsers,
-            totalAvailable: users.length,
+            totalAvailable: siteTotalAvailable,
           };
           return new Ok(toolResult);
         },

--- a/src/tools/web/users/listUsers.ts
+++ b/src/tools/web/users/listUsers.ts
@@ -6,6 +6,7 @@ import { getConfig } from '../../../config.js';
 import { useRestApi } from '../../../restApiInstance.js';
 import { User } from '../../../sdks/tableau/types/user.js';
 import { WebMcpServer } from '../../../server.web.js';
+import { paginate } from '../../../utils/paginate.js';
 import { assertAdmin } from '../adminGate.js';
 import { ConstrainedResult, WebTool } from '../tool.js';
 import { applyUserFilters } from './usersFilterUtils.js';
@@ -78,11 +79,13 @@ export const getListUsersTool = (server: WebMcpServer): WebTool<typeof paramsSch
       openWorldHint: false,
     },
     callback: async (args, extra): Promise<CallToolResult> => {
+      const configWithOverrides = await extra.getConfigWithOverrides();
+
       return await listUsersTool.logAndExecute({
         extra,
         args,
         callback: async () => {
-          const { allUsers, totalAvailable } = await useRestApi({
+          const users = await useRestApi({
             ...extra,
             jwtScopes: listUsersTool.requiredApiScopes,
             callback: async (restApi) => {
@@ -92,49 +95,41 @@ export const getListUsersTool = (server: WebMcpServer): WebTool<typeof paramsSch
                 throw new Error(adminResult.error);
               }
 
-              const pageSize = args.pageSize ?? 1000;
-              const limit = args.limit ?? Number.MAX_SAFE_INTEGER;
-              const allUsers: User[] = [];
-              let pageNumber = 1;
-              let totalAvailable: number | undefined;
+              const maxResultLimit = configWithOverrides.getMaxResultLimit(listUsersTool.name);
 
-              while (allUsers.length < limit) {
-                const result = await restApi.usersMethods.listUsers({
-                  siteId: restApi.siteId,
-                  pageSize: Math.min(pageSize, 1000),
-                  pageNumber,
-                });
+              return paginate({
+                pageConfig: {
+                  pageSize: args.pageSize,
+                  limit: maxResultLimit
+                    ? Math.min(maxResultLimit, args.limit ?? Number.MAX_SAFE_INTEGER)
+                    : args.limit,
+                },
+                getDataFn: async (pageConfig) => {
+                  const result = await restApi.usersMethods.listUsers({
+                    siteId: restApi.siteId,
+                    pageSize: pageConfig.pageSize,
+                    pageNumber: pageConfig.pageNumber,
+                  });
 
-                totalAvailable = result.pagination?.totalAvailable;
-                allUsers.push(...result.users);
-
-                // Stop if we got fewer than pageSize (last page) or no pagination info
-                if (
-                  result.users.length < pageSize ||
-                  !totalAvailable ||
-                  allUsers.length >= totalAvailable
-                ) {
-                  break;
-                }
-
-                pageNumber++;
-              }
-
-              return { allUsers, totalAvailable };
+                  return {
+                    pagination: result.pagination ?? {
+                      pageNumber: pageConfig.pageNumber ?? 1,
+                      pageSize: pageConfig.pageSize ?? 100,
+                      totalAvailable: result.users.length,
+                    },
+                    data: result.users,
+                  };
+                },
+              });
             },
           });
 
           // Apply client-side filtering
-          let filteredUsers = applyUserFilters(allUsers, args.filter);
-
-          // Apply limit to cap total results returned
-          if (args.limit) {
-            filteredUsers = filteredUsers.slice(0, args.limit);
-          }
+          const filteredUsers = applyUserFilters(users, args.filter);
 
           const toolResult: ListUsersToolResult = {
             users: filteredUsers,
-            totalAvailable,
+            totalAvailable: users.length,
           };
           return new Ok(toolResult);
         },

--- a/src/tools/web/users/listUsers.ts
+++ b/src/tools/web/users/listUsers.ts
@@ -82,7 +82,7 @@ export const getListUsersTool = (server: WebMcpServer): WebTool<typeof paramsSch
         extra,
         args,
         callback: async () => {
-          const users = await useRestApi({
+          const result = await useRestApi({
             ...extra,
             jwtScopes: listUsersTool.requiredApiScopes,
             callback: async (restApi) => {
@@ -100,19 +100,21 @@ export const getListUsersTool = (server: WebMcpServer): WebTool<typeof paramsSch
           });
 
           // Apply client-side filtering
-          let filteredUsers = applyUserFilters(users, args.filter);
+          let filteredUsers = applyUserFilters(result.users, args.filter);
 
           // Apply limit to cap total results returned
           if (args.limit) {
             filteredUsers = filteredUsers.slice(0, args.limit);
           }
 
-          return new Ok(filteredUsers);
+          const toolResult: ListUsersToolResult = {
+            users: filteredUsers,
+            totalAvailable: result.pagination?.totalAvailable,
+          };
+          return new Ok(toolResult);
         },
-        constrainSuccessResult: (users) =>
-          constrainUsers({
-            users,
-          }),
+        constrainSuccessResult: (toolResult) =>
+          constrainUsers({ users: toolResult.users, totalAvailable: toolResult.totalAvailable }),
       });
     },
   });
@@ -120,7 +122,18 @@ export const getListUsersTool = (server: WebMcpServer): WebTool<typeof paramsSch
   return listUsersTool;
 };
 
-export function constrainUsers({ users }: { users: Array<User> }): ConstrainedResult<Array<User>> {
+interface ListUsersToolResult {
+  users: Array<User>;
+  totalAvailable?: number;
+}
+
+export function constrainUsers({
+  users,
+  totalAvailable,
+}: {
+  users: Array<User>;
+  totalAvailable?: number;
+}): ConstrainedResult<ListUsersToolResult> {
   if (users.length === 0) {
     return {
       type: 'empty',
@@ -128,5 +141,5 @@ export function constrainUsers({ users }: { users: Array<User> }): ConstrainedRe
     };
   }
 
-  return { type: 'success', result: users };
+  return { type: 'success', result: { users, totalAvailable } };
 }

--- a/src/tools/web/users/mockUser.ts
+++ b/src/tools/web/users/mockUser.ts
@@ -1,0 +1,13 @@
+import { User } from '../../../sdks/tableau/types/user.js';
+
+export const mockUser: User = {
+  id: 'user-abc123',
+  name: 'jsmith',
+  siteRole: 'Creator',
+  email: 'john.smith@example.com',
+  fullName: 'John Smith',
+  lastLogin: '2026-05-20T10:30:00Z',
+  authSetting: 'SAML',
+  locale: 'en_US',
+  language: 'en',
+};

--- a/src/tools/web/users/usersFilterUtils.test.ts
+++ b/src/tools/web/users/usersFilterUtils.test.ts
@@ -1,0 +1,256 @@
+import { describe, expect, it } from 'vitest';
+
+import { User } from '../../../sdks/tableau/types/user.js';
+import {
+  applyUserFilters,
+  exportedForTesting,
+  parseAndValidateUsersFilterString,
+} from './usersFilterUtils.js';
+
+const { getFieldValue, matchesFilter } = exportedForTesting;
+
+const mockUser: User = {
+  id: 'user-123',
+  name: 'jsmith',
+  siteRole: 'Creator',
+  email: 'john.smith@example.com',
+  fullName: 'John Smith',
+  lastLogin: '2026-05-20T10:30:00Z',
+  authSetting: 'SAML',
+  locale: 'en_US',
+  language: 'en',
+};
+
+describe('usersFilterUtils', () => {
+  describe('parseAndValidateUsersFilterString', () => {
+    it('should parse valid filter string', () => {
+      const result = parseAndValidateUsersFilterString('id:eq:user-123');
+      expect(result).toBe('id:eq:user-123');
+    });
+
+    it('should parse multiple filters', () => {
+      const result = parseAndValidateUsersFilterString(
+        'siteRole:eq:Creator,email:eq:test@example.com',
+      );
+      expect(result).toBe('siteRole:eq:Creator,email:eq:test@example.com');
+    });
+
+    it('should throw on invalid field', () => {
+      expect(() => parseAndValidateUsersFilterString('invalidField:eq:value')).toThrow();
+    });
+
+    it('should throw on invalid operator for field', () => {
+      expect(() => parseAndValidateUsersFilterString('id:gt:123')).toThrow();
+    });
+  });
+
+  describe('getFieldValue', () => {
+    it('should get top-level fields', () => {
+      expect(getFieldValue(mockUser, 'id')).toBe('user-123');
+      expect(getFieldValue(mockUser, 'name')).toBe('jsmith');
+      expect(getFieldValue(mockUser, 'siteRole')).toBe('Creator');
+    });
+
+    it('should get user profile fields', () => {
+      expect(getFieldValue(mockUser, 'email')).toBe('john.smith@example.com');
+      expect(getFieldValue(mockUser, 'fullName')).toBe('John Smith');
+      expect(getFieldValue(mockUser, 'lastLogin')).toBe('2026-05-20T10:30:00Z');
+    });
+
+    it('should get authentication and locale fields', () => {
+      expect(getFieldValue(mockUser, 'authSetting')).toBe('SAML');
+      expect(getFieldValue(mockUser, 'locale')).toBe('en_US');
+      expect(getFieldValue(mockUser, 'language')).toBe('en');
+    });
+
+    it('should return undefined for missing optional fields', () => {
+      const minimalUser: User = { id: 'user-456', name: 'test' };
+      expect(getFieldValue(minimalUser, 'email')).toBeUndefined();
+      expect(getFieldValue(minimalUser, 'siteRole')).toBeUndefined();
+    });
+  });
+
+  describe('matchesFilter', () => {
+    describe('eq operator', () => {
+      it('should match equal strings', () => {
+        expect(matchesFilter('Creator', 'eq', 'Creator', 'siteRole')).toBe(true);
+      });
+
+      it('should not match different strings', () => {
+        expect(matchesFilter('Creator', 'eq', 'Viewer', 'siteRole')).toBe(false);
+      });
+    });
+
+    describe('in operator', () => {
+      it('should match value in pipe-separated list', () => {
+        expect(matchesFilter('Creator', 'in', 'Creator|Explorer|Viewer', 'siteRole')).toBe(true);
+      });
+
+      it('should not match value not in list', () => {
+        expect(
+          matchesFilter('ServerAdministrator', 'in', 'Creator|Explorer|Viewer', 'siteRole'),
+        ).toBe(false);
+      });
+    });
+
+    describe('comparison operators (date fields)', () => {
+      it('should compare dates with lt', () => {
+        expect(
+          matchesFilter('2026-05-20T00:00:00Z', 'lt', '2026-05-25T00:00:00Z', 'lastLogin'),
+        ).toBe(true);
+        expect(
+          matchesFilter('2026-05-30T00:00:00Z', 'lt', '2026-05-25T00:00:00Z', 'lastLogin'),
+        ).toBe(false);
+      });
+
+      it('should compare dates with gt', () => {
+        expect(
+          matchesFilter('2026-05-30T00:00:00Z', 'gt', '2026-05-25T00:00:00Z', 'lastLogin'),
+        ).toBe(true);
+        expect(
+          matchesFilter('2026-05-20T00:00:00Z', 'gt', '2026-05-25T00:00:00Z', 'lastLogin'),
+        ).toBe(false);
+        expect(
+          matchesFilter('2026-05-25T00:00:00Z', 'gt', '2026-05-25T00:00:00Z', 'lastLogin'),
+        ).toBe(false);
+      });
+
+      it('should compare dates with gte', () => {
+        expect(
+          matchesFilter('2026-05-25T00:00:00Z', 'gte', '2026-05-25T00:00:00Z', 'lastLogin'),
+        ).toBe(true);
+        expect(
+          matchesFilter('2026-05-24T00:00:00Z', 'gte', '2026-05-25T00:00:00Z', 'lastLogin'),
+        ).toBe(false);
+      });
+
+      it('should compare dates with lte', () => {
+        expect(
+          matchesFilter('2026-05-25T00:00:00Z', 'lte', '2026-05-25T00:00:00Z', 'lastLogin'),
+        ).toBe(true);
+        expect(
+          matchesFilter('2026-05-26T00:00:00Z', 'lte', '2026-05-25T00:00:00Z', 'lastLogin'),
+        ).toBe(false);
+      });
+
+      it('should handle fractional seconds in ISO 8601 dates', () => {
+        expect(
+          matchesFilter('2026-05-25T00:00:00.000Z', 'eq', '2026-05-25T00:00:00Z', 'lastLogin'),
+        ).toBe(true);
+        expect(
+          matchesFilter('2026-05-25T00:00:00.500Z', 'gt', '2026-05-25T00:00:00Z', 'lastLogin'),
+        ).toBe(true);
+      });
+
+      it('should handle timezone offsets in ISO 8601 dates', () => {
+        expect(
+          matchesFilter('2026-05-25T05:00:00+05:00', 'eq', '2026-05-25T00:00:00Z', 'lastLogin'),
+        ).toBe(true);
+      });
+    });
+
+    it('should return false for undefined/null values', () => {
+      expect(matchesFilter(undefined, 'eq', 'value', 'name')).toBe(false);
+      expect(matchesFilter(null as any, 'eq', 'value', 'name')).toBe(false);
+    });
+  });
+
+  describe('applyUserFilters', () => {
+    const users: User[] = [
+      mockUser,
+      {
+        id: 'user-456',
+        name: 'asmith',
+        siteRole: 'Viewer',
+        email: 'alice.smith@example.com',
+        fullName: 'Alice Smith',
+        lastLogin: '2026-05-15T08:00:00Z',
+        authSetting: 'ServerDefault',
+        locale: 'en_GB',
+        language: 'en',
+      },
+      {
+        id: 'user-789',
+        name: 'bjones',
+        siteRole: 'Unlicensed',
+        email: 'bob.jones@example.com',
+        fullName: 'Bob Jones',
+        lastLogin: '2024-12-01T12:00:00Z',
+        authSetting: 'SAML',
+        locale: 'en_US',
+        language: 'en',
+      },
+    ];
+
+    it('should return all users when no filter provided', () => {
+      const result = applyUserFilters(users, undefined);
+      expect(result).toEqual(users);
+    });
+
+    it('should filter by single field with eq', () => {
+      const result = applyUserFilters(users, 'siteRole:eq:Creator');
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('user-123');
+    });
+
+    it('should filter by siteRole with in operator', () => {
+      const result = applyUserFilters(users, 'siteRole:in:Creator|Viewer');
+      expect(result).toHaveLength(2);
+      expect(result[0].siteRole).toBe('Creator');
+      expect(result[1].siteRole).toBe('Viewer');
+    });
+
+    it('should filter by multiple conditions (AND)', () => {
+      const result = applyUserFilters(users, 'siteRole:eq:Creator,authSetting:eq:SAML');
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('user-123');
+    });
+
+    it('should return empty array when no users match', () => {
+      const result = applyUserFilters(users, 'siteRole:eq:ServerAdministrator');
+      expect(result).toHaveLength(0);
+    });
+
+    it('should filter by email', () => {
+      const result = applyUserFilters(users, 'email:eq:alice.smith@example.com');
+      expect(result).toHaveLength(1);
+      expect(result[0].name).toBe('asmith');
+    });
+
+    it('should filter inactive users by lastLogin', () => {
+      const result = applyUserFilters(users, 'lastLogin:lt:2025-01-01T00:00:00Z');
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('user-789');
+    });
+
+    it('should filter by locale', () => {
+      const result = applyUserFilters(users, 'locale:eq:en_US');
+      expect(result).toHaveLength(2);
+    });
+
+    it('should filter by authSetting', () => {
+      const result = applyUserFilters(users, 'authSetting:eq:SAML');
+      expect(result).toHaveLength(2);
+      expect(result[0].authSetting).toBe('SAML');
+      expect(result[1].authSetting).toBe('SAML');
+    });
+
+    it('should handle complex inactive user query', () => {
+      const result = applyUserFilters(
+        users,
+        'siteRole:eq:Unlicensed,lastLogin:lt:2025-01-01T00:00:00Z',
+      );
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('user-789');
+    });
+
+    it('should support date range with same-field multiple conditions', () => {
+      const result = applyUserFilters(
+        users,
+        'lastLogin:gt:2025-01-01T00:00:00Z,lastLogin:lt:2026-05-20T00:00:00Z',
+      );
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('user-456');
+    });
+  });
+});

--- a/src/tools/web/users/usersFilterUtils.ts
+++ b/src/tools/web/users/usersFilterUtils.ts
@@ -1,0 +1,186 @@
+import { z } from 'zod';
+
+import { User } from '../../../sdks/tableau/types/user.js';
+import {
+  FilterOperator,
+  FilterOperatorSchema,
+  parseAndValidateFilterString,
+} from '../../../utils/parseAndValidateFilterString.js';
+
+// === Field and Operator Definitions ===
+// Client-side filtering for users (API doesn't support server-side filtering)
+
+const FilterFieldSchema = z.enum([
+  'id',
+  'name',
+  'siteRole',
+  'email',
+  'fullName',
+  'lastLogin',
+  'authSetting',
+  'locale',
+  'language',
+  'externalAuthUserId',
+]);
+
+type FilterField = z.infer<typeof FilterFieldSchema>;
+
+const allowedOperatorsByField: Record<FilterField, FilterOperator[]> = {
+  id: ['eq', 'in'],
+  name: ['eq', 'in'],
+  siteRole: ['eq', 'in'],
+  email: ['eq', 'in'],
+  fullName: ['eq', 'in'],
+  lastLogin: ['eq', 'gt', 'gte', 'lt', 'lte'],
+  authSetting: ['eq', 'in'],
+  locale: ['eq', 'in'],
+  language: ['eq', 'in'],
+  externalAuthUserId: ['eq', 'in'],
+};
+
+const dateFields: Set<FilterField> = new Set(['lastLogin']);
+
+const _FilterExpressionSchema = z.object({
+  field: FilterFieldSchema,
+  operator: FilterOperatorSchema,
+  value: z.string(),
+});
+
+type FilterExpression = z.infer<typeof _FilterExpressionSchema>;
+
+export function parseAndValidateUsersFilterString(filterString: string): string {
+  return parseAndValidateFilterString<FilterField, FilterExpression>({
+    filterString,
+    allowedOperatorsByField,
+    filterFieldSchema: FilterFieldSchema,
+  });
+}
+
+/**
+ * Apply client-side filtering to users based on filter expressions.
+ * Supports field:operator:value syntax (e.g., "siteRole:eq:Creator")
+ * Supports multiple conditions on the same field (e.g., "lastLogin:gt:X,lastLogin:lt:Y" for date ranges)
+ */
+export function applyUserFilters(users: User[], filterString: string | undefined): User[] {
+  if (!filterString) {
+    return users;
+  }
+
+  // Parse filter expressions directly to preserve duplicate fields (e.g., date ranges)
+  const expressions = filterString
+    .split(',')
+    .map((f) => f.trim())
+    .filter(Boolean);
+
+  const filters = expressions.map((expr) => {
+    const [fieldRaw, operatorRaw, ...valueParts] = expr.split(':');
+    const field = FilterFieldSchema.parse(fieldRaw);
+    const operator = FilterOperatorSchema.parse(operatorRaw);
+
+    if (!allowedOperatorsByField[field].includes(operator)) {
+      throw new Error(
+        `Operator '${operator}' is not allowed for field '${field}'. Allowed operators: ${allowedOperatorsByField[field].join(', ')}`,
+      );
+    }
+
+    return {
+      field,
+      operator,
+      value: valueParts.join(':'),
+    };
+  });
+
+  return users.filter((user) => {
+    return filters.every(({ field, operator, value }) => {
+      const fieldValue = getFieldValue(user, field);
+      return matchesFilter(fieldValue, operator, value, field);
+    });
+  });
+}
+
+function getFieldValue(user: User, field: FilterField): string | number | undefined {
+  switch (field) {
+    case 'id':
+      return user.id;
+    case 'name':
+      return user.name;
+    case 'siteRole':
+      return user.siteRole;
+    case 'email':
+      return user.email;
+    case 'fullName':
+      return user.fullName;
+    case 'lastLogin':
+      return user.lastLogin;
+    case 'authSetting':
+      return user.authSetting;
+    case 'locale':
+      return user.locale;
+    case 'language':
+      return user.language;
+    case 'externalAuthUserId':
+      return user.externalAuthUserId;
+    default:
+      return undefined;
+  }
+}
+
+function matchesFilter(
+  fieldValue: string | number | undefined,
+  operator: FilterOperator,
+  filterValue: string,
+  field: FilterField,
+): boolean {
+  if (fieldValue === undefined || fieldValue === null) {
+    return false;
+  }
+
+  const fieldStr = String(fieldValue);
+
+  switch (operator) {
+    case 'eq':
+      if (dateFields.has(field)) {
+        return new Date(fieldStr).getTime() === new Date(filterValue).getTime();
+      }
+      return fieldStr === filterValue;
+    case 'in':
+      return filterValue.split('|').includes(fieldStr);
+    case 'gt':
+      if (dateFields.has(field)) {
+        return new Date(fieldStr).getTime() > new Date(filterValue).getTime();
+      }
+      return typeof fieldValue === 'number'
+        ? fieldValue > Number(filterValue)
+        : fieldStr > filterValue;
+    case 'gte':
+      if (dateFields.has(field)) {
+        return new Date(fieldStr).getTime() >= new Date(filterValue).getTime();
+      }
+      return typeof fieldValue === 'number'
+        ? fieldValue >= Number(filterValue)
+        : fieldStr >= filterValue;
+    case 'lt':
+      if (dateFields.has(field)) {
+        return new Date(fieldStr).getTime() < new Date(filterValue).getTime();
+      }
+      return typeof fieldValue === 'number'
+        ? fieldValue < Number(filterValue)
+        : fieldStr < filterValue;
+    case 'lte':
+      if (dateFields.has(field)) {
+        return new Date(fieldStr).getTime() <= new Date(filterValue).getTime();
+      }
+      return typeof fieldValue === 'number'
+        ? fieldValue <= Number(filterValue)
+        : fieldStr <= filterValue;
+    default:
+      return false;
+  }
+}
+
+export const exportedForTesting = {
+  FilterFieldSchema,
+  applyUserFilters,
+  getFieldValue,
+  matchesFilter,
+};

--- a/src/utils/paginate.test.ts
+++ b/src/utils/paginate.test.ts
@@ -174,6 +174,50 @@ describe('paginate', () => {
     expect(getDataFn).not.toHaveBeenCalled();
   });
 
+  it('should clamp pageSize to 1000 when a larger value is provided', async () => {
+    const mockData = [{ id: 1 }];
+    const mockPagination: Pagination = {
+      pageNumber: 1,
+      pageSize: 1000,
+      totalAvailable: 1,
+    };
+
+    const getDataFn = vi.fn().mockResolvedValue({
+      pagination: mockPagination,
+      data: mockData,
+    });
+
+    const result = await paginate({
+      pageConfig: { pageSize: 5000, pageNumber: 1 },
+      getDataFn,
+    });
+
+    expect(result).toEqual(mockData);
+    expect(getDataFn).toHaveBeenCalledWith({ pageSize: 1000, pageNumber: 1 });
+  });
+
+  it('should not clamp pageSize when it is at or below 1000', async () => {
+    const mockData = [{ id: 1 }];
+    const mockPagination: Pagination = {
+      pageNumber: 1,
+      pageSize: 500,
+      totalAvailable: 1,
+    };
+
+    const getDataFn = vi.fn().mockResolvedValue({
+      pagination: mockPagination,
+      data: mockData,
+    });
+
+    const result = await paginate({
+      pageConfig: { pageSize: 500, pageNumber: 1 },
+      getDataFn,
+    });
+
+    expect(result).toEqual(mockData);
+    expect(getDataFn).toHaveBeenCalledWith({ pageSize: 500, pageNumber: 1 });
+  });
+
   it('should handle case where totalAvailable equals data length after first page', async () => {
     const mockData = [{ id: 1 }, { id: 2 }];
     const mockPagination: Pagination = {

--- a/src/utils/paginate.ts
+++ b/src/utils/paginate.ts
@@ -19,15 +19,19 @@ type PaginateArgs<T> = {
   getDataFn: (pagination: PageConfig) => Promise<{ pagination: Pagination; data: Array<T> }>;
 };
 
+const MAX_PAGE_SIZE = 1000;
+
 export async function paginate<T>({ pageConfig, getDataFn }: PaginateArgs<T>): Promise<Array<T>> {
   const { pageSize, limit } = pageConfigSchema.parse(pageConfig);
-  const { pagination, data } = await getDataFn(pageConfig);
+  const effectivePageSize = pageSize ? Math.min(pageSize, MAX_PAGE_SIZE) : pageSize;
+
+  const { pagination, data } = await getDataFn({ ...pageConfig, pageSize: effectivePageSize });
   const result = [...data];
 
   let { totalAvailable, pageNumber } = pagination;
   while (totalAvailable > result.length && (!limit || limit > result.length)) {
     const { pagination: nextPagination, data: nextData } = await getDataFn({
-      pageSize,
+      pageSize: effectivePageSize,
       pageNumber: pageNumber + 1,
       limit,
     });

--- a/tests/e2e/server.test.ts
+++ b/tests/e2e/server.test.ts
@@ -36,6 +36,7 @@ describe('server', () => {
       const oauthOnlyTools: ReadonlyArray<WebToolName> = ['revoke-access-token', 'reset-consent'];
       const adminOnlyTools: ReadonlyArray<WebToolName> = [
         'list-extract-refresh-tasks',
+        'list-users',
         'query-admin-insights-ts-events',
         'query-admin-insights-site-content',
         'get-stale-content-report',
@@ -110,6 +111,7 @@ describe('server', () => {
       const oauthOnlyTools: ReadonlyArray<WebToolName> = ['revoke-access-token', 'reset-consent'];
       const adminOnlyTools: ReadonlyArray<WebToolName> = [
         'list-extract-refresh-tasks',
+        'list-users',
         'query-admin-insights-ts-events',
         'query-admin-insights-site-content',
         'get-stale-content-report',

--- a/tests/oauth/embedded-authz/oauth.test.ts
+++ b/tests/oauth/embedded-authz/oauth.test.ts
@@ -140,6 +140,7 @@ describe('OAuth', () => {
       scopes_supported: [
         'tableau:mcp:datasource:read',
         'tableau:mcp:tasks:read',
+        'tableau:mcp:users:read',
         'tableau:mcp:workbook:read',
         'tableau:mcp:content:read',
         'tableau:mcp:view:read',
@@ -168,6 +169,7 @@ describe('OAuth', () => {
       scopes_supported: [
         'tableau:mcp:datasource:read',
         'tableau:mcp:tasks:read',
+        'tableau:mcp:users:read',
         'tableau:mcp:workbook:read',
         'tableau:mcp:content:read',
         'tableau:mcp:view:read',
@@ -201,6 +203,7 @@ describe('OAuth', () => {
       scopes_supported: [
         'tableau:mcp:datasource:read',
         'tableau:mcp:tasks:read',
+        'tableau:mcp:users:read',
         'tableau:mcp:workbook:read',
         'tableau:mcp:content:read',
         'tableau:mcp:view:read',

--- a/tests/oauth/tableau-authz/tests/oauth.test.ts
+++ b/tests/oauth/tableau-authz/tests/oauth.test.ts
@@ -3,6 +3,7 @@ import { expect, test } from './base.js';
 
 const ADMIN_GATED_TOOL_NAMES: ReadonlyArray<string> = [
   'list-extract-refresh-tasks',
+  'list-users',
   'query-admin-insights-ts-events',
   'query-admin-insights-site-content',
   'get-stale-content-report',


### PR DESCRIPTION
## Summary

Adds a new `list-users` MCP tool (JTBD #3A-1) that retrieves all users on a Tableau site with client-side filtering and pagination. This is the foundational tool for the **User License Reclamation** admin workflow.

- Extends user schema with admin fields (`authSetting`, `locale`, `language`, `externalAuthUserId`)
- Adds `GET /sites/:siteId/users` endpoint with response normalization
- Creates admin-gated tool with 9 filterable fields and 6 filter operators
- Implements `pageSize` and `limit` for client-side result capping
- Registers new `tableau:mcp:users:read` MCP scope
- Bumps version to 2.7.0
- Also fixes `list-extract-refresh-tasks` to respect its `pageSize`/`limit` params (previously declared but ignored)

## What this enables

```
// Find inactive users (no login in 6 months)
filter: "lastLogin:lt:2025-12-01T00:00:00Z"

// Find expensive licenses with no recent activity
filter: "siteRole:in:Creator|Explorer,lastLogin:lt:2025-01-01T00:00:00Z"

// License reclamation candidates — first 20 results
filter: "siteRole:eq:Unlicensed", limit: 20
```

## Files changed (21)

**New (8):** tool, filter utils, mock, 4 test files, documentation
**Modified (13):** user.ts, usersApi.ts, usersMethods.ts, tools.ts, toolName.ts, scopes.ts, package.json, package-lock.json, listExtractRefreshTasks.ts + test, e2e test, oauth tests (x2)

## Test plan

- [x] 52 new user tests + 3 new extract-refresh-tasks tests (100% coverage on new code)
- [x] Full test suite passes (1442 tests, 95 files)
- [x] TypeScript compilation clean
- [x] ESLint clean
- [x] Build succeeds
- [x] Tested manually via MCP Inspector against Tableau Cloud (filter, limit, pageSize all verified)
- [x] E2E server test updated with `list-users` in `adminOnlyTools`
- [x] OAuth test updated with `list-users` in `ADMIN_GATED_TOOL_NAMES`
- [x] Embedded OAuth test updated with `tableau:mcp:users:read` in `scopes_supported`
- [x] CI passes

## Related

- **GUS:** [W-22720724](https://gus.my.salesforce.com/lightning/r/ADM_Work__c/a07EE00002b5pKjYAI/view)
- **JTBD:** [#3A-1 in Work Breakdown](https://docs.google.com/document/d/1DMp-4P5ighq027IjA9iBBWLE_6TEEdjW_P1X1dMzVKs)
- **Sibling PR:** [#359 — list-extract-refresh-tasks](https://github.com/tableau/tableau-mcp/pull/359)
- **Implementation Plan:** [264 doc](https://docs.google.com/document/d/148av48p_nM8VDk8awRh49CmkhLI23gYsGZODxlR-SGc)

🤖 Generated with [Claude Code](https://claude.com/claude-code)