### PR TITLE
@W-23160593: Link TELEMETRY_PROVIDER_CONFIG docs to source instead of inline code

### DIFF
--- a/docs/docs/configuration/mcp-config/env-vars.md
+++ b/docs/docs/configuration/mcp-config/env-vars.md
@@ -374,14 +374,7 @@ TELEMETRY_PROVIDER_CONFIG='{"module": "./my-telemetry-provider.js"}'
 ```
 
 The custom provider module should export a default class (or named export `TelemetryProvider`) that
-implements:
-
-```typescript
-interface TelemetryProvider {
-  initialize(): void;
-  recordMetric(name: string, value: number, attributes: Record<string, unknown>): void;
-}
-```
+implements the [`TelemetryProvider`](https://github.com/tableau/tableau-mcp/blob/main/src/telemetry/types.ts) interface.
 
 <hr />
 


### PR DESCRIPTION
## Description

Replaced the inline `TelemetryProvider` interface code block in the TELEMETRY_PROVIDER_CONFIG documentation with a link to the canonical source (`src/telemetry/types.ts`).

## Motivation and Context

The inline interface block in `docs/docs/configuration/mcp-config/env-vars.md` had drifted out of sync with the actual source code. Specifically, it was missing the `recordHistogram` method that exists in the real interface. By linking to the source file instead of duplicating the code, we prevent future documentation drift.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Other (please describe):

## How Has This Been Tested?

This is a documentation-only change. The docs build should pass, and the link correctly points to the canonical TelemetryProvider interface definition in the source code.

## Related Issues

Fixes #269

## Checklist

- [ ] I have updated the version in the package.json file by using `npm run version`. For example,
      use `npm run version:patch` for a patch version bump.
- [x] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have documented any breaking changes in the PR description. For example, renaming a config
      environment variable or changing its default value.

## Contributor Agreement

By submitting this pull request, I confirm that:

- [x] I have read the [CONTRIBUTING guidelines](../../CONTRIBUTING.md) for this project and followed
      its Contribution Checklist.