### PR TITLE
Arm facet slots in shipped manifests; freeze classify.ts as sixth lockstep-core file

### DIFF
--- a/lockstep.hashes.json
+++ b/lockstep.hashes.json
@@ -1,5 +1,6 @@
 {
   "src/desktop/binder/calc-derivation.ts": "5105d466e3c31019affa91320edf3047259301ca5cd27aeb5883ba1faa251098",
+  "src/desktop/binder/classify.ts": "3e4cf32ad029e3b481d88635418ddabbca1bc07df80ccd88785788581f5b4834",
   "src/desktop/binder/escape.ts": "3c79bcf77c33fad64975e95ea57df5fb3e416008633e15dc7a585018fbc92d3f",
   "src/desktop/binder/manifest-types.ts": "9ce310c1e294d3784084b854edf52ef4f7c4cf7a8e13ebba7071dc3957c6114d",
   "src/desktop/binder/manifest-validation.ts": "e29ecfa9e10e57593a4f72e498f35ca8b1b28a1227fc0cb4aed057870566df60",

--- a/src/desktop/binder/classify.ts
+++ b/src/desktop/binder/classify.ts
@@ -20,7 +20,38 @@ import Fuse from 'fuse.js';
 
 import { calcForcedSlotIds } from './calc-derivation.js';
 import type { Derivation, SlotKind, TemplateManifest } from './manifest-types.js';
-import { bareName, type SchemaField, type SchemaSummary } from './schema-summary.js';
+
+/**
+ * SCHEMA SHAPES + `bareName`, inlined so this file stays import-pure — it severs the
+ * divergent `./schema-summary.js` edge (the same convergence move calc-derivation.ts
+ * makes) so the classifier depends only on `./manifest-types.js` + `./calc-derivation.js`
+ * and a byte-identical copy resolves entirely within the shared lockstep-core set.
+ * These MIRROR the schema module's exported `SchemaField`/`SchemaSummary` structurally;
+ * the PRODUCER (`summarizeSchema`) still lives there — only the read-only shapes the
+ * classifier consumes are declared here.
+ */
+interface SchemaField {
+  name: string; // friendly name: caption ?? bare column name
+  caption?: string;
+  columnName: string; // bracketed local name, e.g. "[Region]"
+  role: 'dimension' | 'measure';
+  type: string; // "quantitative" | "nominal" | "ordinal" | ...
+  datatype: string; // "string" | "real" | "integer" | "date" | "datetime" | ...
+  datasource: string;
+  isAggregated: boolean;
+  column_ref: string; // straight from listAvailableFields, e.g. "[Superstore].[sum:Sales:qk]"
+}
+
+interface SchemaSummary {
+  /** The primary datasource — substituted for {{DATASOURCE}} and the expected home of every bound field. */
+  datasource: string;
+  fields: SchemaField[];
+}
+
+/** Strip surrounding brackets from a Tableau field name: "[Region]" -> "Region". */
+function bareName(name: string): string {
+  return name.replace(/^\[|\]$/g, '');
+}
 
 export interface LlmProposeInput {
   ask: string;

--- a/src/desktop/binder/facet.test.ts
+++ b/src/desktop/binder/facet.test.ts
@@ -10,14 +10,16 @@
 // no-cue / no-spare ask binds byte-identically to before. Fail-closed cues: a bare
 // "by <dim>" is ambiguous (could be a color encoding) and is EXCLUDED.
 //
-// tmcp's BUNDLED manifests do not (yet) carry facet slots — the re-snapshot lane
-// adds them via the factory manifests. So every test here uses an INLINE manifest
-// fixture carrying a facet slot, proving the classify.ts feature independent of the
-// bundled data state (see the "independent of bundled data" test below).
+// The inline-fixture tests below prove the classify.ts feature INDEPENDENT of the
+// bundled data state (see the "independent of bundled data" test). As of W27-B the
+// bundled trend-line-chart / ranking-ordered-bar manifests DO carry the optional facet
+// slot (facet_col / facet_row) — copied verbatim from the factory — so a final describe
+// block additionally proves the SHIPPED data end-to-end via loadManifests().
 
 import { describe, expect, it } from 'vitest';
 
 import { classifyNoLlm } from './classify.js';
+import { loadManifests } from './manifest.js';
 import type { Family, SlotKind, SlotSpec, TemplateManifest } from './manifest-types.js';
 import type { SchemaField, SchemaSummary } from './schema-summary.js';
 
@@ -212,5 +214,58 @@ describe('classifyNoLlm — optional small-multiples facet (W23-SM1)', () => {
     // { slot_id, field } (no `derivation`), which the resolver renders [none:…:nk].
     expect(facet).toEqual({ slot_id: 'facet_col', field: 'Region' });
     expect(facet).not.toHaveProperty('derivation');
+  });
+});
+
+// ── PRODUCT PATH: the SHIPPED bundled data (W27-B) ───────────────────────────
+// The inline-fixture tests above prove the classify.ts facet CODE. This block proves
+// the shipped DATA: W27-B copied the factory trend-line-chart / ranking-ordered-bar
+// manifests verbatim (each carrying the optional facet_col / facet_row slot + an
+// off-shelf [Facet] column decl). Loading the REAL bundled manifests (loadManifests())
+// and running a trellis ask exercises the exact path a caller hits — proving the W26-D
+// facet feature is now armed by the actual shipped data, not just inline fixtures.
+describe('classifyNoLlm — optional facet on the SHIPPED bundled manifests (W27-B product path)', () => {
+  const bundled = loadManifests();
+
+  it('the shipped trend-line-chart / ranking-ordered-bar manifests carry the optional facet slot', () => {
+    const facetCol = bundled.get('trend-line-chart')!.slots.find((s) => s.slot_id === 'facet_col');
+    expect(facetCol, 'shipped trend-line-chart carries facet_col').toBeDefined();
+    expect(facetCol!.required).toBe(false);
+    const facetRow = bundled
+      .get('ranking-ordered-bar')!
+      .slots.find((s) => s.slot_id === 'facet_row');
+    expect(facetRow, 'shipped ranking-ordered-bar carries facet_row').toBeDefined();
+    expect(facetRow!.required).toBe(false);
+  });
+
+  it('a trellis ask binds bundled trend-line-chart WITH facet_col from the spare named categorical', () => {
+    // Same trellis ask as the inline-fixture test, but against the FULL 39-manifest
+    // bundled load: 'line' selects the sole fast-path-eligible time-series template
+    // (trend-line-chart), the required slots take Order Date + Sales, and the explicit
+    // trellis cue appends the spare NAMED categorical (Region) to the optional facet_col.
+    const cls = classifyNoLlm(
+      'trellis line chart of Sales over Order Date by Region',
+      bundled,
+      SUMMARY,
+    );
+    expect(cls).not.toBeNull();
+    expect(cls!.template).toBe('trend-line-chart');
+    expect(cls!.bindings).toEqual([
+      { slot_id: 'order_date', field: 'Order Date' },
+      { slot_id: 'sales', field: 'Sales' },
+      { slot_id: 'facet_col', field: 'Region' },
+    ]);
+  });
+
+  it("FAIL-CLOSED on shipped data: a bare 'by <dim>' (no trellis cue) binds trend-line-chart WITHOUT a facet", () => {
+    // Invariant guard: the optional facet must not fire without an explicit cue, so the
+    // un-faceted default render stays byte-unchanged on the shipped manifests too.
+    const cls = classifyNoLlm('line chart of Sales over Order Date by Region', bundled, SUMMARY);
+    expect(cls).not.toBeNull();
+    expect(cls!.template).toBe('trend-line-chart');
+    expect(cls!.bindings).toEqual([
+      { slot_id: 'order_date', field: 'Order Date' },
+      { slot_id: 'sales', field: 'Sales' },
+    ]);
   });
 });

--- a/src/desktop/data/content-manifest.json
+++ b/src/desktop/data/content-manifest.json
@@ -162,8 +162,8 @@
     },
     {
       "path": "data-visualization-templates-xml/ranking-ordered-bar.xml",
-      "sha256": "0f9a70bfdca9171d40022364a94d0ee7fe036dc792f741ab104fc38dc6a28c4e",
-      "bytes": 2430
+      "sha256": "63040f0d4b4ee0f84f995a82ea0a7845453e078708e1cd55aa13f878ffc00d0e",
+      "bytes": 2514
     },
     {
       "path": "data-visualization-templates-xml/ranking-ordered-column.xml",
@@ -187,8 +187,8 @@
     },
     {
       "path": "data-visualization-templates-xml/trend-line-chart.xml",
-      "sha256": "a7b05cae4d0271b7459ab80b7120a4e8a474aa1483944cb0449e0fff7a138d11",
-      "bytes": 2020
+      "sha256": "fe35111190516e789d2db3666a7f4f86899e149839b203079a4e42f297c80f44",
+      "bytes": 2104
     },
     {
       "path": "data-visualization-templates-xml/ww-floating-bars.xml",
@@ -202,8 +202,8 @@
     },
     {
       "path": "template-manifests.index.json",
-      "sha256": "fe7fc0eb310ff22ba364b25dbf08511291f9dad97a4c46a89b042ca09a2b217c",
-      "bytes": 188962
+      "sha256": "28bf5505ca4ae09cf665c57429192d6cce58442ce360cd3fa07065a16f240456",
+      "bytes": 193330
     },
     {
       "path": "template-manifests/box-plot-chart.manifest.json",
@@ -357,8 +357,8 @@
     },
     {
       "path": "template-manifests/ranking-ordered-bar.manifest.json",
-      "sha256": "d1880b8a047d8e169b267e16d0e52a9f1b22a1f1684edf093df30ef230306575",
-      "bytes": 1186
+      "sha256": "ba1931651c6fa8f9871eba46af855d14a656e40671266c2f499aef05b2be7bb8",
+      "bytes": 3214
     },
     {
       "path": "template-manifests/ranking-ordered-column.manifest.json",
@@ -382,8 +382,8 @@
     },
     {
       "path": "template-manifests/trend-line-chart.manifest.json",
-      "sha256": "808d75660cdbaee08c9b34fc2f37467ac5e29433dd4d6eebafc1fb46f88e192c",
-      "bytes": 1924
+      "sha256": "a3f76e50ba83cc1a85656149de632bf29ec17b14b0eed601f70effabf050f6eb",
+      "bytes": 3908
     },
     {
       "path": "template-manifests/ww-floating-bars.manifest.json",

--- a/src/desktop/data/data-visualization-templates-xml/ranking-ordered-bar.xml
+++ b/src/desktop/data/data-visualization-templates-xml/ranking-ordered-bar.xml
@@ -18,6 +18,7 @@
       <datasource-dependencies datasource='{{DATASOURCE}}'>
         <column datatype='string' name='[Region]' role='dimension' type='nominal' />
         <column datatype='real' name='[Sales]' role='measure' type='quantitative' />
+        <column datatype='string' name='[Facet]' role='dimension' type='nominal' />
         <column-instance column='[Region]' derivation='None' name='[none:Region:nk]' pivot='key' type='nominal' />
         <column-instance column='[Sales]' derivation='Sum' name='[sum:Sales:qk]' pivot='key' type='quantitative' />
       </datasource-dependencies>

--- a/src/desktop/data/data-visualization-templates-xml/trend-line-chart.xml
+++ b/src/desktop/data/data-visualization-templates-xml/trend-line-chart.xml
@@ -9,6 +9,7 @@
       <datasource-dependencies datasource='{{DATASOURCE}}'>
         <column datatype='date' name='[Order Date]' role='dimension' type='ordinal' />
         <column datatype='real' name='[Sales]' role='measure' type='quantitative' />
+        <column datatype='string' name='[Facet]' role='dimension' type='nominal' />
         <column-instance column='[Sales]' derivation='Sum' name='[sum:Sales:qk]' pivot='key' type='quantitative' />
         <column-instance column='[Order Date]' derivation='Month-Trunc' name='[tmn:Order Date:qk]' pivot='key' type='quantitative' />
       </datasource-dependencies>

--- a/src/desktop/data/template-manifests.index.json
+++ b/src/desktop/data/template-manifests.index.json
@@ -2935,7 +2935,16 @@
       "fast_path_blockers": [],
       "portability_evidence": {
         "fixture_bind": true,
-        "render_verified": "live-2026-07-04"
+        "render_verified": "live-2026-07-04",
+        "render_evidence": {
+          "basis": "hand-stamp: live render + structural parity + human review (original generic-template stamp; no numeric structural-parity score was retained for this legacy stamp)",
+          "lane": "generic-template live-verify 2026-07-04 (original four: kpi / part-to-whole / ranking / time-series)",
+          "structural": null,
+          "critical_pass": "not recorded (legacy hand-stamp; earned by human review, pass-list ratio not retained)",
+          "high_pass": "not recorded (legacy hand-stamp; earned by human review, pass-list ratio not retained)",
+          "pixel_oracle": "none (generic template has no golden anchor; an anchor-only comparison is circular and is not credited)",
+          "gate_composite": null
+        }
       },
       "datasource_placeholder": true,
       "placeholders": [
@@ -2951,6 +2960,9 @@
         "lowest"
       ],
       "description": "Horizontal bars, one per category; bar length = measure; sorted descending by the measure.",
+      "avoid_when": [
+        "The 'top' here is positional layering — marks drawn on top of a reference line or another chart layer — not a top-N ranking; a positional or annotation placement is not a sorted bar chart."
+      ],
       "slots": [
         {
           "slot_id": "region",
@@ -2975,6 +2987,18 @@
           "kind": "quantitative",
           "bindable": true,
           "required": true
+        },
+        {
+          "slot_id": "facet_row",
+          "template_field": "Facet",
+          "derivation": "none",
+          "role": [
+            "rows"
+          ],
+          "kind": "categorical",
+          "bindable": true,
+          "required": false,
+          "notes": "OPTIONAL small-multiples facet (W23-SM1): a spare categorical dimension the binder places on rows AHEAD of the ranked category pill, trellising the ranking into stacked panes (one ranked bar set per member). Optional → EXCLUDED from the required-bindable fixture_bind set (only {region, sales} count), so fast_path_eligible does not move. Binds ONLY when the ask names/implies a by-<dim> facet (small multiples / trellis / per <dim> / for each) AND a spare categorical remains after the required slots — it never steals the ranked (region) dim, and a bare 'by <dim>' never facets (fail-closed). XML declares [Facet] as a datasource-dependency column the field-swap injector renames to the bound dim; on-shelf pill placement for a bound facet is applied downstream (the default sorted-bar render is byte-unchanged). Modeled on box-plot-chart's required:false facet."
         }
       ],
       "calcs": [],
@@ -3330,7 +3354,16 @@
       "fast_path_blockers": [],
       "portability_evidence": {
         "fixture_bind": true,
-        "render_verified": "live-2026-07-04"
+        "render_verified": "live-2026-07-04",
+        "render_evidence": {
+          "basis": "hand-stamp: live render + structural parity + human review (original generic-template stamp; no numeric structural-parity score was retained for this legacy stamp)",
+          "lane": "generic-template live-verify 2026-07-04 (original four: kpi / part-to-whole / ranking / time-series)",
+          "structural": null,
+          "critical_pass": "not recorded (legacy hand-stamp; earned by human review, pass-list ratio not retained)",
+          "high_pass": "not recorded (legacy hand-stamp; earned by human review, pass-list ratio not retained)",
+          "pixel_oracle": "none (generic template has no golden anchor; an anchor-only comparison is circular and is not credited)",
+          "gate_composite": null
+        }
       },
       "datasource_placeholder": true,
       "placeholders": [
@@ -3344,7 +3377,19 @@
         "time-series",
         "timeline",
         "by-month",
-        "sales-over-time"
+        "sales-over-time",
+        "year-over-year",
+        "yoy",
+        "prior-year",
+        "current-year",
+        "rolling",
+        "moving-average",
+        "moving-sum",
+        "running-total",
+        "month-over-month",
+        "period-over-period",
+        "forecast",
+        "change-over-time"
       ],
       "description": "A line of an aggregated measure over a truncated date on the x-axis; shows trend across time.",
       "slots": [
@@ -3370,6 +3415,18 @@
           "kind": "quantitative",
           "bindable": true,
           "required": true
+        },
+        {
+          "slot_id": "facet_col",
+          "template_field": "Facet",
+          "derivation": "none",
+          "role": [
+            "cols"
+          ],
+          "kind": "categorical",
+          "bindable": true,
+          "required": false,
+          "notes": "OPTIONAL small-multiples facet (W23-SM1): a spare categorical dimension the binder places on cols AHEAD of the truncated date pill, trellising the trend into side-by-side panes (one line per member). Optional → EXCLUDED from the required-bindable fixture_bind set (only {order_date, sales} count), so fast_path_eligible does not move. Binds ONLY when the ask names/implies a by-<dim> facet (small multiples / trellis / per <dim> / for each) AND a spare categorical remains after the required slots — a bare 'by <dim>' never facets (fail-closed), and it never steals a slot-bound dim. XML declares [Facet] as a datasource-dependency column the field-swap injector renames to the bound dim; on-shelf pill placement for a bound facet is applied downstream (the un-faceted default render is byte-unchanged). Modeled on box-plot-chart's required:false facet."
         }
       ],
       "calcs": [],

--- a/src/desktop/data/template-manifests/ranking-ordered-bar.manifest.json
+++ b/src/desktop/data/template-manifests/ranking-ordered-bar.manifest.json
@@ -4,16 +4,34 @@
   "readiness": "GREEN",
   "fast_path_eligible": true,
   "fast_path_blockers": [],
-  "portability_evidence": { "fixture_bind": true, "render_verified": "live-2026-07-04" },
+  "portability_evidence": {
+    "fixture_bind": true,
+    "render_verified": "live-2026-07-04",
+    "render_evidence": {
+      "basis": "hand-stamp: live render + structural parity + human review (original generic-template stamp; no numeric structural-parity score was retained for this legacy stamp)",
+      "lane": "generic-template live-verify 2026-07-04 (original four: kpi / part-to-whole / ranking / time-series)",
+      "structural": null,
+      "critical_pass": "not recorded (legacy hand-stamp; earned by human review, pass-list ratio not retained)",
+      "high_pass": "not recorded (legacy hand-stamp; earned by human review, pass-list ratio not retained)",
+      "pixel_oracle": "none (generic template has no golden anchor; an anchor-only comparison is circular and is not credited)",
+      "gate_composite": null
+    }
+  },
   "datasource_placeholder": true,
   "placeholders": ["TITLE", "DATASOURCE"],
   "intent_keywords": ["ranking", "sorted-bar", "bar", "top", "highest", "lowest"],
   "description": "Horizontal bars, one per category; bar length = measure; sorted descending by the measure.",
+  "avoid_when": [
+    "The 'top' here is positional layering — marks drawn on top of a reference line or another chart layer — not a top-N ranking; a positional or annotation placement is not a sorted bar chart."
+  ],
   "slots": [
     { "slot_id": "region", "template_field": "Region", "derivation": "none",
       "role": ["rows", "sort-dimension"], "kind": "categorical", "bindable": true, "required": true },
     { "slot_id": "sales", "template_field": "Sales", "derivation": "sum",
-      "role": ["cols", "sort-measure"], "kind": "quantitative", "bindable": true, "required": true }
+      "role": ["cols", "sort-measure"], "kind": "quantitative", "bindable": true, "required": true },
+    { "slot_id": "facet_row", "template_field": "Facet", "derivation": "none",
+      "role": ["rows"], "kind": "categorical", "bindable": true, "required": false,
+      "notes": "OPTIONAL small-multiples facet (W23-SM1): a spare categorical dimension the binder places on rows AHEAD of the ranked category pill, trellising the ranking into stacked panes (one ranked bar set per member). Optional \u2192 EXCLUDED from the required-bindable fixture_bind set (only {region, sales} count), so fast_path_eligible does not move. Binds ONLY when the ask names/implies a by-<dim> facet (small multiples / trellis / per <dim> / for each) AND a spare categorical remains after the required slots \u2014 it never steals the ranked (region) dim, and a bare 'by <dim>' never facets (fail-closed). XML declares [Facet] as a datasource-dependency column the field-swap injector renames to the bound dim; on-shelf pill placement for a bound facet is applied downstream (the default sorted-bar render is byte-unchanged). Modeled on box-plot-chart's required:false facet." }
   ],
   "calcs": [],
   "hazards": [

--- a/src/desktop/data/template-manifests/trend-line-chart.manifest.json
+++ b/src/desktop/data/template-manifests/trend-line-chart.manifest.json
@@ -4,17 +4,32 @@
   "readiness": "GREEN",
   "fast_path_eligible": true,
   "fast_path_blockers": [],
-  "portability_evidence": { "fixture_bind": true, "render_verified": "live-2026-07-04" },
+  "portability_evidence": {
+    "fixture_bind": true,
+    "render_verified": "live-2026-07-04",
+    "render_evidence": {
+      "basis": "hand-stamp: live render + structural parity + human review (original generic-template stamp; no numeric structural-parity score was retained for this legacy stamp)",
+      "lane": "generic-template live-verify 2026-07-04 (original four: kpi / part-to-whole / ranking / time-series)",
+      "structural": null,
+      "critical_pass": "not recorded (legacy hand-stamp; earned by human review, pass-list ratio not retained)",
+      "high_pass": "not recorded (legacy hand-stamp; earned by human review, pass-list ratio not retained)",
+      "pixel_oracle": "none (generic template has no golden anchor; an anchor-only comparison is circular and is not credited)",
+      "gate_composite": null
+    }
+  },
   "datasource_placeholder": true,
   "placeholders": ["TITLE", "DATASOURCE"],
-  "intent_keywords": ["trend", "over-time", "line", "time-series", "timeline", "by-month", "sales-over-time"],
+  "intent_keywords": ["trend", "over-time", "line", "time-series", "timeline", "by-month", "sales-over-time", "year-over-year", "yoy", "prior-year", "current-year", "rolling", "moving-average", "moving-sum", "running-total", "month-over-month", "period-over-period", "forecast", "change-over-time"],
   "description": "A line of an aggregated measure over a truncated date on the x-axis; shows trend across time.",
   "slots": [
     { "slot_id": "order_date", "template_field": "Order Date", "derivation": "tmn",
       "role": ["cols"], "kind": "temporal", "bindable": true, "required": true,
       "notes": "XML instance is [tmn:Order Date:qk] derivation='Month-Trunc'. 'tmn' is the real Month-Trunc short-form live Tableau writes; the manifest emits it verbatim (no normalization). templates.ts derivationMap keys both 'tmn' (canonical) and legacy 'tmo' to 'Month-Trunc'." },
     { "slot_id": "sales", "template_field": "Sales", "derivation": "sum",
-      "role": ["rows"], "kind": "quantitative", "bindable": true, "required": true }
+      "role": ["rows"], "kind": "quantitative", "bindable": true, "required": true },
+    { "slot_id": "facet_col", "template_field": "Facet", "derivation": "none",
+      "role": ["cols"], "kind": "categorical", "bindable": true, "required": false,
+      "notes": "OPTIONAL small-multiples facet (W23-SM1): a spare categorical dimension the binder places on cols AHEAD of the truncated date pill, trellising the trend into side-by-side panes (one line per member). Optional \u2192 EXCLUDED from the required-bindable fixture_bind set (only {order_date, sales} count), so fast_path_eligible does not move. Binds ONLY when the ask names/implies a by-<dim> facet (small multiples / trellis / per <dim> / for each) AND a spare categorical remains after the required slots \u2014 a bare 'by <dim>' never facets (fail-closed), and it never steals a slot-bound dim. XML declares [Facet] as a datasource-dependency column the field-swap injector renames to the bound dim; on-shelf pill placement for a bound facet is applied downstream (the un-faceted default render is byte-unchanged). Modeled on box-plot-chart's required:false facet." }
   ],
   "calcs": [],
   "hazards": [


### PR DESCRIPTION
Two change sets, one branch (shared worktree wave):

**Facet slots shipped (a95e7b7c).** Factory manifests/XML copied verbatim (cmp-verified byte-identical): optional `facet_col` on trend-line-chart, optional `facet_row` on ranking-ordered-bar, each with the `[Facet]` base column declared in template XML. Index + content-manifest regenerated via `buildTemplateManifests.ts` (idempotent; 39 templates, fast-path set byte-identical at 10). Product-path tests: a trellis ask against `loadManifests()` binds trend-line-chart with `facet_col=Region`; bare "by X" stays fail-closed with no facet.

**Classify freeze (7ffe1c31).** `classify.ts` becomes the sixth lockstep-core file: the `schema-summary.js` import is severed by inlining `bareName` + local `SchemaField`/`SchemaSummary` shapes (same self-containment move as `calc-derivation.ts`), then added to `lockstep.hashes.json`. Frozen sha256 `3e4cf32ad029e3b481d88635418ddabbca1bc07df80ccd88785788581f5b4834`. Controlled 100-case corpus proof pre/post: identical output hashes, zero outcome changes. a2td consumes via `sync-lockstep-core` next round.

`scripts/agent-check`: ALL GREEN (2416 tests, 6-file lockstep gate OK), exit 0 on the union of both change sets.

Opened by MattGPT (Claude-operated automation) on Matt Filbert's behalf, at his request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)