### PR TITLE
Lockstep round 2: freeze the canonical data-contract core (5 files)

### DIFF
--- a/lockstep.hashes.json
+++ b/lockstep.hashes.json
@@ -1,4 +1,7 @@
 {
+  "src/desktop/binder/calc-derivation.ts": "5105d466e3c31019affa91320edf3047259301ca5cd27aeb5883ba1faa251098",
   "src/desktop/binder/escape.ts": "3c79bcf77c33fad64975e95ea57df5fb3e416008633e15dc7a585018fbc92d3f",
+  "src/desktop/binder/manifest-types.ts": "9ce310c1e294d3784084b854edf52ef4f7c4cf7a8e13ebba7071dc3957c6114d",
+  "src/desktop/binder/manifest-validation.ts": "e29ecfa9e10e57593a4f72e498f35ca8b1b28a1227fc0cb4aed057870566df60",
   "src/desktop/templates/fieldReferenceRewriter.ts": "16bf6cd00eea6d8dfcde797449ecd9fa8bfa8ff21ad81f87fa06e3f0b2f375a9"
 }

--- a/src/desktop/binder/calc-derivation.ts
+++ b/src/desktop/binder/calc-derivation.ts
@@ -17,7 +17,6 @@
 // so the two can never silently drift (the same sync pattern as computeFixtureBind).
 
 import type { CalcInput, CalcResultRole, CalcSlot, SlotKind, SlotSpec } from './manifest-types.js';
-import { bareName } from './schema-summary.js';
 
 /** A calc column parsed from template XML. */
 export interface ParsedCalc {
@@ -73,7 +72,9 @@ export function parseTemplateCalcs(xml: string): ParsedCalc[] {
     const colAttrs = m[1];
     const nameAttr = attr(colAttrs, 'name');
     if (!nameAttr) continue;
-    const template_field = bareName(nameAttr);
+    // bareName inlined to keep this lockstep-core file import-pure (severs the divergent
+    // schema-summary edge): strip surrounding brackets, "[Region]" → "Region".
+    const template_field = nameAttr.replace(/^\[|\]$/g, '');
     if (seen.has(template_field)) continue;
     seen.add(template_field);
     const result_role: CalcResultRole =

--- a/src/desktop/binder/manifest-types.ts
+++ b/src/desktop/binder/manifest-types.ts
@@ -253,10 +253,11 @@ export interface GoldenSpec {
  * The facet names in `removed_facets` / `changed_facets` MUST be members of the golden-parity
  * gate's structural facet vocabulary; an unknown facet fails loud AT THE GATE.
  *
- * PORT NOTE (superset ported from A for A↔B manifest-shape convergence): B's `validateManifest`
- * treats a present `derivation` as PASS-THROUGH (unknown-but-typed), exactly like
- * `render_evidence` — the object-shape / closed-key-set / facet-vocabulary / parent-existence
- * cross-checks live at the golden-parity gate, not in this repo's shape validator.
+ * PORT NOTE (superset ported from A for A↔B manifest-shape convergence): `validateManifest`
+ * ENFORCES this shape — object-ness, the CLOSED key set {parent_template, removed_facets,
+ * changed_facets}, a non-empty `parent_template`, string[] facet lists of non-empty names,
+ * DISJOINT removed/changed sets, and a non-empty exemption union. The facet-vocabulary and
+ * parent-existence cross-checks still live at the golden-parity gate, not in this shape validator.
  */
 export interface DerivationContract {
   /** The template whose golden worksheet anchor this template derives from (e.g. `ww-ou-arrow`). */

--- a/src/desktop/binder/manifest-validation.test.ts
+++ b/src/desktop/binder/manifest-validation.test.ts
@@ -96,17 +96,6 @@ describe('binder/manifest-validation — the new superset fields are additive/pa
     expect(validateManifest(m)).toEqual([]);
   });
 
-  it('accepts an optional DerivationContract on the manifest (pass-through, not re-derived)', () => {
-    const m = baseManifest();
-    const derivation: DerivationContract = {
-      parent_template: 'ww-ou-arrow',
-      removed_facets: ['color-encoding-presence'],
-      changed_facets: ['diff-calc-on-cols'],
-    };
-    m.derivation = derivation;
-    expect(validateManifest(m)).toEqual([]);
-  });
-
   it('types a RenderStampLedgerEntry as an all-optional, fail-closed record', () => {
     // Not part of the on-disk manifest schema — a purely additive convergence type.
     // A partial line must still type-check (every field optional).
@@ -114,5 +103,82 @@ describe('binder/manifest-validation — the new superset fields are additive/pa
     const empty: RenderStampLedgerEntry = {};
     expect(partial.composite).toBe(91);
     expect(Object.keys(empty)).toHaveLength(0);
+  });
+});
+
+describe('binder/manifest-validation — validateManifest ENFORCES the DerivationContract shape (LR2-3)', () => {
+  // Attach a derivation block to a known-valid bundled manifest to exercise the ported shape gate
+  // (superset from A's manifest.ts). The facet-vocabulary / parent-existence cross-checks still
+  // live at the golden-parity gate — this validator only enforces object shape + closed vocab.
+  function withDerivation(d: unknown): unknown {
+    const base = structuredClone(loadManifests().get('ranking-ordered-bar')!) as unknown as Record<
+      string,
+      unknown
+    >;
+    base.derivation = d;
+    return base;
+  }
+
+  it('accepts a well-formed derivation block (disjoint, non-empty union)', () => {
+    const derivation: DerivationContract = {
+      parent_template: 'ww-ou-arrow',
+      removed_facets: ['color-encoding-presence'],
+      changed_facets: ['diff-calc-on-cols'],
+    };
+    expect(validateManifest(withDerivation(derivation))).toEqual([]);
+  });
+
+  it('rejects an UNKNOWN derivation key (closed-vocabulary discipline)', () => {
+    expect(
+      validateManifest(
+        withDerivation({
+          parent_template: 'p',
+          removed_facets: [],
+          changed_facets: ['mark-classes-per-pane'],
+          bogus: 1,
+        }),
+      ).join(' '),
+    ).toMatch(/unknown key 'bogus'/);
+  });
+
+  it('rejects a facet appearing in BOTH removed_facets and changed_facets (must be disjoint)', () => {
+    expect(
+      validateManifest(
+        withDerivation({
+          parent_template: 'p',
+          removed_facets: ['mark-classes-per-pane'],
+          changed_facets: ['mark-classes-per-pane'],
+        }),
+      ).join(' '),
+    ).toMatch(/disjoint/);
+  });
+
+  it('rejects an exemption-free derivation (omit the block for a non-derivation template)', () => {
+    expect(
+      validateManifest(
+        withDerivation({ parent_template: 'p', removed_facets: [], changed_facets: [] }),
+      ).join(' '),
+    ).toMatch(/no exempt facets/);
+  });
+
+  it('rejects a missing/empty parent_template and a non-string-array facet list', () => {
+    expect(
+      validateManifest(
+        withDerivation({
+          parent_template: '',
+          removed_facets: [],
+          changed_facets: ['mark-classes-per-pane'],
+        }),
+      ).join(' '),
+    ).toMatch(/parent_template/);
+    expect(
+      validateManifest(
+        withDerivation({
+          parent_template: 'p',
+          removed_facets: 'not-an-array',
+          changed_facets: ['mark-classes-per-pane'],
+        }),
+      ).join(' '),
+    ).toMatch(/removed_facets/);
   });
 });

--- a/src/desktop/binder/manifest-validation.ts
+++ b/src/desktop/binder/manifest-validation.ts
@@ -556,5 +556,59 @@ export function validateManifest(m: unknown): string[] {
     }
   }
 
+  // derivation is OPTIONAL (Lane G1 / H2.6): the anchored-derivation contract. When present it
+  // must be an object with EXACTLY {parent_template, removed_facets, changed_facets} — an unknown
+  // key fails loud (closed-vocabulary discipline). parent_template is a non-empty string; the two
+  // facet lists are string[] of non-empty strings, DISJOINT, and their union non-empty (an
+  // exemption-free contract is a no-op — omit it). The facet NAMES are cross-checked against the
+  // gate's structural vocabulary by a test (the loader stays decoupled from evals/); an unknown
+  // facet name still fails CLOSED at the gate (DerivationContractError).
+  if (m.derivation !== undefined) {
+    if (!isRecord(m.derivation)) {
+      errors.push(
+        'derivation must be an object { parent_template, removed_facets, changed_facets } when present',
+      );
+    } else {
+      const d = m.derivation;
+      const DERIVATION_KEYS: ReadonlySet<string> = new Set([
+        'parent_template',
+        'removed_facets',
+        'changed_facets',
+      ]);
+      for (const k of Object.keys(d)) {
+        if (!DERIVATION_KEYS.has(k)) {
+          errors.push(
+            `derivation: unknown key '${k}' (allowed: parent_template, removed_facets, changed_facets)`,
+          );
+        }
+      }
+      if (typeof d.parent_template !== 'string' || d.parent_template.trim().length === 0) {
+        errors.push('derivation.parent_template must be a non-empty string');
+      }
+      const facetListOk = (key: string): string[] => {
+        const v = d[key];
+        if (!isStringArray(v) || v.some((s) => s.trim().length === 0)) {
+          errors.push(`derivation.${key} must be a string[] of non-empty facet names`);
+          return [];
+        }
+        return v;
+      };
+      const removed = facetListOk('removed_facets');
+      const changed = facetListOk('changed_facets');
+      const removedSet = new Set(removed);
+      const overlap = changed.filter((f) => removedSet.has(f));
+      if (overlap.length > 0) {
+        errors.push(
+          `derivation: facet(s) [${overlap.join(', ')}] appear in BOTH removed_facets and changed_facets (must be disjoint)`,
+        );
+      }
+      if (removed.length + changed.length === 0) {
+        errors.push(
+          'derivation declares no exempt facets — omit the derivation block for an ordinary (non-derivation) template',
+        );
+      }
+    }
+  }
+
   return errors;
 }


### PR DESCRIPTION
One adjudicated lane (W20-A, LR2-1..4 of the spec-adjudicated round-2 design):

- manifest-types JSDoc canonicalized — the DerivationContract note now states the
  ENFORCED behavior, changed in the same pass as the enforcement (no byte-locked comment
  asserting stale semantics).
- calc-derivation made self-contained (bareName inlined; schema-summary edge severed) —
  the core is manifest-types ← calc-derivation ← manifest-validation with zero
  repo-specific imports.
- validateManifest gains the factory repo's derivation-contract shape gate; the old
  pass-through test replaced by its negative cases (unknown key / facet overlap /
  exemption-free) — strengthened, never weakened. 12 tests (net +4).
- lockstep.hashes.json re-locked at 5 files; the consumer repo carries sha256-equal
  copies (its sync PR stacks on a2td #162).

agent-check ALL GREEN (4 checks incl. mirror hash gate), 2,405 tests.

agent-check ALL GREEN (4 checks incl. mirror hash gate) on the restacked branch.

---
Opened by MattGPT (Claude-operated automation) on Matt Filbert's behalf, at his request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)