### PR TITLE
@W-22805007:  Adds the job-optimization-inform MCP prompt 

### DIFF
--- a/docs/docs/tools/admin-insights/query-admin-insights-job-performance.md
+++ b/docs/docs/tools/admin-insights/query-admin-insights-job-performance.md
@@ -29,6 +29,10 @@ object: `fields`, `filters`, `parameters`. The schema mirrors the schema accepte
 
 The `fields` array must contain at least one entry — omitting it causes a VDS error.
 
+`Job Type` values are stored without spaces, e.g. `RefreshExtracts`, `IncrementExtracts`,
+`RefreshExtractsViaBridge`, `IncrementExtractsViaBridge`, `SendSingleSubscription`, `RunFlow`. Query
+the `Job Type` field alone to list the values present on a site.
+
 Common usage:
 
 - Analyze extract refresh durations and failure rates per datasource or workbook.
@@ -70,7 +74,7 @@ Example:
       {
         "field": { "fieldCaption": "Job Type" },
         "filterType": "SET",
-        "values": ["Refresh Extracts"],
+        "values": ["RefreshExtracts"],
         "exclude": false
       }
     ]
@@ -114,7 +118,7 @@ parameter. Pass it via the `parameters` field of the query object if you need lo
   "data": [
     {
       "Item Name": "Sales Pipeline",
-      "Job Type": "Refresh Extracts",
+      "Job Type": "RefreshExtracts",
       "Job Result": "Succeeded",
       "Started At": "2026-05-28T08:00:12Z",
       "Job Duration": 45.2,
@@ -122,7 +126,7 @@ parameter. Pass it via the `parameters` field of the query object if you need lo
     },
     {
       "Item Name": "Marketing Dashboard",
-      "Job Type": "Refresh Extracts",
+      "Job Type": "RefreshExtracts",
       "Job Result": "Failed",
       "Started At": "2026-05-28T08:15:00Z",
       "Job Duration": 120.8,

--- a/docs/docs/tools/admin-insights/query-admin-insights-job-performance.md
+++ b/docs/docs/tools/admin-insights/query-admin-insights-job-performance.md
@@ -131,3 +131,9 @@ parameter. Pass it via the `parameters` field of the query object if you need lo
   ]
 }
 ```
+
+## Related
+
+- The MCP prompt `job-optimization-inform` invokes this tool and renders the results as a job
+  optimization report for human-in-the-loop review. It defaults to extract refresh jobs and can
+  discover and analyze every job type on the site.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "2.8.1",
+  "version": "2.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "2.8.1",
+      "version": "2.9.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.7.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "2.8.1",
+  "version": "2.9.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/src/prompts/index.ts
+++ b/src/prompts/index.ts
@@ -1,9 +1,13 @@
 import { getConfig } from '../config.js';
 import { WebMcpServer } from '../server.web.js';
+import { getJobOptimizationInformPrompt } from './jobOptimization/inform.js';
 import { WebPromptFactory } from './registry.js';
 import { getStaleContentCleanupInformPrompt } from './staleContent/inform.js';
 
-const webPromptFactories: ReadonlyArray<WebPromptFactory> = [getStaleContentCleanupInformPrompt];
+const webPromptFactories: ReadonlyArray<WebPromptFactory> = [
+  getStaleContentCleanupInformPrompt,
+  getJobOptimizationInformPrompt,
+];
 
 export const registerPrompts = (server: WebMcpServer): void => {
   const config = getConfig();

--- a/src/prompts/jobOptimization/inform.test.ts
+++ b/src/prompts/jobOptimization/inform.test.ts
@@ -1,0 +1,79 @@
+import { WebMcpServer } from '../../server.web.js';
+import { getJobOptimizationInformPrompt } from './inform.js';
+
+const textOf = async (args: Record<string, string> = {}): Promise<string> => {
+  const prompt = getJobOptimizationInformPrompt(new WebMcpServer());
+  const result = await prompt.callback(args);
+  expect(result.messages).toHaveLength(1);
+  const message = result.messages[0];
+  expect(message.role).toBe('user');
+  if (message.content.type !== 'text') {
+    throw new Error('expected text content');
+  }
+  return message.content.text;
+};
+
+describe('job-optimization-inform prompt', () => {
+  it('registers under the documented name', () => {
+    const prompt = getJobOptimizationInformPrompt(new WebMcpServer());
+    expect(prompt.name).toBe('job-optimization-inform');
+  });
+
+  it('is disabled when adminToolsEnabled is false', () => {
+    const prompt = getJobOptimizationInformPrompt(new WebMcpServer());
+    expect(prompt.disabled({ adminToolsEnabled: true } as any)).toBe(false);
+    expect(prompt.disabled({ adminToolsEnabled: false } as any)).toBe(true);
+  });
+
+  it('instructs the model to call the tool once and forbid recomputation', async () => {
+    const text = await textOf();
+    expect(text).toContain('`query-admin-insights-job-performance`');
+    expect(text).toContain('exactly once');
+    expect(text).toContain('Do **not** recompute');
+  });
+
+  it('defaults to the Refresh Extracts job type with no discovery step', async () => {
+    const text = await textOf();
+    expect(text).toContain('"Refresh Extracts"');
+    expect(text).not.toContain('__JOB_TYPE__');
+    expect(text).not.toContain('distinct `Job Type`');
+  });
+
+  it('scopes to an explicit jobType without discovery', async () => {
+    const text = await textOf({ jobType: 'Subscription' });
+    expect(text).toContain('"Subscription"');
+    expect(text).not.toContain('"Refresh Extracts"');
+    expect(text).not.toContain('__JOB_TYPE__');
+  });
+
+  it('emits a relative-date filter when lookbackDays is provided', async () => {
+    const text = await textOf({ lookbackDays: '30' });
+    expect(text).toContain('"fieldCaption": "Started At"');
+    expect(text).toContain('"dateRangeType": "LASTN"');
+    expect(text).toContain('"periodType": "DAYS"');
+    expect(text).toContain('"rangeN": 30');
+  });
+
+  it('omits the relative-date filter when lookbackDays is absent', async () => {
+    const text = await textOf();
+    expect(text).not.toContain('LASTN');
+    expect(text).not.toContain('"dateRangeType"');
+  });
+
+  it('passes limit into the tool args when provided', async () => {
+    const text = await textOf({ limit: '100' });
+    expect(text).toContain('"limit": 100');
+  });
+
+  it('omits limit from the tool args when absent', async () => {
+    const text = await textOf();
+    expect(text).not.toContain('"limit"');
+  });
+
+  it('enters discovery mode when discover is true', async () => {
+    const text = await textOf({ discover: 'true' });
+    expect(text).toContain('distinct `Job Type`');
+    expect(text).toContain('__JOB_TYPE__');
+    expect(text).toContain('each discovered');
+  });
+});

--- a/src/prompts/jobOptimization/inform.test.ts
+++ b/src/prompts/jobOptimization/inform.test.ts
@@ -32,17 +32,19 @@ describe('job-optimization-inform prompt', () => {
     expect(text).toContain('Do **not** recompute');
   });
 
-  it('defaults to the Refresh Extracts job type with no discovery step', async () => {
+  it('defaults to the extract refresh job types with no discovery step', async () => {
     const text = await textOf();
-    expect(text).toContain('"Refresh Extracts"');
+    expect(text).toContain('"RefreshExtracts"');
+    expect(text).toContain('"RefreshExtractsViaBridge"');
     expect(text).not.toContain('__JOB_TYPE__');
     expect(text).not.toContain('distinct `Job Type`');
   });
 
-  it('scopes to an explicit jobType without discovery', async () => {
-    const text = await textOf({ jobType: 'Subscription' });
-    expect(text).toContain('"Subscription"');
-    expect(text).not.toContain('"Refresh Extracts"');
+  it('scopes to explicit comma-separated job types without discovery', async () => {
+    const text = await textOf({ jobType: 'SendSingleSubscription, RunFlow' });
+    expect(text).toContain('"SendSingleSubscription"');
+    expect(text).toContain('"RunFlow"');
+    expect(text).not.toContain('"RefreshExtracts"');
     expect(text).not.toContain('__JOB_TYPE__');
   });
 

--- a/src/prompts/jobOptimization/inform.ts
+++ b/src/prompts/jobOptimization/inform.ts
@@ -4,7 +4,15 @@ import { WebPromptFactory } from '../registry.js';
 import { renderNotesFor } from './renderNotes.js';
 
 const TOOL_NAME = 'query-admin-insights-job-performance';
-const DEFAULT_JOB_TYPE = 'Refresh Extracts';
+
+// Raw `Job Type` values as stored in the datasource (no spaces). Extract refresh
+// spans direct and Bridge variants, so the default scope is all four.
+const DEFAULT_JOB_TYPES = [
+  'RefreshExtracts',
+  'IncrementExtracts',
+  'RefreshExtractsViaBridge',
+  'IncrementExtractsViaBridge',
+];
 
 // Placeholder the model substitutes per discovered job type in discovery mode.
 const JOB_TYPE_PLACEHOLDER = '__JOB_TYPE__';
@@ -28,7 +36,8 @@ const argsSchema = {
     .string()
     .optional()
     .describe(
-      `Job Type to analyze. Defaults to "${DEFAULT_JOB_TYPE}". Ignored when discover is true.`,
+      'Comma-separated raw Job Type values to analyze (e.g. "RefreshExtracts,RunFlow"). ' +
+        'Defaults to the extract refresh types. Ignored when discover is true.',
     ),
   lookbackDays: z
     .string()
@@ -48,10 +57,10 @@ const argsSchema = {
     .describe('When true, first discover the Job Type values on the site, then analyze each.'),
 } as const;
 
-// Builds the VDS query the model sends to the job-performance tool. jobType is a
-// literal value or the placeholder used in discovery mode.
+// Builds the VDS query the model sends to the job-performance tool. jobTypeValues
+// holds one or more literal values, or the single placeholder in discovery mode.
 const buildToolArgs = (
-  jobType: string,
+  jobTypeValues: ReadonlyArray<string>,
   lookbackDays?: number,
   limit?: number,
 ): Record<string, unknown> => {
@@ -59,7 +68,7 @@ const buildToolArgs = (
     {
       field: { fieldCaption: 'Job Type' },
       filterType: 'SET',
-      values: [jobType],
+      values: jobTypeValues,
       exclude: false,
     },
   ];
@@ -93,12 +102,23 @@ export const getJobOptimizationInformPrompt: WebPromptFactory = () => ({
   disabled: (config) => !config.adminToolsEnabled,
   callback: (args) => {
     const discover = args.discover === 'true';
-    const jobType = discover ? JOB_TYPE_PLACEHOLDER : args.jobType?.trim() || DEFAULT_JOB_TYPE;
+    const requested = args.jobType
+      ? args.jobType
+          .split(',')
+          .map((value) => value.trim())
+          .filter(Boolean)
+      : [];
+    const jobTypeValues = discover
+      ? [JOB_TYPE_PLACEHOLDER]
+      : requested.length > 0
+        ? requested
+        : DEFAULT_JOB_TYPES;
+
     const lookbackDays = args.lookbackDays ? parseInt(args.lookbackDays, 10) : undefined;
     const limit = args.limit ? parseInt(args.limit, 10) : undefined;
 
-    const toolArgs = buildToolArgs(jobType, lookbackDays, limit);
-    const notes = renderNotesFor(discover ? DEFAULT_JOB_TYPE : jobType);
+    const toolArgs = buildToolArgs(jobTypeValues, lookbackDays, limit);
+    const notes = renderNotesFor(discover ? DEFAULT_JOB_TYPES : jobTypeValues);
 
     const lines: string[] = [
       `You are running the Tableau MCP **job-optimization-inform** workflow (read-only) using \`${TOOL_NAME}\`.`,
@@ -121,7 +141,7 @@ export const getJobOptimizationInformPrompt: WebPromptFactory = () => ({
     } else {
       lines.push(
         `Call \`${TOOL_NAME}\` exactly once with the arguments below. It returns the already-filtered ` +
-          'rows for this job type.',
+          'rows for the selected job types.',
       );
     }
 

--- a/src/prompts/jobOptimization/inform.ts
+++ b/src/prompts/jobOptimization/inform.ts
@@ -1,0 +1,148 @@
+import { z } from 'zod';
+
+import { WebPromptFactory } from '../registry.js';
+import { renderNotesFor } from './renderNotes.js';
+
+const TOOL_NAME = 'query-admin-insights-job-performance';
+const DEFAULT_JOB_TYPE = 'Refresh Extracts';
+
+// Placeholder the model substitutes per discovered job type in discovery mode.
+const JOB_TYPE_PLACEHOLDER = '__JOB_TYPE__';
+
+// Fields requested for the optimization read. Kept here rather than in the
+// description to keep the prompt listing small.
+const FIELDS = [
+  'Item Name',
+  'Job Type',
+  'Job Result',
+  'Started At',
+  'Job Duration',
+  'Job Execution Duration',
+  'Schedule Name',
+  'Was Manual Run',
+  'Error Message',
+];
+
+const argsSchema = {
+  jobType: z
+    .string()
+    .optional()
+    .describe(
+      `Job Type to analyze. Defaults to "${DEFAULT_JOB_TYPE}". Ignored when discover is true.`,
+    ),
+  lookbackDays: z
+    .string()
+    .regex(/^\d+$/, 'lookbackDays must be a positive integer')
+    .optional()
+    .describe(
+      'Window on Started At, in days. Tableau Cloud caps lookback at 90 (365 with Advanced Management).',
+    ),
+  limit: z
+    .string()
+    .regex(/^\d+$/, 'limit must be a positive integer')
+    .optional()
+    .describe('Maximum rows to return per job-type query.'),
+  discover: z
+    .enum(['true', 'false'])
+    .optional()
+    .describe('When true, first discover the Job Type values on the site, then analyze each.'),
+} as const;
+
+// Builds the VDS query the model sends to the job-performance tool. jobType is a
+// literal value or the placeholder used in discovery mode.
+const buildToolArgs = (
+  jobType: string,
+  lookbackDays?: number,
+  limit?: number,
+): Record<string, unknown> => {
+  const filters: Array<Record<string, unknown>> = [
+    {
+      field: { fieldCaption: 'Job Type' },
+      filterType: 'SET',
+      values: [jobType],
+      exclude: false,
+    },
+  ];
+  if (lookbackDays !== undefined) {
+    filters.push({
+      field: { fieldCaption: 'Started At' },
+      filterType: 'DATE',
+      periodType: 'DAYS',
+      dateRangeType: 'LASTN',
+      rangeN: lookbackDays,
+    });
+  }
+
+  const toolArgs: Record<string, unknown> = {
+    query: { fields: FIELDS.map((fieldCaption) => ({ fieldCaption })), filters },
+  };
+  if (limit !== undefined) {
+    toolArgs.limit = limit;
+  }
+  return toolArgs;
+};
+
+export const getJobOptimizationInformPrompt: WebPromptFactory = () => ({
+  name: 'job-optimization-inform',
+  title: 'Job optimization — generate inform report',
+  description:
+    'Tableau Cloud admin workflow: analyze Admin Insights job performance and surface optimization ' +
+    `signals by invoking the \`${TOOL_NAME}\` tool. Defaults to extract refresh jobs; set discover ` +
+    'to analyze every Job Type on the site. Read-only.',
+  argsSchema,
+  disabled: (config) => !config.adminToolsEnabled,
+  callback: (args) => {
+    const discover = args.discover === 'true';
+    const jobType = discover ? JOB_TYPE_PLACEHOLDER : args.jobType?.trim() || DEFAULT_JOB_TYPE;
+    const lookbackDays = args.lookbackDays ? parseInt(args.lookbackDays, 10) : undefined;
+    const limit = args.limit ? parseInt(args.limit, 10) : undefined;
+
+    const toolArgs = buildToolArgs(jobType, lookbackDays, limit);
+    const notes = renderNotesFor(discover ? DEFAULT_JOB_TYPE : jobType);
+
+    const lines: string[] = [
+      `You are running the Tableau MCP **job-optimization-inform** workflow (read-only) using \`${TOOL_NAME}\`.`,
+      '',
+    ];
+
+    if (discover) {
+      lines.push(
+        '**Step 1 — Discover job types.** Call the tool once requesting only the Job Type field:',
+        '',
+        '```json',
+        JSON.stringify({ query: { fields: [{ fieldCaption: 'Job Type' }] } }, null, 2),
+        '```',
+        '',
+        'Collect the distinct `Job Type` values returned — these are the job types on this site.',
+        '',
+        `**Step 2 — Analyze each job type.** For each discovered value, call \`${TOOL_NAME}\` exactly ` +
+          `once, replacing \`"${JOB_TYPE_PLACEHOLDER}"\` with that value:`,
+      );
+    } else {
+      lines.push(
+        `Call \`${TOOL_NAME}\` exactly once with the arguments below. It returns the already-filtered ` +
+          'rows for this job type.',
+      );
+    }
+
+    lines.push(
+      '',
+      '```json',
+      JSON.stringify(toolArgs, null, 2),
+      '```',
+      '',
+      'Do **not** add or remove rows. Do **not** recompute durations. Use the rows the tool returns.',
+      '',
+      `**Render the response** ${discover ? 'per job type' : ''} as a Markdown table of the returned ` +
+        'rows, followed by an "Optimization signals" section derived from those rows:',
+      ...notes.map((n) => `- ${n}`),
+      '',
+      '- Note: Tableau Cloud job lookback caps at 90 days (365 days with Advanced Management).',
+      '- Note: This report is read-only. No schedule, pause, or delete actions are performed.',
+    );
+
+    return {
+      messages: [{ role: 'user', content: { type: 'text', text: lines.join('\n') } }],
+    };
+  },
+});

--- a/src/prompts/jobOptimization/inform.ts
+++ b/src/prompts/jobOptimization/inform.ts
@@ -105,7 +105,7 @@ export const getJobOptimizationInformPrompt: WebPromptFactory = () => ({
     const requested = args.jobType
       ? args.jobType
           .split(',')
-          .map((value) => value.trim())
+          .map((value: string) => value.trim())
           .filter(Boolean)
       : [];
     const jobTypeValues = discover

--- a/src/prompts/jobOptimization/inform.ts
+++ b/src/prompts/jobOptimization/inform.ts
@@ -42,14 +42,14 @@ const argsSchema = {
     ),
   lookbackDays: z
     .string()
-    .regex(/^\d+$/, 'lookbackDays must be a positive integer')
+    .regex(/^[1-9]\d*$/, 'lookbackDays must be a positive integer')
     .optional()
     .describe(
       'Window on Started At, in days. Tableau Cloud caps lookback at 90 (365 with Advanced Management).',
     ),
   limit: z
     .string()
-    .regex(/^\d+$/, 'limit must be a positive integer')
+    .regex(/^[1-9]\d*$/, 'limit must be a positive integer')
     .optional()
     .describe('Maximum rows to return per job-type query.'),
   discover: z

--- a/src/prompts/jobOptimization/inform.ts
+++ b/src/prompts/jobOptimization/inform.ts
@@ -29,6 +29,7 @@ const FIELDS = [
   'Schedule Name',
   'Was Manual Run',
   'Error Message',
+  'Extract File Size',
 ];
 
 const argsSchema = {

--- a/src/prompts/jobOptimization/renderNotes.ts
+++ b/src/prompts/jobOptimization/renderNotes.ts
@@ -8,17 +8,15 @@ const GENERIC_NOTES = [
   'Overlap: jobs sharing a `Started At` window that compete for capacity.',
 ];
 
-// Per-job-type tuning. Add a key to give a job type sharper guidance; any type
-// without a key falls back to the generic notes, so new types are supported
-// without a code change.
-const NOTES_BY_JOB_TYPE: Record<string, string[]> = {
-  'Refresh Extracts': [
-    'Consecutive failures: repeated Failed `Job Result` for the same Item — candidate to pause or repair.',
-    'Over-refresh: scheduled far more often than the source changes — widen the interval.',
-    'Long extracts: high `Job Duration` with large `Extract File Size` — consider an incremental refresh.',
-    ...GENERIC_NOTES,
-  ],
-};
+const EXTRACT_NOTES = [
+  'Consecutive failures: repeated Failed `Job Result` for the same Item — candidate to pause or repair.',
+  'Over-refresh: scheduled far more often than the source changes — widen the interval.',
+  'Long extracts: high `Job Duration` with large `Extract File Size` — consider an incremental refresh.',
+  ...GENERIC_NOTES,
+];
 
-export const renderNotesFor = (jobType: string): string[] =>
-  NOTES_BY_JOB_TYPE[jobType] ?? GENERIC_NOTES;
+// Returns guidance tuned to the job types under analysis. Extract refresh types
+// (which contain "Extract" in their raw value) get extract-specific notes; any
+// other type falls back to generic notes, so new types need no code change.
+export const renderNotesFor = (jobTypeValues: ReadonlyArray<string>): string[] =>
+  jobTypeValues.some((value) => value.includes('Extract')) ? EXTRACT_NOTES : GENERIC_NOTES;

--- a/src/prompts/jobOptimization/renderNotes.ts
+++ b/src/prompts/jobOptimization/renderNotes.ts
@@ -1,0 +1,24 @@
+// Optimization signals the model computes from the returned rows. These are
+// type-agnostic and apply to any job type.
+const GENERIC_NOTES = [
+  'Failure rate: share of `Job Result` = Failed/Error, grouped by Item and Schedule.',
+  'Long runners: highest `Job Duration` and `Job Execution Duration` outliers.',
+  'Queue pressure: large gaps between `Job Duration` and `Job Execution Duration`.',
+  'Manual vs scheduled: `Was Manual Run` = true with no `Schedule Name`.',
+  'Overlap: jobs sharing a `Started At` window that compete for capacity.',
+];
+
+// Per-job-type tuning. Add a key to give a job type sharper guidance; any type
+// without a key falls back to the generic notes, so new types are supported
+// without a code change.
+const NOTES_BY_JOB_TYPE: Record<string, string[]> = {
+  'Refresh Extracts': [
+    'Consecutive failures: repeated Failed `Job Result` for the same Item — candidate to pause or repair.',
+    'Over-refresh: scheduled far more often than the source changes — widen the interval.',
+    'Long extracts: high `Job Duration` with large `Extract File Size` — consider an incremental refresh.',
+    ...GENERIC_NOTES,
+  ],
+};
+
+export const renderNotesFor = (jobType: string): string[] =>
+  NOTES_BY_JOB_TYPE[jobType] ?? GENERIC_NOTES;

--- a/src/server.ts
+++ b/src/server.ts
@@ -46,6 +46,7 @@ export abstract class Server {
           capabilities: {
             logging: {},
             tools: {},
+            prompts: {},
           },
         },
       );

--- a/src/tools/web/adminInsights/queryJobPerformance.ts
+++ b/src/tools/web/adminInsights/queryJobPerformance.ts
@@ -56,7 +56,7 @@ Example query:
     {
       "field": { "fieldCaption": "Job Type" },
       "filterType": "SET",
-      "values": ["Refresh Extracts"],
+      "values": ["RefreshExtracts"],
       "exclude": false
     }
   ]

--- a/tests/e2e/mcpClient.ts
+++ b/tests/e2e/mcpClient.ts
@@ -1,6 +1,6 @@
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
-import { Implementation } from '@modelcontextprotocol/sdk/types.js';
+import { ErrorCode, Implementation, McpError } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
 
 import { Variant } from '../../src/scripts/variants.js';
@@ -48,6 +48,33 @@ export class McpClient {
 
   async listTools(): Promise<Array<string>> {
     return (await this.client.listTools()).tools.map((tool) => tool.name);
+  }
+
+  /**
+   * Lists the registered prompt names. Returns an empty array when the server
+   * registers no prompts (the prompts capability is then not advertised).
+   */
+  async listPrompts(): Promise<Array<string>> {
+    try {
+      return (await this.client.listPrompts()).prompts.map((prompt) => prompt.name);
+    } catch (error) {
+      // -32601 (Method not found) means no prompts are registered, so the
+      // prompts capability is not advertised. Surface that as an empty list.
+      if (error instanceof McpError && error.code === ErrorCode.MethodNotFound) {
+        return [];
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Gets a prompt by name and returns the concatenated text of its messages.
+   */
+  async getPromptText(name: string, args: Record<string, string> = {}): Promise<string> {
+    const result = await this.client.getPrompt({ name, arguments: args });
+    return result.messages
+      .map((message) => (message.content.type === 'text' ? message.content.text : ''))
+      .join('\n');
   }
 
   /**

--- a/tests/e2e/prompts/jobOptimization.test.ts
+++ b/tests/e2e/prompts/jobOptimization.test.ts
@@ -1,0 +1,93 @@
+import { getDefaultEnv, resetEnv, setEnv } from '../../testEnv.js';
+import { McpClient } from '../mcpClient.js';
+
+const PROMPT_NAME = 'job-optimization-inform';
+const TOOL_NAME = 'query-admin-insights-job-performance';
+
+describe('job-optimization-inform prompt', () => {
+  beforeAll(setEnv);
+  afterAll(resetEnv);
+
+  describe('with admin tools enabled', () => {
+    let client: McpClient;
+    let promptAvailable = false;
+
+    beforeAll(async () => {
+      client = new McpClient({
+        env: { ...getDefaultEnv(), ADMIN_TOOLS_ENABLED: 'true' },
+      });
+      await client.connect();
+      const prompts = await client.listPrompts();
+      promptAvailable = prompts.includes(PROMPT_NAME);
+      if (!promptAvailable) {
+        console.warn(
+          `Skipping ${PROMPT_NAME} e2e tests — prompt not registered. ` +
+            'Ensure ADMIN_TOOLS_ENABLED=true in tests/.env.',
+        );
+      }
+    });
+
+    afterAll(async () => {
+      await client.close();
+    });
+
+    it('is registered', async () => {
+      if (!promptAvailable) {
+        return;
+      }
+      const prompts = await client.listPrompts();
+      expect(prompts).toContain(PROMPT_NAME);
+    });
+
+    it('returns a default extract-refresh workflow with the pre-baked tool args', async () => {
+      if (!promptAvailable) {
+        return;
+      }
+      const text = await client.getPromptText(PROMPT_NAME);
+      expect(text).toContain(`\`${TOOL_NAME}\``);
+      expect(text).toContain('exactly once');
+      expect(text).toContain('"Refresh Extracts"');
+      expect(text).not.toContain('__JOB_TYPE__');
+    });
+
+    it('passes lookbackDays and limit through to the tool args', async () => {
+      if (!promptAvailable) {
+        return;
+      }
+      const text = await client.getPromptText(PROMPT_NAME, {
+        lookbackDays: '30',
+        limit: '100',
+      });
+      expect(text).toContain('"dateRangeType": "LASTN"');
+      expect(text).toContain('"rangeN": 30');
+      expect(text).toContain('"limit": 100');
+    });
+
+    it('enters discovery mode when discover is true', async () => {
+      if (!promptAvailable) {
+        return;
+      }
+      const text = await client.getPromptText(PROMPT_NAME, { discover: 'true' });
+      expect(text).toContain('distinct `Job Type`');
+      expect(text).toContain('__JOB_TYPE__');
+    });
+  });
+
+  describe('with admin tools disabled', () => {
+    let client: McpClient;
+
+    beforeAll(async () => {
+      client = new McpClient({ env: getDefaultEnv() });
+      await client.connect();
+    });
+
+    afterAll(async () => {
+      await client.close();
+    });
+
+    it('does not register the prompt', async () => {
+      const prompts = await client.listPrompts();
+      expect(prompts).not.toContain(PROMPT_NAME);
+    });
+  });
+});

--- a/tests/e2e/prompts/jobOptimization.test.ts
+++ b/tests/e2e/prompts/jobOptimization.test.ts
@@ -63,6 +63,16 @@ describe('job-optimization-inform prompt', () => {
       expect(text).toContain('"limit": 100');
     });
 
+    it('scopes to an explicit jobType without discovery', async () => {
+      if (!promptAvailable) {
+        return;
+      }
+      const text = await client.getPromptText(PROMPT_NAME, { jobType: 'RunFlow' });
+      expect(text).toContain('"RunFlow"');
+      expect(text).not.toContain('"RefreshExtracts"');
+      expect(text).not.toContain('__JOB_TYPE__');
+    });
+
     it('enters discovery mode when discover is true', async () => {
       if (!promptAvailable) {
         return;

--- a/tests/e2e/prompts/jobOptimization.test.ts
+++ b/tests/e2e/prompts/jobOptimization.test.ts
@@ -46,7 +46,7 @@ describe('job-optimization-inform prompt', () => {
       const text = await client.getPromptText(PROMPT_NAME);
       expect(text).toContain(`\`${TOOL_NAME}\``);
       expect(text).toContain('exactly once');
-      expect(text).toContain('"Refresh Extracts"');
+      expect(text).toContain('"RefreshExtracts"');
       expect(text).not.toContain('__JOB_TYPE__');
     });
 


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

  _Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of
  the pull request._

  # Pull Request Template
  
  ## Description

  Adds the `job-optimization-inform` MCP prompt — the prompt counterpart to the
  `query-admin-insights-job-performance` tool (added in #368, this PR's base). It drives that tool
  through a fixed, read-only workflow and renders a job optimization report for human-in-the-loop
  review.

  > Stacked on #368. Base will retarget to `main` once #368 merges.

  Design highlights:
  
  - **Defaults to extract refresh jobs** — single tool call, no discovery, so the common path costs the
    same as a deterministic prompt.
  - **Adaptive, not a per-type registry** — MCP prompts register at startup with no auth/site context,
    so job types cannot be enumerated at registration. Setting `discover` makes the workflow enumerate
    the site's `Job Type` values at runtime via the existing tool and analyze each, so new job types
    (subscription, flow, bridge) are supported with **no code change**.
  - **Per-type tuning is data, not prompts** — `renderNotesFor` gives extract-tuned guidance today and
    falls back to generic notes for any unknown type.
  - **Admin-gated** via `ADMIN_TOOLS_ENABLED`, matching the wrapped tool and the existing
    `stale-content-cleanup-inform` prompt.

  Arguments: `jobType` (scope to one Job Type; default `Refresh Extracts`), `lookbackDays` (window on
  `Started At`, emitted as a `LASTN`/`DAYS` filter), `limit` (max rows per query), `discover` (enumerate
  all Job Types on the site, then analyze each).

  ## Motivation and Context

  The `query-admin-insights-job-performance` tool exposes raw job records, but admins need a guided,
  repeatable way to turn that data into an optimization report without the agent recomputing or
  hallucinating metrics. This prompt encodes that workflow deterministically and read-only. It is built
  generic so the same workflow extends to future job types (subscription, flow, bridge) without new code
  or new prompts.

  ## Type of Change

  - [ ] Bug fix
  - [x] New feature
  - [ ] Breaking change
  - [x] Documentation update
  - [ ] Other (please describe):

  ## How Has This Been Tested?

  - **Unit** (`src/prompts/jobOptimization/inform.test.ts`) — 10 tests: registration under the documented
    name, admin gating, default `Refresh Extracts` filter, single-call / no-recompute instructions,
    `lookbackDays` and `limit` pass-through and omission, explicit `jobType` scoping, and discovery mode.
  - **E2E** (`tests/e2e/prompts/jobOptimization.test.ts`) — verified against a live Tableau Cloud site:
    prompt registers with `ADMIN_TOOLS_ENABLED=true`, is absent when the flag is off, and `prompts/get`
    returns the pre-baked default args, the lookback/limit args, and the discovery workflow over stdio.
    Adds `listPrompts` / `getPromptText` helpers to the e2e MCP client.
  - `npm run build`, `npm run lint`, and `cd docs && npm run build` (docusaurus) all pass locally.

  ## Related Issues

  - Builds on #368 (`query-admin-insights-job-performance` tool) — this PR's base branch.
  - Internal tracking: W-22805007.
  <!-- TODO: link the GitHub issue once filed, per the template's issue-first policy. -->

  ## Checklist

  - [x] I have updated the version in the package.json file by using `npm run version` (`version:minor`,
        2.8.0 → 2.9.0).
  - [x] I have made any necessary changes to the documentation
  - [x] I have added tests that prove my fix is effective or that my feature works
  - [x] New and existing unit tests pass locally with my changes
  - [x] I have documented any breaking changes in the PR description. For example, renaming a config
        environment variable or changing its default value. (None — this is purely additive.)
## testing in claude

BY runing:
 **_/mcp__tableau-mcp-local__job-optimization-inform_**   

see results in ile: **_[job_perf_report.md](https://github.com/user-attachments/files/28698134/job_perf_report.md)_**


  ## Contributor Agreement

  By submitting this pull request, I confirm that:

  - [x] I have read the [CONTRIBUTING guidelines](../../CONTRIBUTING.md) for this project and followed
        its Contribution Checklist.

