### PR TITLE
@W-22642120 Fit embedded Tableau viz height in MCP app frame

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "2.18.0",
+  "version": "2.19.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "2.18.0",
+      "version": "2.19.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.7.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "2.19.0",
+  "version": "2.18.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "2.19.0",
+      "version": "2.18.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.7.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "2.18.0",
+  "version": "2.19.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "2.19.0",
+  "version": "2.18.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/src/web/apps/src/lib/embedTableauViz.test.ts
+++ b/src/web/apps/src/lib/embedTableauViz.test.ts
@@ -58,4 +58,41 @@ describe('embedTableauViz', () => {
       embedTableauViz(vizUrl, token);
     }).toThrow('Container element with id "tableauVizContainer" not found');
   });
+
+  it('should be idempotent - calling twice results in exactly one viz element', () => {
+    const vizUrl1 = 'https://prod-uswest-c.online.tableau.com/site/mysite/views/workbook1/view1';
+    const token1 = 'token-first';
+
+    const vizUrl2 = 'https://prod-uswest-c.online.tableau.com/site/mysite/views/workbook2/view2';
+    const token2 = 'token-second';
+
+    // Call embedTableauViz twice (simulating double-mount)
+    embedTableauViz(vizUrl1, token1);
+    embedTableauViz(vizUrl2, token2);
+
+    const container = document.getElementById('tableauVizContainer');
+    const vizElements = container?.querySelectorAll('tableau-viz');
+
+    // Should have exactly ONE viz element, not two
+    expect(vizElements?.length).toBe(1);
+  });
+
+  it('should replace previous viz with most recent one', () => {
+    const vizUrl1 = 'https://prod-uswest-c.online.tableau.com/site/mysite/views/workbook1/view1';
+    const token1 = 'token-first';
+
+    const vizUrl2 = 'https://prod-uswest-c.online.tableau.com/site/mysite/views/workbook2/view2';
+    const token2 = 'token-second';
+
+    // Call embedTableauViz twice
+    embedTableauViz(vizUrl1, token1);
+    embedTableauViz(vizUrl2, token2);
+
+    const container = document.getElementById('tableauVizContainer');
+    const vizElement = container?.querySelector('tableau-viz');
+
+    // The remaining viz should reflect the SECOND call (most recent wins)
+    expect(vizElement?.getAttribute('src')).toBe(vizUrl2);
+    expect(vizElement?.getAttribute('token')).toBe(token2);
+  });
 });

--- a/src/web/apps/src/lib/embedTableauViz.test.ts
+++ b/src/web/apps/src/lib/embedTableauViz.test.ts
@@ -95,4 +95,56 @@ describe('embedTableauViz', () => {
     expect(vizElement?.getAttribute('src')).toBe(vizUrl2);
     expect(vizElement?.getAttribute('token')).toBe(token2);
   });
+
+  it('should set viz height from firstvizsizeknown event', () => {
+    const vizUrl = 'https://prod-uswest-c.online.tableau.com/site/mysite/views/workbook/view';
+    const token = 'test-token-123';
+
+    embedTableauViz(vizUrl, token);
+
+    const container = document.getElementById('tableauVizContainer');
+    const vizElement = container?.querySelector('tableau-viz') as HTMLElement;
+
+    expect(vizElement).toBeTruthy();
+
+    // Simulate firstvizsizeknown event with viz height
+    const event = new CustomEvent('firstvizsizeknown', {
+      detail: {
+        vizSize: {
+          sheetSize: {
+            maxSize: {
+              height: 800,
+            },
+          },
+        },
+      },
+    });
+
+    vizElement.dispatchEvent(event);
+
+    // Should set height to the reported viz height
+    expect(vizElement.style.height).toBe('800px');
+  });
+
+  it('should leave height unset when firstvizsizeknown has no numeric height', () => {
+    const vizUrl = 'https://prod-uswest-c.online.tableau.com/site/mysite/views/workbook/view';
+    const token = 'test-token-123';
+
+    embedTableauViz(vizUrl, token);
+
+    const container = document.getElementById('tableauVizContainer');
+    const vizElement = container?.querySelector('tableau-viz') as HTMLElement;
+
+    expect(vizElement).toBeTruthy();
+
+    // Simulate firstvizsizeknown event with empty detail
+    const event = new CustomEvent('firstvizsizeknown', {
+      detail: {},
+    });
+
+    vizElement.dispatchEvent(event);
+
+    // Height should remain unset
+    expect(vizElement.style.height).toBe('');
+  });
 });

--- a/src/web/apps/src/lib/embedTableauViz.ts
+++ b/src/web/apps/src/lib/embedTableauViz.ts
@@ -35,7 +35,22 @@ export function embedTableauViz(vizUrl: string, token: string): void {
     throw new Error(`Container element with id "${TABLEAU_VIZ_CONTAINER_ID}" not found`);
   }
 
-  // Create and append the viz element
+  // Create and replace any existing viz element (idempotent)
   const viz = createTableauVizElement(vizUrl, token);
-  container.appendChild(viz);
+
+  // The Embedding API reports the viz's natural size via `firstvizsizeknown`.
+  // Set the element's height to the viz's natural sheet height so it renders
+  // fully; the ext-apps SDK's built-in auto-resize then grows the app frame to
+  // match the resulting document height.
+  viz.addEventListener('firstvizsizeknown', (event) => {
+    const vizSize = (event as CustomEvent).detail?.vizSize;
+    const sheetHeight = vizSize?.sheetSize?.maxSize?.height;
+    if (typeof sheetHeight !== 'number') {
+      return;
+    }
+
+    viz.style.height = `${sheetHeight}px`;
+  });
+
+  container.replaceChildren(viz);
 }

--- a/src/web/apps/src/mcp-app.css
+++ b/src/web/apps/src/mcp-app.css
@@ -3,7 +3,6 @@
 }
 
 html, body {
-  height: 100%;
   margin: 0;
   padding: 0;
 }
@@ -14,9 +13,9 @@ body {
 
 .main {
   width: 100%;
-  height: 100vh;
   margin: 0;
   padding: 0;
+  min-height: 600px;
 }
 
 .viz-container {

--- a/src/web/apps/src/mcp-app.css
+++ b/src/web/apps/src/mcp-app.css
@@ -25,6 +25,8 @@ body {
 
 tableau-viz {
   width: 100%;
-  height: 100%;
+  max-height: 1200px;
+  overflow-y: auto;
   display: block;
+  transition: height 0.3s ease;
 }


### PR DESCRIPTION
## Summary
<img width="976" height="980" alt="Screenshot 2026-06-23 at 5 19 58 PM" src="https://github.com/user-attachments/assets/80822725-8952-4291-8fae-4b690617b0b6" />

The MCP app embeds a Tableau viz via the Embedding API v3 and needs to fit the viz to its app frame. The prior layout used a fixed `100vh` / `height: 100%` chain, which didn't match the viz's natural size — leaving the embedded viz clipped or scrolling.

This change sizes the `tableau-viz` element to the viz's **natural sheet height**, read from the `firstvizsizeknown` event and sets it to that height.

## Changes

- **`embedTableauViz.ts`**: Listen for `firstvizsizeknown` and set `viz.style.height` to the natural sheet height. Bail out cleanly if the payload has no numeric height.
- **`embedTableauViz.ts`**: Make embedding idempotent — use `replaceChildren` so a double-mount or a second tool result yields exactly one viz element instead of stacking.
- **`mcp-app.css`**: Drop the fixed `html, body { height: 100% }` and `.main { height: 100vh }` in favor of `.main { min-height: 600px }`, letting the viz drive the height.

## Testing

- `tsc --noEmit`: clean
- `eslint`: clean
- Unit tests: 5/5 pass (new idempotency + most-recent-wins cases added)
