### PR TITLE
@W-22760495: Add query-admin-insights-job-performance tool

### DIFF
--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -42,6 +42,7 @@ Tableau's official MCP Server. Helping Agents see and understand data.
 | [search-content](tools/content-exploration/search-content.md)                                                         | Searches for content in a Tableau site ([Content Exploration API][content-exploration])                             |
 | [query-admin-insights-ts-events](tools/admin-insights/query-admin-insights-ts-events.md)                              | Admin-only. Issues a VDS query against the Admin Insights `TS Events` datasource ([VDS API][vds])                   |
 | [query-admin-insights-site-content](tools/admin-insights/query-admin-insights-site-content.md)                        | Admin-only. Issues a VDS query against the Admin Insights `Site Content` datasource ([VDS API][vds])                |
+| [query-admin-insights-job-performance](tools/admin-insights/query-admin-insights-job-performance.md)                  | Admin-only. Issues a VDS query against the Admin Insights `Job Performance` datasource ([VDS API][vds])             |
 | [get-stale-content-report](tools/admin-insights/get-stale-content-report.md)                                          | Admin-only. Deterministic stale-content report from `Site Content` ([VDS API][vds])                                 |
 
 [query]:

--- a/docs/docs/tools/admin-insights/query-admin-insights-job-performance.md
+++ b/docs/docs/tools/admin-insights/query-admin-insights-job-performance.md
@@ -1,0 +1,133 @@
+---
+sidebar_position: 3
+---
+
+# Query Admin Insights — Job Performance
+
+Issues a [VizQL Data Service (VDS)](https://help.tableau.com/current/api/vizql-data-service/en-us/index.html)
+query against the Admin Insights `Job Performance` published datasource on the connected Tableau Cloud
+site. Returns records of extract refresh jobs, subscription jobs, flow runs, and bridge jobs.
+
+The tool is admin-only — it is registered only when `ADMIN_TOOLS_ENABLED=true`, and at request
+time it verifies the caller's site role and rejects anything below
+`SiteAdministratorCreator` / `SiteAdministratorExplorer` / `ServerAdministrator`. The Admin
+Insights datasource LUID is resolved automatically; callers do not pass `datasourceLuid`.
+
+## APIs called
+
+- [Query Datasource (VDS)](https://help.tableau.com/current/api/vizql-data-service/en-us/reference/index.html#tag/HeadlessBI/operation/QueryDatasource)
+- [Query Data Sources (REST)](https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref_data_sources.htm#query_data_sources) — used internally to resolve the `Job Performance` dataset LUID
+- [Get User on Site (REST)](https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref_users_and_groups.htm#get_user_on_site) — used internally for the admin gate
+
+## Required arguments
+
+### `query`
+
+A fully formed VDS [`query`](https://help.tableau.com/current/api/vizql-data-service/en-us/reference/index.html#tag/HeadlessBI/operation/QueryDatasource)
+object: `fields`, `filters`, `parameters`. The schema mirrors the schema accepted by the
+[`query-datasource`](../data-qna/query-datasource.md) tool.
+
+The `fields` array must contain at least one entry — omitting it causes a VDS error.
+
+Common usage:
+
+- Analyze extract refresh durations and failure rates per datasource or workbook.
+- Identify extracts with high consecutive failure counts or long run times.
+- Compare scheduled frequency against actual job completion times to recommend schedule optimization.
+- Find jobs that overlap or compete for resources in the same time window.
+
+### Available fields
+
+| Category | Fields |
+|----------|--------|
+| **Job identity** | Job ID, Job LUID, Job Type, Job Result, Final Job Result |
+| **Item details** | Item ID, Item LUID, Item Name, Item Type, Item Hyperlink |
+| **Timing (UTC)** | Created At, Queued At, Started At, Completed At, Overflow Queued At |
+| **Timing (local)** | Created At (local), Queued At (local), Started At (local), Completed At (local), Overflow Queued At (local) |
+| **Durations (seconds)** | Job Duration, Job Execution Duration, Job Queued Duration, Job Overflow Queued Duration |
+| **Schedule** | Schedule Name, Schedule LUID |
+| **Owner/Project** | Owner Email, Parent Project Name, Parent Project Owner Email |
+| **Extract** | Extract File Size |
+| **Subscription** | Subscriber Email, Subscriber ID, Subscription Subject |
+| **Bridge** | Agent Name, Agent Version, Agent Timezone, Agent is Pooled?, Pool Name, Bridge Started At, Bridge Completed At, Bridge Started At (Local), Bridge Completed At (Local), Bridge Refresh Duration, Bridge Extract Upload Duration, Bridge Job Result, Bridge Error Message, Bridge Error Type, Bridge Initiator User Name |
+| **Flags** | Was Manual Run, Was Overflow Queued |
+| **Other** | Error Message, Admin Insights Published At |
+
+Example:
+
+```json
+{
+  "query": {
+    "fields": [
+      { "fieldCaption": "Item Name" },
+      { "fieldCaption": "Job Type" },
+      { "fieldCaption": "Job Result" },
+      { "fieldCaption": "Started At" },
+      { "fieldCaption": "Job Duration" },
+      { "fieldCaption": "Schedule Name" }
+    ],
+    "filters": [
+      {
+        "field": { "fieldCaption": "Job Type" },
+        "filterType": "SET",
+        "values": ["Refresh Extracts"],
+        "exclude": false
+      }
+    ]
+  }
+}
+```
+
+## Optional arguments
+
+### `limit`
+
+The maximum number of rows to return. The tool will pass this through as `rowLimit` on the VDS
+request and additionally truncate the response if VDS returns more rows than requested.
+
+Example: `500`
+
+See also: [`MAX_RESULT_LIMIT`](../../configuration/mcp-config/env-vars.md#max_result_limit)
+
+## Parameters
+
+The Job Performance datasource exposes a `Timezone` parameter (integer offset, e.g. `-7` for PDT).
+Local-time fields (`Started At (local)`, `Completed At (local)`, etc.) are adjusted by this
+parameter. Pass it via the `parameters` field of the query object if you need local-time output.
+
+## Notes and caveats
+
+- Tableau Cloud Job Performance lookback caps at **90 days by default** (365 days with Advanced
+  Management).
+- The datasource does not support server-side pagination — use filters and `limit` to control
+  response size. For large sites, always filter by `Job Type` and/or a date range on `Started At`.
+- This tool intentionally bypasses the standard datasource access checker because the Admin
+  Insights datasources are internal/known and admin-gated independently.
+- For the complete field schema with data types and descriptions, use
+  [`get-datasource-metadata`](../data-qna/get-datasource-metadata.md) with the Job Performance
+  datasource LUID.
+
+## Example result
+
+```json
+{
+  "data": [
+    {
+      "Item Name": "Sales Pipeline",
+      "Job Type": "Refresh Extracts",
+      "Job Result": "Succeeded",
+      "Started At": "2026-05-28T08:00:12Z",
+      "Job Duration": 45.2,
+      "Schedule Name": "Daily at 8am"
+    },
+    {
+      "Item Name": "Marketing Dashboard",
+      "Job Type": "Refresh Extracts",
+      "Job Result": "Failed",
+      "Started At": "2026-05-28T08:15:00Z",
+      "Job Duration": 120.8,
+      "Schedule Name": "Daily at 8am"
+    }
+  ]
+}
+```

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "2.7.4",
+  "version": "2.8.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/src/server/oauth/scopes.ts
+++ b/src/server/oauth/scopes.ts
@@ -202,6 +202,15 @@ const toolScopeMap: Record<
       'tableau:users:read',
     ]),
   },
+  'query-admin-insights-job-performance': {
+    mcp: ['tableau:mcp:datasource:read'],
+    api: new Set([
+      'tableau:viz_data_service:read',
+      'tableau:content:read',
+      'tableau:mcp_site_settings:read',
+      'tableau:users:read',
+    ]),
+  },
   // Server-side anti-join: runs TS Events + Site Content VDS queries internally,
   // applies threshold, returns final filtered rows. Deterministic — no LLM math.
   'get-stale-content-report': {
@@ -225,6 +234,7 @@ function getEnabledToolNames(): Set<WebToolName> {
     enabledTools.delete('list-users');
     enabledTools.delete('query-admin-insights-ts-events');
     enabledTools.delete('query-admin-insights-site-content');
+    enabledTools.delete('query-admin-insights-job-performance');
     enabledTools.delete('get-stale-content-report');
   }
 

--- a/src/tools/web/adminInsights/queryJobPerformance.test.ts
+++ b/src/tools/web/adminInsights/queryJobPerformance.test.ts
@@ -1,0 +1,92 @@
+import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { Err, Ok } from 'ts-results-es';
+
+import { Query } from '../../../sdks/tableau/apis/vizqlDataServiceApi.js';
+import { WebMcpServer } from '../../../server.web.js';
+import { Provider } from '../../../utils/provider.js';
+import { getMockRequestHandlerExtra } from '../toolContext.mock.js';
+import { getQueryAdminInsightsJobPerformanceTool } from './queryJobPerformance.js';
+import { adminInsightsResolver } from './resolver.js';
+
+const mocks = vi.hoisted(() => ({
+  mockQueryDatasource: vi.fn(),
+  mockListDatasources: vi.fn(),
+  mockAssertAdmin: vi.fn(),
+}));
+
+vi.mock('../../../restApiInstance.js', () => ({
+  useRestApi: vi.fn().mockImplementation(async ({ callback }) =>
+    callback({
+      siteId: 'site-test',
+      userId: 'user-test',
+      vizqlDataServiceMethods: {
+        queryDatasource: mocks.mockQueryDatasource,
+      },
+      datasourcesMethods: {
+        listDatasources: mocks.mockListDatasources,
+      },
+    }),
+  ),
+}));
+
+vi.mock('../adminGate.js', () => ({
+  assertAdmin: mocks.mockAssertAdmin,
+}));
+
+const validQuery: Query = {
+  fields: [{ fieldCaption: 'Job ID' }],
+};
+
+describe('query-admin-insights-job-performance tool', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    adminInsightsResolver.clearCache();
+
+    mocks.mockAssertAdmin.mockResolvedValue(new Ok(true));
+    mocks.mockListDatasources.mockResolvedValue({
+      pagination: { pageNumber: 1, pageSize: 100, totalAvailable: 1 },
+      datasources: [{ id: 'luid-jp', name: 'Job Performance' }],
+    });
+  });
+
+  it('exposes the documented tool name', () => {
+    const tool = getQueryAdminInsightsJobPerformanceTool(new WebMcpServer());
+    expect(tool.name).toBe('query-admin-insights-job-performance');
+  });
+
+  it('runs the VDS query against the resolved Job Performance LUID and returns OK', async () => {
+    mocks.mockQueryDatasource.mockResolvedValue(
+      new Ok({ data: [{ 'Job ID': 'job-1', 'Started At': '2026-05-01T10:00:00Z' }] }),
+    );
+
+    const result = await getToolResult({ query: validQuery });
+
+    expect(result.isError).toBeFalsy();
+    expect(mocks.mockListDatasources).toHaveBeenCalled();
+    expect(mocks.mockQueryDatasource).toHaveBeenCalledWith(
+      expect.objectContaining({
+        datasource: { datasourceLuid: 'luid-jp' },
+      }),
+    );
+  });
+
+  it('returns 403 when the caller is not an admin', async () => {
+    mocks.mockAssertAdmin.mockResolvedValueOnce(
+      new Err('This tool requires site administrator permissions. Your site role is: Viewer'),
+    );
+
+    const result = await getToolResult({ query: validQuery });
+
+    expect(result.isError).toBe(true);
+    if (result.content[0].type !== 'text') {
+      throw new Error('expected text content');
+    }
+    expect(result.content[0].text).toContain('admin');
+  });
+});
+
+async function getToolResult(params: { query: Query }): Promise<CallToolResult> {
+  const tool = getQueryAdminInsightsJobPerformanceTool(new WebMcpServer());
+  const callback = await Provider.from(tool.callback);
+  return await callback({ query: params.query, limit: undefined }, getMockRequestHandlerExtra());
+}

--- a/src/tools/web/adminInsights/queryJobPerformance.ts
+++ b/src/tools/web/adminInsights/queryJobPerformance.ts
@@ -34,31 +34,38 @@ uses \`fieldCaption\` matching the column names below. Common usage:
 - Compare scheduled frequency against actual job completion times to recommend schedule optimization.
 - Find jobs that overlap or compete for resources in the same time window.
 
-Available field captions:
-- Job ID, Job Type (e.g. "refresh_extracts", "subscription", "flow_run", "bridge_refresh")
-- Content ID, Content Name, Content Type (e.g. "Datasource", "Workbook", "Flow")
-- Started At, Completed At, Job Duration (seconds)
-- Job Status (e.g. "Success", "Failed", "Cancelled")
-- Schedule Name, Schedule Frequency, Schedule Type
-- Site LUID, Task LUID
-- Worker
-- Content Owner Email, Content Owner Name
+Available field captions (use exact names with \`fieldCaption\`):
+- **Job identity**: Job ID, Job LUID, Job Type, Job Result, Final Job Result
+- **Item details**: Item ID, Item LUID, Item Name, Item Type, Item Hyperlink
+- **Timing (UTC)**: Created At, Queued At, Started At, Completed At, Overflow Queued At
+- **Timing (local)**: Created At (local), Queued At (local), Started At (local), Completed At (local), Overflow Queued At (local)
+- **Durations (seconds)**: Job Duration, Job Execution Duration, Job Queued Duration, Job Overflow Queued Duration
+- **Schedule**: Schedule Name, Schedule LUID
+- **Owner/Project**: Owner Email, Parent Project Name, Parent Project Owner Email
+- **Extract**: Extract File Size
+- **Subscription**: Subscriber Email, Subscriber ID, Subscription Subject
+- **Bridge**: Agent Name, Agent Version, Agent Timezone, Agent is Pooled?, Pool Name, Bridge Started At, Bridge Completed At, Bridge Started At (Local), Bridge Completed At (Local), Bridge Refresh Duration, Bridge Extract Upload Duration, Bridge Job Result, Bridge Error Message, Bridge Error Type, Bridge Initiator User Name
+- **Flags**: Was Manual Run, Was Overflow Queued
+- **Other**: Error Message, Admin Insights Published At
+
+Parameters: Timezone (integer offset, e.g. -7 for PDT)
 
 Example query:
 \`\`\`json
 {
   "fields": [
-    { "fieldCaption": "Content Name" },
+    { "fieldCaption": "Item Name" },
     { "fieldCaption": "Job Type" },
-    { "fieldCaption": "Job Status" },
+    { "fieldCaption": "Job Result" },
     { "fieldCaption": "Started At" },
-    { "fieldCaption": "Job Duration (seconds)" }
+    { "fieldCaption": "Job Duration" },
+    { "fieldCaption": "Schedule Name" }
   ],
   "filters": [
     {
       "field": { "fieldCaption": "Job Type" },
       "filterType": "SET",
-      "values": ["refresh_extracts"],
+      "values": ["Refresh Extracts"],
       "exclude": false
     }
   ]

--- a/src/tools/web/adminInsights/queryJobPerformance.ts
+++ b/src/tools/web/adminInsights/queryJobPerformance.ts
@@ -27,28 +27,19 @@ records of extract refresh jobs, subscription jobs, flow runs, and bridge jobs o
 Cloud site. This tool is restricted to Tableau site administrators on Tableau Cloud sites with Admin
 Insights enabled.
 
-Caller supplies a fully formed VDS \`query\` object with at least one entry in \`fields\`. Each field
-uses \`fieldCaption\` matching the column names below. Common usage:
+Caller supplies a fully formed VDS \`query\` object (fields, filters, parameters). Common usage:
 - Analyze extract refresh durations and failure rates per datasource or workbook.
 - Identify extracts with high consecutive failure counts or long run times.
 - Compare scheduled frequency against actual job completion times to recommend schedule optimization.
 - Find jobs that overlap or compete for resources in the same time window.
 
-Available field captions (use exact names with \`fieldCaption\`):
-- **Job identity**: Job ID, Job LUID, Job Type, Job Result, Final Job Result
-- **Item details**: Item ID, Item LUID, Item Name, Item Type, Item Hyperlink
-- **Timing (UTC)**: Created At, Queued At, Started At, Completed At, Overflow Queued At
-- **Timing (local)**: Created At (local), Queued At (local), Started At (local), Completed At (local), Overflow Queued At (local)
-- **Durations (seconds)**: Job Duration, Job Execution Duration, Job Queued Duration, Job Overflow Queued Duration
-- **Schedule**: Schedule Name, Schedule LUID
-- **Owner/Project**: Owner Email, Parent Project Name, Parent Project Owner Email
-- **Extract**: Extract File Size
-- **Subscription**: Subscriber Email, Subscriber ID, Subscription Subject
-- **Bridge**: Agent Name, Agent Version, Agent Timezone, Agent is Pooled?, Pool Name, Bridge Started At, Bridge Completed At, Bridge Started At (Local), Bridge Completed At (Local), Bridge Refresh Duration, Bridge Extract Upload Duration, Bridge Job Result, Bridge Error Message, Bridge Error Type, Bridge Initiator User Name
-- **Flags**: Was Manual Run, Was Overflow Queued
-- **Other**: Error Message, Admin Insights Published At
+Key field captions include: Job ID, Job Type, Job Result, Item Name, Item Type, Started At,
+Completed At, Job Duration, Job Execution Duration, Schedule Name, Owner Email, Extract File Size.
+For the full list of 52 available fields, use \`get-datasource-metadata\` on the Job Performance
+datasource or see the tool documentation.
 
-Parameters: Timezone (integer offset, e.g. -7 for PDT)
+The datasource exposes a Timezone parameter that adjusts local-time fields. Pass it inside
+\`query.parameters\` as \`{ "parameterCaption": "Timezone", "dataType": "INTEGER", "value": -7 }\`.
 
 Example query:
 \`\`\`json

--- a/src/tools/web/adminInsights/queryJobPerformance.ts
+++ b/src/tools/web/adminInsights/queryJobPerformance.ts
@@ -1,0 +1,106 @@
+import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { z } from 'zod';
+
+import { getConfig } from '../../../config.js';
+import { querySchema } from '../../../sdks/tableau/apis/vizqlDataServiceApi.js';
+import { WebMcpServer } from '../../../server.web.js';
+import { WebTool } from '../tool.js';
+import { runAdminInsightsQuery } from './adminInsightsToolBase.js';
+import { ADMIN_INSIGHTS_DATASETS } from './resolver.js';
+
+const paramsSchema = {
+  query: querySchema,
+  limit: z.number().int().min(1).optional(),
+};
+
+export const getQueryAdminInsightsJobPerformanceTool = (
+  server: WebMcpServer,
+): WebTool<typeof paramsSchema> => {
+  const config = getConfig();
+  const tool = new WebTool({
+    server,
+    name: 'query-admin-insights-job-performance',
+    disabled: !config.adminToolsEnabled,
+    description: `
+Queries the Admin Insights "Job Performance" published datasource via the VizQL Data Service. Returns
+records of extract refresh jobs, subscription jobs, flow runs, and bridge jobs on the current Tableau
+Cloud site. This tool is restricted to Tableau site administrators on Tableau Cloud sites with Admin
+Insights enabled.
+
+Caller supplies a fully formed VDS \`query\` object with at least one entry in \`fields\`. Each field
+uses \`fieldCaption\` matching the column names below. Common usage:
+- Analyze extract refresh durations and failure rates per datasource or workbook.
+- Identify extracts with high consecutive failure counts or long run times.
+- Compare scheduled frequency against actual job completion times to recommend schedule optimization.
+- Find jobs that overlap or compete for resources in the same time window.
+
+Available field captions:
+- Job ID, Job Type (e.g. "refresh_extracts", "subscription", "flow_run", "bridge_refresh")
+- Content ID, Content Name, Content Type (e.g. "Datasource", "Workbook", "Flow")
+- Started At, Completed At, Job Duration (seconds)
+- Job Status (e.g. "Success", "Failed", "Cancelled")
+- Schedule Name, Schedule Frequency, Schedule Type
+- Site LUID, Task LUID
+- Worker
+- Content Owner Email, Content Owner Name
+
+Example query:
+\`\`\`json
+{
+  "fields": [
+    { "fieldCaption": "Content Name" },
+    { "fieldCaption": "Job Type" },
+    { "fieldCaption": "Job Status" },
+    { "fieldCaption": "Started At" },
+    { "fieldCaption": "Job Duration (seconds)" }
+  ],
+  "filters": [
+    {
+      "field": { "fieldCaption": "Job Type" },
+      "filterType": "SET",
+      "values": ["refresh_extracts"],
+      "exclude": false
+    }
+  ]
+}
+\`\`\`
+
+Notes:
+- The \`query.fields\` array must contain at least one field — omitting it causes a VDS error.
+- Tableau Cloud lookback is 90 days by default (365 days with Advanced Management).
+- The underlying datasource LUID is resolved automatically; callers do not pass datasourceLuid.
+- This tool bypasses the standard datasource access checker because the dataset is internal
+  and admin-gated.
+`.trim(),
+    paramsSchema,
+    annotations: {
+      title: 'Query Admin Insights — Job Performance',
+      readOnlyHint: true,
+      openWorldHint: false,
+    },
+    callback: async ({ query, limit }, extra): Promise<CallToolResult> => {
+      const configWithOverrides = await extra.getConfigWithOverrides();
+      return await tool.logAndExecute({
+        extra,
+        args: { query, limit },
+        callback: async () => {
+          const maxResultLimit = configWithOverrides.getMaxResultLimit(tool.name);
+          const rowLimit = maxResultLimit
+            ? Math.min(maxResultLimit, limit ?? Number.MAX_SAFE_INTEGER)
+            : limit;
+
+          return await runAdminInsightsQuery({
+            extra,
+            jwtScopes: tool.requiredApiScopes,
+            datasetName: ADMIN_INSIGHTS_DATASETS.JOB_PERFORMANCE,
+            query,
+            rowLimit,
+          });
+        },
+        constrainSuccessResult: (queryOutput) => ({ type: 'success', result: queryOutput }),
+      });
+    },
+  });
+
+  return tool;
+};

--- a/src/tools/web/adminInsights/resolver.ts
+++ b/src/tools/web/adminInsights/resolver.ts
@@ -9,6 +9,7 @@ export const ADMIN_INSIGHTS_PROJECT_NAME = 'Admin Insights';
 export const ADMIN_INSIGHTS_DATASETS = {
   TS_EVENTS: 'TS Events',
   SITE_CONTENT: 'Site Content',
+  JOB_PERFORMANCE: 'Job Performance',
 } as const;
 
 export type AdminInsightsDataset =

--- a/src/tools/web/toolName.ts
+++ b/src/tools/web/toolName.ts
@@ -25,6 +25,7 @@ export const webToolNames = [
   'reset-consent',
   'query-admin-insights-ts-events',
   'query-admin-insights-site-content',
+  'query-admin-insights-job-performance',
   'get-stale-content-report',
 ] as const;
 export type WebToolName = (typeof webToolNames)[number];
@@ -71,6 +72,7 @@ export const webToolGroups = {
   'admin-insights': [
     'query-admin-insights-ts-events',
     'query-admin-insights-site-content',
+    'query-admin-insights-job-performance',
     'get-stale-content-report',
   ],
 } as const satisfies Record<WebToolGroupName, Array<WebToolName>>;

--- a/src/tools/web/tools.ts
+++ b/src/tools/web/tools.ts
@@ -1,4 +1,5 @@
 import { getGetStaleContentReportTool } from './adminInsights/getStaleContentReport.js';
+import { getQueryAdminInsightsJobPerformanceTool } from './adminInsights/queryJobPerformance.js';
 import { getQueryAdminInsightsSiteContentTool } from './adminInsights/querySiteContent.js';
 import { getQueryAdminInsightsTsEventsTool } from './adminInsights/queryTsEvents.js';
 import { getSearchContentTool } from './contentExploration/searchContent.js';
@@ -53,5 +54,6 @@ export const webToolFactories = [
   getResetConsentTool,
   getQueryAdminInsightsTsEventsTool,
   getQueryAdminInsightsSiteContentTool,
+  getQueryAdminInsightsJobPerformanceTool,
   getGetStaleContentReportTool,
 ];

--- a/tests/e2e/server.test.ts
+++ b/tests/e2e/server.test.ts
@@ -39,6 +39,7 @@ describe('server', () => {
         'list-users',
         'query-admin-insights-ts-events',
         'query-admin-insights-site-content',
+        'query-admin-insights-job-performance',
         'get-stale-content-report',
       ];
       let expectedToolNames = [...webToolNames];
@@ -114,6 +115,7 @@ describe('server', () => {
         'list-users',
         'query-admin-insights-ts-events',
         'query-admin-insights-site-content',
+        'query-admin-insights-job-performance',
         'get-stale-content-report',
       ];
       let expectedWebToolNames = [...webToolNames];


### PR DESCRIPTION
## Summary
- Adds new `query-admin-insights-job-performance` VDS tool (JTBD 1A-3) that queries the Admin Insights "Job Performance" datasource via VizQL Data Service
- Enables LLM agents to analyze extract refresh durations, failure rates, and schedule patterns for schedule optimization recommendations
- Follows the established pattern from `queryTsEvents` and `querySiteContent` — admin-gated, Cloud-only, with automatic dataset LUID resolution

## Changes
- `src/tools/web/adminInsights/queryJobPerformance.ts` — new tool factory
- `src/tools/web/adminInsights/queryJobPerformance.test.ts` — unit tests
- `src/tools/web/adminInsights/resolver.ts` — added `JOB_PERFORMANCE` to dataset registry
- `src/tools/web/toolName.ts` — registered tool name + group
- `src/tools/web/tools.ts` — registered factory
- `src/server/oauth/scopes.ts` — scope mapping + feature-flag disable

## Test plan
- [x] Unit tests pass (`npx vitest run src/tools/web/adminInsights/queryJobPerformance.test.ts`)
- [x] Build passes (`npm run build`)
- [x] Tool appears in MCP tool list when `ADMIN_TOOLS_ENABLED=true`
- [x] Tool hidden when `ADMIN_TOOLS_ENABLED=false`
- [x] VDS query executes against a Tableau Cloud site with Admin Insights enabled
- [x] Non-admin callers receive 403 rejection

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="1325" height="842" alt="Screenshot 2026-05-31 at 7 47 41 PM" src="https://github.com/user-attachments/assets/fbfc5d82-57b0-4b25-b220-82d281db1bf4" />
