### PR TITLE
@W-23160588: Fix feature config load path for Claude Desktop Extension

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN npm ci --ignore-scripts
 
 # Copy source and build
 COPY src ./src
+COPY features.json ./
 RUN npm run build
 
 # Production stage

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "2.18.1",
+  "version": "2.18.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "2.18.1",
+      "version": "2.18.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.7.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "2.18.2",
+  "version": "2.18.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "2.18.2",
+      "version": "2.18.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.7.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "2.18.1",
+  "version": "2.18.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "2.18.2",
+  "version": "2.18.3",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/src/features/featureGate.test.ts
+++ b/src/features/featureGate.test.ts
@@ -5,6 +5,11 @@ vi.mock('fs', () => ({
   readFileSync: vi.fn(),
 }));
 
+vi.mock('../utils/getDirname.js', () => ({
+  getDirname: vi.fn(() => '/mock/module/directory'),
+}));
+
+import { getDirname } from '../utils/getDirname.js';
 import { getFeatureGate, resetFeatureGate } from './featureGate.js';
 
 describe('FeatureGate', () => {
@@ -14,6 +19,23 @@ describe('FeatureGate', () => {
   });
 
   describe('loadFeatures', () => {
+    it('should resolve features.json relative to module directory not process.cwd()', () => {
+      const config = { mcpapps: true };
+      vi.mocked(readFileSync).mockReturnValue(JSON.stringify(config));
+
+      getFeatureGate();
+
+      expect(getDirname).toHaveBeenCalled();
+      expect(readFileSync).toHaveBeenCalledWith(
+        expect.stringContaining('/mock/module/directory'),
+        'utf-8',
+      );
+      expect(readFileSync).toHaveBeenCalledWith(
+        expect.stringMatching(/\/mock\/module\/directory.*features\.json$/),
+        'utf-8',
+      );
+    });
+
     it('should load valid feature config file', () => {
       const config = { mcpapps: true, pulse: false };
       vi.mocked(readFileSync).mockReturnValue(JSON.stringify(config));

--- a/src/features/featureGate.ts
+++ b/src/features/featureGate.ts
@@ -2,6 +2,7 @@ import { readFileSync } from 'fs';
 import path from 'path';
 
 import { log } from '../logging/logger.js';
+import { getDirname } from '../utils/getDirname.js';
 
 const FEATURES_CONFIG_PATH = 'features.json';
 
@@ -22,7 +23,7 @@ export class FeatureGate {
   }
 
   private loadFeatures(): Map<string, boolean> {
-    const filePath = path.join(process.cwd(), FEATURES_CONFIG_PATH);
+    const filePath = path.join(getDirname(), FEATURES_CONFIG_PATH);
 
     try {
       const fileContent = readFileSync(filePath, 'utf-8');

--- a/src/scripts/build.ts
+++ b/src/scripts/build.ts
@@ -85,6 +85,13 @@ const globalValues: Record<GlobalIdentifierName, string> = {
 
   await chmod(buildOptions.outfile, '755');
 
+  console.log('🏗️ Copying features.json to build directory...');
+  await copyFile(
+    resolve(process.cwd(), 'features.json'),
+    resolve(process.cwd(), 'build', 'features.json'),
+  );
+  console.log('✅ features.json copied successfully');
+
   console.log('🏗️ Building MCP Apps...');
   try {
     const appsDir = resolve(process.cwd(), 'src/web/apps');


### PR DESCRIPTION
## Description

Fixed a critical bug where `features.json` was loaded from `process.cwd()` instead of the module directory, causing all features to be silently disabled when running as a Claude Desktop Extension (where `process.cwd()` resolves to `C:\WINDOWS\system32`).

**Changes:**
- Modified `featureGate.ts` to load `features.json` relative to module directory using `getDirname()` utility
- Added build step in `build.ts` to copy `features.json` into the `build/` output directory
- Added test case to verify path resolution uses module directory instead of `process.cwd()`

## Motivation and Context

**Root Cause:**
When the MCP server runs as a Claude Desktop Extension on Windows, `process.cwd()` returns `C:\WINDOWS\system32`, causing `features.json` to be read from the wrong location. This resulted in all feature flags being silently disabled due to file-not-found error handling.

**Solution:**
Use `getDirname()` utility (which resolves to the module's directory via `import.meta.url`) to construct the path to `features.json`. Additionally, ensure `features.json` is copied into the build output directory during the build process.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## How Has This Been Tested?

- **Unit tests**: Added test case `should resolve features.json relative to module directory not process.cwd()` that verifies `getDirname()` is called and path resolution is correct
- **Build verification**: Build passes successfully with `features.json` copied to build directory
- **Existing tests**: All 1848 unit tests pass
- **Lint**: ESLint runs clean

## Related Issues

Fixes #418

GUS Work Item: @W-23160588

## Checklist

- [ ] I have updated the version in the package.json file by using `npm run version`. For example,
      use `npm run version:patch` for a patch version bump.
- [ ] I have made any necessary changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have documented any breaking changes in the PR description. For example, renaming a config
      environment variable or changing its default value.

## Contributor Agreement

By submitting this pull request, I confirm that:

- [x] I have read the [CONTRIBUTING guidelines](../../CONTRIBUTING.md) for this project and followed
      its Contribution Checklist.