### PR TITLE
Add tableau-heroku MCP endpoint to config.http.json

### DIFF
--- a/config.http.json
+++ b/config.http.json
@@ -3,6 +3,10 @@
     "tableau": {
       "type": "streamable-http",
       "url": "http://127.0.0.1:3927/tableau-mcp"
+    },
+    "tableau-heroku": {
+      "type": "streamable-http",
+      "url": "https://tableau-mcpapps-60795bc59119.herokuapp.com/tableau-mcp"
     }
   }
 }


### PR DESCRIPTION
## Summary

Adds a `tableau-heroku` streamable-http server entry to `config.http.json`, pointing at the deployed Heroku instance (`tableau-mcpapps`) alongside the existing local `127.0.0.1:3927` endpoint.

## Change

```diff
     "tableau": {
       "type": "streamable-http",
       "url": "http://127.0.0.1:3927/tableau-mcp"
+    },
+    "tableau-heroku": {
+      "type": "streamable-http",
+      "url": "https://tableau-mcpapps-60795bc59119.herokuapp.com/tableau-mcp"
     }
```

This lets the HTTP config target the hosted deployment without removing the local-dev endpoint.

## Notes
- Config-only change; no code or behavior changes to the server itself.