### PR TITLE
@W-23093455: Server-authoritative pending-deletion tag gate for delete tools

### DIFF
--- a/docs/docs/prompts/stale-content-cleanup-apply.md
+++ b/docs/docs/prompts/stale-content-cleanup-apply.md
@@ -20,9 +20,9 @@ The prompt sequences existing deterministic tools — it performs no calculation
 2. **Resolve LUIDs (read-only)** — the report emits a numeric `itemId`, not the LUID the delete tools need. Each item's LUID is resolved via `list-workbooks` / `list-datasources` filtered by name and project. Ambiguous matches are skipped, never guessed.
 3. **Notify report (read-only)** — builds an owner-notification table using the report's `ownerEmail`, falling back to [`list-users`](../tools/users/list-users.md) filtered by owner LUID (`id:in:...`) for any gaps. Report-only; no email is sent.
 4. **Human confirmation break** — presents the resolved items and owners and requires explicit approval before any tag or delete. In a dry run (the default) the workflow stops here, having written nothing.
-5. **Tag approved items (reversible)** — only for approved items, calls the matching delete tool ([`delete-workbook`](../tools/workbooks/delete-workbook.md) / [`delete-datasource`](../tools/data-qna/delete-datasource.md)) in preview mode to tag each `pending-deletion` and obtain a per-item `confirmationToken`. Nothing is deleted.
+5. **Tag approved items (reversible)** — only for approved items, calls the matching delete tool ([`delete-workbook`](../tools/workbooks/delete-workbook.md) / [`delete-datasource`](../tools/data-qna/delete-datasource.md)) in preview mode to tag each `pending-deletion`. The tag is the server-side record the delete step verifies. Nothing is deleted.
 6. **Grace check** — confirms the notification window has elapsed and the items are still the intended targets.
-7. **Delete (confirmed)** — only for approved items, calls the delete tool with `confirm: true` and the exact `confirmationToken` from step 5. Deleted content goes to the Tableau recycle bin (recoverable for a limited time).
+7. **Delete (confirmed)** — only for approved items, calls the delete tool with `confirm: true`. The tool re-fetches each item and deletes only if it still carries the `pending-deletion` tag from step 5 — a confirmed delete on an untagged item is rejected server-side. Deleted content goes to the Tableau recycle bin (recoverable for a limited time).
 
 ## Arguments
 

--- a/docs/docs/tools/data-qna/delete-datasource.md
+++ b/docs/docs/tools/data-qna/delete-datasource.md
@@ -15,11 +15,11 @@ The tool is **two-phase** to keep the destructive action safe:
 1. **Preview** (default — `confirm` omitted or `false`): tags the data source with
    `pending-deletion` (reversible, visible in the Tableau UI; label configurable via the `tag`
    argument), reports the data source name, project, and owner, **warns which workbooks and flows
-   depend on it and may break**, returns a `confirmationToken`, and does **not** delete anything.
-2. **Delete** (`confirm: true` + `confirmationToken`): permanently removes the data source. The
-   token from the preview step is **required** — deletion is rejected without a matching token,
-   a friction gate requiring a deliberate second call rather than a blind one-shot call (see the
-   [`confirmationToken`](#confirmationtoken) note on what this does and does not guarantee). On Tableau Cloud the data source
+   depend on it and may break**, and does **not** delete anything.
+2. **Delete** (`confirm: true`): permanently removes the data source. Before deleting, the server
+   re-fetches the data source and **verifies it carries the pending-deletion tag** applied in the
+   preview step. A confirmed delete against an untagged data source is rejected (see the
+   [server-authoritative gate](#server-authoritative-gate) note). On Tableau Cloud the data source
    is moved to the [recycle bin](https://help.tableau.com/current/pro/desktop/en-us/recycle_bin.htm)
    and can be restored for a limited time before permanent removal; on Tableau Server there is no
    recycle bin and deletion is permanent.
@@ -27,10 +27,18 @@ The tool is **two-phase** to keep the destructive action safe:
 :::warning[Human confirmation required]
 Between the preview and the delete, the calling agent is instructed (via the tool description and
 the preview response) to surface the data source identity **and its dependent content** to the user
-and obtain explicit approval before deleting. The `confirmationToken` enforces that a preview ran,
-but the **human approval** step is a prompt-level expectation — agents must not auto-confirm or
-compute the token themselves.
+and obtain explicit approval before deleting. The server-side tag gate guarantees the preview ran,
+but the **human approval** step is a prompt-level expectation — agents must not auto-confirm.
 :::
+
+### Server-authoritative gate
+
+The confirm phase does not trust any caller-supplied value. It re-fetches the data source from
+Tableau and only deletes if the data source is currently tagged `pending-deletion` (or the custom
+`tag` value). The tag is server-side state that the caller can only set by running the preview
+phase, so the gate genuinely proves a preview happened — it **cannot** be bypassed by computing or
+guessing a token. The live re-fetch deliberately ignores any cached copy so the check reflects the
+data source's current state at delete time.
 
 :::note[Dependent content is not deleted]
 Deleting a published data source does **not** delete the workbooks or flows that use it. Those
@@ -69,21 +77,12 @@ Example: `222ea993-9391-4910-a167-56b3d19b4e3b`
 ### `confirm`
 
 When omitted or `false`, runs the non-destructive preview (tags, warns about dependents, and
-reports). When `true`, permanently deletes the data source (also requires `confirmationToken`).
+reports). When `true`, permanently deletes the data source — but only if the data source already
+carries the pending-deletion tag from a prior preview (verified by a live re-fetch; see
+[server-authoritative gate](#server-authoritative-gate)). Pass the same `tag` value used in the
+preview if you overrode the default.
 
 Example: `true`
-
-### `confirmationToken`
-
-Required when `confirm` is `true`. The `confirmationToken` value returned by the preview step for
-this data source. Deletion is rejected without a matching token — a friction gate requiring a
-deliberate second call rather than a blind single call.
-
-The token is a deterministic `sha256(siteId:datasourceId)` value, so it enforces an explicit second
-call but does **not** prove the preview/tag step actually ran (a caller who knows the datasource LUID
-can compute it). Guaranteeing a preview happened would require server-side state.
-
-Example: `3a7f9c2e1b04`
 
 ### `tag`
 

--- a/docs/docs/tools/data-qna/delete-datasource.md
+++ b/docs/docs/tools/data-qna/delete-datasource.md
@@ -24,11 +24,14 @@ The tool is **two-phase** to keep the destructive action safe:
    and can be restored for a limited time before permanent removal; on Tableau Server there is no
    recycle bin and deletion is permanent.
 
-:::warning[Human confirmation required]
+:::warning[Human confirmation required — advisory, not enforced]
 Between the preview and the delete, the calling agent is instructed (via the tool description and
 the preview response) to surface the data source identity **and its dependent content** to the user
-and obtain explicit approval before deleting. The server-side tag gate guarantees the preview ran,
-but the **human approval** step is a prompt-level expectation — agents must not auto-confirm.
+and obtain explicit approval before deleting. This human-approval step is a **prompt-level
+expectation, not a server guarantee**: the tag gate proves a preview *ran*, but the server cannot
+observe whether a human actually approved. An agent that calls preview and then confirm itself
+satisfies the gate with no human in the loop. Enforcing true human-in-the-loop (out-of-band
+approval the agent cannot forge) is tracked as follow-up work.
 :::
 
 ### Server-authoritative gate
@@ -37,8 +40,14 @@ The confirm phase does not trust any caller-supplied value. It re-fetches the da
 Tableau and only deletes if the data source is currently tagged `pending-deletion` (or the custom
 `tag` value). The tag is server-side state that the caller can only set by running the preview
 phase, so the gate genuinely proves a preview happened — it **cannot** be bypassed by computing or
-guessing a token. The live re-fetch deliberately ignores any cached copy so the check reflects the
-data source's current state at delete time.
+guessing a token, which the prior `confirmationToken` (a caller-derivable `sha256`) could be. The
+live re-fetch deliberately ignores any cached copy so the check reflects the data source's current
+state at delete time.
+
+**What this gate does and does not guarantee.** It proves a preview *ran* (closing the
+caller-computable-token bypass). It does **not** prove a *human approved* — an agent that runs both
+the preview and the confirm satisfies it on its own. Server-enforced human-in-the-loop requires an
+out-of-band approval primitive (e.g. MCP URL-mode elicitation) and is tracked as follow-up work.
 
 :::note[Dependent content is not deleted]
 Deleting a published data source does **not** delete the workbooks or flows that use it. Those

--- a/docs/docs/tools/workbooks/delete-workbook.md
+++ b/docs/docs/tools/workbooks/delete-workbook.md
@@ -22,11 +22,14 @@ The tool is **two-phase** to keep the destructive action safe:
    moved to the [recycle bin](https://help.tableau.com/current/pro/desktop/en-us/recycle_bin.htm)
    and can be restored for a limited time before permanent removal.
 
-:::warning Human confirmation required
+:::warning Human confirmation required — advisory, not enforced
 Between the preview and the delete, the calling agent is instructed (via the tool description and
 the preview response) to surface the workbook identity to the user and obtain explicit approval
-before deleting. The server-side tag gate guarantees the preview ran, but the **human approval**
-step is a prompt-level expectation — agents must not auto-confirm.
+before deleting. This human-approval step is a **prompt-level expectation, not a server guarantee**:
+the tag gate proves a preview *ran*, but the server cannot observe whether a human actually approved.
+An agent that calls preview and then confirm itself satisfies the gate with no human in the loop.
+Enforcing true human-in-the-loop (out-of-band approval the agent cannot forge) is tracked as
+follow-up work.
 :::
 
 ### Server-authoritative gate
@@ -34,9 +37,15 @@ step is a prompt-level expectation — agents must not auto-confirm.
 The confirm phase does not trust any caller-supplied value. It re-fetches the workbook from Tableau
 and only deletes if the workbook is currently tagged `pending-deletion` (or the custom `tag` value).
 The tag is server-side state that the caller can only set by running the preview phase, so the gate
-genuinely proves a preview happened — it **cannot** be bypassed by computing or guessing a token.
-The live re-fetch deliberately ignores any cached copy so the check reflects the workbook's current
-state at delete time.
+genuinely proves a preview happened — it **cannot** be bypassed by computing or guessing a token,
+which the prior `confirmationToken` (a caller-derivable `sha256`) could be. The live re-fetch
+deliberately ignores any cached copy so the check reflects the workbook's current state at delete
+time.
+
+**What this gate does and does not guarantee.** It proves a preview *ran* (closing the
+caller-computable-token bypass). It does **not** prove a *human approved* — an agent that runs both
+the preview and the confirm satisfies it on its own. Server-enforced human-in-the-loop requires an
+out-of-band approval primitive (e.g. MCP URL-mode elicitation) and is tracked as follow-up work.
 
 ## Tool scoping
 

--- a/docs/docs/tools/workbooks/delete-workbook.md
+++ b/docs/docs/tools/workbooks/delete-workbook.md
@@ -14,21 +14,29 @@ The tool is **two-phase** to keep the destructive action safe:
 
 1. **Preview** (default — `confirm` omitted or `false`): tags the workbook with
    `pending-deletion` (reversible, visible in the Tableau UI; label configurable via the `tag`
-   argument), reports the workbook name, project, and owner, returns a `confirmationToken`, and does
-   **not** delete anything.
-2. **Delete** (`confirm: true` + `confirmationToken`): permanently removes the workbook. The token
-   from the preview step is **required** — deletion is rejected without a matching token, a friction
-   gate requiring a deliberate second call rather than a blind one-shot call (see the
-   [`confirmationToken`](#confirmationtoken) note on what this does and does not guarantee). On Tableau Cloud the workbook is moved to
-   the [recycle bin](https://help.tableau.com/current/pro/desktop/en-us/recycle_bin.htm) and can be
-   restored for a limited time before permanent removal.
+   argument), reports the workbook name, project, and owner, and does **not** delete anything.
+2. **Delete** (`confirm: true`): permanently removes the workbook. Before deleting, the server
+   re-fetches the workbook and **verifies it carries the pending-deletion tag** applied in the
+   preview step. A confirmed delete against an untagged workbook is rejected (see the
+   [server-authoritative gate](#server-authoritative-gate) note). On Tableau Cloud the workbook is
+   moved to the [recycle bin](https://help.tableau.com/current/pro/desktop/en-us/recycle_bin.htm)
+   and can be restored for a limited time before permanent removal.
 
 :::warning Human confirmation required
 Between the preview and the delete, the calling agent is instructed (via the tool description and
 the preview response) to surface the workbook identity to the user and obtain explicit approval
-before deleting. The `confirmationToken` enforces that a preview ran, but the **human approval**
-step is a prompt-level expectation — agents must not auto-confirm or compute the token themselves.
+before deleting. The server-side tag gate guarantees the preview ran, but the **human approval**
+step is a prompt-level expectation — agents must not auto-confirm.
 :::
+
+### Server-authoritative gate
+
+The confirm phase does not trust any caller-supplied value. It re-fetches the workbook from Tableau
+and only deletes if the workbook is currently tagged `pending-deletion` (or the custom `tag` value).
+The tag is server-side state that the caller can only set by running the preview phase, so the gate
+genuinely proves a preview happened — it **cannot** be bypassed by computing or guessing a token.
+The live re-fetch deliberately ignores any cached copy so the check reflects the workbook's current
+state at delete time.
 
 ## Tool scoping
 
@@ -59,21 +67,12 @@ Example: `222ea993-9391-4910-a167-56b3d19b4e3b`
 ### `confirm`
 
 When omitted or `false`, runs the non-destructive preview (tags and reports). When `true`,
-permanently deletes the workbook (also requires `confirmationToken`).
+permanently deletes the workbook — but only if the workbook already carries the pending-deletion tag
+from a prior preview (verified by a live re-fetch; see
+[server-authoritative gate](#server-authoritative-gate)). Pass the same `tag` value used in the
+preview if you overrode the default.
 
 Example: `true`
-
-### `confirmationToken`
-
-Required when `confirm` is `true`. The `confirmationToken` value returned by the preview step for
-this workbook. Deletion is rejected without a matching token — a friction gate requiring a
-deliberate second call rather than a blind single call.
-
-The token is a deterministic `sha256(siteId:workbookId)` value, so it enforces an explicit second
-call but does **not** prove the preview/tag step actually ran (a caller who knows the workbook LUID
-can compute it). Guaranteeing a preview happened would require server-side state.
-
-Example: `3a7f9c2e1b04`
 
 ### `tag`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "2.18.1",
+  "version": "2.18.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "2.18.1",
+      "version": "2.18.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.7.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "2.18.0",
+  "version": "2.18.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "2.18.0",
+      "version": "2.18.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.7.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "2.18.0",
+  "version": "2.18.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "2.18.1",
+  "version": "2.18.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/src/errors/mcpToolError.ts
+++ b/src/errors/mcpToolError.ts
@@ -58,6 +58,18 @@ export class DatasourceNotAllowedError extends McpToolError {
   }
 }
 
+// Thrown by the two-phase delete tools when a confirmed delete (`confirm: true`) is requested but the
+// target resource is not carrying the pending-deletion tag. The tag is server-side state set by a
+// prior, distinct preview call, so its presence — verified by a fresh re-fetch — is the authoritative
+// proof that a preview actually ran. Unlike a caller-computable confirmation token, this gate cannot
+// be bypassed by deriving a value: the caller has no way to mark the resource as pending deletion
+// other than by running the preview phase. statusCode 409: a required precondition/state is missing.
+export class PreviewNotRunError extends McpToolError {
+  constructor(message: string) {
+    super({ type: 'preview-not-run', message, statusCode: 409 });
+  }
+}
+
 export class FeatureDisabledError extends McpToolError {
   constructor(message: string) {
     super({ type: 'feature-disabled', message, statusCode: 404 });

--- a/src/prompts/_lib/confirm.test.ts
+++ b/src/prompts/_lib/confirm.test.ts
@@ -51,20 +51,20 @@ describe('renderHitlGate', () => {
 });
 
 describe('renderConfirmInstructions', () => {
-  it('inserts the tool reference and requires confirm: true with the preview token', () => {
+  it('inserts the tool reference and requires confirm: true with the pending-deletion tag', () => {
     const text = renderConfirmInstructions({
       toolRef: '`delete-workbook`',
       itemNoun: 'stale item',
     });
     expect(text).toContain('`delete-workbook`');
     expect(text).toContain('`confirm: true`');
-    expect(text).toContain('`confirmationToken`');
+    expect(text).toContain('pending-deletion tag');
   });
 
-  it('forbids auto-confirming or fabricating the token', () => {
+  it('forbids auto-confirming and batch-confirming', () => {
     const text = renderConfirmInstructions({ toolRef: '`delete-datasource`' });
     expect(text).toContain('Do NOT auto-confirm');
-    expect(text).toContain('Do NOT compute, guess, or reuse');
+    expect(text).toContain('never batch-confirm');
   });
 
   it('accepts a routing-table phrase as the tool reference', () => {

--- a/src/prompts/_lib/confirm.ts
+++ b/src/prompts/_lib/confirm.ts
@@ -1,13 +1,22 @@
 /**
  * Shared human-in-the-loop (HITL) confirmation primitive for destructive "Apply" prompts.
  *
- * The MCP SDK exposes no runtime elicitation/sampling primitive (v1.x), and prompts are pure text
- * generators. So HITL here is a *prompt-text contract*: every Apply prompt injects the same, strongly
- * worded instruction blocks telling the model to STOP and obtain explicit human approval before any
- * destructive call. The delete tools additionally enforce the gate server-side (a confirmed delete
- * is rejected unless the item carries the pending-deletion tag from its preview). Centralizing the wording keeps the
- * gate identical across the Apply surface (stale-content cleanup, extract-refresh optimization,
- * license reclamation, …) and makes it the single place to harden the language over time.
+ * Prompts are pure text generators, so HITL here is a *prompt-text contract*: every Apply prompt
+ * injects the same, strongly worded instruction blocks telling the model to STOP and obtain explicit
+ * human approval before any destructive call. The delete tools additionally enforce a
+ * server-authoritative gate (a confirmed delete is rejected unless the item carries the
+ * pending-deletion tag from its preview). That gate proves a preview *ran*, NOT that a human
+ * *approved* — an agent that runs both phases itself satisfies it. It closes the prior
+ * caller-computable-token bypass (W-23093455) but leaves human approval advisory.
+ *
+ * Real, enforced HITL needs an out-of-band signal the agent cannot forge. The installed MCP SDK
+ * (>=1.26; this repo runs 1.29) DOES expose `server.elicitInput(...)` with URL-mode elicitation
+ * (`UrlElicitationRequiredError`), which routes approval to a human out of band. Adopting it is
+ * tracked under W-23125362; until then the human-approval step here is advisory.
+ *
+ * Centralizing the wording keeps the gate identical across the Apply surface (stale-content cleanup,
+ * extract-refresh optimization, license reclamation, …) and makes it the single place to harden the
+ * language over time.
  *
  * These are content-type-agnostic: callers pass the action wording and the content nouns.
  */

--- a/src/prompts/_lib/confirm.ts
+++ b/src/prompts/_lib/confirm.ts
@@ -4,7 +4,8 @@
  * The MCP SDK exposes no runtime elicitation/sampling primitive (v1.x), and prompts are pure text
  * generators. So HITL here is a *prompt-text contract*: every Apply prompt injects the same, strongly
  * worded instruction blocks telling the model to STOP and obtain explicit human approval before any
- * destructive call, and to never fabricate a confirmation token. Centralizing the wording keeps the
+ * destructive call. The delete tools additionally enforce the gate server-side (a confirmed delete
+ * is rejected unless the item carries the pending-deletion tag from its preview). Centralizing the wording keeps the
  * gate identical across the Apply surface (stale-content cleanup, extract-refresh optimization,
  * license reclamation, …) and makes it the single place to harden the language over time.
  *
@@ -55,8 +56,9 @@ export function renderHitlGate({
 
 /**
  * Renders the instruction for the second, confirmed call against a two-phase delete tool. The tool
- * returns a per-item confirmationToken from its preview phase; the model must echo that exact value
- * and must never compute or guess it.
+ * enforces a server-authoritative gate: before deleting it re-fetches the item and verifies it
+ * carries the pending-deletion tag applied in the preview phase. The model cannot bypass this by
+ * fabricating a value — the only way to satisfy the gate is to have run the preview (tag) step.
  *
  * `toolRef` is inserted verbatim, so callers control its formatting: pass a single backticked tool
  * name (e.g. "`delete-workbook`") for a one-tool prompt, or a phrase pointing at a routing table
@@ -73,9 +75,10 @@ export function renderConfirmInstructions({
 }): string {
   return [
     `Only AFTER the user approves a given ${itemNoun}, call ${toolRef} for that ${itemNoun} ` +
-      'with `confirm: true` and the exact `confirmationToken` value that tool returned for it in ' +
-      'the preview step.',
-    'Do NOT auto-confirm. Do NOT compute, guess, or reuse a `confirmationToken` from a different ' +
-      `${itemNoun} — use only the token the preview returned for that same ${itemNoun}.`,
+      'with `confirm: true` (using the same `tag` value used to tag it in the preview step). The ' +
+      'tool re-fetches the item and verifies the pending-deletion tag before deleting; a delete on ' +
+      'an untagged item is rejected server-side.',
+    `Do NOT auto-confirm. Confirm each ${itemNoun} individually — never batch-confirm items the ` +
+      'user has not explicitly approved.',
   ].join('\n');
 }

--- a/src/prompts/staleContent/apply.ts
+++ b/src/prompts/staleContent/apply.ts
@@ -218,8 +218,8 @@ export const getStaleContentCleanupApplyPrompt: WebPromptFactory = () => ({
             '**Step 5 — Tag approved items (reversible).** ONLY for the items the user explicitly approved above, ' +
               "call each item's `deleteTool` with `confirm` omitted " +
               `and \`tag: "${tag}"\` (and the resolved \`idArg\` value). This tags the item '${tag}' (reversible, visible in the ` +
-              "Tableau UI) and returns a per-item `confirmationToken`. Nothing is deleted in this step. Keep each item's " +
-              '`confirmationToken`. Do NOT tag any item the user did not approve.',
+              'Tableau UI). Nothing is deleted in this step. The tag is the server-side record that the preview ran; ' +
+              'the delete step verifies it. Do NOT tag any item the user did not approve.',
             '',
             '**Step 6 — Grace check.** Before deleting, confirm with the user that the grace/notification window has elapsed ' +
               'and re-verify the items are still the intended, still-stale targets.',

--- a/src/tools/web/datasources/deleteDatasource.test.ts
+++ b/src/tools/web/datasources/deleteDatasource.test.ts
@@ -294,6 +294,18 @@ describe('deleteDatasourceTool', () => {
     expect(tagSchema.safeParse('a'.repeat(201)).success).toBe(false);
   });
 
+  it('should reject a tag with characters outside the safe class (prompt-injection guard)', () => {
+    const tool = getDeleteDatasourceTool(new WebMcpServer());
+    const tagSchema = (tool.paramsSchema as { tag: z.ZodOptional<z.ZodString> }).tag;
+    // Allowed: letters, numbers, spaces, underscores, dashes.
+    expect(tagSchema.safeParse('stale pending-deletion_2024').success).toBe(true);
+    // The tag is interpolated into model-facing preview text; quotes/backticks/newlines that
+    // could coerce auto-confirming must be rejected at the schema boundary.
+    expect(tagSchema.safeParse('pending"; confirm: true').success).toBe(false);
+    expect(tagSchema.safeParse('pending`delete`').success).toBe(false);
+    expect(tagSchema.safeParse('pending\ndelete').success).toBe(false);
+  });
+
   it('should fall back to the default tag when the caller passes an empty or whitespace tag', async () => {
     const result = await getToolResult({ datasourceId: 'ds-1', tag: '   ' });
     expect(result.isError).toBe(false);

--- a/src/tools/web/datasources/deleteDatasource.test.ts
+++ b/src/tools/web/datasources/deleteDatasource.test.ts
@@ -7,15 +7,7 @@ import { WebMcpServer } from '../../../server.web.js';
 import invariant from '../../../utils/invariant.js';
 import { Provider } from '../../../utils/provider.js';
 import { getMockRequestHandlerExtra } from '../toolContext.mock.js';
-import {
-  computeConfirmationToken,
-  DEFAULT_PENDING_DELETION_TAG,
-  getDeleteDatasourceTool,
-} from './deleteDatasource.js';
-
-const TEST_SITE_ID = 'test-site-id';
-const validToken = (datasourceId: string): string =>
-  computeConfirmationToken(TEST_SITE_ID, datasourceId);
+import { DEFAULT_PENDING_DELETION_TAG, getDeleteDatasourceTool } from './deleteDatasource.js';
 
 const mockDatasource = {
   id: 'ds-1',
@@ -23,6 +15,13 @@ const mockDatasource = {
   project: { id: 'proj-1', name: 'Finance' },
   owner: { id: 'owner-1' },
   tags: {},
+};
+
+// A data source that has been through the preview phase: carries the pending-deletion tag the
+// confirm phase re-fetches and verifies before deleting.
+const mockTaggedDatasource = {
+  ...mockDatasource,
+  tags: { tag: [{ label: DEFAULT_PENDING_DELETION_TAG }] },
 };
 
 // Metadata API reverse-lineage response: ds-1 has 1 downstream workbook + 1 flow.
@@ -153,7 +152,6 @@ describe('deleteDatasourceTool', () => {
     const result = await getToolResult({
       datasourceId: 'ds-1',
       confirm: true,
-      confirmationToken: validToken('ds-1'),
     });
     expect(result.isError).toBe(true);
     invariant(result.content[0].type === 'text');
@@ -187,7 +185,6 @@ describe('deleteDatasourceTool', () => {
     const result = await getToolResult({
       datasourceId: 'ds-1',
       confirm: true,
-      confirmationToken: validToken('ds-1'),
     });
     expect(result.isError).toBe(true);
     invariant(result.content[0].type === 'text');
@@ -196,30 +193,43 @@ describe('deleteDatasourceTool', () => {
     expect(mocks.mockDeleteDatasource).not.toHaveBeenCalled();
   });
 
-  // --- Confirmation token gate ---
+  // --- Server-authoritative pending-deletion tag gate ---
 
-  it('should return a confirmation token on preview', async () => {
-    const result = await getToolResult({ datasourceId: 'ds-1' });
-    expect(result.isError).toBe(false);
-    invariant(result.content[0].type === 'text');
-    expect(result.content[0].text).toContain(validToken('ds-1'));
-  });
-
-  it('should reject delete when confirmationToken is missing', async () => {
+  it('should block delete when the datasource is not tagged pending-deletion (bypass closed)', async () => {
+    // A caller that jumps straight to confirm: true without previewing. The live re-fetch returns a
+    // datasource with no pending-deletion tag, so the destructive path must be rejected. This proves
+    // the caller-computable-token bypass is closed: there is no value a caller can supply to delete.
+    mocks.mockQueryDatasource.mockResolvedValue(mockDatasource); // tags: {}
     const result = await getToolResult({ datasourceId: 'ds-1', confirm: true });
     expect(result.isError).toBe(true);
     invariant(result.content[0].type === 'text');
-    expect(result.content[0].text).toContain('confirmationToken');
+    expect(result.content[0].text).toContain('not tagged');
+    expect(result.content[0].text).toContain(DEFAULT_PENDING_DELETION_TAG);
+    // Re-fetched to verify state, but never deleted.
+    expect(mocks.mockQueryDatasource).toHaveBeenCalled();
     expect(mocks.mockDeleteDatasource).not.toHaveBeenCalled();
   });
 
-  it('should reject a token computed for a different datasource', async () => {
-    const result = await getToolResult({
-      datasourceId: 'ds-1',
-      confirm: true,
-      confirmationToken: validToken('ds-OTHER'),
+  it('should verify the tag with a fresh live re-fetch, not the access-check cached content', async () => {
+    // The access check may hand back a stale cached datasource; the gate must NOT trust it. Cached
+    // content carries the tag, but the authoritative live re-fetch does not → delete is blocked.
+    mocks.mockIsDatasourceAllowed.mockResolvedValue({
+      allowed: true,
+      content: mockTaggedDatasource,
     });
+    mocks.mockQueryDatasource.mockResolvedValue(mockDatasource); // live: untagged
+    const result = await getToolResult({ datasourceId: 'ds-1', confirm: true });
     expect(result.isError).toBe(true);
+    expect(mocks.mockQueryDatasource).toHaveBeenCalled();
+    expect(mocks.mockDeleteDatasource).not.toHaveBeenCalled();
+  });
+
+  it('should surface a re-fetch error on confirm and not delete', async () => {
+    mocks.mockQueryDatasource.mockRejectedValue(new Error('Datasource not found'));
+    const result = await getToolResult({ datasourceId: 'ds-1', confirm: true });
+    expect(result.isError).toBe(true);
+    invariant(result.content[0].type === 'text');
+    expect(result.content[0].text).toContain('Datasource not found');
     expect(mocks.mockDeleteDatasource).not.toHaveBeenCalled();
   });
 
@@ -308,11 +318,11 @@ describe('deleteDatasourceTool', () => {
 
   // --- Delete phase ---
 
-  it('should delete the datasource when confirm is true and report its identity', async () => {
+  it('should delete the datasource when confirm is true and it is tagged pending-deletion', async () => {
+    mocks.mockQueryDatasource.mockResolvedValue(mockTaggedDatasource);
     const result = await getToolResult({
       datasourceId: 'ds-1',
       confirm: true,
-      confirmationToken: validToken('ds-1'),
     });
     expect(result.isError).toBe(false);
     invariant(result.content[0].type === 'text');
@@ -329,11 +339,37 @@ describe('deleteDatasourceTool', () => {
     expect(mocks.mockGraphql).not.toHaveBeenCalled();
   });
 
+  it('should verify a caller-provided tag on confirm', async () => {
+    // The delete is gated on the same custom tag the caller previewed with.
+    mocks.mockQueryDatasource.mockResolvedValue({
+      ...mockDatasource,
+      tags: { tag: [{ label: 'stale-pending-deletion' }] },
+    });
+    const result = await getToolResult({
+      datasourceId: 'ds-1',
+      confirm: true,
+      tag: 'stale-pending-deletion',
+    });
+    expect(result.isError).toBe(false);
+    expect(mocks.mockDeleteDatasource).toHaveBeenCalled();
+  });
+
+  it('should block confirm when the resource carries a different tag than the one requested', async () => {
+    mocks.mockQueryDatasource.mockResolvedValue(mockTaggedDatasource); // default tag only
+    const result = await getToolResult({
+      datasourceId: 'ds-1',
+      confirm: true,
+      tag: 'some-other-tag',
+    });
+    expect(result.isError).toBe(true);
+    expect(mocks.mockDeleteDatasource).not.toHaveBeenCalled();
+  });
+
   it('should wire the tool-mapped API scopes into useRestApi', async () => {
+    mocks.mockQueryDatasource.mockResolvedValue(mockTaggedDatasource);
     await getToolResult({
       datasourceId: 'ds-1',
       confirm: true,
-      confirmationToken: validToken('ds-1'),
     });
     // Pin the scopes the tool requests so drift in toolScopeMap['delete-datasource'].api
     // (a removed or added scope) fails here instead of silently shipping. Order-independent:
@@ -386,12 +422,12 @@ describe('deleteDatasourceTool', () => {
   });
 
   it('should handle API errors gracefully', async () => {
-    const errorMessage = 'Datasource not found';
+    const errorMessage = 'Datasource delete failed';
+    mocks.mockQueryDatasource.mockResolvedValue(mockTaggedDatasource);
     mocks.mockDeleteDatasource.mockRejectedValue(new Error(errorMessage));
     const result = await getToolResult({
-      datasourceId: 'nonexistent',
+      datasourceId: 'ds-1',
       confirm: true,
-      confirmationToken: validToken('nonexistent'),
     });
     expect(result.isError).toBe(true);
     invariant(result.content[0].type === 'text');
@@ -402,7 +438,6 @@ describe('deleteDatasourceTool', () => {
 async function getToolResult(args: {
   datasourceId: string;
   confirm?: boolean;
-  confirmationToken?: string;
   tag?: string;
 }): Promise<CallToolResult> {
   const tool = getDeleteDatasourceTool(new WebMcpServer());
@@ -411,7 +446,6 @@ async function getToolResult(args: {
     {
       datasourceId: args.datasourceId,
       confirm: args.confirm,
-      confirmationToken: args.confirmationToken,
       tag: args.tag,
     },
     getMockRequestHandlerExtra(),

--- a/src/tools/web/datasources/deleteDatasource.test.ts
+++ b/src/tools/web/datasources/deleteDatasource.test.ts
@@ -229,7 +229,8 @@ describe('deleteDatasourceTool', () => {
     const result = await getToolResult({ datasourceId: 'ds-1', confirm: true });
     expect(result.isError).toBe(true);
     invariant(result.content[0].type === 'text');
-    expect(result.content[0].text).toContain('Datasource not found');
+    // Match loosely so the test asserts the error is surfaced, not the exact upstream wording.
+    expect(result.content[0].text).toMatch(/not found/i);
     expect(mocks.mockDeleteDatasource).not.toHaveBeenCalled();
   });
 

--- a/src/tools/web/datasources/deleteDatasource.ts
+++ b/src/tools/web/datasources/deleteDatasource.ts
@@ -47,10 +47,18 @@ const paramsSchema = {
   tag: z
     .string()
     .max(200)
+    // Constrain to a safe tag character class. `tag` is interpolated into the preview-response text
+    // the model reads back, so restricting it to alphanumerics/space/underscore/dash closes a
+    // prompt-injection vector (e.g. a value with quotes/backticks trying to coerce auto-confirming).
+    .regex(
+      /^[A-Za-z0-9 _-]+$/,
+      'tag must contain only letters, numbers, spaces, underscores, and dashes',
+    )
     .optional()
     .describe(
       'Label applied to the data source during the preview phase to mark it as pending deletion ' +
-        `(reversible, visible in the Tableau UI). Defaults to '${DEFAULT_PENDING_DELETION_TAG}'.`,
+        '(reversible, visible in the Tableau UI). Letters, numbers, spaces, underscores, and dashes ' +
+        `only. Defaults to '${DEFAULT_PENDING_DELETION_TAG}'.`,
     ),
 };
 

--- a/src/tools/web/datasources/deleteDatasource.ts
+++ b/src/tools/web/datasources/deleteDatasource.ts
@@ -1,13 +1,12 @@
 import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
-import { createHash } from 'crypto';
 import { Ok } from 'ts-results-es';
 import { z } from 'zod';
 
 import { getConfig } from '../../../config.js';
 import {
   AdminOnlyError,
-  ArgsValidationError,
   DatasourceNotAllowedError,
+  PreviewNotRunError,
 } from '../../../errors/mcpToolError.js';
 import { log } from '../../../logging/logger.js';
 import { useRestApi } from '../../../restApiInstance.js';
@@ -33,21 +32,6 @@ const RECYCLE_BIN_DOC_URL = 'https://help.tableau.com/current/pro/desktop/en-us/
 // purely additive; extract to a shared _lib module once both delete tools have merged.
 export const DEFAULT_PENDING_DELETION_TAG = 'pending-deletion';
 
-/**
- * Deterministic confirmation token derived from the site + datasource. The preview phase returns
- * it; the delete phase requires a matching value. This forces an explicit, deliberate second call
- * with a datasource-specific token rather than a blind one-shot delete.
- *
- * NOTE: this is a friction/correctness gate, NOT proof that a preview actually ran. The token is a
- * pure sha256(siteId:datasourceId) — both inputs are known to any caller (siteId from the connected
- * site, datasourceId from the tool arg), so a caller can compute it without previewing. Guaranteeing
- * a preview/tag step happened would require server-side state (e.g. gating on the pending-deletion
- * tag set during preview). Stateless by design so it works across instances and restarts.
- */
-export function computeConfirmationToken(siteId: string, datasourceId: string): string {
-  return createHash('sha256').update(`${siteId}:${datasourceId}`).digest('hex').slice(0, 12);
-}
-
 const paramsSchema = {
   datasourceId: z.string().describe('The LUID of the published data source to delete.'),
   confirm: z
@@ -56,17 +40,9 @@ const paramsSchema = {
     .describe(
       'When omitted or false, runs a non-destructive preview: tags the data source as pending ' +
         'deletion, warns about dependent workbooks/flows, and reports what would be deleted. When ' +
-        'true, deletes the data source. On Tableau Cloud it can be restored from the recycle bin ' +
-        'for a limited time; on Tableau Server deletion is permanent.',
-    ),
-  confirmationToken: z
-    .string()
-    .optional()
-    .describe(
-      'Required when confirm is true. The confirmationToken returned by the preview step ' +
-        '(confirm omitted/false) for this data source. Deletion is rejected without a matching ' +
-        'token — a friction gate requiring a distinct second call. Note the token is a deterministic ' +
-        'hash of caller-known inputs, so it adds deliberation but does not by itself prove a preview ran.',
+        'true, deletes the data source — but only if it is currently tagged as pending deletion by ' +
+        'a prior preview call (the server re-fetches and verifies the tag). On Tableau Cloud it can ' +
+        'be restored from the recycle bin for a limited time; on Tableau Server deletion is permanent.',
     ),
   tag: z
     .string()
@@ -94,25 +70,26 @@ This tool is **two-phase** to keep the destructive action safe:
 1. **Preview (default — \`confirm\` omitted or false):** tags the data source as pending deletion
    (reversible, visible in the Tableau UI; label configurable via \`tag\`, default
    \`${DEFAULT_PENDING_DELETION_TAG}\`), reports the data source name, project, and owner, **warns
-   which workbooks and flows depend on it and may break**, returns a \`confirmationToken\`, and does
-   **not** delete anything.
-2. **Delete (\`confirm: true\` + \`confirmationToken\`):** permanently removes the data source. The
-   token from step 1 is required — deletion is rejected without it, a friction gate requiring a
-   deliberate second call rather than a blind one-shot delete (the token is a deterministic hash of
-   caller-known inputs, so it adds deliberation but does not by itself prove a preview ran). On Tableau Cloud the data source is moved to the recycle bin and can be restored
-   for a limited time before permanent removal (see ${RECYCLE_BIN_DOC_URL}); on Tableau Server there
-   is no recycle bin and deletion is permanent. Dependent workbooks and flows are **not** deleted,
-   but will lose this data source.
+   which workbooks and flows depend on it and may break**, and does **not** delete anything.
+2. **Delete (\`confirm: true\`):** permanently removes the data source. Before deleting, the server
+   re-fetches the data source and verifies it is tagged as pending deletion (the tag applied in
+   step 1). If the tag is absent the deletion is rejected — this is a server-authoritative gate that
+   genuinely requires the preview phase to have run; it cannot be bypassed by computing a token,
+   because the caller has no way to set the tag other than by previewing. On Tableau Cloud the data
+   source is moved to the recycle bin and can be restored for a limited time before permanent removal
+   (see ${RECYCLE_BIN_DOC_URL}); on Tableau Server there is no recycle bin and deletion is permanent.
+   Dependent workbooks and flows are **not** deleted, but will lose this data source.
 
 **Required human confirmation:** After preview, present the data source (name, project, owner) and
-its dependent content to the user and get explicit approval before deleting. Do not auto-confirm or
-compute the \`confirmationToken\` yourself — use the exact value the preview returned.
+its dependent content to the user and get explicit approval before calling again with \`confirm: true\`.
+Do not auto-confirm — get the user's explicit approval first.
 
 **Parameters:**
 - \`datasourceId\` (required) – The LUID of the data source. Obtain it from \`list-datasources\`.
-- \`confirm\` (optional) – Set \`true\` to perform the deletion. Defaults to preview.
-- \`confirmationToken\` (optional) – Required when \`confirm\` is true; the token from the preview step.
-- \`tag\` (optional) – Preview tag label. Defaults to \`${DEFAULT_PENDING_DELETION_TAG}\`.
+- \`confirm\` (optional) – Set \`true\` to perform the deletion (requires the pending-deletion tag from
+  a prior preview). Defaults to preview.
+- \`tag\` (optional) – Preview tag label. Defaults to \`${DEFAULT_PENDING_DELETION_TAG}\`. If you
+  previewed with a custom tag, pass the same value when confirming.
 `.trim(),
     paramsSchema,
     annotations: {
@@ -126,15 +103,12 @@ compute the \`confirmationToken\` yourself — use the exact value the preview r
       idempotentHint: false,
       openWorldHint: false,
     },
-    callback: async (
-      { datasourceId, confirm, confirmationToken, tag },
-      extra,
-    ): Promise<CallToolResult> => {
+    callback: async ({ datasourceId, confirm, tag }, extra): Promise<CallToolResult> => {
       const configWithOverrides = await extra.getConfigWithOverrides();
 
       return await deleteDatasourceTool.logAndExecute<string>({
         extra,
-        args: { datasourceId, confirm, confirmationToken, tag },
+        args: { datasourceId, confirm, tag },
         callback: async () => {
           return await useRestApi({
             ...extra,
@@ -146,20 +120,10 @@ compute the \`confirmationToken\` yourself — use the exact value the preview r
               }
 
               const siteId = restApi.siteId;
-              const expectedToken = computeConfirmationToken(siteId, datasourceId);
 
-              // Gate the destructive path on the confirmation token BEFORE any read or write, so a
-              // missing/mismatched token is rejected with zero side effects. This forces a
-              // deliberate two-step delete; it does not prove a preview ran (the token is a
-              // deterministic hash of caller-known inputs — see computeConfirmationToken).
-              if (confirm && confirmationToken !== expectedToken) {
-                return new ArgsValidationError(
-                  'Deletion requires the confirmationToken returned by the preview step. ' +
-                    'Run delete-datasource with confirm omitted (or false) for this datasourceId ' +
-                    'first, then call again with confirm: true and the confirmationToken from that ' +
-                    'response.',
-                ).toErr();
-              }
+              // Treat undefined, empty, and whitespace-only tags as "use the default" so a blank
+              // label never gets applied (preview) or verified against (confirm).
+              const pendingTag = tag?.trim() ? tag : DEFAULT_PENDING_DELETION_TAG;
 
               // Honor the same tool-scoping rules the read tools enforce (e.g. get-datasource-metadata):
               // a data source outside the configured bounded context cannot be tagged or deleted.
@@ -172,10 +136,49 @@ compute the \`confirmationToken\` yourself — use the exact value the preview r
                 return new DatasourceNotAllowedError(isDatasourceAllowedResult.message).toErr();
               }
 
-              // Resolve identity in both phases so the response (preview AND the final delete
-              // confirmation) always names the data source, project, and owner for an auditable
-              // record of exactly what was acted on. Reuse the data source already fetched by the
-              // access check when a project/tag scope forced it, otherwise fetch it now.
+              if (confirm) {
+                // Server-authoritative HITL gate: re-fetch the data source LIVE and verify it carries
+                // the pending-deletion tag set by a prior preview call. The tag is server-side state
+                // the caller cannot fabricate, so its presence is genuine proof the preview ran —
+                // unlike a caller-computable confirmation token, this gate cannot be bypassed. We
+                // query fresh here (not the access-check's cached content) so the check reflects the
+                // current server state at delete time. Rejected with zero destructive side effects.
+                const datasource = await restApi.datasourcesMethods.queryDatasource({
+                  datasourceId,
+                  siteId,
+                });
+                const isPendingDeletion = datasource.tags?.tag?.some((t) => t.label === pendingTag);
+                if (!isPendingDeletion) {
+                  return new PreviewNotRunError(
+                    `Deletion blocked: data source ${datasourceId} is not tagged '${pendingTag}' as ` +
+                      'pending deletion. Run delete-datasource with confirm omitted (or false) for this ' +
+                      'datasourceId first to preview and tag it, then call again with confirm: true. This ' +
+                      'gate verifies server-side state and cannot be bypassed by computing a token.',
+                  ).toErr();
+                }
+
+                const ownerEmail = await resolveOwnerEmail(
+                  restApi,
+                  siteId,
+                  datasource.owner?.id,
+                  'delete-datasource',
+                );
+                const projectName = datasource.project?.name ?? 'unknown project';
+                const ownerText = ownerEmail ? `owner ${ownerEmail}` : 'owner unknown';
+
+                await restApi.datasourcesMethods.deleteDatasource({ datasourceId, siteId });
+                return new Ok(
+                  `Deleted data source '${datasource.name}' (id ${datasourceId}) in '${projectName}', ${ownerText}. ` +
+                    `On Tableau Cloud it can be restored from the recycle bin (${RECYCLE_BIN_DOC_URL}) for a ` +
+                    'limited time before permanent removal; on Tableau Server deletion is permanent. ' +
+                    'Dependent workbooks and flows were not deleted but no longer have this data source.',
+                );
+              }
+
+              // Preview phase: warn about dependents, tag as pending deletion, report. No deletion.
+              // Resolve identity so the response names the data source, project, and owner for an
+              // auditable record of exactly what was acted on. Reuse the data source already fetched
+              // by the access check when a project/tag scope forced it, otherwise fetch it now.
               const datasource =
                 isDatasourceAllowedResult.content ??
                 (await restApi.datasourcesMethods.queryDatasource({
@@ -191,26 +194,12 @@ compute the \`confirmationToken\` yourself — use the exact value the preview r
               const projectName = datasource.project?.name ?? 'unknown project';
               const ownerText = ownerEmail ? `owner ${ownerEmail}` : 'owner unknown';
 
-              if (confirm) {
-                await restApi.datasourcesMethods.deleteDatasource({ datasourceId, siteId });
-                return new Ok(
-                  `Deleted data source '${datasource.name}' (id ${datasourceId}) in '${projectName}', ${ownerText}. ` +
-                    `On Tableau Cloud it can be restored from the recycle bin (${RECYCLE_BIN_DOC_URL}) for a ` +
-                    'limited time before permanent removal; on Tableau Server deletion is permanent. ' +
-                    'Dependent workbooks and flows were not deleted but no longer have this data source.',
-                );
-              }
-
-              // Preview phase: warn about dependents, tag as pending deletion, report. No deletion.
               const dependencyWarning = await describeDownstreamDependencies({
                 restApi,
                 datasourceId,
                 disableMetadataApiRequests: configWithOverrides.disableMetadataApiRequests,
               });
 
-              // Treat undefined, empty, and whitespace-only tags as "use the default" so a
-              // blank label never gets applied to the data source.
-              const pendingTag = tag?.trim() ? tag : DEFAULT_PENDING_DELETION_TAG;
               await restApi.datasourcesMethods.addTagsToDatasource({
                 datasourceId,
                 siteId,
@@ -224,7 +213,8 @@ compute the \`confirmationToken\` yourself — use the exact value the preview r
                   'NEXT STEP — REQUIRED: show this data source (name, project, owner) and its dependent ' +
                   'content to the user and ask them to explicitly confirm deleting it. Do NOT delete ' +
                   'without the user’s approval. ' +
-                  `Once approved, call again with confirm: true and confirmationToken: ${expectedToken}. ` +
+                  'Once approved, call again with confirm: true (the server will verify this ' +
+                  `'${pendingTag}' tag before deleting). ` +
                   'On Tableau Cloud deleted data sources are recoverable from the recycle bin ' +
                   `(${RECYCLE_BIN_DOC_URL}) for a limited time; on Tableau Server deletion is permanent.`,
               );

--- a/src/tools/web/datasources/deleteDatasource.ts
+++ b/src/tools/web/datasources/deleteDatasource.ts
@@ -131,7 +131,7 @@ Do not auto-confirm — get the user's explicit approval first.
 
               // Treat undefined, empty, and whitespace-only tags as "use the default" so a blank
               // label never gets applied (preview) or verified against (confirm).
-              const pendingTag = tag?.trim() ? tag : DEFAULT_PENDING_DELETION_TAG;
+              const pendingTag = tag?.trim() || DEFAULT_PENDING_DELETION_TAG;
 
               // Honor the same tool-scoping rules the read tools enforce (e.g. get-datasource-metadata):
               // a data source outside the configured bounded context cannot be tagged or deleted.
@@ -145,18 +145,22 @@ Do not auto-confirm — get the user's explicit approval first.
               }
 
               if (confirm) {
-                // Server-authoritative HITL gate: re-fetch the data source LIVE and verify it carries
-                // the pending-deletion tag set by a prior preview call. The tag is server-side state
-                // the caller cannot fabricate, so its presence is genuine proof the preview ran —
-                // unlike a caller-computable confirmation token, this gate cannot be bypassed. We
-                // query fresh here (not the access-check's cached content) so the check reflects the
-                // current server state at delete time. Rejected with zero destructive side effects.
+                // Server-authoritative gate: re-fetch the data source LIVE and verify it carries the
+                // pending-deletion tag set by a prior preview call. The tag is server-side state that
+                // a caller going through this MCP tool cannot set without running the preview — so its
+                // presence is genuine proof the preview ran, and (unlike a caller-computable token)
+                // this gate cannot be bypassed by an agent. NOTE: this is not full human-in-the-loop;
+                // it proves the preview ran, not that a human approved (an agent that runs both phases
+                // satisfies it). We query fresh here (not the access-check's cached content) so the
+                // check reflects current server state at delete time. Rejected with zero side effects.
                 const datasource = await restApi.datasourcesMethods.queryDatasource({
                   datasourceId,
                   siteId,
                 });
-                const isPendingDeletion = datasource.tags?.tag?.some((t) => t.label === pendingTag);
-                if (!isPendingDeletion) {
+                const isTaggedForDeletion = datasource.tags?.tag?.some(
+                  (t) => t.label === pendingTag,
+                );
+                if (!isTaggedForDeletion) {
                   return new PreviewNotRunError(
                     `Deletion blocked: data source ${datasourceId} is not tagged '${pendingTag}' as ` +
                       'pending deletion. Run delete-datasource with confirm omitted (or false) for this ' +

--- a/src/tools/web/workbooks/deleteWorkbook.test.ts
+++ b/src/tools/web/workbooks/deleteWorkbook.test.ts
@@ -219,7 +219,8 @@ describe('deleteWorkbookTool', () => {
     const result = await getToolResult({ workbookId: 'wb-1', confirm: true });
     expect(result.isError).toBe(true);
     invariant(result.content[0].type === 'text');
-    expect(result.content[0].text).toContain('Workbook not found');
+    // Match loosely so the test asserts the error is surfaced, not the exact upstream wording.
+    expect(result.content[0].text).toMatch(/not found/i);
     expect(mocks.mockDeleteWorkbook).not.toHaveBeenCalled();
   });
 
@@ -321,6 +322,19 @@ describe('deleteWorkbookTool', () => {
     });
     expect(result.isError).toBe(false);
     expect(mocks.mockDeleteWorkbook).toHaveBeenCalled();
+  });
+
+  it('should block confirm when the workbook carries a different tag than the one requested', async () => {
+    // Live re-fetch returns the default tag, but the caller confirms with a custom tag → the gate
+    // verifies the requested label specifically, so the delete is blocked.
+    mocks.mockGetWorkbook.mockResolvedValue(mockTaggedWorkbook); // default tag only
+    const result = await getToolResult({
+      workbookId: 'wb-1',
+      confirm: true,
+      tag: 'some-other-tag',
+    });
+    expect(result.isError).toBe(true);
+    expect(mocks.mockDeleteWorkbook).not.toHaveBeenCalled();
   });
 
   it('should handle API errors gracefully', async () => {

--- a/src/tools/web/workbooks/deleteWorkbook.test.ts
+++ b/src/tools/web/workbooks/deleteWorkbook.test.ts
@@ -1,5 +1,6 @@
 import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { Err, Ok } from 'ts-results-es';
+import { z } from 'zod';
 
 import { WebMcpServer } from '../../../server.web.js';
 import invariant from '../../../utils/invariant.js';
@@ -101,6 +102,25 @@ describe('deleteWorkbookTool', () => {
       idempotentHint: true,
       openWorldHint: false,
     });
+  });
+
+  it('should reject a tag that exceeds the schema length cap', () => {
+    const tool = getDeleteWorkbookTool(new WebMcpServer());
+    const tagSchema = (tool.paramsSchema as { tag: z.ZodOptional<z.ZodString> }).tag;
+    expect(tagSchema.safeParse('a'.repeat(200)).success).toBe(true);
+    expect(tagSchema.safeParse('a'.repeat(201)).success).toBe(false);
+  });
+
+  it('should reject a tag with characters outside the safe class (prompt-injection guard)', () => {
+    const tool = getDeleteWorkbookTool(new WebMcpServer());
+    const tagSchema = (tool.paramsSchema as { tag: z.ZodOptional<z.ZodString> }).tag;
+    // Allowed: letters, numbers, spaces, underscores, dashes.
+    expect(tagSchema.safeParse('stale pending-deletion_2024').success).toBe(true);
+    // The tag is interpolated into model-facing preview text; quotes/backticks/newlines that
+    // could coerce auto-confirming must be rejected at the schema boundary.
+    expect(tagSchema.safeParse('pending"; confirm: true').success).toBe(false);
+    expect(tagSchema.safeParse('pending`delete`').success).toBe(false);
+    expect(tagSchema.safeParse('pending\ndelete').success).toBe(false);
   });
 
   // --- AuthZ (mirrors delete-extract-refresh-task) ---

--- a/src/tools/web/workbooks/deleteWorkbook.test.ts
+++ b/src/tools/web/workbooks/deleteWorkbook.test.ts
@@ -5,16 +5,15 @@ import { WebMcpServer } from '../../../server.web.js';
 import invariant from '../../../utils/invariant.js';
 import { Provider } from '../../../utils/provider.js';
 import { getMockRequestHandlerExtra } from '../toolContext.mock.js';
-import {
-  computeConfirmationToken,
-  DEFAULT_PENDING_DELETION_TAG,
-  getDeleteWorkbookTool,
-} from './deleteWorkbook.js';
+import { DEFAULT_PENDING_DELETION_TAG, getDeleteWorkbookTool } from './deleteWorkbook.js';
 import { mockWorkbook } from './mockWorkbook.js';
 
-const TEST_SITE_ID = 'test-site-id';
-const validToken = (workbookId: string): string =>
-  computeConfirmationToken(TEST_SITE_ID, workbookId);
+// A workbook that has been through the preview phase: carries the pending-deletion tag the confirm
+// phase re-fetches and verifies before deleting.
+const mockTaggedWorkbook = {
+  ...mockWorkbook,
+  tags: { tag: [{ label: DEFAULT_PENDING_DELETION_TAG }] },
+};
 
 const mocks = vi.hoisted(() => ({
   mockGetWorkbook: vi.fn(),
@@ -116,7 +115,6 @@ describe('deleteWorkbookTool', () => {
     const result = await getToolResult({
       workbookId: 'wb-1',
       confirm: true,
-      confirmationToken: validToken('wb-1'),
     });
     expect(result.isError).toBe(true);
     invariant(result.content[0].type === 'text');
@@ -150,7 +148,6 @@ describe('deleteWorkbookTool', () => {
     const result = await getToolResult({
       workbookId: 'wb-1',
       confirm: true,
-      confirmationToken: validToken('wb-1'),
     });
     expect(result.isError).toBe(true);
     invariant(result.content[0].type === 'text');
@@ -170,43 +167,39 @@ describe('deleteWorkbookTool', () => {
     expect(mocks.mockAddTagsToWorkbook).toHaveBeenCalled();
   });
 
-  // --- Confirmation token (double-confirm gate) ---
+  // --- Server-authoritative pending-deletion tag gate ---
 
-  it('should return a confirmation token on preview', async () => {
-    const result = await getToolResult({ workbookId: 'wb-1' });
-    expect(result.isError).toBe(false);
-    invariant(result.content[0].type === 'text');
-    expect(result.content[0].text).toContain(validToken('wb-1'));
-  });
-
-  it('should reject delete when confirmationToken is missing', async () => {
+  it('should block delete when the workbook is not tagged pending-deletion (bypass closed)', async () => {
+    // A caller that jumps straight to confirm: true without previewing. The live re-fetch returns a
+    // workbook with no pending-deletion tag (mockWorkbook carries only 'tag-1'), so the destructive
+    // path must be rejected. Proves the caller-computable-token bypass is closed.
+    mocks.mockGetWorkbook.mockResolvedValue(mockWorkbook);
     const result = await getToolResult({ workbookId: 'wb-1', confirm: true });
     expect(result.isError).toBe(true);
     invariant(result.content[0].type === 'text');
-    expect(result.content[0].text).toContain('confirmationToken');
-    expect(mocks.mockGetWorkbook).not.toHaveBeenCalled();
+    expect(result.content[0].text).toContain('not tagged');
+    expect(result.content[0].text).toContain(DEFAULT_PENDING_DELETION_TAG);
+    expect(mocks.mockGetWorkbook).toHaveBeenCalled();
     expect(mocks.mockDeleteWorkbook).not.toHaveBeenCalled();
   });
 
-  it('should reject delete when confirmationToken is wrong', async () => {
-    const result = await getToolResult({
-      workbookId: 'wb-1',
-      confirm: true,
-      confirmationToken: 'not-the-right-token',
-    });
+  it('should verify the tag with a fresh live re-fetch, not the access-check cached content', async () => {
+    // The gate must NOT trust possibly-stale cached content. Cached carries the tag, live does not →
+    // delete is blocked.
+    mocks.mockIsWorkbookAllowed.mockResolvedValue({ allowed: true, content: mockTaggedWorkbook });
+    mocks.mockGetWorkbook.mockResolvedValue(mockWorkbook); // live: untagged
+    const result = await getToolResult({ workbookId: 'wb-1', confirm: true });
+    expect(result.isError).toBe(true);
+    expect(mocks.mockGetWorkbook).toHaveBeenCalled();
+    expect(mocks.mockDeleteWorkbook).not.toHaveBeenCalled();
+  });
+
+  it('should surface a re-fetch error on confirm and not delete', async () => {
+    mocks.mockGetWorkbook.mockRejectedValue(new Error('Workbook not found'));
+    const result = await getToolResult({ workbookId: 'wb-1', confirm: true });
     expect(result.isError).toBe(true);
     invariant(result.content[0].type === 'text');
-    expect(result.content[0].text).toContain('confirmationToken');
-    expect(mocks.mockDeleteWorkbook).not.toHaveBeenCalled();
-  });
-
-  it('should reject a token computed for a different workbook', async () => {
-    const result = await getToolResult({
-      workbookId: 'wb-1',
-      confirm: true,
-      confirmationToken: validToken('wb-OTHER'),
-    });
-    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Workbook not found');
     expect(mocks.mockDeleteWorkbook).not.toHaveBeenCalled();
   });
 
@@ -274,11 +267,11 @@ describe('deleteWorkbookTool', () => {
 
   // --- Delete phase (confirm: true) ---
 
-  it('should delete the workbook when confirm is true and report its identity', async () => {
+  it('should delete the workbook when confirm is true and it is tagged pending-deletion', async () => {
+    mocks.mockGetWorkbook.mockResolvedValue(mockTaggedWorkbook);
     const result = await getToolResult({
       workbookId: 'wb-1',
       confirm: true,
-      confirmationToken: validToken('wb-1'),
     });
     expect(result.isError).toBe(false);
     invariant(result.content[0].type === 'text');
@@ -296,13 +289,27 @@ describe('deleteWorkbookTool', () => {
     expect(mocks.mockAddTagsToWorkbook).not.toHaveBeenCalled();
   });
 
+  it('should verify a caller-provided tag on confirm', async () => {
+    mocks.mockGetWorkbook.mockResolvedValue({
+      ...mockWorkbook,
+      tags: { tag: [{ label: 'stale-pending-deletion' }] },
+    });
+    const result = await getToolResult({
+      workbookId: 'wb-1',
+      confirm: true,
+      tag: 'stale-pending-deletion',
+    });
+    expect(result.isError).toBe(false);
+    expect(mocks.mockDeleteWorkbook).toHaveBeenCalled();
+  });
+
   it('should handle API errors gracefully', async () => {
-    const errorMessage = 'Workbook not found';
+    const errorMessage = 'Workbook delete failed';
+    mocks.mockGetWorkbook.mockResolvedValue(mockTaggedWorkbook);
     mocks.mockDeleteWorkbook.mockRejectedValue(new Error(errorMessage));
     const result = await getToolResult({
-      workbookId: 'nonexistent',
+      workbookId: 'wb-1',
       confirm: true,
-      confirmationToken: validToken('nonexistent'),
     });
     expect(result.isError).toBe(true);
     invariant(result.content[0].type === 'text');
@@ -313,7 +320,6 @@ describe('deleteWorkbookTool', () => {
 async function getToolResult(args: {
   workbookId: string;
   confirm?: boolean;
-  confirmationToken?: string;
   tag?: string;
 }): Promise<CallToolResult> {
   const tool = getDeleteWorkbookTool(new WebMcpServer());
@@ -322,7 +328,6 @@ async function getToolResult(args: {
     {
       workbookId: args.workbookId,
       confirm: args.confirm,
-      confirmationToken: args.confirmationToken,
       tag: args.tag,
     },
     getMockRequestHandlerExtra(),

--- a/src/tools/web/workbooks/deleteWorkbook.ts
+++ b/src/tools/web/workbooks/deleteWorkbook.ts
@@ -1,12 +1,11 @@
 import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
-import { createHash } from 'crypto';
 import { Ok } from 'ts-results-es';
 import { z } from 'zod';
 
 import { getConfig } from '../../../config.js';
 import {
   AdminOnlyError,
-  ArgsValidationError,
+  PreviewNotRunError,
   WorkbookNotAllowedError,
 } from '../../../errors/mcpToolError.js';
 import { useRestApi } from '../../../restApiInstance.js';
@@ -24,21 +23,6 @@ const RECYCLE_BIN_DOC_URL = 'https://help.tableau.com/current/pro/desktop/en-us/
 // argument to use their own vocabulary.
 export const DEFAULT_PENDING_DELETION_TAG = 'pending-deletion';
 
-/**
- * Deterministic confirmation token derived from the site + workbook. The preview phase returns it;
- * the delete phase requires a matching value. This forces an explicit, deliberate second call with
- * a workbook-specific token rather than a blind one-shot delete.
- *
- * NOTE: this is a friction/correctness gate, NOT proof that a preview actually ran. The token is a
- * pure sha256(siteId:workbookId) — both inputs are known to any caller (siteId from the connected
- * site, workbookId from the tool arg), so a caller can compute it without previewing. Guaranteeing
- * a preview/tag step happened would require server-side state (e.g. gating on the pending-deletion
- * tag set during preview). Stateless by design so it works across server instances and restarts.
- */
-export function computeConfirmationToken(siteId: string, workbookId: string): string {
-  return createHash('sha256').update(`${siteId}:${workbookId}`).digest('hex').slice(0, 12);
-}
-
 const paramsSchema = {
   workbookId: z.string().describe('The LUID of the workbook to delete.'),
   confirm: z
@@ -46,17 +30,10 @@ const paramsSchema = {
     .optional()
     .describe(
       'When omitted or false, runs a non-destructive preview: tags the workbook as pending ' +
-        'deletion and reports what would be deleted. When true, permanently deletes the workbook ' +
-        '(recoverable from the Tableau recycle bin for a limited time).',
-    ),
-  confirmationToken: z
-    .string()
-    .optional()
-    .describe(
-      'Required when confirm is true. The confirmationToken returned by the preview step ' +
-        '(confirm omitted/false) for this workbook. Deletion is rejected without a matching token ' +
-        '— a friction gate requiring a distinct second call. Note the token is a deterministic hash ' +
-        'of caller-known inputs, so it adds deliberation but does not by itself prove a preview ran.',
+        'deletion and reports what would be deleted. When true, permanently deletes the workbook — ' +
+        'but only if it is currently tagged as pending deletion by a prior preview call (the server ' +
+        're-fetches and verifies the tag). Deleted workbooks are recoverable from the Tableau recycle ' +
+        'bin for a limited time.',
     ),
   tag: z
     .string()
@@ -82,23 +59,26 @@ This tool is **two-phase** to keep the destructive action safe:
 
 1. **Preview (default — \`confirm\` omitted or false):** tags the workbook as pending deletion
    (reversible, visible in the Tableau UI; label configurable via \`tag\`, default
-   \`${DEFAULT_PENDING_DELETION_TAG}\`), reports the workbook name, project, and owner, returns a
-   \`confirmationToken\`, and does **not** delete anything.
-2. **Delete (\`confirm: true\` + \`confirmationToken\`):** permanently removes the workbook. The
-   token from step 1 is required — deletion is rejected without it, a friction gate requiring a
-   deliberate second call rather than a blind one-shot delete (the token is a deterministic hash of
-   caller-known inputs, so it adds deliberation but does not by itself prove a preview ran). On Tableau Cloud the workbook is moved to the recycle bin and can be restored
-   for a limited time before permanent removal (see ${RECYCLE_BIN_DOC_URL}).
+   \`${DEFAULT_PENDING_DELETION_TAG}\`), reports the workbook name, project, and owner, and does
+   **not** delete anything.
+2. **Delete (\`confirm: true\`):** permanently removes the workbook. Before deleting, the server
+   re-fetches the workbook and verifies it is tagged as pending deletion (the tag applied in step 1).
+   If the tag is absent the deletion is rejected — this is a server-authoritative gate that genuinely
+   requires the preview phase to have run; it cannot be bypassed by computing a token, because the
+   caller has no way to set the tag other than by previewing. On Tableau Cloud the workbook is moved
+   to the recycle bin and can be restored for a limited time before permanent removal (see
+   ${RECYCLE_BIN_DOC_URL}).
 
 **Required human confirmation:** After preview, present the workbook (name, project, owner) to the
-user and get explicit approval before deleting. Do not auto-confirm or compute the
-\`confirmationToken\` yourself — use the exact value the preview returned.
+user and get explicit approval before calling again with \`confirm: true\`. Do not auto-confirm — get
+the user's explicit approval first.
 
 **Parameters:**
 - \`workbookId\` (required) – The LUID of the workbook. Obtain it from \`list-workbooks\`.
-- \`confirm\` (optional) – Set \`true\` to perform the deletion. Defaults to preview.
-- \`confirmationToken\` (optional) – Required when \`confirm\` is true; the token from the preview step.
-- \`tag\` (optional) – Preview tag label. Defaults to \`${DEFAULT_PENDING_DELETION_TAG}\`.
+- \`confirm\` (optional) – Set \`true\` to perform the deletion (requires the pending-deletion tag from
+  a prior preview). Defaults to preview.
+- \`tag\` (optional) – Preview tag label. Defaults to \`${DEFAULT_PENDING_DELETION_TAG}\`. If you
+  previewed with a custom tag, pass the same value when confirming.
 `.trim(),
     paramsSchema,
     annotations: {
@@ -108,13 +88,10 @@ user and get explicit approval before deleting. Do not auto-confirm or compute t
       idempotentHint: true,
       openWorldHint: false,
     },
-    callback: async (
-      { workbookId, confirm, confirmationToken, tag },
-      extra,
-    ): Promise<CallToolResult> => {
+    callback: async ({ workbookId, confirm, tag }, extra): Promise<CallToolResult> => {
       return await deleteWorkbookTool.logAndExecute<string>({
         extra,
-        args: { workbookId, confirm, confirmationToken, tag },
+        args: { workbookId, confirm, tag },
         callback: async () => {
           return await useRestApi({
             ...extra,
@@ -126,19 +103,10 @@ user and get explicit approval before deleting. Do not auto-confirm or compute t
               }
 
               const siteId = restApi.siteId;
-              const expectedToken = computeConfirmationToken(siteId, workbookId);
 
-              // Gate the destructive path on the confirmation token BEFORE any read or write, so a
-              // missing/mismatched token is rejected with zero side effects. This forces a
-              // deliberate two-step delete; it does not prove a preview ran (the token is a
-              // deterministic hash of caller-known inputs — see computeConfirmationToken).
-              if (confirm && confirmationToken !== expectedToken) {
-                return new ArgsValidationError(
-                  'Deletion requires the confirmationToken returned by the preview step. ' +
-                    'Run delete-workbook with confirm omitted (or false) for this workbookId first, ' +
-                    'then call again with confirm: true and the confirmationToken from that response.',
-                ).toErr();
-              }
+              // Treat undefined, empty, and whitespace-only tags as "use the default" so a blank
+              // label never gets applied (preview) or verified against (confirm).
+              const pendingTag = tag?.trim() ? tag : DEFAULT_PENDING_DELETION_TAG;
 
               // Honor the same tool-scoping rules the read tools enforce (e.g. get-workbook):
               // a workbook outside the configured bounded context cannot be tagged or deleted.
@@ -151,10 +119,45 @@ user and get explicit approval before deleting. Do not auto-confirm or compute t
                 return new WorkbookNotAllowedError(isWorkbookAllowedResult.message).toErr();
               }
 
-              // Resolve identity in both phases so the response (preview AND the final delete
-              // confirmation) always names the workbook, project, and owner for an auditable
-              // record of exactly what was acted on. Reuse the workbook already fetched by the
-              // access check when a project scope forced it, otherwise fetch it now.
+              if (confirm) {
+                // Server-authoritative HITL gate: re-fetch the workbook LIVE and verify it carries the
+                // pending-deletion tag set by a prior preview call. The tag is server-side state the
+                // caller cannot fabricate, so its presence is genuine proof the preview ran — unlike a
+                // caller-computable confirmation token, this gate cannot be bypassed. We query fresh
+                // here (not the access-check's cached content) so the check reflects the current server
+                // state at delete time. Rejected with zero destructive side effects.
+                const workbook = await restApi.workbooksMethods.getWorkbook({ workbookId, siteId });
+                const isPendingDeletion = workbook.tags?.tag?.some((t) => t.label === pendingTag);
+                if (!isPendingDeletion) {
+                  return new PreviewNotRunError(
+                    `Deletion blocked: workbook ${workbookId} is not tagged '${pendingTag}' as pending ` +
+                      'deletion. Run delete-workbook with confirm omitted (or false) for this workbookId ' +
+                      'first to preview and tag it, then call again with confirm: true. This gate verifies ' +
+                      'server-side state and cannot be bypassed by computing a token.',
+                  ).toErr();
+                }
+
+                const ownerEmail = await resolveOwnerEmail(
+                  restApi,
+                  siteId,
+                  workbook.owner?.id,
+                  'delete-workbook',
+                );
+                const projectName = workbook.project?.name ?? 'unknown project';
+                const ownerText = ownerEmail ? `owner ${ownerEmail}` : 'owner unknown';
+
+                await restApi.workbooksMethods.deleteWorkbook({ workbookId, siteId });
+                return new Ok(
+                  `Deleted workbook '${workbook.name}' (id ${workbookId}) in '${projectName}', ${ownerText}. ` +
+                    `It can be restored from the Tableau recycle bin (${RECYCLE_BIN_DOC_URL}) for a ` +
+                    'limited time before permanent removal.',
+                );
+              }
+
+              // Preview phase: tag as pending deletion and report. No deletion.
+              // Resolve identity so the response names the workbook, project, and owner for an
+              // auditable record of exactly what was acted on. Reuse the workbook already fetched by
+              // the access check when a project scope forced it, otherwise fetch it now.
               const workbook =
                 isWorkbookAllowedResult.content ??
                 (await restApi.workbooksMethods.getWorkbook({ workbookId, siteId }));
@@ -167,19 +170,6 @@ user and get explicit approval before deleting. Do not auto-confirm or compute t
               const projectName = workbook.project?.name ?? 'unknown project';
               const ownerText = ownerEmail ? `owner ${ownerEmail}` : 'owner unknown';
 
-              if (confirm) {
-                await restApi.workbooksMethods.deleteWorkbook({ workbookId, siteId });
-                return new Ok(
-                  `Deleted workbook '${workbook.name}' (id ${workbookId}) in '${projectName}', ${ownerText}. ` +
-                    `It can be restored from the Tableau recycle bin (${RECYCLE_BIN_DOC_URL}) for a ` +
-                    'limited time before permanent removal.',
-                );
-              }
-
-              // Preview phase: tag as pending deletion and report. No deletion.
-              // Treat undefined, empty, and whitespace-only tags as "use the default" so a
-              // blank label never gets applied to the workbook.
-              const pendingTag = tag?.trim() ? tag : DEFAULT_PENDING_DELETION_TAG;
               await restApi.workbooksMethods.addTagsToWorkbook({
                 workbookId,
                 siteId,
@@ -191,7 +181,8 @@ user and get explicit approval before deleting. Do not auto-confirm or compute t
                   `It has been tagged '${pendingTag}' (reversible). ` +
                   'NEXT STEP — REQUIRED: show this workbook (name, project, owner) to the user and ask them ' +
                   'to explicitly confirm deleting it. Do NOT delete without the user’s approval. ' +
-                  `Once approved, call again with confirm: true and confirmationToken: ${expectedToken}. ` +
+                  'Once approved, call again with confirm: true (the server will verify this ' +
+                  `'${pendingTag}' tag before deleting). ` +
                   `Deleted workbooks are recoverable from the Tableau recycle bin (${RECYCLE_BIN_DOC_URL}) ` +
                   'for a limited time.',
               );

--- a/src/tools/web/workbooks/deleteWorkbook.ts
+++ b/src/tools/web/workbooks/deleteWorkbook.ts
@@ -37,10 +37,19 @@ const paramsSchema = {
     ),
   tag: z
     .string()
+    .max(200)
+    // Constrain to a safe tag character class. `tag` is interpolated into the preview-response text
+    // the model reads back, so restricting it to alphanumerics/space/underscore/dash closes a
+    // prompt-injection vector (e.g. a value with quotes/backticks trying to coerce auto-confirming).
+    .regex(
+      /^[A-Za-z0-9 _-]+$/,
+      'tag must contain only letters, numbers, spaces, underscores, and dashes',
+    )
     .optional()
     .describe(
       'Label applied to the workbook during the preview phase to mark it as pending deletion ' +
-        `(reversible, visible in the Tableau UI). Defaults to '${DEFAULT_PENDING_DELETION_TAG}'.`,
+        '(reversible, visible in the Tableau UI). Letters, numbers, spaces, underscores, and dashes ' +
+        `only. Defaults to '${DEFAULT_PENDING_DELETION_TAG}'.`,
     ),
 };
 

--- a/src/tools/web/workbooks/deleteWorkbook.ts
+++ b/src/tools/web/workbooks/deleteWorkbook.ts
@@ -115,7 +115,7 @@ the user's explicit approval first.
 
               // Treat undefined, empty, and whitespace-only tags as "use the default" so a blank
               // label never gets applied (preview) or verified against (confirm).
-              const pendingTag = tag?.trim() ? tag : DEFAULT_PENDING_DELETION_TAG;
+              const pendingTag = tag?.trim() || DEFAULT_PENDING_DELETION_TAG;
 
               // Honor the same tool-scoping rules the read tools enforce (e.g. get-workbook):
               // a workbook outside the configured bounded context cannot be tagged or deleted.
@@ -129,15 +129,17 @@ the user's explicit approval first.
               }
 
               if (confirm) {
-                // Server-authoritative HITL gate: re-fetch the workbook LIVE and verify it carries the
-                // pending-deletion tag set by a prior preview call. The tag is server-side state the
-                // caller cannot fabricate, so its presence is genuine proof the preview ran — unlike a
-                // caller-computable confirmation token, this gate cannot be bypassed. We query fresh
-                // here (not the access-check's cached content) so the check reflects the current server
-                // state at delete time. Rejected with zero destructive side effects.
+                // Server-authoritative gate: re-fetch the workbook LIVE and verify it carries the
+                // pending-deletion tag set by a prior preview call. The tag is server-side state that
+                // a caller going through this MCP tool cannot set without running the preview — so its
+                // presence is genuine proof the preview ran, and (unlike a caller-computable token)
+                // this gate cannot be bypassed by an agent. NOTE: this is not full human-in-the-loop;
+                // it proves the preview ran, not that a human approved (an agent that runs both phases
+                // satisfies it). We query fresh here (not the access-check's cached content) so the
+                // check reflects current server state at delete time. Rejected with zero side effects.
                 const workbook = await restApi.workbooksMethods.getWorkbook({ workbookId, siteId });
-                const isPendingDeletion = workbook.tags?.tag?.some((t) => t.label === pendingTag);
-                if (!isPendingDeletion) {
+                const isTaggedForDeletion = workbook.tags?.tag?.some((t) => t.label === pendingTag);
+                if (!isTaggedForDeletion) {
                   return new PreviewNotRunError(
                     `Deletion blocked: workbook ${workbookId} is not tagged '${pendingTag}' as pending ` +
                       'deletion. Run delete-workbook with confirm omitted (or false) for this workbookId ' +

--- a/tests/e2e/datasources/deleteDatasource.test.ts
+++ b/tests/e2e/datasources/deleteDatasource.test.ts
@@ -50,7 +50,7 @@ describe('delete-datasource', () => {
     }
   });
 
-  it('should preview (tag, no delete), warn on dependents, and return a confirmation token', async () => {
+  it('should preview (tag, no delete) and warn on dependents', async () => {
     if (!toolsAvailable) {
       return;
     }
@@ -69,15 +69,18 @@ describe('delete-datasource', () => {
 
     expect(message).toContain('Preview');
     expect(message).toContain('pending-deletion');
-    expect(message).toContain('confirmationToken');
   });
 
-  it('should reject a confirmed delete without the confirmation token', async () => {
+  it('should reject a confirmed delete when the data source is not tagged pending-deletion', async () => {
     if (!toolsAvailable) {
       return;
     }
-    const previewId = process.env.DELETE_DATASOURCE_E2E_ID;
-    if (!previewId) {
+    // Bypass-closed: a caller that jumps straight to confirm: true (skipping the preview/tag step)
+    // must be rejected by the server-authoritative tag gate, never deleting. Uses a distinct,
+    // never-previewed LUID so the live re-fetch finds no pending-deletion tag.
+    const untaggedId =
+      process.env.DELETE_DATASOURCE_E2E_UNTAGGED_ID ?? process.env.DELETE_DATASOURCE_E2E_ID;
+    if (!untaggedId) {
       return;
     }
 
@@ -85,16 +88,16 @@ describe('delete-datasource', () => {
     try {
       await client.callTool('delete-datasource', {
         schema: z.string(),
-        toolArgs: { datasourceId: previewId, confirm: true },
+        toolArgs: { datasourceId: untaggedId, confirm: true },
       });
     } catch (e) {
       threw = true;
-      expect(String(e)).toContain('confirmationToken');
+      expect(String(e)).toContain('not tagged');
     }
     expect(threw).toBe(true);
   });
 
-  it('should delete a disposable datasource via preview → token → confirm (opt-in)', async () => {
+  it('should delete a disposable datasource via preview (tag) → confirm (opt-in)', async () => {
     if (!toolsAvailable) {
       return;
     }
@@ -104,19 +107,20 @@ describe('delete-datasource', () => {
       return;
     }
 
-    // 1. Preview to obtain the confirmation token.
+    // 1. Preview applies the pending-deletion tag server-side (no token to capture).
     const preview = await client.callTool('delete-datasource', {
       schema: z.string(),
       toolArgs: { datasourceId: disposableId },
     });
-    const match = preview.match(/confirmationToken:\s*([a-f0-9]+)/i);
-    invariant(match, `Preview did not return a confirmationToken: ${preview}`);
-    const confirmationToken = match[1];
+    invariant(
+      preview.includes('pending-deletion'),
+      `Preview did not tag the data source: ${preview}`,
+    );
 
-    // 2. Confirm the delete with the token.
+    // 2. Confirm: the server re-fetches, verifies the tag, then deletes.
     const message = await client.callTool('delete-datasource', {
       schema: z.string(),
-      toolArgs: { datasourceId: disposableId, confirm: true, confirmationToken },
+      toolArgs: { datasourceId: disposableId, confirm: true },
     });
 
     expect(message).toContain('Deleted');

--- a/tests/e2e/workbooks/deleteWorkbook.test.ts
+++ b/tests/e2e/workbooks/deleteWorkbook.test.ts
@@ -50,7 +50,7 @@ describe('delete-workbook', () => {
     }
   });
 
-  it('should preview (tag, no delete) and return a confirmation token', async () => {
+  it('should preview (tag, no delete)', async () => {
     if (!toolsAvailable) {
       return;
     }
@@ -66,34 +66,36 @@ describe('delete-workbook', () => {
     });
 
     expect(message).toContain('Preview');
-    expect(message).toContain('stale-pending-deletion');
-    expect(message).toContain('confirmationToken');
+    expect(message).toContain('pending-deletion');
   });
 
-  it('should reject a confirmed delete without the confirmation token', async () => {
+  it('should reject a confirmed delete when the workbook is not tagged pending-deletion', async () => {
     if (!toolsAvailable) {
       return;
     }
-    const previewId = process.env.DELETE_WORKBOOK_E2E_ID;
-    if (!previewId) {
+    // Bypass-closed: a caller that jumps straight to confirm: true (skipping the preview/tag step)
+    // must be rejected by the server-authoritative tag gate, never deleting. Uses a distinct,
+    // never-previewed LUID so the live re-fetch finds no pending-deletion tag.
+    const untaggedId =
+      process.env.DELETE_WORKBOOK_E2E_UNTAGGED_ID ?? process.env.DELETE_WORKBOOK_E2E_ID;
+    if (!untaggedId) {
       return;
     }
 
-    // Destructive path is gated: confirm without a token must error, not delete.
     let threw = false;
     try {
       await client.callTool('delete-workbook', {
         schema: z.string(),
-        toolArgs: { workbookId: previewId, confirm: true },
+        toolArgs: { workbookId: untaggedId, confirm: true },
       });
     } catch (e) {
       threw = true;
-      expect(String(e)).toContain('confirmationToken');
+      expect(String(e)).toContain('not tagged');
     }
     expect(threw).toBe(true);
   });
 
-  it('should delete a disposable workbook via preview → token → confirm (opt-in)', async () => {
+  it('should delete a disposable workbook via preview (tag) → confirm (opt-in)', async () => {
     if (!toolsAvailable) {
       return;
     }
@@ -103,19 +105,17 @@ describe('delete-workbook', () => {
       return;
     }
 
-    // 1. Preview to obtain the confirmation token.
+    // 1. Preview applies the pending-deletion tag server-side (no token to capture).
     const preview = await client.callTool('delete-workbook', {
       schema: z.string(),
       toolArgs: { workbookId: disposableId },
     });
-    const match = preview.match(/confirmationToken:\s*([a-f0-9]+)/i);
-    invariant(match, `Preview did not return a confirmationToken: ${preview}`);
-    const confirmationToken = match[1];
+    invariant(preview.includes('pending-deletion'), `Preview did not tag the workbook: ${preview}`);
 
-    // 2. Confirm the delete with the token.
+    // 2. Confirm: the server re-fetches, verifies the tag, then deletes.
     const message = await client.callTool('delete-workbook', {
       schema: z.string(),
-      toolArgs: { workbookId: disposableId, confirm: true, confirmationToken },
+      toolArgs: { workbookId: disposableId, confirm: true },
     });
 
     expect(message).toContain('Deleted');


### PR DESCRIPTION
## Summary

Replaces the caller-computable confirmation token in the `delete-datasource` and `delete-workbook` tools with a **server-authoritative pending-deletion tag gate**.

The prior gate was `sha256(siteId:resourceId).slice(0, 12)` — both inputs are caller-known, so the token is **caller-computable**. A model/caller could skip the preview (and the human approval it represents) by computing the token itself. The MCP HITL/audit guidance names this exact construction the **"Bad / Advisory Pattern"**, and the old code comment already admitted the real fix needs server-side state.

The fix makes the gate verify state the **server controls**: on `confirm: true` the tool re-fetches the resource live (never trusting the access-check cached copy) and deletes only if it carries the `pending-deletion` tag applied during a prior preview. A confirmed delete on an untagged resource is rejected with the new `PreviewNotRunError` (HTTP 409). The tag can only be set by running the preview phase, so the gate genuinely proves a preview happened and **cannot be bypassed** by deriving a value.

### Scope: what this does and does not fix

This PR closes the **caller-computable-token** bypass — that is its entire claim. It does **not** enforce human-in-the-loop approval. The tag gate proves *a preview ran*, not *a human approved*: an agent that runs both the preview and the confirm itself satisfies the gate with no human in the loop. The human-approval step in the prompts/docs is **advisory** (a prompt-text contract), now labelled as such.

Real, server-enforced HITL needs an out-of-band signal the agent cannot forge — MCP URL-mode elicitation (`server.elicitInput`, available in the installed SDK 1.29) routes approval to a human in the browser/Tableau UI. That is tracked as follow-up under **W-23125362** and intentionally out of scope here.

## Motivation and Context

This is the dependency work item (**W-23093455**) of the broader common mutation-tool safety layer (W-23125362). It closes the bypass in the stale-content delete flow by enforcing the preview/confirm gate server-side rather than via an advisory token. The per-call `tag` override still works; the non-forgeable part is the tag's presence on the server, not its name.

Cloud vs. Server: the gate is identical; only the delete consequence differs (recycle bin on Cloud, permanent on Server) — already described in the tool docs.

## Type of Change

- [x] Bug fix (security: closes the caller-computable-token bypass; HITL remains advisory)
- [ ] New feature
- [x] Breaking change (the `confirmationToken` argument is removed; confirm now requires the resource to be tagged from a prior preview)
- [x] Documentation update
- [ ] Other

## Changes

- **`src/errors/mcpToolError.ts`**: add `PreviewNotRunError` (type `preview-not-run`, status 409).
- **`src/tools/web/datasources/deleteDatasource.ts`** / **`workbooks/deleteWorkbook.ts`**: drop `computeConfirmationToken` + the `confirmationToken` param; on confirm, re-fetch live via `queryDatasource` / `getWorkbook` and verify the pending-deletion tag before deleting. Updated tool + `confirm` descriptions.
- **`src/prompts/_lib/confirm.ts`** / **`src/prompts/staleContent/apply.ts`**: describe the server-authoritative tag gate instead of echoing a token.
- **`docs/`**: rewrite `delete-datasource.md`, `delete-workbook.md`, and `stale-content-cleanup-apply.md` to the tag-gate model (new "Server-authoritative gate" section).
- **`package.json`**: bump 2.18.0 → 2.18.1.

## How Has This Been Tested?

- [x] `npm run lint` — clean
- [x] `npm run build` — succeeds
- [x] `npm test` — 1845/1845 unit tests pass
- [ ] `npm run test:e2e` — requires `tests/.env` (Tableau Cloud creds); e2e flows rewritten to preview(tag)→confirm and lint-checked, to be run by reviewer / CI

Unit coverage added/updated for both delete tools: bypass-closed (confirm on an untagged resource → `PreviewNotRunError`, no delete), live-vs-cached re-fetch (cached tagged, live untagged → blocked), re-fetch error surfaced with no delete, custom-tag verify, mismatched-tag block. E2E tests rewritten to the tag flow with a new `DELETE_*_E2E_UNTAGGED_ID` knob for the bypass-closed case.

## Related Issues

- Resolves **W-23093455**.
- Dependency of **W-23125362** (common mutation-tool safety layer).

## Checklist

- [x] I have updated the version in package.json via `npm run version:patch` (2.18.0 → 2.18.1)
- [x] I have made any necessary changes to the documentation
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] I have documented breaking changes in the PR description (removal of the `confirmationToken` argument)
