### PR TITLE
Add comprehensive Pulse service error code guidance

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "2.21.0",
+  "version": "2.21.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "2.21.0",
+      "version": "2.21.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.7.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "2.21.0",
+  "version": "2.21.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/src/errors/pulseInsightsApiError.test.ts
+++ b/src/errors/pulseInsightsApiError.test.ts
@@ -49,12 +49,34 @@ describe('formatPulseInsightsApiError', () => {
   });
 
   it.each([
+    // Definition specification
     ['400901', 'Missing measure field'],
     ['400902', 'Missing time dimension field'],
     ['400914', 'Invalid measure aggregation'],
+    ['400987', 'Missing basic specification'],
+    // Measurement period / comparison
+    ['400945', 'No measurement period present'],
     ['400946', 'No granularity specified'],
     ['400947', 'No range specified'],
+    ['400948', 'No comparison config present'],
+    // Constraints
+    ['400969', 'is_running_total cannot be true'],
     ['400972', 'Invalid input metric'],
+    // Auth
+    ['401003', 'Datasource authentication failed'],
+    ['403901', 'User lacks permissions on this datasource'],
+    ['403905', 'define metrics'],
+    // Not found
+    ['404900', 'Core metric (definition) not found'],
+    ['404939', 'Datasource is inaccessible'],
+    // Conflict
+    ['409902', 'same specification already exists'],
+    // Rate limiting
+    ['429956', 'already attempted in the past 24 hours'],
+    // Timeout
+    ['408901', 'Request timed out'],
+    // Server errors
+    ['500900', 'retryable'],
   ])('provides guidance for error code %s', (code, expectedFragment) => {
     const result = formatPulseInsightsApiError(400, { code, message: '0x00000000' });
     expect(result.message).toContain(expectedFragment);

--- a/src/errors/pulseInsightsApiError.ts
+++ b/src/errors/pulseInsightsApiError.ts
@@ -1,7 +1,77 @@
 const PULSE_INSIGHTS_ERROR_GUIDANCE: Record<string, string> = {
-  // Measurement period / comparison
+  // ── General ──────────────────────────────────────────────────────
+  '400000':
+    'General validation error. Check that: version is 1, at least one metric is provided, all metric keys are unique and non-empty, and input counts are within limits.',
+
+  // ── Time / format validation (400700-series) ─────────────────────
+  '400700': 'Invalid time format.',
+  '400701': 'Invalid user LUID.',
+  '400702': 'Invalid site LUID.',
   '400732':
     'Invalid measurement period. Check that the date format is YYYY-MM-DD and that start/end dates are valid.',
+  '400733': 'Invalid order-by field.',
+  '400734': 'Invalid order-by direction.',
+  '400735': 'Invalid order-by format.',
+  '400736': 'Invalid filter format.',
+  '400737': 'Invalid filter operator.',
+  '400738': 'Invalid filter date format.',
+  '400739': 'Invalid dynamic offset configuration.',
+  '400740': 'Invalid pagination token.',
+  '400741': 'Prompt exceeds the token limit.',
+
+  // ── Definition specification (400900-series) ─────────────────────
+  '400900': 'Missing filter field name.',
+  '400901':
+    'Missing measure field. Ensure basic_specification.measure.field is a non-empty string.',
+  '400902': 'Missing time dimension field. Ensure basic_specification.time_dimension.field is set.',
+  '400903':
+    'Invalid definition type. Use either basic_specification, abstract_query_specification, or viz_state_specification.',
+  '400904': 'Missing abstract query definition.',
+  '400905': 'Missing definition field.',
+  '400906': 'User link exceeds character limit.',
+  '400907': 'Invalid user link.',
+  '400908': 'Metric model is missing required fields.',
+  '400909': 'Metadata is missing required fields.',
+  '400910': 'Invalid datasource ID.',
+  '400911': 'Invalid field mask.',
+  '400912': 'Missing core metric name.',
+  '400913': 'Missing datasource.',
+  '400914':
+    'Invalid measure aggregation. Set basic_specification.measure.aggregation to a valid value (e.g., AGGREGATION_SUM, AGGREGATION_AVERAGE, AGGREGATION_USER).',
+  '400915': 'Default metric cannot be deleted.',
+  '400916': 'Exceeded maximum total scoped metrics for this definition.',
+  '400917': 'Invalid filter value.',
+  '400918': 'Invalid query input fields.',
+  '400919': 'Invalid record-level identifier.',
+  '400920': 'Invalid field value.',
+  '400921': 'Unsupported aggregation function.',
+  '400922': 'Invalid comparisons field.',
+  '400923': 'Invalid scoped metric ID.',
+  '400924': 'BigQuery connection error.',
+  '400925': 'Datasource info retrieval error.',
+  '400926': 'Incorrect data type.',
+  '400927': 'Database general error.',
+  '400928': 'Invalid formula.',
+  '400929': 'Value too large.',
+  '400930': 'Calculated field is already aggregated.',
+  '400931': 'Context canceled.',
+  '400932': 'Invalid definition ID.',
+  '400933': 'Invalid abstract query specification.',
+  '400934': 'Invalid parameters — over capacity.',
+  '400935': 'Invalid viz state specification.',
+  '400936': 'Invalid granularity value.',
+  '400937': 'Exceeded maximum total ACL objects for definition.',
+  '400938': 'Invalid argument for entitlements.',
+
+  // ── Filters ──────────────────────────────────────────────────────
+  '400940': 'Filter operator is missing or unspecified.',
+  '400941':
+    'Filter value is missing. Provide at least one value. Filters cannot mix string and boolean data types.',
+  '400942': 'Abstract query output fields count error.',
+  '400943': 'Viz state is missing a column.',
+  '400944': 'Viz state is missing a row.',
+
+  // ── Measurement period / comparison ──────────────────────────────
   '400945':
     'No measurement period present. Set metric_specification.measurement_period with both granularity and range.',
   '400946':
@@ -13,56 +83,117 @@ const PULSE_INSIGHTS_ERROR_GUIDANCE: Record<string, string> = {
   '400949':
     'No comparison type specified, or BY_CONFIG comparison is missing the required specific_comparison config.',
 
-  // Definition specification
-  '400900': 'Missing filter field name.',
-  '400901':
-    'Missing measure field. Ensure basic_specification.measure.field is a non-empty string.',
-  '400902': 'Missing time dimension field. Ensure basic_specification.time_dimension.field is set.',
-  '400903':
-    'Invalid definition type. Use either basic_specification, abstract_query_specification, or viz_state_specification.',
-  '400905': 'Missing definition field.',
-  '400910': 'Invalid datasource ID.',
-  '400913': 'Missing datasource.',
-  '400914':
-    'Invalid measure aggregation. Set basic_specification.measure.aggregation to a valid value (e.g., AGGREGATION_SUM, AGGREGATION_AVERAGE, AGGREGATION_USER).',
-  '400936': 'Invalid granularity value.',
-  '400987':
-    'Missing basic specification. Ensure definition includes a basic_specification with measure and time_dimension.',
-
-  // Filters
-  '400940': 'Filter operator is missing or unspecified.',
-  '400941':
-    'Filter value is missing. Provide at least one value, or mixed string and boolean data types in the same filter.',
-
-  // Extension options / scoping
-  '400969': 'Conflicting options: is_running_total cannot be true when is_summable is false.',
-  '400972':
-    'Invalid input metric. Time dimension must be absent when both range and comparison are unspecified.',
-  '400988': 'Missing extension_options.',
-
-  // Field values
-  '400958': 'Missing or incorrectly formatted field ID.',
-  '400960': 'Field ID not set in the request.',
-  '400970': 'Unsupported field type for the requested operation.',
-
-  // GAI / insights
-  '400955': 'AI-powered insights (GAI) is not enabled for this site.',
-  '400957': 'Missing insight options.',
-  '400983': 'Missing representation options.',
-
-  // Bundle-specific
+  // ── Bundle-specific ──────────────────────────────────────────────
   '400950': 'Invalid bundle type.',
   '400951': 'Invalid timezone.',
   '400952': 'Invalid date override.',
+  '400953': 'Invalid GAI feedback.',
+  '400954': 'Invalid GAI generation ID.',
+  '400955': 'AI-powered insights (GAI) is not enabled for this site.',
+  '400956': 'Invalid insight feedback.',
+  '400957': 'Missing insight options.',
 
-  // General
-  '400000':
-    'General validation error. Check that: version is 1, at least one metric is provided, all metric keys are unique and non-empty, and input counts are within limits.',
+  // ── Field values ─────────────────────────────────────────────────
+  '400958': 'Missing or incorrectly formatted field ID.',
+  '400959': 'Invalid page size.',
+  '400960': 'Field ID not set in the request.',
+  '400961': 'Query parameters not valid.',
+  '400962': 'Previous offset not valid.',
+  '400963': 'Invalid page offset.',
+  '400964': 'Invalid metric ID.',
+  '400965': 'Invalid allowed dimensions.',
+  '400966': 'VDS column not found.',
+  '400967': 'Database configuration issue.',
+  '400968': 'Invalid VDS abstract query argument.',
+
+  // ── Constraint violations ────────────────────────────────────────
+  '400969': 'Conflicting options: is_running_total cannot be true when is_summable is false.',
+  '400970': 'Unsupported field type for the requested operation.',
+  '400971':
+    'Unknown definition specification type. Use either basic_specification, abstract_query_specification, or viz_state_specification.',
+  '400972':
+    'Invalid input metric. Time dimension must be absent when both range and comparison are unspecified.',
+  '400973': 'Incompatible time dimension field role.',
+  '400974': 'Incompatible time dimension data type.',
+  '400975': 'Incompatible aggregation data type.',
+  '400976': 'User has no subscriptions.',
+  '400977': 'Invalid locale.',
+  '400978': 'Invalid currency code.',
+  '400979': 'Invalid record-level name data type.',
+  '400980': 'Invalid record-level ID data type.',
+  '400981': 'Record-level ID is empty.',
+  '400982': 'Query canceled.',
+  '400983': 'Missing representation options.',
+  '400984': 'Missing datasource goal specification.',
+  '400985': 'Unsupported datasource goal specification.',
+  '400986': 'Unsupported aggregation for datasource goals.',
+  '400987':
+    'Missing basic specification. Ensure definition includes a basic_specification with measure and time_dimension.',
+  '400988': 'Missing extension_options.',
+  '400999': 'Pulse feature is disabled on this site.',
+
+  // ── Authentication / authorization ───────────────────────────────
+  '401002': 'Invalid authentication credentials.',
+  '401003':
+    'Datasource authentication failed. The datasource owner may need to re-authorize the OAuth connection in Tableau Cloud.',
+  '403900': 'User lacks required site permissions.',
+  '403901': 'User lacks permissions on this datasource.',
+  '403902': 'Permission denied: cannot edit this definition.',
+  '403903': 'Permission denied: cannot delete this definition.',
+  '403904': 'Permission denied: cannot edit goals.',
+  '403905':
+    'User lacks the "define metrics" permission on this datasource. Contact the datasource owner.',
+  '403906': 'Permission denied by entitlements.',
+  '403907': 'Connection to EGPT is forbidden.',
+
+  // ── Not found ────────────────────────────────────────────────────
+  '404900': 'Core metric (definition) not found.',
+  '404901': 'Scoped metric not found.',
+  '404902': 'Measure aggregation not found.',
+  '404903': 'Datasource semantic model not found.',
+  '404904': 'Datasource field not found.',
+  '404905': 'Field values not found.',
+  '404906': 'Batch not found.',
+  '404907': 'Site not found.',
+  '404908': 'Datasource goal field not found.',
+  '404931': 'Formula contains a table calculation, which is not supported.',
+  '404932': 'Field does not exist.',
+  '404933': 'Base column does not exist.',
+  '404934': 'Unknown field.',
+  '404935': 'Database table is missing.',
   '404936': 'Missing datasource ID or definition specification.',
+  '404937': 'Record-level name field does not exist in the datasource.',
+  '404938': 'Record-level ID field does not exist in the datasource.',
+  '404939': 'Datasource is inaccessible.',
+  '404950': 'API endpoint not found.',
+  '404957': 'Summary not found.',
+  '404958': 'Alert not found.',
 
-  // Duplicate detection
+  // ── Timeout ──────────────────────────────────────────────────────
+  '408901': 'Request timed out (context deadline exceeded). Try again or simplify the request.',
+
+  // ── Conflict / duplicate ─────────────────────────────────────────
+  '409901': 'A scoped metric with the same definition already exists.',
   '409902':
     'A metric definition with the same specification already exists. Change the measure, aggregation, time dimension, or definition filters.',
+  '409903': 'A metric with the same name already exists for this datasource.',
+  '409904': 'Invalid viz state string.',
+  '409905': 'Goals are not supported on this metric type.',
+  '409906': 'Invalid offset_from_today value.',
+  '409907': 'Duplicate tag.',
+  '409908': 'Tag not found.',
+  '409909': 'VDS conflict error.',
+
+  // ── Rate limiting ────────────────────────────────────────────────
+  '423900': 'Entitlements resource is locked.',
+  '429900': 'Entitlements resource exhausted.',
+  '429956': 'Summary generation was already attempted in the past 24 hours. Try again later.',
+  '429957': 'VDS resource exhausted. Try again later.',
+
+  // ── Server errors ────────────────────────────────────────────────
+  '500000': 'Internal service error.',
+  '500900': 'Internal service error (retryable). Try the request again.',
+  '503900': 'Entitlements service is unavailable. Try again later.',
 };
 
 export function formatPulseInsightsApiError(


### PR DESCRIPTION
Expand the error guidance map from ~30 codes to the full set of Pulse service error codes covering all categories: definition validation, measurement periods, filters, authentication, permissions, not-found, conflicts, rate limiting, timeouts, and server errors.

Notably adds auth codes (401002, 401003, 403900-403907) so agents can surface actionable messages when datasource credentials expire or users lack permissions, instead of opaque HTTP status codes.

**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of
the pull request._

# Pull Request Template

<!-- Thank you for your contribution! Please fill out the following template to help us review your pull
request! -->

## Description

<!-- Please include a summary of the change. -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## How Has This Been Tested?

<!-- Please describe the tests that you performed to verify your changes. -->

## Related Issues

<!-- List any related issues, pull requests, or discussions. -->

## Checklist

- [ ] I have updated the version in the package.json file by using `npm run version`. For example,
      use `npm run version:patch` for a patch version bump.
- [ ] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have documented any breaking changes in the PR description. For example, renaming a config
      environment variable or changing its default value.

## Contributor Agreement

By submitting this pull request, I confirm that:

- [ ] I have read the [CONTRIBUTING guidelines](../../CONTRIBUTING.md) for this project and followed
      its Contribution Checklist.
