### PR TITLE
@W-23149256 prerelease-aware npm + Docker publish (hotfix without moving latest) + release runbook

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -19,6 +19,24 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Preflight — release tag must match package.json version
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        # The `latest` guard below keys off the release TAG NAME while the npm
+        # side (publish.yml) keys off package.json — this preflight (same check
+        # in both workflows) makes a mismatch fail loudly instead of letting the
+        # two registries disagree about moving `latest`.
+        run: |
+          VERSION="$(node -p "require('./package.json').version")"
+          if [[ -z "$VERSION" || "$VERSION" == "undefined" ]]; then
+            echo "::error::Could not read version from package.json — aborting"
+            exit 1
+          fi
+          if [[ "$RELEASE_TAG" != "v$VERSION" ]]; then
+            echo "::error::Release tag '$RELEASE_TAG' != 'v$VERSION' (package.json) — aborting. Tag the exact commit whose package.json matches, or fix the release tag."
+            exit 1
+          fi
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -38,7 +38,10 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
-            type=raw,value=latest,enable=${{ github.event_name == 'release' }}
+            # Move `latest` only for STABLE releases — a prerelease/hotfix tag
+            # (one containing a `-`, e.g. v2.18.0-hotfix.1) gets its exact-version
+            # Docker tag but must NOT steal `latest`, mirroring the npm publish guard.
+            type=raw,value=latest,enable=${{ github.event_name == 'release' && !contains(github.event.release.tag_name, '-') }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v5

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,32 @@ jobs:
           npm install -g npm@latest
           npm ci
           npm run build
-          npm publish
+          # Prerelease-aware publish. A SemVer prerelease version (one containing a
+          # `-`, e.g. 2.18.0-hotfix.1; build metadata `+...` is NOT a prerelease)
+          # must NOT reassign the `latest` npm dist-tag — otherwise a hotfix off an
+          # old release line would steal `latest` from the real release line. npm
+          # moves `latest` on EVERY bare `npm publish`, so prereleases publish
+          # under a dedicated dist-tag instead.
+          # NOTE: the dist-tag must NOT itself be a valid SemVer version (npm
+          # rejects that), so we use `hotfix-v<version>` rather than the bare
+          # version. Consumers pin the exact version (`@2.18.0-hotfix.1`)
+          # regardless; the dist-tag is just a non-`latest` pointer.
+          # Fail CLOSED: if the version can't be read, abort before publishing —
+          # a bare publish on an empty version would wrongly move `latest`.
+          # VERSION comes from package.json (the repo's own committed value, not
+          # external input) into a shell var — no ${{ }} interpolation here.
+          VERSION="$(node -p "require('./package.json').version")"
+          if [[ -z "$VERSION" || "$VERSION" == "undefined" ]]; then
+            echo "::error::Could not read version from package.json — aborting publish (refusing to risk moving 'latest')"
+            exit 1
+          fi
+          if [[ "$VERSION" == *-* ]]; then
+            echo "Prerelease $VERSION -> npm publish --tag hotfix-v$VERSION (NOT moving 'latest')"
+            npm publish --tag "hotfix-v$VERSION"
+          else
+            echo "Stable $VERSION -> npm publish (moves 'latest')"
+            npm publish
+          fi
   upload-mcpb:
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,9 +14,13 @@ jobs:
         with:
           node-version: '>=22.7.5'
           registry-url: https://registry.npmjs.org/
-      - run: |
+      - env:
+          # Passed via env (not inline ${{ }} in the script) — the tag name is
+          # release-author-controlled input; env keeps it out of shell parsing.
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
           git fetch --tags
-          git checkout -b publish ${{ github.event.release.tag_name }}
+          git checkout -b publish "$RELEASE_TAG"
           npm install -g npm@latest
           npm ci
           npm run build
@@ -37,6 +41,14 @@ jobs:
           VERSION="$(node -p "require('./package.json').version")"
           if [[ -z "$VERSION" || "$VERSION" == "undefined" ]]; then
             echo "::error::Could not read version from package.json — aborting publish (refusing to risk moving 'latest')"
+            exit 1
+          fi
+          # PREFLIGHT: the release tag must be exactly v<package.json version>.
+          # npm decides prerelease-vs-stable from package.json while Docker
+          # (docker-publish.yml) decides from the release tag name — a mismatch
+          # would let the two registries disagree about moving `latest`.
+          if [[ "$RELEASE_TAG" != "v$VERSION" ]]; then
+            echo "::error::Release tag '$RELEASE_TAG' != 'v$VERSION' (package.json) — aborting. Tag the exact commit whose package.json matches, or fix the release tag."
             exit 1
           fi
           if [[ "$VERSION" == *-* ]]; then

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,6 +61,10 @@ Use GitHub Issues page to submit issues, enhancement requests and discuss ideas.
 
 > **NOTE**: Be sure to [sync your fork](https://help.github.com/articles/syncing-a-fork/) before making a pull request.
 
+# Releasing
+
+Normal releases and the hotfix process (shipping a fix off an already-deployed version without moving the npm `latest` dist-tag) are documented in [docs/RELEASE.md](docs/RELEASE.md).
+
 # Contributor License Agreement ("CLA")
 In order to accept your pull request, we need you to submit a CLA. You only need
 to do this once to work on any of Salesforce's open source projects.

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -4,6 +4,8 @@
 
 A merge to `main` that bumps `package.json` version triggers `.github/workflows/tag.yml`, which tags `v<version>`. Cutting a GitHub release from that tag triggers `.github/workflows/publish.yml`, which runs `npm publish` — publishing the new version and moving the npm `latest` dist-tag to it. This is the common path; nothing about it changes.
 
+> **The Release publish is the trigger.** Both `publish.yml` and `docker-publish.yml` fire on `release: published` — pushing a tag alone publishes **nothing**. And both preflight that the release tag equals `v<package.json version>` at the tagged commit; a mismatch fails the run before anything publishes (npm keys prerelease-vs-stable off `package.json`, Docker off the tag name — the preflight keeps them agreeing).
+
 ## Hotfix release
 
 Use this when a livesite issue needs a code fix shipped against an **already-deployed** version, without pulling in unrelated changes that have landed on `main` since, and **without moving the `latest` dist-tag** off the current release line.
@@ -34,7 +36,7 @@ Say Hyperforce consumes `2.18.0`:
    git tag v2.18.0-hotfix.1
    git push origin v2.18.0-hotfix.1
    ```
-   Then on GitHub, create a Release from tag `v2.18.0-hotfix.1`. The release "target" branch doesn't matter — `publish.yml` checks out the tag's exact commit — but selecting the hotfix branch keeps it unambiguous. The workflow detects the prerelease version and runs `npm publish --tag hotfix-v2.18.0-hotfix.1`, publishing the hotfix **without moving `latest`**.
+   Then on GitHub, create a Release from tag `v2.18.0-hotfix.1` and **mark it as a pre-release** in the UI (`gh release create v2.18.0-hotfix.1 --prerelease`). Publishing the Release — not the tag push — is what triggers the workflows. The release "target" branch doesn't matter — `publish.yml` checks out the tag's exact commit — but selecting the hotfix branch keeps it unambiguous. The workflow detects the prerelease version and runs `npm publish --tag hotfix-v2.18.0-hotfix.1`, publishing the hotfix **without moving `latest`**.
 5. **Consume in Hyperforce.** Pin `@tableau/mcp-server@2.18.0-hotfix.1` (by exact version) in the Hyperforce repo.
 
 Verify `latest` was not disturbed:
@@ -44,6 +46,10 @@ npm dist-tag ls @tableau/mcp-server
 # hotfix-v2.18.0-hotfix.1: 2.18.0-hotfix.1 <- the hotfix, on its own tag
 ```
 (If `main` has already advanced past the deployed line, `latest` will point at that newer version — the point is only that the hotfix did **not** move it.)
+
+### If a publish run fails partway
+
+npm versions are **immutable** — once `npm publish` for a version succeeds, re-running the whole workflow will fail on the npm step with a "cannot publish over existing version" error. If a later job failed (mcpb upload, Docker), use **"Re-run failed jobs"** on the workflow run, not "Re-run all jobs". If the npm publish itself was the failure, fix the cause and re-run; nothing was published, so the full rerun is safe.
 
 ### Why this shape
 - **No `main` drift:** the fix ships off the exact deployed tag, not the moving `main`.

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,0 +1,51 @@
+# Releasing `@tableau/mcp-server`
+
+## Normal release
+
+A merge to `main` that bumps `package.json` version triggers `.github/workflows/tag.yml`, which tags `v<version>`. Cutting a GitHub release from that tag triggers `.github/workflows/publish.yml`, which runs `npm publish` — publishing the new version and moving the npm `latest` dist-tag to it. This is the common path; nothing about it changes.
+
+## Hotfix release
+
+Use this when a livesite issue needs a code fix shipped against an **already-deployed** version, without pulling in unrelated changes that have landed on `main` since, and **without moving the `latest` dist-tag** off the current release line.
+
+The publish pipeline is **prerelease-aware**: any version with a SemVer prerelease identifier (a `-`, e.g. `2.18.0-hotfix.1`) is published under a dedicated `hotfix-v<version>` npm dist-tag, never `latest`. (The dist-tag can't be the bare version — npm rejects a dist-tag that parses as a valid SemVer version — so it's `hotfix-v2.18.0-hotfix.1`; you still install by exact version.) The Docker image (`docker-publish.yml`) is guarded the same way: a prerelease tag gets its exact-version Docker tag but does not move Docker's `latest`. So a hotfix never disturbs `latest` on either registry.
+
+Say Hyperforce consumes `2.18.0`:
+
+1. **Branch off the deployed tag.** Create `hotfix/2.18.0` with HEAD at the `v2.18.0` tag:
+   ```
+   git fetch --tags
+   git checkout -b hotfix/2.18.0 v2.18.0
+   ```
+2. **Fix on `main` first, then cherry-pick.** Land the bug fix on `main` as usual, then cherry-pick it onto the hotfix branch:
+   ```
+   git checkout hotfix/2.18.0
+   git cherry-pick <fix-commit-sha>
+   ```
+   (main → hotfix ordering, so you can never forget to get the fix back onto `main`.)
+3. **Bump to a hotfix prerelease version** on the hotfix branch — `2.18.0-hotfix.1` (increment `.N` for subsequent hotfixes on the same line):
+   ```
+   npm version 2.18.0-hotfix.1 --no-git-tag-version
+   git commit -am "@W-XXXXXXXX hotfix: <summary> (2.18.0-hotfix.1)"
+   git push origin hotfix/2.18.0
+   ```
+4. **Tag + release from the hotfix branch.** Create tag `v2.18.0-hotfix.1` on the hotfix branch, push it, and cut a GitHub release from that tag:
+   ```
+   git tag v2.18.0-hotfix.1
+   git push origin v2.18.0-hotfix.1
+   ```
+   Then on GitHub, create a Release from tag `v2.18.0-hotfix.1`. The release "target" branch doesn't matter — `publish.yml` checks out the tag's exact commit — but selecting the hotfix branch keeps it unambiguous. The workflow detects the prerelease version and runs `npm publish --tag hotfix-v2.18.0-hotfix.1`, publishing the hotfix **without moving `latest`**.
+5. **Consume in Hyperforce.** Pin `@tableau/mcp-server@2.18.0-hotfix.1` (by exact version) in the Hyperforce repo.
+
+Verify `latest` was not disturbed:
+```
+npm dist-tag ls @tableau/mcp-server
+# latest: 2.18.0                          <- the deployed line, unchanged
+# hotfix-v2.18.0-hotfix.1: 2.18.0-hotfix.1 <- the hotfix, on its own tag
+```
+(If `main` has already advanced past the deployed line, `latest` will point at that newer version — the point is only that the hotfix did **not** move it.)
+
+### Why this shape
+- **No `main` drift:** the fix ships off the exact deployed tag, not the moving `main`.
+- **No `latest` move:** `npm publish` reassigns `latest` on every bare publish; the prerelease guard in `publish.yml` publishes hotfixes under their own dist-tag so the normal release line keeps `latest`.
+- **main → hotfix cherry-pick order:** guarantees the fix is on `main` before it ships, so the next normal release already contains it.


### PR DESCRIPTION
## W-23149256 — Formalize the hotfix release path

Today a livesite fix can only ship by pushing to `main` and upgrading Hyperforce to that version — which drags in any unrelated changes that landed on `main` since, and there's no way to ship a surgical fix off the exact deployed version without moving the npm `latest` dist-tag. This formalizes a hotfix path. Andy's spec; continuity-critical (he holds the release process and departs 2026-07-02 — landing this before a livesite issue forces it, and before he's gone).

### What changed
- **`.github/workflows/publish.yml`** — prerelease-aware `npm publish`. A version carrying a SemVer prerelease identifier (a `-`, e.g. `2.18.0-hotfix.1`) publishes under a dedicated **`hotfix-v<version>`** dist-tag and never moves `latest`; the stable path is unchanged (bare `npm publish`). It **fails closed** if the version can't be read (refuses to risk moving `latest`). The dist-tag is deliberately not the bare version — npm rejects a dist-tag that parses as a valid SemVer version.
- **`.github/workflows/docker-publish.yml`** — Docker `latest` now skips prerelease tags (mirrors the npm guard), so a hotfix gets its exact-version Docker tag without stealing `latest`.
- **`docs/RELEASE.md`** (new) — the normal + hotfix runbook (branch off the deployed tag → fix on `main` then cherry-pick → bump to `-hotfix.N` → release from the hotfix branch → pin the exact version in Hyperforce) + the rationale. Linked from CONTRIBUTING.

### Verification
Stable path provably unchanged (bare `npm publish`, `upload-mcpb` untouched); prerelease/stable/empty-version cases table-tested; the chosen dist-tag confirmed non-SemVer (npm-acceptable). This is a CI/process change — no `src/` touched, so `scripts/agent-check` isn't the relevant gate.

A pre-push dual-model self-review (GPT-5.5 + Opus) on the local diff caught and fixed three blockers before the first commit: npm rejecting a valid-SemVer dist-tag (would have failed every hotfix publish), Docker `latest` moving on hotfixes, and a fail-open on an unreadable version.

### One thing worth a maintainer eye
The dist-tag scheme is `hotfix-v<version>` (a hotfix never moves `latest`; consumers pin the exact version). If whoever owns the Hyperforce consume step prefers a single reusable `hotfix` pointer instead, that's a one-line change — flagging since it's a release-ergonomics call.