### PR TITLE
@W-22804761: Add list-schedules admin tool

### DIFF
--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -43,6 +43,9 @@ Tableau's official MCP Server. Helping Agents see and understand data.
 | [query-admin-insights-ts-events](tools/admin-insights/query-admin-insights-ts-events.md)                              | Admin-only. Issues a VDS query against the Admin Insights `TS Events` datasource ([VDS API][vds])                   |
 | [query-admin-insights-site-content](tools/admin-insights/query-admin-insights-site-content.md)                        | Admin-only. Issues a VDS query against the Admin Insights `Site Content` datasource ([VDS API][vds])                |
 | [get-stale-content-report](tools/admin-insights/get-stale-content-report.md)                                          | Admin-only. Deterministic stale-content report from `Site Content` ([VDS API][vds])                                 |
+| [list-users](tools/users/list-users.md)                                                                               | Admin-only. Retrieves a list of users on the Tableau site ([REST API][list-users])                                  |
+| [list-extract-refresh-tasks](tools/tasks/list-extract-refresh-tasks.md)                                               | Admin-only. Lists extract refresh tasks for the site ([REST API][list-extract-refresh-tasks])                       |
+| [list-schedules](tools/tasks/list-schedules.md)                                                                       | Admin-only. Lists the site's refresh schedules, aggregated from extract refresh tasks ([REST API][list-extract-refresh-tasks]) |
 
 [query]:
   https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref_data_sources.htm#query_data_sources
@@ -50,6 +53,10 @@ Tableau's official MCP Server. Helping Agents see and understand data.
   https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref_workbooks_and_views.htm#query_workbooks_for_site
 [list-projects]:
   https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref_projects.htm#query_projects
+[list-users]:
+  https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref_users_and_groups.htm#get_users_on_site
+[list-extract-refresh-tasks]:
+  https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref_extract_and_encryption.htm#list_extract_refresh_tasks_in_site
 [list-views]:
   https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref_workbooks_and_views.htm#query_views_for_site
 [list-custom-views]:

--- a/docs/docs/tools/tasks/list-schedules.md
+++ b/docs/docs/tools/tasks/list-schedules.md
@@ -1,0 +1,182 @@
+---
+sidebar_position: 2
+---
+
+# List Schedules
+
+Retrieves the list of refresh schedules in use on the Tableau site. Each schedule includes its frequency and next run time, plus aggregation metadata describing how many extract refresh tasks run on it (`taskCount`) and which data sources and workbooks those tasks target.
+
+:::warning Admin Only
+This tool is restricted to Tableau site administrators and requires the `ADMIN_TOOLS_ENABLED` feature flag to be enabled.
+:::
+
+:::info Tableau Cloud schedule model
+Tableau Cloud does not expose a standalone schedules collection — the `GET /sites/{siteId}/schedules` and server-level `GET /schedules` endpoints are **Tableau Server only**. On Cloud, schedule information is only available embedded in each task. This tool derives the schedule universe by aggregating the distinct schedules referenced by the site's extract refresh tasks.
+:::
+
+## APIs called
+
+- [Get Extract Refresh Tasks in Site](https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref_extract_and_encryption.htm#list_extract_refresh_tasks_in_site)
+
+## Use cases
+
+Use this tool when you need to:
+- Enumerate the distinct refresh schedules configured on the site
+- See how many tasks (and which content) share a given schedule
+- Identify under- or over-used schedules for consolidation
+- Analyze schedule usage for extract refresh schedule optimization
+
+## Required permissions
+
+- **Tableau Cloud**: Requires `tableau:tasks:read` OAuth scope
+- **Tableau Server**: Site or server administrators
+- **Site Role**: Must be one of:
+  - SiteAdministratorCreator
+  - SiteAdministratorExplorer  
+  - ServerAdministrator
+
+## Configuration
+
+Enable this tool by setting the feature flag:
+
+```bash
+ADMIN_TOOLS_ENABLED=true
+```
+
+See also: [Environment Variables](../../configuration/mcp-config/env-vars.md)
+
+## Arguments
+
+| Argument | Type | Required | Description |
+|----------|------|----------|-------------|
+| `filter` | string | No | Client-side filter string with format `field:operator:value`. Multiple filters are comma-separated (AND logic). |
+| `pageSize` | number | No | Reserved for future server-side pagination; currently informational. |
+| `limit` | number | No | Maximum total schedules to return (client-side limit after filtering). |
+
+:::note API Limitation
+The Tableau REST API does not expose schedules as a standalone collection on Tableau Cloud. Schedules are aggregated from the site's extract refresh tasks, and filtering and limiting are performed client-side by this tool.
+:::
+
+## Filterable Fields
+
+| Field | Type | Operators | Example |
+|-------|------|-----------|---------|
+| `id` | string | `eq`, `in` | `id:eq:sched-123` |
+| `name` | string | `eq`, `in` | `name:eq:Daily Refresh` |
+| `type` | string | `eq`, `in` | `type:eq:Extract` |
+| `state` | string | `eq`, `in` | `state:eq:Active` |
+| `frequency` | string | `eq`, `in` | `frequency:eq:Daily` |
+| `priority` | number | `eq`, `gt`, `gte`, `lt`, `lte` | `priority:gte:5` |
+| `taskCount` | number | `eq`, `gt`, `gte`, `lt`, `lte` | `taskCount:gt:1` |
+| `nextRunAt` | string (ISO 8601) | `eq`, `gt`, `gte`, `lt`, `lte` | `nextRunAt:lt:2026-05-25T00:00:00Z` |
+| `createdAt` | string (ISO 8601) | `eq`, `gt`, `gte`, `lt`, `lte` | `createdAt:gte:2026-01-01T00:00:00Z` |
+| `updatedAt` | string (ISO 8601) | `eq`, `gt`, `gte`, `lt`, `lte` | `updatedAt:gte:2026-05-01T00:00:00Z` |
+
+### Frequencies
+
+Common values for `frequency`:
+- `Hourly`
+- `Daily`
+- `Weekly`
+- `Monthly`
+
+### States
+
+Common values for `state`:
+- `Active` - Schedule is enabled and running
+- `Suspended` - Schedule is paused
+
+### Filter Examples
+
+- Find all daily schedules: `frequency:eq:Daily`
+- Multiple frequencies: `frequency:in:Daily|Weekly`
+- Shared schedules (more than one task): `taskCount:gt:1`
+- Single-task schedules (consolidation candidates): `taskCount:eq:1`
+- High-priority daily schedules: `frequency:eq:Daily,priority:gte:5`
+- Schedules running before a cutoff: `nextRunAt:lt:2026-06-01T00:00:00Z`
+
+## Response structure
+
+Each schedule includes:
+
+- `id` – schedule ID (when available)
+- `name` – schedule name (when available)
+- `type` – schedule type (e.g., `Extract`)
+- `state` – `Active` or `Suspended`
+- `frequency` – `Hourly`, `Daily`, `Weekly`, or `Monthly`
+- `priority` – schedule priority
+- `nextRunAt` – timestamp of the next scheduled run (ISO 8601 format)
+- `createdAt` – timestamp the schedule was created (ISO 8601 format)
+- `updatedAt` – timestamp the schedule was last updated (ISO 8601 format)
+- `frequencyDetails` – detailed interval configuration (hours, minutes, weekDay, monthDay)
+- `taskCount` – number of extract refresh tasks that run on this schedule
+- `datasourceIds` – distinct data source IDs whose tasks use this schedule
+- `workbookIds` – distinct workbook IDs whose tasks use this schedule
+
+## Example result
+
+```json
+[
+  {
+    "id": "schedule-123",
+    "name": "Daily Early Morning",
+    "type": "Extract",
+    "state": "Active",
+    "frequency": "Daily",
+    "priority": 50,
+    "nextRunAt": "2026-05-21T06:00:00Z",
+    "frequencyDetails": {
+      "intervals": {
+        "interval": [{ "hours": 6, "minutes": 0 }]
+      }
+    },
+    "taskCount": 3,
+    "datasourceIds": ["2d935df8-fe7e-4fd8-bb14-35eb4ba31d45"],
+    "workbookIds": ["3e046e08-f8a3-4f09-c26f-46fa5b8bef13"]
+  },
+  {
+    "id": "schedule-456",
+    "name": "Weekly Sunday",
+    "type": "Extract",
+    "state": "Active",
+    "frequency": "Weekly",
+    "priority": 70,
+    "nextRunAt": "2026-05-25T08:00:00Z",
+    "frequencyDetails": {
+      "intervals": {
+        "interval": [{ "weekDay": "Sunday", "hours": 8, "minutes": 0 }]
+      }
+    },
+    "taskCount": 1,
+    "datasourceIds": ["a1b2c3d4-e5f6-7890-abcd-ef1234567890"]
+  }
+]
+```
+
+## Empty result
+
+If no schedules are found, the tool returns a message:
+
+```
+No schedules were found. Either none exist or you do not have permission to view them.
+```
+
+## Use Case: Extract Refresh Schedule Optimization
+
+This tool supports extract refresh schedule optimization (JTBD #2 from the Admin Tools roadmap) by exposing the schedule universe so it can be paired with [List Extract Refresh Tasks](./list-extract-refresh-tasks.md) and job performance data:
+
+```javascript
+// Find consolidation candidates: schedules used by only one task
+filter: "taskCount:eq:1"
+
+// Find heavily shared daily schedules
+filter: "frequency:eq:Daily,taskCount:gt:5"
+
+// Find high-priority schedules that may be over-provisioned
+filter: "priority:gte:70"
+```
+
+The results can inform decisions about:
+- Consolidating single-task schedules onto shared schedules
+- Downgrading or disabling under-used schedules
+- Moving refresh windows to balance load

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "2.7.0",
+      "version": "2.8.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.7.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/src/sdks/tableau/types/schedule.ts
+++ b/src/sdks/tableau/types/schedule.ts
@@ -1,0 +1,28 @@
+import { z } from 'zod';
+
+import { extractRefreshScheduleSchema } from './extractRefreshTask.js';
+
+/**
+ * A distinct schedule aggregated from the site's extract refresh tasks.
+ *
+ * Tableau Cloud does not expose a standalone "schedules" collection - the
+ * `GET /sites/{siteId}/schedules` and server-level `GET /schedules` endpoints
+ * are Tableau Server only. On Cloud, schedule information is only available
+ * embedded in each task's `schedule` object. This tool therefore derives the
+ * schedule universe by aggregating the distinct schedules referenced by the
+ * site's extract refresh tasks.
+ *
+ * The base fields mirror {@link extractRefreshScheduleSchema}; the `taskCount`,
+ * `datasourceIds`, and `workbookIds` fields are aggregation metadata describing
+ * which tasks share the schedule.
+ */
+export const scheduleSchema = extractRefreshScheduleSchema.extend({
+  /** Number of extract refresh tasks that run on this schedule. */
+  taskCount: z.number(),
+  /** Distinct data source IDs whose extract refresh tasks use this schedule. */
+  datasourceIds: z.array(z.string()).optional(),
+  /** Distinct workbook IDs whose extract refresh tasks use this schedule. */
+  workbookIds: z.array(z.string()).optional(),
+});
+
+export type Schedule = z.infer<typeof scheduleSchema>;

--- a/src/server/oauth/scopes.ts
+++ b/src/server/oauth/scopes.ts
@@ -83,6 +83,12 @@ const toolScopeMap: Record<
     mcp: ['tableau:mcp:users:read'],
     api: new Set(['tableau:users:read']),
   },
+  // Aggregates schedules from extract refresh tasks; reuses the tasks read scope.
+  // 'tableau:users:read' is required by adminGate.assertAdmin.
+  'list-schedules': {
+    mcp: ['tableau:mcp:tasks:read'],
+    api: new Set(['tableau:tasks:read', 'tableau:users:read']),
+  },
   'list-workbooks': {
     mcp: ['tableau:mcp:workbook:read'],
     api: new Set(['tableau:content:read', 'tableau:mcp_site_settings:read']),
@@ -223,6 +229,7 @@ function getEnabledToolNames(): Set<WebToolName> {
   if (!config.adminToolsEnabled) {
     enabledTools.delete('list-extract-refresh-tasks');
     enabledTools.delete('list-users');
+    enabledTools.delete('list-schedules');
     enabledTools.delete('query-admin-insights-ts-events');
     enabledTools.delete('query-admin-insights-site-content');
     enabledTools.delete('get-stale-content-report');

--- a/src/tools/web/schedules/listSchedules.test.ts
+++ b/src/tools/web/schedules/listSchedules.test.ts
@@ -1,0 +1,146 @@
+import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { Ok } from 'ts-results-es';
+
+import { WebMcpServer } from '../../../server.web.js';
+import invariant from '../../../utils/invariant.js';
+import { Provider } from '../../../utils/provider.js';
+import { mockExtractRefreshTask } from '../extractRefreshTasks/mockExtractRefreshTask.js';
+import { getMockRequestHandlerExtra } from '../toolContext.mock.js';
+import { getListSchedulesTool } from './listSchedules.js';
+
+const mocks = vi.hoisted(() => ({
+  mockListExtractRefreshTasks: vi.fn(),
+  mockQueryUserOnSite: vi.fn(),
+  mockAssertAdmin: vi.fn(),
+}));
+
+vi.mock('../../../restApiInstance.js', () => ({
+  useRestApi: vi.fn().mockImplementation(async ({ callback }) =>
+    callback({
+      tasksMethods: {
+        listExtractRefreshTasks: mocks.mockListExtractRefreshTasks,
+      },
+      usersMethods: {
+        queryUserOnSite: mocks.mockQueryUserOnSite,
+      },
+      siteId: 'test-site-id',
+      userId: 'test-user-id',
+    }),
+  ),
+}));
+
+vi.mock('../adminGate.js', () => ({
+  assertAdmin: mocks.mockAssertAdmin,
+}));
+
+vi.mock('../../../config.js', () => ({
+  getConfig: vi.fn(() => ({
+    adminToolsEnabled: true,
+    productTelemetryEnabled: false,
+    productTelemetryEndpoint: 'https://test.com',
+    server: 'https://test.tableau.com',
+  })),
+}));
+
+describe('listSchedulesTool', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.mockAssertAdmin.mockResolvedValue(new Ok(true));
+    mocks.mockQueryUserOnSite.mockResolvedValue({ siteRole: 'SiteAdministratorCreator' });
+  });
+
+  it('should create a tool instance with correct properties', () => {
+    const tool = getListSchedulesTool(new WebMcpServer());
+    expect(tool.name).toBe('list-schedules');
+    expect(tool.description).toContain('Retrieves the list of schedules');
+    expect(tool.paramsSchema).toHaveProperty('filter');
+    expect(tool.paramsSchema).toHaveProperty('pageSize');
+    expect(tool.paramsSchema).toHaveProperty('limit');
+  });
+
+  it('should aggregate schedules from tasks', async () => {
+    mocks.mockListExtractRefreshTasks.mockResolvedValue([
+      mockExtractRefreshTask,
+      { ...mockExtractRefreshTask, id: 'task-456', datasource: { id: 'datasource-def' } },
+    ]);
+    const result = await getToolResult({});
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+    const parsed = JSON.parse(`${result.content[0].text}`);
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0].id).toBe('schedule-xyz');
+    expect(parsed[0].taskCount).toBe(2);
+    expect(parsed[0].datasourceIds.sort()).toEqual(['datasource-abc', 'datasource-def']);
+  });
+
+  it('should return empty message when no tasks are found', async () => {
+    mocks.mockListExtractRefreshTasks.mockResolvedValue([]);
+    const result = await getToolResult({});
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+    expect(result.content[0].text).toBe(
+      'No schedules were found. Either none exist or you do not have permission to view them.',
+    );
+  });
+
+  it('should apply a client-side filter', async () => {
+    mocks.mockListExtractRefreshTasks.mockResolvedValue([
+      mockExtractRefreshTask,
+      {
+        ...mockExtractRefreshTask,
+        id: 'task-weekly',
+        schedule: { id: 'schedule-weekly', frequency: 'Weekly' },
+      },
+    ]);
+    const result = await getToolResult({ filter: 'frequency:eq:Weekly' });
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+    const parsed = JSON.parse(`${result.content[0].text}`);
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0].id).toBe('schedule-weekly');
+  });
+
+  it('should apply a client-side limit', async () => {
+    mocks.mockListExtractRefreshTasks.mockResolvedValue([
+      { ...mockExtractRefreshTask, id: 't1', schedule: { id: 's1' } },
+      { ...mockExtractRefreshTask, id: 't2', schedule: { id: 's2' } },
+      { ...mockExtractRefreshTask, id: 't3', schedule: { id: 's3' } },
+    ]);
+    const result = await getToolResult({ limit: 2 });
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+    expect(JSON.parse(`${result.content[0].text}`)).toHaveLength(2);
+  });
+
+  it('should error when the user is not an admin', async () => {
+    mocks.mockAssertAdmin.mockResolvedValue({
+      isErr: () => true,
+      error: 'This tool requires site administrator permissions.',
+    });
+    mocks.mockListExtractRefreshTasks.mockResolvedValue([mockExtractRefreshTask]);
+    const result = await getToolResult({});
+    expect(result.isError).toBe(true);
+    invariant(result.content[0].type === 'text');
+    expect(result.content[0].text).toContain('site administrator');
+  });
+
+  it('should reject an invalid filter', async () => {
+    mocks.mockListExtractRefreshTasks.mockResolvedValue([mockExtractRefreshTask]);
+    const result = await getToolResult({ filter: 'bogus:eq:x' });
+    expect(result.isError).toBe(true);
+  });
+
+  it('should handle API errors gracefully', async () => {
+    mocks.mockListExtractRefreshTasks.mockRejectedValue(new Error('API Error'));
+    const result = await getToolResult({});
+    expect(result.isError).toBe(true);
+    invariant(result.content[0].type === 'text');
+    expect(result.content[0].text).toContain('API Error');
+  });
+});
+
+async function getToolResult(args: any = {}): Promise<CallToolResult> {
+  const tool = getListSchedulesTool(new WebMcpServer());
+  const callback = await Provider.from(tool.callback);
+  return await callback(args, getMockRequestHandlerExtra());
+}

--- a/src/tools/web/schedules/listSchedules.ts
+++ b/src/tools/web/schedules/listSchedules.ts
@@ -1,0 +1,154 @@
+import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { Ok } from 'ts-results-es';
+import { z } from 'zod';
+
+import { getConfig } from '../../../config.js';
+import { BoundedContext } from '../../../overridableConfig.js';
+import { useRestApi } from '../../../restApiInstance.js';
+import { Schedule } from '../../../sdks/tableau/types/schedule.js';
+import { WebMcpServer } from '../../../server.web.js';
+import { assertAdmin } from '../adminGate.js';
+import { ConstrainedResult, WebTool } from '../tool.js';
+import { aggregateSchedulesFromTasks, applySchedulesFilters } from './schedulesUtils.js';
+
+const paramsSchema = {
+  filter: z.string().optional(),
+  pageSize: z.number().int().positive().optional(),
+  limit: z.number().int().positive().optional(),
+};
+
+export const getListSchedulesTool = (server: WebMcpServer): WebTool<typeof paramsSchema> => {
+  const config = getConfig();
+
+  const listSchedulesTool = new WebTool({
+    server,
+    name: 'list-schedules',
+    disabled: !config.adminToolsEnabled,
+    description: `
+  Retrieves the list of schedules in use on the Tableau site. Each schedule describes when extracts refresh (e.g. frequency, next run time) and includes aggregation metadata: how many extract refresh tasks run on it (\`taskCount\`) and which data sources and workbooks those tasks target.
+
+  This tool is restricted to Tableau site administrators and requires the \`ADMIN_TOOLS_ENABLED\` feature flag to be enabled.
+
+  Use this tool when you need to:
+  - Enumerate the distinct refresh schedules configured on the site
+  - See how many tasks (and which content) share a given schedule
+  - Analyze schedule usage for extract refresh schedule optimization
+
+  **Parameters:**
+  - \`filter\` (optional) – Client-side filter string with format \`field:operator:value\`. Multiple filters are comma-separated (AND logic).
+  - \`pageSize\` (optional) – Reserved for future server-side pagination; currently informational.
+  - \`limit\` (optional) – Maximum total schedules to return (client-side limit after filtering).
+
+  **Filterable Fields:**
+
+  | Field | Type | Operators | Example |
+  |-------|------|-----------|---------|
+  | \`id\` | string | \`eq\`, \`in\` | \`id:eq:sched-123\` |
+  | \`name\` | string | \`eq\`, \`in\` | \`name:eq:Daily Refresh\` |
+  | \`type\` | string | \`eq\`, \`in\` | \`type:eq:Extract\` |
+  | \`state\` | string | \`eq\`, \`in\` | \`state:eq:Active\` |
+  | \`frequency\` | string | \`eq\`, \`in\` | \`frequency:eq:Daily\` |
+  | \`priority\` | number | \`eq\`, \`gt\`, \`gte\`, \`lt\`, \`lte\` | \`priority:gte:5\` |
+  | \`taskCount\` | number | \`eq\`, \`gt\`, \`gte\`, \`lt\`, \`lte\` | \`taskCount:gt:1\` |
+  | \`nextRunAt\` | string (ISO 8601) | \`eq\`, \`gt\`, \`gte\`, \`lt\`, \`lte\` | \`nextRunAt:lt:2026-05-25T00:00:00Z\` |
+  | \`createdAt\` | string (ISO 8601) | \`eq\`, \`gt\`, \`gte\`, \`lt\`, \`lte\` | \`createdAt:gte:2026-01-01T00:00:00Z\` |
+  | \`updatedAt\` | string (ISO 8601) | \`eq\`, \`gt\`, \`gte\`, \`lt\`, \`lte\` | \`updatedAt:gte:2026-05-01T00:00:00Z\` |
+
+  **Filter Examples:**
+  - Single filter: \`frequency:eq:Daily\`
+  - Multiple filters (AND): \`frequency:eq:Daily,taskCount:gt:1\`
+  - IN operator: \`frequency:in:Daily|Weekly\`
+
+  **Note:** Tableau Cloud does not expose a standalone schedules collection (the \`GET /sites/{siteId}/schedules\` and server-level \`GET /schedules\` endpoints are Tableau Server only). This tool derives the schedule universe by aggregating the distinct schedules referenced by the site's extract refresh tasks via \`tableau:tasks:read\`. Filtering and limiting are performed client-side.
+  `,
+    paramsSchema,
+    annotations: {
+      title: 'List Schedules',
+      readOnlyHint: true,
+      openWorldHint: false,
+    },
+    callback: async (args, extra): Promise<CallToolResult> => {
+      const configWithOverrides = await extra.getConfigWithOverrides();
+
+      return await listSchedulesTool.logAndExecute({
+        extra,
+        args,
+        callback: async () => {
+          const tasks = await useRestApi({
+            ...extra,
+            jwtScopes: listSchedulesTool.requiredApiScopes,
+            callback: async (restApi) => {
+              // Verify user has admin privileges
+              const adminResult = await assertAdmin(restApi, extra);
+              if (adminResult.isErr()) {
+                throw new Error(adminResult.error);
+              }
+
+              return restApi.tasksMethods.listExtractRefreshTasks({
+                siteId: restApi.siteId,
+              });
+            },
+          });
+
+          // Aggregate distinct schedules, then apply client-side filtering and limit
+          const schedules = aggregateSchedulesFromTasks(tasks);
+          const filteredSchedules = applySchedulesFilters(schedules, args.filter);
+          const limitedSchedules =
+            args.limit !== undefined ? filteredSchedules.slice(0, args.limit) : filteredSchedules;
+
+          return new Ok(limitedSchedules);
+        },
+        constrainSuccessResult: (schedules) =>
+          constrainSchedules({
+            schedules,
+            boundedContext: configWithOverrides.boundedContext,
+          }),
+      });
+    },
+  });
+
+  return listSchedulesTool;
+};
+
+export function constrainSchedules({
+  schedules,
+  boundedContext,
+}: {
+  schedules: Array<Schedule>;
+  boundedContext: BoundedContext;
+}): ConstrainedResult<Array<Schedule>> {
+  if (schedules.length === 0) {
+    return {
+      type: 'empty',
+      message:
+        'No schedules were found. Either none exist or you do not have permission to view them.',
+    };
+  }
+
+  const { datasourceIds, workbookIds } = boundedContext;
+
+  // Keep only schedules that touch at least one allowed data source / workbook.
+  if (datasourceIds) {
+    schedules = schedules.filter((schedule) =>
+      schedule.datasourceIds?.some((id) => datasourceIds.has(id)),
+    );
+  }
+
+  if (workbookIds) {
+    schedules = schedules.filter((schedule) =>
+      schedule.workbookIds?.some((id) => workbookIds.has(id)),
+    );
+  }
+
+  if (schedules.length === 0) {
+    return {
+      type: 'empty',
+      message: [
+        'The set of allowed schedules is limited by the server configuration.',
+        'While schedules were found, they were all filtered out by the server configuration.',
+      ].join(' '),
+    };
+  }
+
+  return { type: 'success', result: schedules };
+}

--- a/src/tools/web/schedules/schedulesUtils.test.ts
+++ b/src/tools/web/schedules/schedulesUtils.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest';
+
+import { ExtractRefreshTask } from '../../../sdks/tableau/types/extractRefreshTask.js';
+import {
+  aggregateSchedulesFromTasks,
+  applySchedulesFilters,
+  exportedForTesting,
+  parseAndValidateSchedulesFilterString,
+} from './schedulesUtils.js';
+
+const { getScheduleKey } = exportedForTesting;
+
+function task(overrides: Partial<ExtractRefreshTask>): ExtractRefreshTask {
+  return { id: 'task', ...overrides };
+}
+
+describe('aggregateSchedulesFromTasks', () => {
+  it('groups tasks sharing the same schedule id and counts them', () => {
+    const tasks = [
+      task({ id: 't1', datasource: { id: 'ds1' }, schedule: { id: 's1', frequency: 'Daily' } }),
+      task({ id: 't2', datasource: { id: 'ds2' }, schedule: { id: 's1', frequency: 'Daily' } }),
+      task({ id: 't3', workbook: { id: 'wb1' }, schedule: { id: 's1', frequency: 'Daily' } }),
+    ];
+
+    const schedules = aggregateSchedulesFromTasks(tasks);
+
+    expect(schedules).toHaveLength(1);
+    expect(schedules[0].id).toBe('s1');
+    expect(schedules[0].taskCount).toBe(3);
+    expect(schedules[0].datasourceIds?.sort()).toEqual(['ds1', 'ds2']);
+    expect(schedules[0].workbookIds).toEqual(['wb1']);
+  });
+
+  it('separates distinct schedules', () => {
+    const tasks = [
+      task({ id: 't1', schedule: { id: 's1', frequency: 'Daily' } }),
+      task({ id: 't2', schedule: { id: 's2', frequency: 'Weekly' } }),
+    ];
+
+    const schedules = aggregateSchedulesFromTasks(tasks);
+
+    expect(schedules).toHaveLength(2);
+    expect(schedules.map((s) => s.id).sort()).toEqual(['s1', 's2']);
+  });
+
+  it('falls back to a composite key when schedule id is absent', () => {
+    const tasks = [
+      task({ id: 't1', schedule: { name: 'Nightly', frequency: 'Daily', nextRunAt: 'X' } }),
+      task({ id: 't2', schedule: { name: 'Nightly', frequency: 'Daily', nextRunAt: 'X' } }),
+    ];
+
+    const schedules = aggregateSchedulesFromTasks(tasks);
+
+    expect(schedules).toHaveLength(1);
+    expect(schedules[0].taskCount).toBe(2);
+    expect(schedules[0].name).toBe('Nightly');
+  });
+
+  it('skips tasks with no identifiable schedule', () => {
+    const tasks = [task({ id: 't1' }), task({ id: 't2', schedule: {} })];
+    expect(aggregateSchedulesFromTasks(tasks)).toEqual([]);
+  });
+
+  it('omits empty id arrays', () => {
+    const schedules = aggregateSchedulesFromTasks([task({ id: 't1', schedule: { id: 's1' } })]);
+    expect(schedules[0].datasourceIds).toBeUndefined();
+    expect(schedules[0].workbookIds).toBeUndefined();
+  });
+});
+
+describe('getScheduleKey', () => {
+  it('prefers the schedule id', () => {
+    expect(getScheduleKey(task({ schedule: { id: 's1', name: 'n' } }))).toBe('id:s1');
+  });
+
+  it('returns undefined when no schedule', () => {
+    expect(getScheduleKey(task({}))).toBeUndefined();
+  });
+});
+
+describe('parseAndValidateSchedulesFilterString', () => {
+  it('accepts valid field/operator pairs', () => {
+    expect(parseAndValidateSchedulesFilterString('frequency:eq:Daily')).toBe('frequency:eq:Daily');
+    expect(parseAndValidateSchedulesFilterString('taskCount:gt:1')).toBe('taskCount:gt:1');
+  });
+
+  it('rejects an unknown field', () => {
+    expect(() => parseAndValidateSchedulesFilterString('bogus:eq:x')).toThrow();
+  });
+
+  it('rejects a disallowed operator for a field', () => {
+    expect(() => parseAndValidateSchedulesFilterString('frequency:gt:Daily')).toThrow();
+  });
+});
+
+describe('applySchedulesFilters', () => {
+  const schedules = [
+    { taskCount: 3, frequency: 'Daily', state: 'Active', priority: 10 },
+    { taskCount: 1, frequency: 'Weekly', state: 'Suspended', priority: 5 },
+  ];
+
+  it('returns all schedules when no filter', () => {
+    expect(applySchedulesFilters(schedules, undefined)).toHaveLength(2);
+  });
+
+  it('filters by eq', () => {
+    const result = applySchedulesFilters(schedules, 'frequency:eq:Daily');
+    expect(result).toHaveLength(1);
+    expect(result[0].frequency).toBe('Daily');
+  });
+
+  it('filters by numeric gt', () => {
+    const result = applySchedulesFilters(schedules, 'taskCount:gt:1');
+    expect(result).toHaveLength(1);
+    expect(result[0].taskCount).toBe(3);
+  });
+
+  it('filters by in', () => {
+    const result = applySchedulesFilters(schedules, 'frequency:in:Daily|Weekly');
+    expect(result).toHaveLength(2);
+  });
+
+  it('ANDs multiple filters', () => {
+    const result = applySchedulesFilters(schedules, 'frequency:eq:Daily,priority:gte:10');
+    expect(result).toHaveLength(1);
+  });
+});

--- a/src/tools/web/schedules/schedulesUtils.ts
+++ b/src/tools/web/schedules/schedulesUtils.ts
@@ -1,0 +1,226 @@
+import { z } from 'zod';
+
+import { ExtractRefreshTask } from '../../../sdks/tableau/types/extractRefreshTask.js';
+import { Schedule } from '../../../sdks/tableau/types/schedule.js';
+import {
+  FilterOperator,
+  FilterOperatorSchema,
+  parseAndValidateFilterString,
+} from '../../../utils/parseAndValidateFilterString.js';
+
+// === Schedule aggregation ===
+
+/**
+ * Build a stable identity key for a task's schedule so that tasks sharing the
+ * same schedule are grouped together. Tableau Cloud does not always populate
+ * `schedule.id`, so we fall back to a composite of the human-meaningful fields.
+ */
+function getScheduleKey(task: ExtractRefreshTask): string | undefined {
+  const schedule = task.schedule;
+  if (!schedule) {
+    return undefined;
+  }
+  if (schedule.id) {
+    return `id:${schedule.id}`;
+  }
+  const composite = [schedule.name, schedule.frequency, schedule.nextRunAt]
+    .filter((v) => v !== undefined && v !== '')
+    .join('|');
+  return composite ? `composite:${composite}` : undefined;
+}
+
+/**
+ * Aggregate the distinct schedules referenced by a site's extract refresh tasks.
+ *
+ * Each returned schedule carries the underlying schedule fields plus aggregation
+ * metadata: how many tasks run on it (`taskCount`) and which data sources and
+ * workbooks those tasks target.
+ *
+ * Tasks whose schedule cannot be identified (no `schedule` object and no usable
+ * fields) are skipped - they contribute no schedule to enumerate.
+ */
+export function aggregateSchedulesFromTasks(tasks: ExtractRefreshTask[]): Schedule[] {
+  const byKey = new Map<
+    string,
+    { schedule: Schedule; datasourceIds: Set<string>; workbookIds: Set<string> }
+  >();
+
+  for (const task of tasks) {
+    const key = getScheduleKey(task);
+    if (!key || !task.schedule) {
+      continue;
+    }
+
+    let entry = byKey.get(key);
+    if (!entry) {
+      entry = {
+        schedule: { ...task.schedule, taskCount: 0 },
+        datasourceIds: new Set<string>(),
+        workbookIds: new Set<string>(),
+      };
+      byKey.set(key, entry);
+    }
+
+    entry.schedule.taskCount += 1;
+    if (task.datasource?.id) {
+      entry.datasourceIds.add(task.datasource.id);
+    }
+    if (task.workbook?.id) {
+      entry.workbookIds.add(task.workbook.id);
+    }
+  }
+
+  return Array.from(byKey.values()).map(({ schedule, datasourceIds, workbookIds }) => ({
+    ...schedule,
+    ...(datasourceIds.size > 0 ? { datasourceIds: Array.from(datasourceIds) } : {}),
+    ...(workbookIds.size > 0 ? { workbookIds: Array.from(workbookIds) } : {}),
+  }));
+}
+
+// === Field and Operator Definitions ===
+// Client-side filtering for schedules (derived data, no server-side filter support)
+
+const FilterFieldSchema = z.enum([
+  'id',
+  'name',
+  'type',
+  'state',
+  'frequency',
+  'priority',
+  'taskCount',
+  'nextRunAt',
+  'createdAt',
+  'updatedAt',
+]);
+
+type FilterField = z.infer<typeof FilterFieldSchema>;
+
+const allowedOperatorsByField: Record<FilterField, FilterOperator[]> = {
+  id: ['eq', 'in'],
+  name: ['eq', 'in'],
+  type: ['eq', 'in'],
+  state: ['eq', 'in'],
+  frequency: ['eq', 'in'],
+  priority: ['eq', 'gt', 'gte', 'lt', 'lte'],
+  taskCount: ['eq', 'gt', 'gte', 'lt', 'lte'],
+  nextRunAt: ['eq', 'gt', 'gte', 'lt', 'lte'],
+  createdAt: ['eq', 'gt', 'gte', 'lt', 'lte'],
+  updatedAt: ['eq', 'gt', 'gte', 'lt', 'lte'],
+};
+
+const _FilterExpressionSchema = z.object({
+  field: FilterFieldSchema,
+  operator: FilterOperatorSchema,
+  value: z.string(),
+});
+
+type FilterExpression = z.infer<typeof _FilterExpressionSchema>;
+
+export function parseAndValidateSchedulesFilterString(filterString: string): string {
+  return parseAndValidateFilterString<FilterField, FilterExpression>({
+    filterString,
+    allowedOperatorsByField,
+    filterFieldSchema: FilterFieldSchema,
+  });
+}
+
+/**
+ * Apply client-side filtering to aggregated schedules based on filter expressions.
+ * Supports field:operator:value syntax (e.g., "frequency:eq:Daily").
+ */
+export function applySchedulesFilters(
+  schedules: Schedule[],
+  filterString: string | undefined,
+): Schedule[] {
+  if (!filterString) {
+    return schedules;
+  }
+
+  const validatedFilter = parseAndValidateSchedulesFilterString(filterString);
+  const filters = validatedFilter.split(',').map((f) => {
+    const [field, operator, ...valueParts] = f.split(':');
+    return {
+      field: field as FilterField,
+      operator: operator as FilterOperator,
+      value: valueParts.join(':'),
+    };
+  });
+
+  return schedules.filter((schedule) => {
+    return filters.every(({ field, operator, value }) => {
+      const fieldValue = getFieldValue(schedule, field);
+      return matchesFilter(fieldValue, operator, value);
+    });
+  });
+}
+
+function getFieldValue(schedule: Schedule, field: FilterField): string | number | undefined {
+  switch (field) {
+    case 'id':
+      return schedule.id;
+    case 'name':
+      return schedule.name;
+    case 'type':
+      return schedule.type;
+    case 'state':
+      return schedule.state;
+    case 'frequency':
+      return schedule.frequency;
+    case 'priority':
+      return schedule.priority;
+    case 'taskCount':
+      return schedule.taskCount;
+    case 'nextRunAt':
+      return schedule.nextRunAt;
+    case 'createdAt':
+      return schedule.createdAt;
+    case 'updatedAt':
+      return schedule.updatedAt;
+    default:
+      return undefined;
+  }
+}
+
+function matchesFilter(
+  fieldValue: string | number | undefined,
+  operator: FilterOperator,
+  filterValue: string,
+): boolean {
+  if (fieldValue === undefined || fieldValue === null) {
+    return false;
+  }
+
+  const fieldStr = String(fieldValue);
+
+  switch (operator) {
+    case 'eq':
+      return fieldStr === filterValue;
+    case 'in':
+      return filterValue.split('|').includes(fieldStr);
+    case 'gt':
+      return typeof fieldValue === 'number'
+        ? fieldValue > Number(filterValue)
+        : fieldStr > filterValue;
+    case 'gte':
+      return typeof fieldValue === 'number'
+        ? fieldValue >= Number(filterValue)
+        : fieldStr >= filterValue;
+    case 'lt':
+      return typeof fieldValue === 'number'
+        ? fieldValue < Number(filterValue)
+        : fieldStr < filterValue;
+    case 'lte':
+      return typeof fieldValue === 'number'
+        ? fieldValue <= Number(filterValue)
+        : fieldStr <= filterValue;
+    default:
+      return false;
+  }
+}
+
+export const exportedForTesting = {
+  FilterFieldSchema,
+  getScheduleKey,
+  getFieldValue,
+  matchesFilter,
+};

--- a/src/tools/web/toolName.ts
+++ b/src/tools/web/toolName.ts
@@ -2,6 +2,7 @@ export const webToolNames = [
   'list-datasources',
   'list-extract-refresh-tasks',
   'list-users',
+  'list-schedules',
   'list-workbooks',
   'list-projects',
   'list-views',
@@ -65,7 +66,7 @@ export const webToolGroups = {
     'generate-pulse-insight-brief',
   ],
   'content-exploration': ['search-content'],
-  tasks: ['list-extract-refresh-tasks'],
+  tasks: ['list-extract-refresh-tasks', 'list-schedules'],
   users: ['list-users'],
   'token-management': ['revoke-access-token', 'reset-consent'],
   'admin-insights': [

--- a/src/tools/web/tools.ts
+++ b/src/tools/web/tools.ts
@@ -16,6 +16,7 @@ import { getListPulseMetricSubscriptionsTool } from './pulse/listMetricSubscript
 import { getQueryDatasourceTool } from './queryDatasource/queryDatasource.js';
 import { getResetConsentTool } from './resetConsent/resetConsent.js';
 import { getRevokeAccessTokenTool } from './revokeAccessToken/revokeAccessToken.js';
+import { getListSchedulesTool } from './schedules/listSchedules.js';
 import { getListUsersTool } from './users/listUsers.js';
 import { getGetCustomViewDataTool } from './views/getCustomViewData.js';
 import { getGetCustomViewImageTool } from './views/getCustomViewImage.js';
@@ -31,6 +32,7 @@ export const webToolFactories = [
   getListDatasourcesTool,
   getListExtractRefreshTasksTool,
   getListUsersTool,
+  getListSchedulesTool,
   getQueryDatasourceTool,
   getListAllPulseMetricDefinitionsTool,
   getListPulseMetricDefinitionsFromDefinitionIdsTool,

--- a/tests/e2e/tasks/listSchedules.test.ts
+++ b/tests/e2e/tasks/listSchedules.test.ts
@@ -1,0 +1,59 @@
+import { z } from 'zod';
+
+import { scheduleSchema } from '../../../src/sdks/tableau/types/schedule.js';
+import invariant from '../../../src/utils/invariant.js';
+import { getDefaultEnv, resetEnv, setEnv } from '../../testEnv.js';
+import { McpClient } from '../mcpClient.js';
+
+describe('list-schedules', () => {
+  let client: McpClient;
+  let toolsAvailable = false;
+
+  beforeAll(setEnv);
+  afterAll(resetEnv);
+
+  beforeAll(async () => {
+    client = new McpClient({
+      env: { ...getDefaultEnv(), ADMIN_TOOLS_ENABLED: 'true' },
+    });
+    await client.connect();
+    const tools = await client.listTools();
+    toolsAvailable = tools.includes('list-schedules');
+    if (!toolsAvailable) {
+      console.warn(
+        'Skipping list-schedules e2e tests — admin tools not registered. ' +
+          'Ensure ADMIN_TOOLS_ENABLED=true in tests/.env.',
+      );
+    }
+  });
+
+  afterAll(async () => {
+    await client.close();
+  });
+
+  it('should return schedules or the empty-result message', async () => {
+    if (!toolsAvailable) {
+      return;
+    }
+
+    // The schedule list is derived from extract refresh tasks. On a site with no
+    // tasks the tool returns the empty-result message (plain text) instead of a
+    // JSON array, so we call the raw client and accept either shape.
+    const result = await client.client.callTool({ name: 'list-schedules', arguments: {} });
+
+    expect(result.isError).toBeFalsy();
+    invariant(Array.isArray(result.content));
+    expect(result.content).toHaveLength(1);
+    const text = result.content[0].text;
+    invariant(typeof text === 'string');
+
+    if (text.startsWith('No schedules were found')) {
+      expect(text).toContain('No schedules were found');
+    } else {
+      const schedules = z.array(scheduleSchema.passthrough()).parse(JSON.parse(text));
+      schedules.forEach((schedule) => {
+        expect(typeof schedule.taskCount).toBe('number');
+      });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Adds a new admin-gated MCP tool **`list-schedules`** that enumerates the distinct refresh schedules in use on a Tableau site, with per-schedule aggregation metadata (`taskCount`, `datasourceIds`, `workbookIds`).

Work item: **W-22804761** (epic 264 — Tableau MCP for Admins, JTBD#2 Extract Refresh Schedule Optimization). Feeds the future `extract-optimization-inform` prompt by giving it the schedule universe to join against extract-refresh tasks.

## Important: endpoint reality vs. the work item

The work item specified wrapping `GET /sites/{siteId}/schedules` ("Cloud only"). Verified live against a Tableau Cloud admin site:

| Endpoint | Result on Cloud |
|----------|-----------------|
| `GET /sites/{siteId}/schedules` (WI target) | **404** — route does not exist |
| `GET /schedules` (server-level Query Schedules) | **401** — Tableau **Server only** |
| `GET /sites/{siteId}/tasks/extractRefreshes` (sibling) | **200** |

Tableau Cloud exposes **no standalone schedules collection** — schedule data is only available embedded in each task's `schedule` object. The tool therefore derives the schedule universe by **aggregating the distinct schedules referenced by the site's extract refresh tasks** (`tableau:tasks:read`). No new REST endpoint or method class is required.

## Changes

- **Schema** `src/sdks/tableau/types/schedule.ts` — `scheduleSchema` reusing `extractRefreshScheduleSchema` plus aggregation fields (`taskCount`, `datasourceIds`, `workbookIds`).
- **Tool** `src/tools/web/schedules/listSchedules.ts` — `WebTool` factory, admin-gated (`disabled: !config.adminToolsEnabled` + `assertAdmin`), client-side filter + limit, `constrainSchedules` result shaping honoring bounded context.
- **Utils** `src/tools/web/schedules/schedulesUtils.ts` — `aggregateSchedulesFromTasks` (groups by `schedule.id`, falling back to a `name|frequency|nextRunAt` composite key) + client-side filter validation/application via the shared `parseAndValidateFilterString`.
- **Registration** — `toolName.ts` (added to `tasks` group), `tools.ts` (factory), `scopes.ts` (`toolScopeMap`: mcp `tableau:mcp:tasks:read`; api `tableau:tasks:read` + `tableau:users:read`, the latter required by `assertAdmin`; plus admin-flag `enabledTools.delete`).
- **Tests** — unit (`schedulesUtils.test.ts`, `listSchedules.test.ts`) + happy-path E2E (`tests/e2e/tasks/listSchedules.test.ts`, skip-if-not-registered guard).
- **Docs** — `docs/docs/tools/tasks/list-schedules.md`.
- **Version** — bump `2.7.0` → `2.8.0`.

## Access control

Gated behind the existing `ADMIN_TOOLS_ENABLED` feature flag (reused; no new flag) **and** a runtime `assertAdmin` site-role check, matching `list-extract-refresh-tasks` / `list-users`.

## Behavior notes

- `filter` supports `field:operator:value` (comma-separated AND) over `id`, `name`, `type`, `state`, `frequency`, `priority`, `taskCount`, `nextRunAt`, `createdAt`, `updatedAt`. Validation happens inside the executed callback so invalid filters return a clean tool error.
- `pageSize` is accepted but informational (data is aggregated/filtered client-side); `limit` applies a client-side cap.

## Testing

- `npm run build` ✓
- `npm run lint` ✓
- `npx vitest run` → **1465 passed / 96 files** ✓
- E2E against a live Cloud admin site ✓ (test site has 0 extract-refresh tasks → returns the empty-result message; the tool, admin gate, and registration are exercised).
- Gating verified live via `listTools`: present only with `ADMIN_TOOLS_ENABLED=true`, absent when false/unset.


## Manual testing:
### Tableau Schedules Report

**Site:** admin-insights-tmcp-site (10ax.online.tableau.com)  
**Generated:** 2026-06-04  
**Distinct schedules:** 4  
**Total extract-refresh tasks:** 5  
**Source:** tmcp `list-schedules` (aggregates extract-refresh tasks). Verified vs REST `/tasks/extractRefreshes` (5 tasks → 4 schedules).

### Summary

| Metric | Value |
|---|---|
| Distinct schedules | 4 |
| Total tasks across schedules | 5 |
| Frequencies | Daily:2, Monthly:1, Weekly:1 |

### Schedules

| # | Frequency | Next Run (UTC) | Start | Tasks | Detail | Datasource IDs |
|---|---|---|---|---|---|---|
| 1 | Daily | 2026-06-07T14:15:00Z | 07:15:00 | 1 | hours=12, weekDay=Sunday | bfb28876-62ce-4238-bc44-51f91053b489 |
| 2 | Daily | 2026-06-08T14:10:00Z | 07:10:00 | 2 | hours=8, weekDay=Monday | 6a3bf884-ebe9-45df-840f-478d2a4d61b8, 29950092-f3e5-4ad7-ba52-2a2ba291d9d6 |
| 3 | Weekly | 2026-06-08T14:25:00Z | 07:25:00 | 1 | weekDay=Monday | 46a91e80-791f-4779-a724-8fcf0bfbf91e |
| 4 | Monthly | 2026-07-01T14:25:00Z | 07:25:00 | 1 | monthDay=1 | d148a9f2-891b-4593-9fab-8cb21fde337b |

### Verification

| Check | Tool | REST ground truth | Status |
|---|---|---|---|
| Distinct schedules | 4 | 4 | PASS |
| Total tasks | 5 | 5 | PASS |
| Per-schedule taskCount | 1/1/2/1 | 1/1/2/1 | PASS |

### Notes
- All schedules target **datasource** extracts (no workbook extracts present).
- Schedule with 2 tasks: Daily, nextRun 2026-06-08T14:10 — shared by 2 datasources.
- tmcp exposes schedules as an **aggregation of extract-refresh tasks**, not a raw site-schedule list (Tableau Cloud has no classic site schedules API). Counts reconcile exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
