### PR TITLE
Relax Pulse tool schema optionality to match API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "2.20.1",
+  "version": "2.20.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "2.20.1",
+      "version": "2.20.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.7.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "2.20.1",
+  "version": "2.20.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/src/sdks/tableau/types/pulse.test.ts
+++ b/src/sdks/tableau/types/pulse.test.ts
@@ -1,6 +1,9 @@
 import {
   PulseMetric,
   PulseMetricDefinition,
+  pulseBundleRequestSchema,
+  pulseInsightBriefRequestSchema,
+  metricGroupContextSchema,
   pulseMetricDefinitionSchema,
   pulseMetricDefinitionViewEnum,
   pulseMetricSchema,
@@ -99,6 +102,167 @@ describe('PulseMetricSubscription schema', () => {
       metric_id: 5678,
     };
     expect(() => pulseMetricSubscriptionSchema.parse(data)).toThrow();
+  });
+});
+
+describe('pulseBundleRequestSchema optionality', () => {
+  const minimalBundleRequest = {
+    bundle_request: {
+      version: 1,
+      options: {
+        output_format: 'OUTPUT_FORMAT_HTML' as const,
+        time_zone: 'UTC',
+        language: 'LANGUAGE_EN_US' as const,
+        locale: 'LOCALE_EN_US' as const,
+      },
+      input: {
+        metadata: {},
+        metric: {
+          definition: {
+            datasource: { id: 'ds-1' },
+            basic_specification: {
+              measure: { field: 'Sales', aggregation: 'AGGREGATION_SUM' },
+              time_dimension: { field: 'Order Date' },
+              filters: [],
+            },
+            is_running_total: false,
+          },
+          metric_specification: {
+            measurement_period: {
+              granularity: 'GRANULARITY_BY_MONTH',
+              range: 'RANGE_LAST_COMPLETE',
+            },
+            comparison: { comparison: 'TIME_COMPARISON_PREVIOUS_PERIOD' },
+          },
+        },
+      },
+    },
+  };
+
+  it('accepts a bundle request without extension_options', () => {
+    expect(() => pulseBundleRequestSchema.parse(minimalBundleRequest)).not.toThrow();
+  });
+
+  it('accepts a bundle request without representation_options', () => {
+    expect(() => pulseBundleRequestSchema.parse(minimalBundleRequest)).not.toThrow();
+    expect(pulseBundleRequestSchema.parse(minimalBundleRequest).bundle_request.input.metric.representation_options).toBeUndefined();
+  });
+
+  it('accepts a bundle request without insights_options', () => {
+    expect(() => pulseBundleRequestSchema.parse(minimalBundleRequest)).not.toThrow();
+    expect(pulseBundleRequestSchema.parse(minimalBundleRequest).bundle_request.input.metric.insights_options).toBeUndefined();
+  });
+
+  it('accepts a bundle request without metric_specification.filters', () => {
+    expect(() => pulseBundleRequestSchema.parse(minimalBundleRequest)).not.toThrow();
+    expect(pulseBundleRequestSchema.parse(minimalBundleRequest).bundle_request.input.metric.metric_specification.filters).toBeUndefined();
+  });
+
+  it('accepts a bundle request without metadata name, metric_id, or definition_id', () => {
+    expect(() => pulseBundleRequestSchema.parse(minimalBundleRequest)).not.toThrow();
+  });
+
+  it('accepts a bundle request with partial representation_options', () => {
+    const req = {
+      ...minimalBundleRequest,
+      bundle_request: {
+        ...minimalBundleRequest.bundle_request,
+        input: {
+          ...minimalBundleRequest.bundle_request.input,
+          metric: {
+            ...minimalBundleRequest.bundle_request.input.metric,
+            representation_options: {
+              type: 'NUMBER_FORMAT_TYPE_NUMBER',
+            },
+          },
+        },
+      },
+    };
+    expect(() => pulseBundleRequestSchema.parse(req)).not.toThrow();
+  });
+
+  it('still requires datasource.id', () => {
+    const req = structuredClone(minimalBundleRequest);
+    // @ts-expect-error - intentionally removing required field
+    req.bundle_request.input.metric.definition.datasource = {};
+    expect(() => pulseBundleRequestSchema.parse(req)).toThrow();
+  });
+
+  it('still requires measure.field', () => {
+    const req = structuredClone(minimalBundleRequest);
+    // @ts-expect-error - intentionally removing required field
+    req.bundle_request.input.metric.definition.basic_specification.measure = { aggregation: 'AGGREGATION_SUM' };
+    expect(() => pulseBundleRequestSchema.parse(req)).toThrow();
+  });
+
+  it('still requires measurement_period.granularity', () => {
+    const req = structuredClone(minimalBundleRequest);
+    // @ts-expect-error - intentionally removing required field
+    req.bundle_request.input.metric.metric_specification.measurement_period = { range: 'RANGE_LAST_COMPLETE' };
+    expect(() => pulseBundleRequestSchema.parse(req)).toThrow();
+  });
+});
+
+describe('metricGroupContextSchema optionality', () => {
+  const minimalContext = [
+    {
+      metadata: { name: 'Sales' },
+      metric: {
+        definition: {
+          datasource: { id: 'ds-1' },
+          basic_specification: {
+            measure: { field: 'Sales', aggregation: 'AGGREGATION_SUM' },
+            time_dimension: { field: 'Date' },
+            filters: [],
+          },
+          is_running_total: false,
+        },
+        metric_specification: {
+          measurement_period: {
+            granularity: 'GRANULARITY_BY_MONTH',
+            range: 'RANGE_LAST_COMPLETE',
+          },
+          comparison: { comparison: 'TIME_COMPARISON_PREVIOUS_PERIOD' },
+        },
+      },
+    },
+  ];
+
+  it('accepts metric_group_context without extension_options', () => {
+    expect(() => metricGroupContextSchema.parse(minimalContext)).not.toThrow();
+  });
+
+  it('accepts metric_group_context without representation_options', () => {
+    expect(() => metricGroupContextSchema.parse(minimalContext)).not.toThrow();
+  });
+
+  it('accepts metric_group_context without insights_options', () => {
+    expect(() => metricGroupContextSchema.parse(minimalContext)).not.toThrow();
+  });
+
+  it('accepts metric_group_context without candidates', () => {
+    expect(() => metricGroupContextSchema.parse(minimalContext)).not.toThrow();
+  });
+
+  it('accepts metric_group_context without metadata.metric_id or definition_id', () => {
+    expect(() => metricGroupContextSchema.parse(minimalContext)).not.toThrow();
+    const parsed = metricGroupContextSchema.parse(minimalContext);
+    expect(parsed[0].metadata.metric_id).toBeUndefined();
+    expect(parsed[0].metadata.definition_id).toBeUndefined();
+  });
+
+  it('still requires metadata.name', () => {
+    const ctx = structuredClone(minimalContext);
+    // @ts-expect-error - intentionally removing required field
+    delete ctx[0].metadata.name;
+    expect(() => metricGroupContextSchema.parse(ctx)).toThrow();
+  });
+
+  it('still requires definition.datasource', () => {
+    const ctx = structuredClone(minimalContext);
+    // @ts-expect-error - intentionally removing required field
+    delete ctx[0].metric.definition.datasource;
+    expect(() => metricGroupContextSchema.parse(ctx)).toThrow();
   });
 });
 

--- a/src/sdks/tableau/types/pulse.test.ts
+++ b/src/sdks/tableau/types/pulse.test.ts
@@ -138,36 +138,13 @@ describe('pulseBundleRequestSchema optionality', () => {
     },
   };
 
-  it('accepts a bundle request without extension_options', () => {
-    expect(() => pulseBundleRequestSchema.parse(minimalBundleRequest)).not.toThrow();
-  });
-
-  it('accepts a bundle request without representation_options', () => {
-    expect(() => pulseBundleRequestSchema.parse(minimalBundleRequest)).not.toThrow();
-    expect(
-      pulseBundleRequestSchema.parse(minimalBundleRequest).bundle_request.input.metric
-        .representation_options,
-    ).toBeUndefined();
-  });
-
-  it('accepts a bundle request without insights_options', () => {
-    expect(() => pulseBundleRequestSchema.parse(minimalBundleRequest)).not.toThrow();
-    expect(
-      pulseBundleRequestSchema.parse(minimalBundleRequest).bundle_request.input.metric
-        .insights_options,
-    ).toBeUndefined();
-  });
-
-  it('accepts a bundle request without metric_specification.filters', () => {
-    expect(() => pulseBundleRequestSchema.parse(minimalBundleRequest)).not.toThrow();
-    expect(
-      pulseBundleRequestSchema.parse(minimalBundleRequest).bundle_request.input.metric
-        .metric_specification.filters,
-    ).toBeUndefined();
-  });
-
-  it('accepts a bundle request without metadata name, metric_id, or definition_id', () => {
-    expect(() => pulseBundleRequestSchema.parse(minimalBundleRequest)).not.toThrow();
+  it('accepts a bundle request without optional fields', () => {
+    const parsed = pulseBundleRequestSchema.parse(minimalBundleRequest);
+    const metric = parsed.bundle_request.input.metric;
+    expect(metric.extension_options).toBeUndefined();
+    expect(metric.representation_options).toBeUndefined();
+    expect(metric.insights_options).toBeUndefined();
+    expect(metric.metric_specification.filters).toBeUndefined();
   });
 
   it('accepts a bundle request with partial representation_options', () => {
@@ -240,27 +217,15 @@ describe('metricGroupContextSchema optionality', () => {
     },
   ];
 
-  it('accepts metric_group_context without extension_options', () => {
-    expect(() => metricGroupContextSchema.parse(minimalContext)).not.toThrow();
-  });
-
-  it('accepts metric_group_context without representation_options', () => {
-    expect(() => metricGroupContextSchema.parse(minimalContext)).not.toThrow();
-  });
-
-  it('accepts metric_group_context without insights_options', () => {
-    expect(() => metricGroupContextSchema.parse(minimalContext)).not.toThrow();
-  });
-
-  it('accepts metric_group_context without candidates', () => {
-    expect(() => metricGroupContextSchema.parse(minimalContext)).not.toThrow();
-  });
-
-  it('accepts metric_group_context without metadata.metric_id or definition_id', () => {
-    expect(() => metricGroupContextSchema.parse(minimalContext)).not.toThrow();
+  it('accepts metric_group_context without optional fields', () => {
     const parsed = metricGroupContextSchema.parse(minimalContext);
-    expect(parsed[0].metadata.metric_id).toBeUndefined();
-    expect(parsed[0].metadata.definition_id).toBeUndefined();
+    const ctx = parsed[0];
+    expect(ctx.metric.extension_options).toBeUndefined();
+    expect(ctx.metric.representation_options).toBeUndefined();
+    expect(ctx.metric.insights_options).toBeUndefined();
+    expect(ctx.metric.candidates).toBeUndefined();
+    expect(ctx.metadata.metric_id).toBeUndefined();
+    expect(ctx.metadata.definition_id).toBeUndefined();
   });
 
   it('still requires metadata.name', () => {

--- a/src/sdks/tableau/types/pulse.test.ts
+++ b/src/sdks/tableau/types/pulse.test.ts
@@ -165,31 +165,6 @@ describe('pulseBundleRequestSchema optionality', () => {
     };
     expect(() => pulseBundleRequestSchema.parse(req)).not.toThrow();
   });
-
-  it('still requires datasource.id', () => {
-    const req = structuredClone(minimalBundleRequest);
-    // @ts-expect-error - intentionally removing required field
-    req.bundle_request.input.metric.definition.datasource = {};
-    expect(() => pulseBundleRequestSchema.parse(req)).toThrow();
-  });
-
-  it('still requires measure.field', () => {
-    const req = structuredClone(minimalBundleRequest);
-    // @ts-expect-error - intentionally removing required field
-    req.bundle_request.input.metric.definition.basic_specification.measure = {
-      aggregation: 'AGGREGATION_SUM',
-    };
-    expect(() => pulseBundleRequestSchema.parse(req)).toThrow();
-  });
-
-  it('still requires measurement_period.granularity', () => {
-    const req = structuredClone(minimalBundleRequest);
-    // @ts-expect-error - intentionally removing required field
-    req.bundle_request.input.metric.metric_specification.measurement_period = {
-      range: 'RANGE_LAST_COMPLETE',
-    };
-    expect(() => pulseBundleRequestSchema.parse(req)).toThrow();
-  });
 });
 
 describe('metricGroupContextSchema optionality', () => {
@@ -226,20 +201,6 @@ describe('metricGroupContextSchema optionality', () => {
     expect(ctx.metric.candidates).toBeUndefined();
     expect(ctx.metadata.metric_id).toBeUndefined();
     expect(ctx.metadata.definition_id).toBeUndefined();
-  });
-
-  it('still requires metadata.name', () => {
-    const ctx = structuredClone(minimalContext);
-    // @ts-expect-error - intentionally removing required field
-    delete ctx[0].metadata.name;
-    expect(() => metricGroupContextSchema.parse(ctx)).toThrow();
-  });
-
-  it('still requires definition.datasource', () => {
-    const ctx = structuredClone(minimalContext);
-    // @ts-expect-error - intentionally removing required field
-    delete ctx[0].metric.definition.datasource;
-    expect(() => metricGroupContextSchema.parse(ctx)).toThrow();
   });
 });
 

--- a/src/sdks/tableau/types/pulse.test.ts
+++ b/src/sdks/tableau/types/pulse.test.ts
@@ -1,9 +1,8 @@
 import {
+  metricGroupContextSchema,
+  pulseBundleRequestSchema,
   PulseMetric,
   PulseMetricDefinition,
-  pulseBundleRequestSchema,
-  pulseInsightBriefRequestSchema,
-  metricGroupContextSchema,
   pulseMetricDefinitionSchema,
   pulseMetricDefinitionViewEnum,
   pulseMetricSchema,
@@ -145,17 +144,26 @@ describe('pulseBundleRequestSchema optionality', () => {
 
   it('accepts a bundle request without representation_options', () => {
     expect(() => pulseBundleRequestSchema.parse(minimalBundleRequest)).not.toThrow();
-    expect(pulseBundleRequestSchema.parse(minimalBundleRequest).bundle_request.input.metric.representation_options).toBeUndefined();
+    expect(
+      pulseBundleRequestSchema.parse(minimalBundleRequest).bundle_request.input.metric
+        .representation_options,
+    ).toBeUndefined();
   });
 
   it('accepts a bundle request without insights_options', () => {
     expect(() => pulseBundleRequestSchema.parse(minimalBundleRequest)).not.toThrow();
-    expect(pulseBundleRequestSchema.parse(minimalBundleRequest).bundle_request.input.metric.insights_options).toBeUndefined();
+    expect(
+      pulseBundleRequestSchema.parse(minimalBundleRequest).bundle_request.input.metric
+        .insights_options,
+    ).toBeUndefined();
   });
 
   it('accepts a bundle request without metric_specification.filters', () => {
     expect(() => pulseBundleRequestSchema.parse(minimalBundleRequest)).not.toThrow();
-    expect(pulseBundleRequestSchema.parse(minimalBundleRequest).bundle_request.input.metric.metric_specification.filters).toBeUndefined();
+    expect(
+      pulseBundleRequestSchema.parse(minimalBundleRequest).bundle_request.input.metric
+        .metric_specification.filters,
+    ).toBeUndefined();
   });
 
   it('accepts a bundle request without metadata name, metric_id, or definition_id', () => {
@@ -191,14 +199,18 @@ describe('pulseBundleRequestSchema optionality', () => {
   it('still requires measure.field', () => {
     const req = structuredClone(minimalBundleRequest);
     // @ts-expect-error - intentionally removing required field
-    req.bundle_request.input.metric.definition.basic_specification.measure = { aggregation: 'AGGREGATION_SUM' };
+    req.bundle_request.input.metric.definition.basic_specification.measure = {
+      aggregation: 'AGGREGATION_SUM',
+    };
     expect(() => pulseBundleRequestSchema.parse(req)).toThrow();
   });
 
   it('still requires measurement_period.granularity', () => {
     const req = structuredClone(minimalBundleRequest);
     // @ts-expect-error - intentionally removing required field
-    req.bundle_request.input.metric.metric_specification.measurement_period = { range: 'RANGE_LAST_COMPLETE' };
+    req.bundle_request.input.metric.metric_specification.measurement_period = {
+      range: 'RANGE_LAST_COMPLETE',
+    };
     expect(() => pulseBundleRequestSchema.parse(req)).toThrow();
   });
 });

--- a/src/sdks/tableau/types/pulse.ts
+++ b/src/sdks/tableau/types/pulse.ts
@@ -40,13 +40,13 @@ const pulseSpecificationSchema = z.object({
 });
 
 export const pulseExtensionOptionsSchema = z.object({
-  allowed_dimensions: z.array(z.string()),
-  allowed_granularities: z.array(z.string()),
-  offset_from_today: z.number(),
+  allowed_dimensions: z.array(z.string()).optional(),
+  allowed_granularities: z.array(z.string()).optional(),
+  offset_from_today: z.number().optional(),
 });
 
 export const pulseMetricSpecificationSchema = z.object({
-  filters: z.array(pulseFilterSchema),
+  filters: z.array(pulseFilterSchema).optional(),
   measurement_period: z.object({
     granularity: z.string(),
     range: z.string(),
@@ -72,22 +72,27 @@ export const pulseMetricSchema = z.object({
 
 export const pulseRepresentationOptionsSchema = z.object({
   type: z.string(),
-  number_units: z.object({
-    singular_noun: z.string(),
-    plural_noun: z.string(),
-  }),
-  sentiment_type: z.string(),
-  row_level_id_field: z.object({ identifier_col: z.string() }),
-  row_level_entity_names: z.object({
-    entity_name_singular: z.string().optional(),
-    entity_name_plural: z.string().optional(),
-  }),
-  row_level_name_field: z.object({ name_col: z.string() }),
-  currency_code: z.string(),
+  number_units: z
+    .object({
+      singular_noun: z.string().optional(),
+      plural_noun: z.string().optional(),
+    })
+    .optional(),
+  sentiment_type: z.string().optional(),
+  row_level_id_field: z.object({ identifier_col: z.string().optional() }).optional(),
+  row_level_entity_names: z
+    .object({
+      entity_name_singular: z.string().optional(),
+      entity_name_plural: z.string().optional(),
+    })
+    .optional(),
+  row_level_name_field: z.object({ name_col: z.string().optional() }).optional(),
+  currency_code: z.string().optional(),
 });
 
 export const insightOptionsSchema = z.object({
-  settings: z.array(z.object({ type: z.string(), disabled: z.boolean() })),
+  show_insights: z.boolean().optional(),
+  settings: z.array(z.object({ type: z.string(), disabled: z.boolean() })).optional(),
 });
 
 export const comparisonSchema = z.object({
@@ -301,22 +306,22 @@ export const metricGroupContextSchema = z.array(
   z.object({
     metadata: z.object({
       name: z.string(),
-      metric_id: z.string(),
-      definition_id: z.string(),
+      metric_id: z.string().optional(),
+      definition_id: z.string().optional(),
     }),
     metric: z.object({
       definition: pulseSpecificationSchema,
       metric_specification: pulseMetricSpecificationSchema,
-      extension_options: pulseExtensionOptionsSchema,
-      representation_options: pulseRepresentationOptionsSchema,
-      insights_options: insightOptionsSchema,
+      extension_options: pulseExtensionOptionsSchema.optional(),
+      representation_options: pulseRepresentationOptionsSchema.optional(),
+      insights_options: insightOptionsSchema.optional(),
       goals: z
         .object({
           datasource_goals: datasourceGoalsSchema.optional(),
           metric_goals: pulseGoalsSchema.optional(),
         })
         .optional(),
-      candidates: z.array(pulseCorrelationCandidateDefinitionSchema),
+      candidates: z.array(pulseCorrelationCandidateDefinitionSchema).optional(),
     }),
   }),
 );
@@ -361,9 +366,9 @@ export const pulseBundleRequestSchema = z.object({
           is_running_total: z.boolean(),
         }),
         metric_specification: pulseMetricSpecificationSchema,
-        extension_options: pulseExtensionOptionsSchema,
-        representation_options: pulseRepresentationOptionsSchema,
-        insights_options: insightOptionsSchema,
+        extension_options: pulseExtensionOptionsSchema.optional(),
+        representation_options: pulseRepresentationOptionsSchema.optional(),
+        insights_options: insightOptionsSchema.optional(),
         goals: pulseGoalsSchema.optional(),
       }),
     }),


### PR DESCRIPTION
The Zod schemas for the insight bundle and brief tools required several fields that are optional in the Pulse Insights API proto definitions. This caused agents to fail at schema validation before the API call was even made — they had to fabricate empty strings for fields like number_units.singular_noun or row_level_id_field that the API does not require.

Fields made optional to match the proto:
- representation_options: number_units, sentiment_type, row_level_id_field, row_level_entity_names, row_level_name_field, currency_code, and all sub-fields
- extension_options: allowed_dimensions, allowed_granularities, offset_from_today
- insights_options: settings array, added show_insights field
- metric_specification.filters
- metricGroupContext: extension_options, representation_options, insights_options, candidates, metadata.metric_id, metadata.definition_id
- Bundle request: extension_options, representation_options, insights_options

Adds 16 tests verifying that minimal payloads (without optional fields) pass schema validation, while truly required fields (datasource.id, measure.field, granularity, etc.) still reject.

**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of
the pull request._

# Pull Request Template

<!-- Thank you for your contribution! Please fill out the following template to help us review your pull
request! -->

## Description

<!-- Please include a summary of the change. -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## How Has This Been Tested?

<!-- Please describe the tests that you performed to verify your changes. -->

## Related Issues

<!-- List any related issues, pull requests, or discussions. -->

## Checklist

- [ ] I have updated the version in the package.json file by using `npm run version`. For example,
      use `npm run version:patch` for a patch version bump.
- [ ] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have documented any breaking changes in the PR description. For example, renaming a config
      environment variable or changing its default value.

## Contributor Agreement

By submitting this pull request, I confirm that:

- [ ] I have read the [CONTRIBUTING guidelines](../../CONTRIBUTING.md) for this project and followed
      its Contribution Checklist.
