### PR TITLE
Classifier plural-boundary fix + lockstep mirror gate

### DIFF
--- a/lockstep.hashes.json
+++ b/lockstep.hashes.json
@@ -1,0 +1,4 @@
+{
+  "src/desktop/binder/escape.ts": "3c79bcf77c33fad64975e95ea57df5fb3e416008633e15dc7a585018fbc92d3f",
+  "src/desktop/templates/fieldReferenceRewriter.ts": "16bf6cd00eea6d8dfcde797449ecd9fa8bfa8ff21ad81f87fa06e3f0b2f375a9"
+}

--- a/scripts/agent-check
+++ b/scripts/agent-check
@@ -61,6 +61,13 @@ else
   skip "unit tests (npx unavailable)"
 fi
 
+# ---- Lockstep-core hash gate (W14-LS1 mirror; see scripts/check-lockstep.mjs) --
+if have node; then
+  run "lockstep-core hash gate" node scripts/check-lockstep.mjs
+else
+  skip "lockstep-core hash gate (node unavailable)"
+fi
+
 # ---- Verdict -----------------------------------------------------------------
 echo
 if [ "$ran" -eq 0 ]; then

--- a/scripts/check-lockstep.mjs
+++ b/scripts/check-lockstep.mjs
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+// scripts/check-lockstep.mjs
+//
+// LOCKSTEP-CORE HASH GATE (W14-LS1 mirror). This repo is the CANONICAL home of the
+// lockstep-core engine files; consumer repos (agent-to-tableau-desktop) carry
+// byte-identical copies verified by the same sha256 manifest. This gate fails when a
+// core file changes without `lockstep.hashes.json` being regenerated — making silent
+// drift impossible to merge on either side.
+//
+// Intentional engine change? Update the core file, then regenerate the manifest:
+//   node scripts/check-lockstep.mjs --update
+// and re-sync consumers (a2td: `node scripts/sync-lockstep-core.mjs`), so both repos'
+// manifests carry the same hashes — that equality IS the cross-repo invariant.
+
+import { createHash } from 'node:crypto';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, '..');
+const HASHES_REL = 'lockstep.hashes.json';
+
+const sha256 = (buf) => createHash('sha256').update(buf).digest('hex');
+
+const hashesPath = join(REPO_ROOT, HASHES_REL);
+const manifest = JSON.parse(readFileSync(hashesPath, 'utf8'));
+const entries = Object.entries(manifest);
+if (entries.length === 0) {
+  console.error(`[check-lockstep] FATAL: ${HASHES_REL} lists no files.`);
+  process.exit(2);
+}
+
+if (process.argv.includes('--update')) {
+  const updated = Object.fromEntries(
+    Object.keys(manifest).map((rel) => [rel, sha256(readFileSync(join(REPO_ROOT, rel)))]),
+  );
+  writeFileSync(hashesPath, JSON.stringify(updated, null, 2) + '\n');
+  console.log(`[check-lockstep] regenerated ${HASHES_REL} (${entries.length} files). Re-sync consumer repos.`);
+  process.exit(0);
+}
+
+const drift = [];
+for (const [rel, expected] of entries) {
+  let actual;
+  try {
+    actual = sha256(readFileSync(join(REPO_ROOT, rel)));
+  } catch (e) {
+    drift.push(`  MISSING  ${rel}  (${e.code ?? e.message})`);
+    continue;
+  }
+  if (actual !== expected) {
+    drift.push(`  DRIFT    ${rel}\n    expected ${expected}\n    actual   ${actual}`);
+  }
+}
+
+if (drift.length > 0) {
+  console.error(`[check-lockstep] FAIL: lockstep-core drift (${drift.length}/${entries.length}):`);
+  console.error(drift.join('\n'));
+  console.error(
+    `\n  These files are byte-locked with consumer repos. If this change is an intentional\n` +
+      `  engine update: \`node scripts/check-lockstep.mjs --update\`, commit the manifest with\n` +
+      `  the change, and re-sync consumers so both manifests carry identical hashes.`,
+  );
+  process.exit(1);
+}
+console.log(`[check-lockstep] OK: ${entries.length} lockstep-core file(s) match ${HASHES_REL}.`);

--- a/scripts/check-lockstep.mjs
+++ b/scripts/check-lockstep.mjs
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+/* eslint-disable no-console */
 // scripts/check-lockstep.mjs
 //
 // LOCKSTEP-CORE HASH GATE (W14-LS1 mirror). This repo is the CANONICAL home of the
@@ -21,6 +22,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(__dirname, '..');
 const HASHES_REL = 'lockstep.hashes.json';
 
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type -- plain .mjs, no TS annotations
 const sha256 = (buf) => createHash('sha256').update(buf).digest('hex');
 
 const hashesPath = join(REPO_ROOT, HASHES_REL);
@@ -36,7 +38,9 @@ if (process.argv.includes('--update')) {
     Object.keys(manifest).map((rel) => [rel, sha256(readFileSync(join(REPO_ROOT, rel)))]),
   );
   writeFileSync(hashesPath, JSON.stringify(updated, null, 2) + '\n');
-  console.log(`[check-lockstep] regenerated ${HASHES_REL} (${entries.length} files). Re-sync consumer repos.`);
+  console.log(
+    `[check-lockstep] regenerated ${HASHES_REL} (${entries.length} files). Re-sync consumer repos.`,
+  );
   process.exit(0);
 }
 
@@ -58,9 +62,9 @@ if (drift.length > 0) {
   console.error(`[check-lockstep] FAIL: lockstep-core drift (${drift.length}/${entries.length}):`);
   console.error(drift.join('\n'));
   console.error(
-    `\n  These files are byte-locked with consumer repos. If this change is an intentional\n` +
-      `  engine update: \`node scripts/check-lockstep.mjs --update\`, commit the manifest with\n` +
-      `  the change, and re-sync consumers so both manifests carry identical hashes.`,
+    '\n  These files are byte-locked with consumer repos. If this change is an intentional\n' +
+      '  engine update: `node scripts/check-lockstep.mjs --update`, commit the manifest with\n' +
+      '  the change, and re-sync consumers so both manifests carry identical hashes.',
   );
   process.exit(1);
 }

--- a/src/desktop/binder/classify.ts
+++ b/src/desktop/binder/classify.ts
@@ -109,6 +109,26 @@ function escapeRegex(s: string): string {
 }
 
 /**
+ * PLURALIZABLE CHART-NOUN TOKENS (FS4b token-class guard). Singular chart-type
+ * nouns whose natural English plural (`bar`→`bars`, `column`→`columns`, `map`→
+ * `maps`) an ask commonly uses ("Stacked bars", "Maps"). A keyword phrase earns a
+ * trailing-`s` tolerance in `phraseIndexInAsk` ONLY when its FINAL token is in this
+ * set, so the tolerance stays scoped to deterministic chart-type nouns and never
+ * broadens matching for a non-noun keyword (e.g. "trend"→"trends" stays a miss).
+ * A multi-token compound ("stacked-bar") pluralizes on its final token only. Kept
+ * as bare tokens (not the phrase set CHART_NOUN_KEYWORDS) because the plural sits on
+ * the final token — "stacked-bar"/"sorted-bar"/"vertical-bar" all pluralize via "bar".
+ */
+const PLURALIZABLE_CHART_NOUNS: ReadonlySet<string> = new Set([
+  'bar',
+  'column',
+  'map',
+  'treemap',
+  'pie',
+  'donut',
+]);
+
+/**
  * Index of the first whole-token occurrence of `phrase` in `ask`, else -1.
  * Boundaries are non-alphanumeric so "bar" matches "bar chart" but not "sidebar".
  * A HYPHEN in a keyword matches a hyphen OR whitespace in the ask, so a compound
@@ -116,12 +136,21 @@ function escapeRegex(s: string): string {
  * matches the natural spaced form a user types ("stacked bar", "over time"). This
  * lets a distinctive multi-token chart noun keep its keyword-match specificity when
  * the ask spells it with a space — the classifier stays no-LLM and deterministic.
+ *
+ * PLURAL TOLERANCE (FS4b): when the phrase's FINAL token is a chart noun
+ * (`PLURALIZABLE_CHART_NOUNS`), an optional trailing `s` is allowed on that token so
+ * "bars"/"columns"/"maps"/"stacked bars" match "bar"/"column"/"map"/"stacked-bar".
+ * Scoped to chart nouns only — no stemming, no mid-token change, no broadening of
+ * non-noun keywords; the singular still matches unchanged.
  */
 function phraseIndexInAsk(ask: string, phrase: string): number {
   const p = phrase.toLowerCase().trim();
   if (!p) return -1;
   const body = escapeRegex(p).replace(/-/g, '[\\s-]+');
-  const re = new RegExp(`(^|[^a-z0-9])${body}([^a-z0-9]|$)`);
+  const tokens = p.split(/[^a-z0-9]+/).filter(Boolean);
+  const finalToken = tokens[tokens.length - 1];
+  const pluralSuffix = finalToken && PLURALIZABLE_CHART_NOUNS.has(finalToken) ? 's?' : '';
+  const re = new RegExp(`(^|[^a-z0-9])${body}${pluralSuffix}([^a-z0-9]|$)`);
   const match = re.exec(ask.toLowerCase());
   return match ? match.index : -1;
 }

--- a/src/desktop/binder/within-family-disambiguation.test.ts
+++ b/src/desktop/binder/within-family-disambiguation.test.ts
@@ -314,6 +314,54 @@ describe('classifyNoLlm — geo slot name affinity', () => {
   });
 });
 
+// ── (5) PLURAL CHART-NOUN BOUNDARY (FS4b) ─────────────────────────────────────
+// phraseIndexInAsk tolerates a trailing plural `s` on the FINAL token of a keyword
+// phrase, but ONLY when that final token is a chart noun (bar→bars, column→columns,
+// map→maps, stacked-bar→stacked bars). Non-noun keywords get NO plural tolerance,
+// so matching is not broadened for them. Evidence asks: R008/R043 (stacked bars),
+// R020 (Maps).
+describe('classifyNoLlm — plural chart-noun boundary', () => {
+  it('binds when the ask pluralizes a single-token chart noun ("bars" → "bar")', () => {
+    const m = mapOf(synth('rank', 'ranking', ['bar'], catVal()));
+    const res = classifyNoLlm('bars of Sales by Region', m, SUMMARY);
+    expect(res).not.toBeNull();
+    expect(res!.template).toBe('rank');
+  });
+
+  it('binds when the ask pluralizes the FINAL token of a multi-token chart noun ("stacked bars" → "stacked-bar")', () => {
+    const m = mapOf(synth('p2w', 'part-to-whole', ['stacked-bar'], catVal()));
+    const res = classifyNoLlm('Stacked bars of Sales by Region', m, SUMMARY);
+    expect(res).not.toBeNull();
+    expect(res!.template).toBe('p2w');
+  });
+
+  it('binds when the ask pluralizes the "map" chart noun ("Maps" → "map")', () => {
+    const m = mapOf(synth('geo', 'spatial', ['map'], catVal()));
+    const res = classifyNoLlm('Maps of Sales by Region', m, SUMMARY);
+    expect(res).not.toBeNull();
+    expect(res!.template).toBe('geo');
+  });
+
+  it('does NOT grant plural tolerance to a non-chart-noun keyword ("trends" ≠ "trend")', () => {
+    const m = mapOf(synth('ts', 'time-series', ['trend'], catVal()));
+    expect(classifyNoLlm('trends of Sales by Region', m, SUMMARY)).toBeNull();
+  });
+
+  it('leaves an exact singular chart-noun match unchanged', () => {
+    const m = mapOf(synth('rank', 'ranking', ['bar'], catVal()));
+    const res = classifyNoLlm('bar chart of Sales by Region', m, SUMMARY);
+    expect(res).not.toBeNull();
+    expect(res!.template).toBe('rank');
+  });
+
+  it('tolerates ONLY a trailing +s, not a fuzzy prefix ("bare" ≠ "bar")', () => {
+    // Guards against over-broadening: the plural rule appends an optional `s`, so a
+    // longer word that merely starts with the noun ("bare") must still fail closed.
+    const m = mapOf(synth('rank', 'ranking', ['bar'], catVal()));
+    expect(classifyNoLlm('bare of Sales by Region', m, SUMMARY)).toBeNull();
+  });
+});
+
 // ── determinism ───────────────────────────────────────────────────────────────
 describe('classifyNoLlm — determinism', () => {
   it('same inputs produce identical selection + bindings', () => {


### PR DESCRIPTION
Two small post-convergence commits:

- **Plural-boundary routing (from the 101-real-ask sweep):** `phraseIndexInAsk` accepts a trailing plural s on a keyword phrase's final token only when it's a singular chart noun (bar/column/map/treemap/pie/donut) — 'Stacked bars' and 'Maps' now route while non-noun keywords get no tolerance ('bare' ≠ 'bar'). Guard proven load-bearing by TDD in both directions; 6 tests.
- **Lockstep mirror gate:** this repo is the canonical home of the lockstep-core engine files; agent-to-tableau-desktop carries sha256-locked copies. `scripts/check-lockstep.mjs` (agent-check's fourth check) fails when a core file changes without regenerating `lockstep.hashes.json` (`--update`), so silent cross-repo drift can't merge from either side. (One fix-forward commit lint-cleans the gate script — the middle commit pushed with a red lint check, orchestrator sequencing error, corrected immediately.)

agent-check ALL GREEN (4 checks) at HEAD.

---
Opened by MattGPT (Claude-operated automation) on Matt Filbert's behalf, at his request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)