### PR TITLE
@W-22551291: Fix get-stale-content-report null-field parse error; restore admin-insights tool docs + links

### DIFF
--- a/docs/docs/configuration/mcp-config/env-vars.md
+++ b/docs/docs/configuration/mcp-config/env-vars.md
@@ -427,9 +427,9 @@ Enables admin-only tools that require site administrator permissions.
 - Default: `false`
 - When `true`, enables tools that are restricted to Tableau site administrators:
   - [`list-extract-refresh-tasks`](../../tools/tasks/list-extract-refresh-tasks.md)
-  - `query-admin-insights-ts-events`
-  - `query-admin-insights-site-content`
-  - `get-stale-content-report`
+  - [`query-admin-insights-ts-events`](../../tools/admin-insights/query-admin-insights-ts-events.md)
+  - [`query-admin-insights-site-content`](../../tools/admin-insights/query-admin-insights-site-content.md)
+  - [`get-stale-content-report`](../../tools/admin-insights/get-stale-content-report.md)
 - These tools require the user to have one of the following site roles:
   - SiteAdministratorCreator
   - SiteAdministratorExplorer
@@ -455,7 +455,7 @@ Tune lower if site role / project metadata changes need to propagate faster. Tun
 
 ## `STALE_CONTENT_MIN_AGE_DAYS`
 
-Default minimum days since last access for content to be considered stale by the `get-stale-content-report` tool. Callers can pass an explicit `minAgeDays` argument to override per-call.
+Default minimum days since last access for content to be considered stale by the [`get-stale-content-report`](../../tools/admin-insights/get-stale-content-report.md) tool. Callers can pass an explicit `minAgeDays` argument to override per-call.
 
 - Default: `90`
 - Minimum: `1`

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -40,9 +40,9 @@ Tableau's official MCP Server. Helping Agents see and understand data.
 | [generate-pulse-metric-value-insight-bundle](tools/pulse/generate-pulse-metric-value-insight-bundle.md)               | Generate Pulse Metric Value Insight Bundle ([Pulse API][pulse])                                                     |
 | [generate-pulse-insight-brief](tools/pulse/generate-pulse-insight-brief.md)                                           | Generate AI-powered Pulse Insight Brief (Discover) ([Pulse API][pulse])                                             |
 | [search-content](tools/content-exploration/search-content.md)                                                         | Searches for content in a Tableau site ([Content Exploration API][content-exploration])                             |
-| query-admin-insights-ts-events                                                                                        | Admin-only. Issues a VDS query against the Admin Insights `TS Events` datasource ([VDS API][vds])                   |
-| query-admin-insights-site-content                                                                                     | Admin-only. Issues a VDS query against the Admin Insights `Site Content` datasource ([VDS API][vds])                |
-| get-stale-content-report                                                                                              | Admin-only. Deterministic stale-content report from `Site Content` ([VDS API][vds])                                 |
+| [query-admin-insights-ts-events](tools/admin-insights/query-admin-insights-ts-events.md)                              | Admin-only. Issues a VDS query against the Admin Insights `TS Events` datasource ([VDS API][vds])                   |
+| [query-admin-insights-site-content](tools/admin-insights/query-admin-insights-site-content.md)                        | Admin-only. Issues a VDS query against the Admin Insights `Site Content` datasource ([VDS API][vds])                |
+| [get-stale-content-report](tools/admin-insights/get-stale-content-report.md)                                          | Admin-only. Deterministic stale-content report from `Site Content` ([VDS API][vds])                                 |
 
 [query]:
   https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref_data_sources.htm#query_data_sources

--- a/docs/docs/tools/admin-insights/get-stale-content-report.md
+++ b/docs/docs/tools/admin-insights/get-stale-content-report.md
@@ -1,0 +1,121 @@
+---
+sidebar_position: 3
+---
+
+# Get Stale Content Report
+
+Builds a deterministic report of stale Tableau Cloud content (workbooks and published
+datasources) by querying the Admin Insights `Site Content` datasource — which exposes a
+`Last Accessed At` field per item — applying the staleness threshold server-side, and returning
+already-filtered rows.
+
+The server applies the threshold comparison, optional project filter, and sort. Clients receive
+only items where days since last use exceed the threshold. **No client-side math is required.**
+
+The tool is admin-only — it is registered only when `ADMIN_TOOLS_ENABLED=true`, and at request
+time it verifies the caller's site role and rejects anything below
+`SiteAdministratorCreator` / `SiteAdministratorExplorer` / `ServerAdministrator`.
+
+## APIs called
+
+- [Query Datasource (VDS)](https://help.tableau.com/current/api/vizql-data-service/en-us/reference/index.html#tag/HeadlessBI/operation/QueryDatasource) — single VDS call against the `Site Content` Admin Insights datasource
+- [Query Data Sources (REST)](https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref_data_sources.htm#query_data_sources) — used internally to resolve the `Site Content` dataset LUID
+- [Query Projects (REST)](https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref_projects.htm#query_projects) — used internally to resolve project LUIDs to names when a project scope is set
+- [Get User on Site (REST)](https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref_users_and_groups.htm#get_user_on_site) — used internally for the admin gate
+
+## Optional arguments
+
+### `minAgeDays`
+
+Minimum days since last access for content to be considered stale. The server applies the
+condition `daysSinceLastUse > minAgeDays` (strict greater-than).
+
+If omitted, falls back to the server-configured threshold
+[`STALE_CONTENT_MIN_AGE_DAYS`](../../configuration/mcp-config/env-vars.md), which defaults to
+`90` — the Tableau Cloud TS Events lookback ceiling.
+
+Range: `1`–`3650`.
+
+Example: `30`
+
+<hr />
+
+### `projectIds`
+
+Optional list of project LUIDs to scope the report to. The server resolves the LUIDs to project
+names via the Tableau REST API and filters the `Site Content` datasource by
+`Item Parent Project Name`. The LUID → name lookup is cached for 5 minutes per site.
+
+If omitted, falls back to the server-configured
+[`INCLUDE_PROJECT_IDS`](../../configuration/mcp-config/env-vars.md) bound (if any). When both are
+set, the final scope is the intersection.
+
+Example: `["af59ee84-a375-4cb4-84b9-eaa7864f59fb"]`
+
+<hr />
+
+### `itemTypes`
+
+Optional filter for item types. Defaults to `["Workbook", "Datasource"]`. Allowed values:
+`Workbook`, `Datasource`.
+
+Example: `["Datasource"]`
+
+## Notes and caveats
+
+- The Tableau-managed `Admin Insights` project is **excluded by design** — its datasources are
+  admin-owned and refreshed by Tableau, not user content. The exclusion is enforced as a
+  server-side VDS filter on `Item Parent Project Name`.
+- `Last Accessed At` is `null` for items that have never been accessed. The report ages those
+  items from `Created At` instead and flags them with `neverAccessed: true`.
+- Rows are sorted descending by `daysSinceLastUse`, then by `size`.
+- Tableau Cloud `Last Accessed At` is populated whenever the underlying `TS Events` access stream
+  records an access — items beyond the 90-day Cloud event lookback may show `null` even if they
+  were accessed earlier. Items with `daysSinceLastUse ≥ 90` should be interpreted accordingly.
+
+## Example result
+
+```json
+{
+  "thresholdDays": 90,
+  "totalStaleItems": 2,
+  "totalStaleSizeBytes": 5586253,
+  "rows": [
+    {
+      "itemId": "1412202",
+      "itemType": "Workbook",
+      "itemName": "World Indicators",
+      "project": "Samples",
+      "ownerEmail": "owner@example.com",
+      "createdAt": "2025-09-02T23:26:02",
+      "updatedAt": "2025-09-02T23:26:02",
+      "lastUsedDate": "2025-09-02T23:26:02",
+      "daysSinceLastUse": 259,
+      "size": 796179,
+      "neverAccessed": true
+    },
+    {
+      "itemId": "5092116",
+      "itemType": "Datasource",
+      "itemName": "California Schools (frpm + schools)",
+      "project": "default",
+      "ownerEmail": "owner@example.com",
+      "createdAt": "2026-01-13T22:22:19",
+      "updatedAt": "2026-01-13T22:22:20",
+      "lastUsedDate": "2026-01-13T22:22:19",
+      "daysSinceLastUse": 126,
+      "size": 4269845,
+      "neverAccessed": true
+    }
+  ]
+}
+```
+
+## Related
+
+- [`query-admin-insights-site-content`](./query-admin-insights-site-content.md) — generic VDS
+  wrapper this tool builds on; expose this tool's behavior as a generic Site Content query when
+  ad-hoc field selections are needed.
+- [`query-admin-insights-ts-events`](./query-admin-insights-ts-events.md) — TS Events sibling tool.
+- The MCP prompt `stale-content-cleanup-inform` invokes this tool and renders the response as a
+  Markdown table for HITL review.

--- a/docs/docs/tools/admin-insights/query-admin-insights-site-content.md
+++ b/docs/docs/tools/admin-insights/query-admin-insights-site-content.md
@@ -1,0 +1,111 @@
+---
+sidebar_position: 2
+---
+
+# Query Admin Insights — Site Content
+
+Issues a [VizQL Data Service (VDS)](https://help.tableau.com/current/api/vizql-data-service/en-us/index.html)
+query against the Admin Insights `Site Content` published datasource on the connected Tableau
+Cloud site. Returns the universe of content items (workbooks, datasources, views, flows,
+projects) — including items that have **never been accessed**.
+
+The tool is admin-only — it is registered only when `ADMIN_TOOLS_ENABLED=true`, and at request
+time it verifies the caller's site role and rejects anything below
+`SiteAdministratorCreator` / `SiteAdministratorExplorer` / `ServerAdministrator`. The Admin
+Insights datasource LUID is resolved automatically; callers do not pass `datasourceLuid`.
+
+## APIs called
+
+- [Query Datasource (VDS)](https://help.tableau.com/current/api/vizql-data-service/en-us/reference/index.html#tag/HeadlessBI/operation/QueryDatasource)
+- [Query Data Sources (REST)](https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref_data_sources.htm#query_data_sources) — used internally to resolve the `Site Content` dataset LUID
+- [Get User on Site (REST)](https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref_users_and_groups.htm#get_user_on_site) — used internally for the admin gate
+
+## Required arguments
+
+### `query`
+
+A fully formed VDS [`query`](https://help.tableau.com/current/api/vizql-data-service/en-us/reference/index.html#tag/HeadlessBI/operation/QueryDatasource)
+object: `fields`, `filters`, `parameters`. The schema mirrors the schema accepted by the
+[`query-datasource`](../data-qna/query-datasource.md) tool.
+
+Common usage:
+
+- Build a stale-content report: list all Workbooks and Datasources with `Item ID`, `Item Name`,
+  `Item Parent Project Name`, `Owner Email`, `Created At`, `Updated At`, `Last Accessed At`,
+  `Size (bytes)`. The deterministic
+  [`get-stale-content-report`](./get-stale-content-report.md) tool wraps exactly this query and
+  applies the staleness threshold server-side.
+- Inventory content per project or per owner.
+- Identify never-accessed items by selecting `Last Accessed At` and filtering for `null`.
+
+Example:
+
+```json
+{
+  "query": {
+    "fields": [
+      { "fieldCaption": "Item ID" },
+      { "fieldCaption": "Item Type" },
+      { "fieldCaption": "Item Name" },
+      { "fieldCaption": "Item Parent Project Name" },
+      { "fieldCaption": "Owner Email" },
+      { "fieldCaption": "Created At" },
+      { "fieldCaption": "Updated At" },
+      { "fieldCaption": "Last Accessed At" },
+      { "fieldCaption": "Size (bytes)" }
+    ],
+    "filters": [
+      {
+        "field": { "fieldCaption": "Item Type" },
+        "filterType": "SET",
+        "values": ["Workbook", "Datasource"],
+        "exclude": false
+      }
+    ]
+  }
+}
+```
+
+## Optional arguments
+
+### `limit`
+
+The maximum number of rows to return. The tool will pass this through as `rowLimit` on the VDS
+request and additionally truncate the response if VDS returns more rows than requested.
+
+Example: `1000`
+
+See also: [`MAX_RESULT_LIMIT`](../../configuration/mcp-config/env-vars.md#max_result_limit)
+
+## Notes and caveats
+
+- `Site Content` exposes a native `Last Accessed At` field per item — the value is `null` for
+  items that have never been accessed. This is a key advantage over a TS Events anti-join, which
+  is bounded by the 90-day event lookback window.
+- Field captions on `Site Content` differ from those on `TS Events` on the same site (e.g.
+  `Item ID` here vs `Item Id` on TS Events; `Item Parent Project Name` here vs `Project Name`
+  on TS Events). Inspect the dataset schema with
+  [`get-datasource-metadata`](../data-qna/get-datasource-metadata.md) when in doubt.
+- The `Item ID` field is returned as an integer by VDS, not a string.
+- This tool intentionally bypasses the standard datasource access checker because the Admin
+  Insights datasources are internal/known and admin-gated independently.
+
+## Example result
+
+```json
+{
+  "data": [
+    {
+      "Item ID": 1412202,
+      "Item Type": "Workbook",
+      "Item Name": "World Indicators",
+      "Item Parent Project Name": "Samples",
+      "Owner Email": "owner@example.com",
+      "Created At": "2025-09-02T23:26:02",
+      "Updated At": "2025-09-02T23:26:02",
+      "Last Accessed At": null,
+      "Size (bytes)": 796179
+    }
+  ]
+}
+```

--- a/docs/docs/tools/admin-insights/query-admin-insights-ts-events.md
+++ b/docs/docs/tools/admin-insights/query-admin-insights-ts-events.md
@@ -1,0 +1,96 @@
+---
+sidebar_position: 1
+---
+
+# Query Admin Insights — TS Events
+
+Issues a [VizQL Data Service (VDS)](https://help.tableau.com/current/api/vizql-data-service/en-us/index.html)
+query against the Admin Insights `TS Events` published datasource on the connected Tableau Cloud
+site. Returns audit events (Access, Publish, Update, Delete, etc.) for content and users on the
+site.
+
+The tool is admin-only — it is registered only when `ADMIN_TOOLS_ENABLED=true`, and at request
+time it verifies the caller's site role and rejects anything below
+`SiteAdministratorCreator` / `SiteAdministratorExplorer` / `ServerAdministrator`. The Admin
+Insights datasource LUID is resolved automatically; callers do not pass `datasourceLuid`.
+
+## APIs called
+
+- [Query Datasource (VDS)](https://help.tableau.com/current/api/vizql-data-service/en-us/reference/index.html#tag/HeadlessBI/operation/QueryDatasource)
+- [Query Data Sources (REST)](https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref_data_sources.htm#query_data_sources) — used internally to resolve the `TS Events` dataset LUID
+- [Get User on Site (REST)](https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref_users_and_groups.htm#get_user_on_site) — used internally for the admin gate
+
+## Required arguments
+
+### `query`
+
+A fully formed VDS [`query`](https://help.tableau.com/current/api/vizql-data-service/en-us/reference/index.html#tag/HeadlessBI/operation/QueryDatasource)
+object: `fields`, `filters`, `parameters`. The schema mirrors the schema accepted by the
+[`query-datasource`](../data-qna/query-datasource.md) tool.
+
+Common usage:
+
+- Identify last-access timestamp per content item: filter `Event Type` to `"Access"`, group by
+  `Item Id` and `Item Type`, aggregate `MAX(Event Date)`.
+- Audit which users last accessed a workbook within the 90-day window.
+
+Example:
+
+```json
+{
+  "query": {
+    "fields": [
+      { "fieldCaption": "Item Id" },
+      { "fieldCaption": "Item Type" },
+      { "fieldCaption": "Event Date", "function": "MAX", "fieldAlias": "last_access" }
+    ],
+    "filters": [
+      {
+        "field": { "fieldCaption": "Event Type" },
+        "filterType": "SET",
+        "values": ["Access"],
+        "exclude": false
+      },
+      {
+        "field": { "fieldCaption": "Item Type" },
+        "filterType": "SET",
+        "values": ["Workbook", "Datasource"],
+        "exclude": false
+      }
+    ]
+  }
+}
+```
+
+## Optional arguments
+
+### `limit`
+
+The maximum number of rows to return. The tool will pass this through as `rowLimit` on the VDS
+request and additionally truncate the response if VDS returns more rows than requested.
+
+Example: `1000`
+
+See also: [`MAX_RESULT_LIMIT`](../../configuration/mcp-config/env-vars.md#max_result_limit)
+
+## Notes and caveats
+
+- Tableau Cloud TS Events lookback caps at **90 days by default** (365 days with Advanced
+  Management). Beyond the lookback window, items cannot be distinguished from each other on
+  last-access timestamps.
+- Field captions on TS Events differ from those on Site Content on the same site. For TS Events,
+  the item-identifier caption is `Item Id` (Title Case), not `Item ID`. Inspect the dataset
+  schema with [`get-datasource-metadata`](../data-qna/get-datasource-metadata.md) when in doubt.
+- This tool intentionally bypasses the standard datasource access checker because the Admin
+  Insights datasources are internal/known and admin-gated independently.
+
+## Example result
+
+```json
+{
+  "data": [
+    { "Item Id": "5092107", "Item Type": "Datasource", "last_access": "2026-04-15T00:00:00Z" },
+    { "Item Id": "1412202", "Item Type": "Workbook", "last_access": "2026-05-08T21:12:45Z" }
+  ]
+}
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "2.6.2",
+  "version": "2.6.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "2.6.2",
+      "version": "2.6.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.7.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "2.6.2",
+  "version": "2.6.3",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/src/tools/web/adminInsights/getStaleContentReport.test.ts
+++ b/src/tools/web/adminInsights/getStaleContentReport.test.ts
@@ -394,6 +394,40 @@ describe('get-stale-content-report tool', () => {
     expect(neverFlagged?.neverAccessed).toBe(true);
   });
 
+  it('accepts rows where Item Parent Project Name is null (top-level content)', async () => {
+    const { Ok } = await import('ts-results-es');
+    mocks.mockQueryDatasource.mockResolvedValueOnce(
+      Ok({
+        data: [
+          {
+            'Item ID': 'wb-toplevel',
+            'Item Type': 'Workbook',
+            'Item Name': 'Top-Level WB',
+            'Item Parent Project Name': null,
+            'Owner Email': null,
+            'Created At': '2024-01-01T00:00:00Z',
+            'Last Accessed At': null,
+            'Size (bytes)': null,
+          },
+        ],
+      }),
+    );
+
+    const result = await getToolResult({ minAgeDays: 90 });
+
+    expect(result.isError).toBeFalsy();
+    if (result.content[0].type !== 'text') {
+      throw new Error('expected text content');
+    }
+    const payload = JSON.parse(result.content[0].text) as {
+      rows: Array<{ itemId: string; project: string | null; ownerEmail: string | null }>;
+    };
+    const row = payload.rows.find((r) => r.itemId === 'wb-toplevel');
+    expect(row).toBeDefined();
+    expect(row?.project).toBeNull();
+    expect(row?.ownerEmail).toBeNull();
+  });
+
   it('rejects when caller is not an admin', async () => {
     mocks.mockAssertAdmin.mockResolvedValueOnce(
       new Err('This tool requires site administrator permissions. Your site role is: Viewer'),

--- a/src/tools/web/adminInsights/getStaleContentReport.ts
+++ b/src/tools/web/adminInsights/getStaleContentReport.ts
@@ -60,15 +60,15 @@ export type StaleContentRow = {
 // `.passthrough()` keeps any additional keys VDS might add without rejecting the row.
 const siteContentRowSchema = z
   .object({
-    'Item ID': z.union([z.string(), z.number()]).optional(),
-    'Item Type': z.string().optional(),
-    'Item Name': z.string().optional(),
-    'Item Parent Project Name': z.string().optional(),
-    'Owner Email': z.string().optional(),
-    'Created At': z.string().optional(),
-    'Updated At': z.string().optional(),
+    'Item ID': z.union([z.string(), z.number()]).nullable().optional(),
+    'Item Type': z.string().nullable().optional(),
+    'Item Name': z.string().nullable().optional(),
+    'Item Parent Project Name': z.string().nullable().optional(),
+    'Owner Email': z.string().nullable().optional(),
+    'Created At': z.string().nullable().optional(),
+    'Updated At': z.string().nullable().optional(),
     'Last Accessed At': z.string().nullable().optional(),
-    'Size (bytes)': z.union([z.number(), z.string()]).optional(),
+    'Size (bytes)': z.union([z.number(), z.string()]).nullable().optional(),
   })
   .passthrough();
 


### PR DESCRIPTION
## Description

Two related changes:

**1. Bug fix — `get-stale-content-report` null-field parse error**

The Zod schema for the Admin Insights "Site Content" rows (`siteContentRowSchema`) only accepted `string | undefined`, but the VizQL Data Service returns `null` for several fields on top-level content — most notably `Item Parent Project Name` for items that have no parent project. This caused the tool to throw a `ZodError: Expected string, received null` and fail the entire report on sites with top-level content.

Fix: made all `siteContentRowSchema` fields `.nullable().optional()` (matching the already-nullable `Last Accessed At`). `computeStaleRows` was already null-safe (`typeof === 'string'` guards on every field, mapping `null` to `null` in the output), so no downstream change was required.

**2. Docs — restore admin-insights tool pages + links**

Restores the three admin-insights tool docs that were removed earlier in the W-22551291 PR series, and re-links them from `intro.md` and `env-vars.md`:

- `docs/docs/tools/admin-insights/get-stale-content-report.md`
- `docs/docs/tools/admin-insights/query-admin-insights-site-content.md`
- `docs/docs/tools/admin-insights/query-admin-insights-ts-events.md`

## Motivation and Context

The stale-content report failed against real Tableau Cloud sites (reproduced on `admin-insights-tmcp-site`) whenever the Site Content datasource returned a `null` `Item Parent Project Name`. The schema was stricter than the actual VDS payload. The doc pages were also missing, leaving the `intro.md` and `env-vars.md` references as dead/plain-text entries.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Other (please describe):

## How Has This Been Tested?

- Added a unit test in `getStaleContentReport.test.ts` ("accepts rows where Item Parent Project Name is null") that exercises the schema parse path with a top-level item. Verified it reproduces the exact live `ZodError` when the fix is reverted.
- Full unit suite passes locally (`npm test`): 1390 tests.
- `tsc --noEmit` and `npm run lint` clean.
- Docs site builds successfully (`npm run build` in `docs/`) — all restored admin-insights links resolve.

## Related Issues

W-22551291

## Checklist

- [x] I have updated the version in the package.json file by using `npm run version` (patch bump to 2.6.3).
- [x] I have made any necessary changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have documented any breaking changes in the PR description. For example, renaming a config
      environment variable or changing its default value.

## Contributor Agreement

By submitting this pull request, I confirm that:

- [x] I have read the [CONTRIBUTING guidelines](../../CONTRIBUTING.md) for this project and followed
      its Contribution Checklist.
