### PR TITLE
@W-22903855: Fix get-datasource-metadata failure for datasources with Tableau relationships

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "2.7.3",
+  "version": "2.7.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "2.7.3",
+      "version": "2.7.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.7.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "2.7.3",
+  "version": "2.7.4",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/src/sdks/tableau/apis/vizqlDataServiceApi.test.ts
+++ b/src/sdks/tableau/apis/vizqlDataServiceApi.test.ts
@@ -1,4 +1,4 @@
-import { fieldSchema, filterSchema } from './vizqlDataServiceApi.js';
+import { datasourceModelResponseSchema, fieldSchema, filterSchema } from './vizqlDataServiceApi.js';
 
 describe('Field schema', () => {
   it('accepts a minimal valid Field', () => {
@@ -29,6 +29,74 @@ describe('Field schema', () => {
   it('rejects a Field with both function and calculation', () => {
     const data = { fieldCaption: 'Profit', function: 'SUM', calculation: 'SUM([Profit])' };
     expect(() => fieldSchema.parse(data)).toThrow();
+  });
+});
+
+describe('Datasource model response schema', () => {
+  it('accepts a single-table model with no relationships', () => {
+    const data = {
+      logicalTables: [{ logicalTableId: 'pp-2025.csv_35B9C215', caption: 'pp-2025.csv' }],
+      logicalTableRelationships: [],
+    };
+    expect(() => datasourceModelResponseSchema.parse(data)).not.toThrow();
+  });
+
+  it('accepts a multi-table model with relationships that include an expression', () => {
+    const data = {
+      logicalTables: [
+        { logicalTableId: 'Orders_ECFCA1FB', caption: 'Orders' },
+        { logicalTableId: 'People_D7302373', caption: 'People' },
+      ],
+      logicalTableRelationships: [
+        {
+          fromLogicalTable: { logicalTableId: 'Orders_ECFCA1FB' },
+          toLogicalTable: { logicalTableId: 'People_D7302373' },
+          expression: {
+            op: 'and',
+            relationships: [{ operator: '=', fromField: 'Region', toField: 'Region' }],
+          },
+        },
+      ],
+    };
+    expect(() => datasourceModelResponseSchema.parse(data)).not.toThrow();
+  });
+
+  it('accepts a multi-table model with relationships that omit the expression', () => {
+    // Reproduces tableau/tableau-mcp#364: Tableau returns relationships without
+    // an `expression` key when the relationship is implicit.
+    const data = {
+      logicalTables: [
+        { logicalTableId: 'Orders_ECFCA1FB' },
+        { logicalTableId: 'People_D7302373' },
+        { logicalTableId: 'Returns_2AA0FE4D' },
+      ],
+      logicalTableRelationships: [
+        {
+          fromLogicalTable: { logicalTableId: 'Orders_ECFCA1FB' },
+          toLogicalTable: { logicalTableId: 'People_D7302373' },
+        },
+        {
+          fromLogicalTable: { logicalTableId: 'Orders_ECFCA1FB' },
+          toLogicalTable: { logicalTableId: 'Returns_2AA0FE4D' },
+        },
+      ],
+    };
+    expect(() => datasourceModelResponseSchema.parse(data)).not.toThrow();
+  });
+
+  it('leaves a missing expression absent rather than synthesizing one', () => {
+    const data = {
+      logicalTables: [{ logicalTableId: 'Orders_ECFCA1FB' }, { logicalTableId: 'People_D7302373' }],
+      logicalTableRelationships: [
+        {
+          fromLogicalTable: { logicalTableId: 'Orders_ECFCA1FB' },
+          toLogicalTable: { logicalTableId: 'People_D7302373' },
+        },
+      ],
+    };
+    const parsed = datasourceModelResponseSchema.parse(data);
+    expect(parsed.logicalTableRelationships[0]).not.toHaveProperty('expression');
+    expect(parsed.logicalTableRelationships[0].expression).toBeUndefined();
   });
 });
 

--- a/src/sdks/tableau/apis/vizqlDataServiceApi.ts
+++ b/src/sdks/tableau/apis/vizqlDataServiceApi.ts
@@ -376,7 +376,8 @@ const logicalTableRelationshipSchema = z
         op: z.string().optional(),
         relationships: z.array(relationshipClauseSchema),
       })
-      .passthrough(),
+      .passthrough()
+      .optional(),
   })
   .passthrough();
 

--- a/src/tools/web/getDatasourceMetadata/datasourceMetadataUtils.ts
+++ b/src/tools/web/getDatasourceMetadata/datasourceMetadataUtils.ts
@@ -75,16 +75,18 @@ export const datasourceModelSchema = z.object({
       toLogicalTable: z.object({
         logicalTableId: z.string(),
       }),
-      expression: z.object({
-        op: z.string().optional(),
-        relationships: z.array(
-          z.object({
-            operator: z.string(),
-            fromField: z.string(),
-            toField: z.string(),
-          }),
-        ),
-      }),
+      expression: z
+        .object({
+          op: z.string().optional(),
+          relationships: z.array(
+            z.object({
+              operator: z.string(),
+              fromField: z.string(),
+              toField: z.string(),
+            }),
+          ),
+        })
+        .optional(),
     }),
   ),
 });

--- a/src/tools/web/getDatasourceMetadata/getDatasourceMetadata.test.ts
+++ b/src/tools/web/getDatasourceMetadata/getDatasourceMetadata.test.ts
@@ -126,6 +126,19 @@ const mockDatasourceModelResponses = vi.hoisted(() => ({
       },
     ],
   },
+  // Reproduces tableau/tableau-mcp#364: relationships without an `expression` key.
+  noExpression: {
+    logicalTables: [
+      { logicalTableId: 'Orders_123456789', caption: 'Orders' },
+      { logicalTableId: 'Returns_987654321', caption: 'Returns' },
+    ],
+    logicalTableRelationships: [
+      {
+        fromLogicalTable: { logicalTableId: 'Orders_123456789' },
+        toLogicalTable: { logicalTableId: 'Returns_987654321' },
+      },
+    ],
+  },
 }));
 
 const mockListFieldsResponses = vi.hoisted(() => ({
@@ -391,6 +404,29 @@ describe('getDatasourceMetadataTool', () => {
       },
     });
     expect(mocks.mockGraphql).toHaveBeenCalledWith(expect.stringContaining('datasourceFieldInfo'));
+  });
+
+  it('should return metadata for a multi-table model whose relationships omit expression', async () => {
+    // Regression test for tableau/tableau-mcp#364.
+    mocks.mockReadMetadata.mockResolvedValue(new Ok(mockReadMetadataResponses.success));
+    mocks.mockGetDatasourceModel.mockResolvedValue(
+      new Ok(mockDatasourceModelResponses.noExpression),
+    );
+    mocks.mockGraphql.mockResolvedValue(mockListFieldsResponses.success);
+
+    const result = await getToolResult();
+
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+    const responseData = JSON.parse(result.content[0].text);
+
+    expect(responseData.datasourceModel).toMatchObject(mockDatasourceModelResponses.noExpression);
+    // The missing expression must remain absent, not be synthesized into an empty object.
+    expect(responseData.datasourceModel.logicalTableRelationships[0]).not.toHaveProperty(
+      'expression',
+    );
+    expect(responseData.fieldGroups.length).toBeGreaterThan(0);
+    expect(responseData.parameters.length).toBeGreaterThan(0);
   });
 
   it('should handle empty readMetadata response gracefully', async () => {


### PR DESCRIPTION
## Description
`get-datasource-metadata` failed for published datasources containing multiple logical tables connected by Tableau relationships. The Tableau VizQL Data Service API returned HTTP 200 with a valid datasource model, but the MCP server rejected it client-side with a Zodios response-validation error and returned no field metadata to the client.
This PR makes the relationship `expression` field optional in both relevant Zod schemas so relationship-based datasources parse correctly while keeping all other validation intact.
## Motivation and Context
Tableau can omit `expression` on otherwise valid `logicalTableRelationships` entries (for example, implicit relationships in a Superstore Orders + People + Returns datasource), but our Zod schemas marked `expression` as **required**. Single-table datasources were unaffected because `logicalTableRelationships` is empty, so the relationship object was never validated.
Observed error:
Zodios: Invalid response from endpoint 'post /get-datasource-model' status: 200 cause: [{ "code": "invalid_type", "expected": "object", "received": "undefined", "path": ["logicalTableRelationships", 0, "expression"], "message": "Required" }]

Fix: make `expression` optional in
- `src/sdks/tableau/apis/vizqlDataServiceApi.ts` — the VDS `get-datasource-model` response schema that produced the error, and
- `src/tools/web/getDatasourceMetadata/datasourceMetadataUtils.ts` — the tool's output schema, which is validated by the e2e/eval/oauth suites.
A missing `expression` is left absent/undefined; we do not synthesize an empty expression object. No downstream code reads `relationship.expression` (verified), so no additional guards are needed.
A possible follow-up (intentionally **not** in this PR, to keep it minimal): `getDatasourceModel` and `readMetadata` re-throw `ZodiosError` instead of converting it to the graceful raw-data-plus-warning path that `queryDatasource` already uses. A future change could mirror that pattern so the tool degrades gracefully on any future schema drift.
## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):
## How Has This Been Tested?
Targeted Vitest run (97 passed):
npx vitest run
src/sdks/tableau/apis/vizqlDataServiceApi.test.ts
src/tools/web/getDatasourceMetadata/getDatasourceMetadata.test.ts


Added coverage:
- Schema-level tests via the exported `datasourceModelResponseSchema`: single-table (no relationships) parses; multi-table **with** `expression` parses; multi-table **without** `expression` parses (regression); and a missing `expression` stays absent rather than being synthesized.
- Tool-level regression test for `get-datasource-metadata` with a relationships-without-`expression` fixture: asserts `isError === false` and that the response still includes `datasourceModel`, `fieldGroups`, and `parameters`, with the relationship's `expression` remaining absent.
Regression confirmation: with the API schema change temporarily reverted, the "missing expression" tests fail with the exact `path: ["logicalTableRelationships", 0, "expression"]` ZodError from the issue; they pass with the fix applied.
ESLint passes on all changed files.
Typecheck note: `tsc --noEmit` still reports one pre-existing, unrelated error — `src/scripts/build.ts(7,32): Cannot find module 'vite-plugin-singlefile'`. This is not caused by this PR; it was confirmed by reproducing the error with the schema changes stashed.
## Related Issues
Fixes #364.
## Checklist
- [x] I have updated the version in the package.json file by using `npm run version`. For example, use `npm run version:patch` for a patch version bump.
- [x] I have made any necessary changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have documented any breaking changes in the PR description. For example, renaming a config environment variable or changing its default value.
## Contributor Agreement
By submitting this pull request, I confirm that:
- [x] I have read the [CONTRIBUTING guidelines](../../CONTRIBUTING.md) for this project and followed its Contribution Checklist.