### PR TITLE
@W-23337643: export FeatureGateProvider and TelemetryProvider as types-only subpaths

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM node:22-alpine AS builder
 WORKDIR /app
 
 # Install all dependencies and skip lifecycle scripts
-COPY package.json package-lock.json tsconfig.json ./
+COPY package.json package-lock.json tsconfig.json tsconfig.providers.json ./
 RUN npm ci --ignore-scripts
 
 # Copy source and build

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "2.23.0",
+  "version": "2.24.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"
@@ -20,13 +20,19 @@
   },
   "exports": {
     ".": "./build/index.js",
-    "./tracing": "./build/telemetry/tracing.js"
+    "./tracing": "./build/telemetry/tracing.js",
+    "./features/featureGateProvider": {
+      "types": "./build/features/featureGateProvider.d.ts"
+    },
+    "./telemetry/telemetryProvider": {
+      "types": "./build/telemetry/telemetryProvider.d.ts"
+    }
   },
   "scripts": {
-    "build": "tsx src/scripts/build.ts",
-    "build:desktop": "tsx src/scripts/build.ts --variant desktop",
-    "build:combined": "tsx src/scripts/build.ts --variant combined",
-    "build:dev": "tsx src/scripts/build.ts --dev",
+    "build": "tsx src/scripts/build.ts && tsc --project tsconfig.providers.json",
+    "build:desktop": "tsx src/scripts/build.ts --variant desktop && tsc --project tsconfig.providers.json",
+    "build:combined": "tsx src/scripts/build.ts --variant combined && tsc --project tsconfig.providers.json",
+    "build:dev": "tsx src/scripts/build.ts --dev && tsc --project tsconfig.providers.json",
     "build:docker": "docker build -t tableau-mcp .",
     ":build:mcpb": "npx -y @anthropic-ai/mcpb pack . tableau-mcp.mcpb",
     "build:mcpb": "run-s build:manifest :build:mcpb",

--- a/src/features/featureGateProvider.ts
+++ b/src/features/featureGateProvider.ts
@@ -1,0 +1,17 @@
+/**
+ * Public, dependency-free provider contract for feature gating.
+ *
+ * This module is exposed as a package subpath (`@tableau/mcp-server/features/featureGateProvider`)
+ * so external deployments can implement a custom feature gate provider against a stable type,
+ * without importing the server's internal config schemas. Keep it free of runtime dependencies.
+ */
+
+/**
+ * Feature gate provider interface
+ */
+export interface FeatureGateProvider {
+  /**
+   * Check if a feature is enabled
+   */
+  isFeatureEnabled(featureName: string): boolean;
+}

--- a/src/features/init.ts
+++ b/src/features/init.ts
@@ -5,9 +5,9 @@
 import { resolve } from 'path';
 
 import { getConfig } from '../config.js';
+import type { FeatureGateProvider } from './featureGateProvider.js';
 import { log } from '../logging/logger.js';
 import { ServerFeatureGate } from './serverFeatureGate.js';
-import { FeatureGateProvider } from './types.js';
 
 // Re-export type for consumers
 export type { FeatureGateProvider };

--- a/src/features/init.ts
+++ b/src/features/init.ts
@@ -9,9 +9,6 @@ import { log } from '../logging/logger.js';
 import type { FeatureGateProvider } from './featureGateProvider.js';
 import { ServerFeatureGate } from './serverFeatureGate.js';
 
-// Re-export type for consumers
-export type { FeatureGateProvider };
-
 function isRecord(obj: unknown): obj is Record<string, unknown> {
   return typeof obj === 'object' && obj !== null && !Array.isArray(obj);
 }

--- a/src/features/init.ts
+++ b/src/features/init.ts
@@ -5,8 +5,8 @@
 import { resolve } from 'path';
 
 import { getConfig } from '../config.js';
-import type { FeatureGateProvider } from './featureGateProvider.js';
 import { log } from '../logging/logger.js';
+import type { FeatureGateProvider } from './featureGateProvider.js';
 import { ServerFeatureGate } from './serverFeatureGate.js';
 
 // Re-export type for consumers

--- a/src/features/serverFeatureGate.ts
+++ b/src/features/serverFeatureGate.ts
@@ -3,7 +3,7 @@ import path from 'path';
 
 import { log } from '../logging/logger.js';
 import { getDirname } from '../utils/getDirname.js';
-import { FeatureGateProvider } from './types.js';
+import type { FeatureGateProvider } from './featureGateProvider.js';
 
 const FEATURES_CONFIG_PATH = 'features.json';
 

--- a/src/features/types.ts
+++ b/src/features/types.ts
@@ -1,16 +1,6 @@
 import { z } from 'zod';
 
 /**
- * Feature gate provider interface
- */
-export interface FeatureGateProvider {
-  /**
-   * Check if a feature is enabled
-   */
-  isFeatureEnabled(featureName: string): boolean;
-}
-
-/**
  * Valid feature gate provider names
  */
 export const featureGateProviderSchema = z.enum(['server', 'custom']);

--- a/src/server/latencyMiddleware.test.ts
+++ b/src/server/latencyMiddleware.test.ts
@@ -2,7 +2,7 @@ import { AuthInfo } from '@modelcontextprotocol/sdk/server/auth/types.js';
 import { EventEmitter } from 'events';
 
 import * as telemetryInit from '../telemetry/init.js';
-import { TelemetryProvider } from '../telemetry/types.js';
+import type { TelemetryProvider } from '../telemetry/telemetryProvider.js';
 import { latencyMiddleware } from './latencyMiddleware.js';
 import { AuthenticatedRequest } from './oauth/types.js';
 

--- a/src/telemetry/init.ts
+++ b/src/telemetry/init.ts
@@ -7,7 +7,7 @@ import { resolve } from 'path';
 import { getConfig } from '../config.js';
 import { log } from '../logging/logger.js';
 import { NoOpTelemetryProvider } from './noop.js';
-import { TelemetryProvider } from './types.js';
+import type { TelemetryProvider } from './telemetryProvider.js';
 
 /**
  * Get all instance methods from a class prototype

--- a/src/telemetry/noop.ts
+++ b/src/telemetry/noop.ts
@@ -6,7 +6,7 @@
  * when telemetry is not needed.
  */
 
-import { TelemetryAttributes, TelemetryProvider } from './types.js';
+import type { TelemetryAttributes, TelemetryProvider } from './telemetryProvider.js';
 
 export class NoOpTelemetryProvider implements TelemetryProvider {
   initialize(): void {

--- a/src/telemetry/telemetryProvider.ts
+++ b/src/telemetry/telemetryProvider.ts
@@ -5,9 +5,7 @@
  * so external deployments can implement a custom telemetry provider against a stable type,
  * without importing the server's internal config schemas or zod. Keep it free of runtime dependencies.
  *
- * `TelemetryAttributes` is hand-written here (rather than `z.infer` of the internal
- * `telemetryAttributesSchema`) so this file has no runtime imports. A compile-time guard in
- * `./types.ts` asserts the two stay in sync.
+ * `TelemetryAttributes` is hand-written here to avoid runtime dependencies.
  */
 
 /**

--- a/src/telemetry/telemetryProvider.ts
+++ b/src/telemetry/telemetryProvider.ts
@@ -1,0 +1,60 @@
+/**
+ * Public, dependency-free provider contract for telemetry.
+ *
+ * This module is exposed as a package subpath (`@tableau/mcp-server/telemetry/telemetryProvider`)
+ * so external deployments can implement a custom telemetry provider against a stable type,
+ * without importing the server's internal config schemas or zod. Keep it free of runtime dependencies.
+ *
+ * `TelemetryAttributes` is hand-written here (rather than `z.infer` of the internal
+ * `telemetryAttributesSchema`) so this file has no runtime imports. A compile-time guard in
+ * `./types.ts` asserts the two stay in sync.
+ */
+
+/**
+ * Attributes/dimensions attached to a telemetry metric.
+ * Values can be strings, numbers, booleans, or undefined.
+ */
+export type TelemetryAttributes = Record<string, string | number | boolean | undefined>;
+
+/**
+ * Telemetry provider interface for metrics collection.
+ */
+export interface TelemetryProvider {
+  /**
+   * Initialize the telemetry provider.
+   */
+  initialize(): void;
+
+  /**
+   * Record a custom metric with the given name and attributes.
+   *
+   * @param name - The metric name (e.g., 'apm_mcp_tool_calls')
+   * @param value - The metric value (default: 1 for counters)
+   * @param attributes - Dimensions/tags for the metric
+   *
+   * @example
+   * ```typescript
+   * telemetry.recordMetric('apm_mcp_tool_calls', 1, {
+   *   tool_name: 'list-pulse-metric-subscriptions',
+   * });
+   * ```
+   */
+  recordMetric(name: string, value: number, attributes: TelemetryAttributes): void;
+
+  /**
+   * Record a histogram observation (e.g., latency) with the given name and attributes.
+   *
+   * @param name - The metric name (e.g., 'http_server_request_duration')
+   * @param value - The observed value (e.g., duration in milliseconds)
+   * @param attributes - Dimensions/tags for the metric
+   *
+   * @example
+   * ```typescript
+   * telemetry.recordHistogram('apm_mcp_tool_duration', 142.5, {
+   *   tool_name: 'get-datasource-metadata',
+   *   success: true,
+   * });
+   * ```
+   */
+  recordHistogram(name: string, value: number, attributes: TelemetryAttributes): void;
+}

--- a/src/telemetry/types.ts
+++ b/src/telemetry/types.ts
@@ -1,47 +1,5 @@
 import { z } from 'zod';
-
-/**
- * Telemetry provider interface for metrics collection.
- */
-export interface TelemetryProvider {
-  /**
-   * Initialize the telemetry provider.
-   */
-  initialize(): void;
-
-  /**
-   * Record a custom metric with the given name and attributes.
-   *
-   * @param name - The metric name (e.g., 'apm_mcp_tool_calls')
-   * @param value - The metric value (default: 1 for counters)
-   * @param attributes - Dimensions/tags for the metric
-   *
-   * @example
-   * ```typescript
-   * telemetry.recordMetric('apm_mcp_tool_calls', 1, {
-   *   tool_name: 'list-pulse-metric-subscriptions',
-   * });
-   * ```
-   */
-  recordMetric(name: string, value: number, attributes: TelemetryAttributes): void;
-
-  /**
-   * Record a histogram observation (e.g., latency) with the given name and attributes.
-   *
-   * @param name - The metric name (e.g., 'http_server_request_duration')
-   * @param value - The observed value (e.g., duration in milliseconds)
-   * @param attributes - Dimensions/tags for the metric
-   *
-   * @example
-   * ```typescript
-   * telemetry.recordHistogram('apm_mcp_tool_duration', 142.5, {
-   *   tool_name: 'get-datasource-metadata',
-   *   success: true,
-   * });
-   * ```
-   */
-  recordHistogram(name: string, value: number, attributes: TelemetryAttributes): void;
-}
+import type { TelemetryAttributes } from './telemetryProvider.js';
 
 /**
  * Schema for telemetry attributes.
@@ -51,7 +9,18 @@ export const telemetryAttributesSchema = z.record(
   z.string(),
   z.union([z.string(), z.number(), z.boolean(), z.undefined()]),
 );
-export type TelemetryAttributes = z.infer<typeof telemetryAttributesSchema>;
+
+// Compile-time guard: the hand-written `TelemetryAttributes` in ./telemetryProvider.ts must stay
+// structurally identical to the type inferred from `telemetryAttributesSchema`. If either drifts,
+// one of these assignments fails to type-check.
+type _AttributesInSyncA = z.infer<typeof telemetryAttributesSchema> extends TelemetryAttributes
+  ? true
+  : never;
+type _AttributesInSyncB = TelemetryAttributes extends z.infer<typeof telemetryAttributesSchema>
+  ? true
+  : never;
+const _attributesInSync: [_AttributesInSyncA, _AttributesInSyncB] = [true, true];
+void _attributesInSync;
 
 /**
  * Valid telemetry provider names

--- a/src/telemetry/types.ts
+++ b/src/telemetry/types.ts
@@ -1,26 +1,5 @@
 import { z } from 'zod';
 
-import type { TelemetryAttributes } from './telemetryProvider.js';
-
-/**
- * Schema for telemetry attributes.
- * Values can be strings, numbers, booleans, or undefined.
- */
-export const telemetryAttributesSchema = z.record(
-  z.string(),
-  z.union([z.string(), z.number(), z.boolean(), z.undefined()]),
-);
-
-// Compile-time guard: the hand-written `TelemetryAttributes` in ./telemetryProvider.ts must stay
-// structurally identical to the type inferred from `telemetryAttributesSchema`. If either drifts,
-// one of these assignments fails to type-check.
-type _AttributesInSyncA =
-  z.infer<typeof telemetryAttributesSchema> extends TelemetryAttributes ? true : never;
-type _AttributesInSyncB =
-  TelemetryAttributes extends z.infer<typeof telemetryAttributesSchema> ? true : never;
-const _attributesInSync: [_AttributesInSyncA, _AttributesInSyncB] = [true, true];
-void _attributesInSync;
-
 /**
  * Valid telemetry provider names
  */

--- a/src/telemetry/types.ts
+++ b/src/telemetry/types.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+
 import type { TelemetryAttributes } from './telemetryProvider.js';
 
 /**
@@ -13,12 +14,10 @@ export const telemetryAttributesSchema = z.record(
 // Compile-time guard: the hand-written `TelemetryAttributes` in ./telemetryProvider.ts must stay
 // structurally identical to the type inferred from `telemetryAttributesSchema`. If either drifts,
 // one of these assignments fails to type-check.
-type _AttributesInSyncA = z.infer<typeof telemetryAttributesSchema> extends TelemetryAttributes
-  ? true
-  : never;
-type _AttributesInSyncB = TelemetryAttributes extends z.infer<typeof telemetryAttributesSchema>
-  ? true
-  : never;
+type _AttributesInSyncA =
+  z.infer<typeof telemetryAttributesSchema> extends TelemetryAttributes ? true : never;
+type _AttributesInSyncB =
+  TelemetryAttributes extends z.infer<typeof telemetryAttributesSchema> ? true : never;
 const _attributesInSync: [_AttributesInSyncA, _AttributesInSyncB] = [true, true];
 void _attributesInSync;
 

--- a/tsconfig.providers.json
+++ b/tsconfig.providers.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "outDir": "./build",
+    "rootDir": "./src",
+    "types": []
+  },
+  "include": ["src/features/featureGateProvider.ts", "src/telemetry/telemetryProvider.ts"],
+  "exclude": ["node_modules", "tests"]
+}


### PR DESCRIPTION
## Summary

Export `FeatureGateProvider` and `TelemetryProvider` as **types-only** npm package subpaths so external deployments (e.g., `tabhf-mcp-svc`) can implement custom providers against a stable, versioned type instead of hand-mirroring the interface.

## What Changed

### Public provider contracts
- **New dependency-free leaf modules** for both provider interfaces:
  - `src/features/featureGateProvider.ts` → `FeatureGateProvider`
  - `src/telemetry/telemetryProvider.ts` → `TelemetryProvider`, `TelemetryAttributes`
- Both modules are kept completely free of runtime dependencies (no zod, no config imports)
- `TelemetryAttributes` is **hand-written** as a simple `Record<string, string | number | boolean | undefined>` rather than `z.infer` of a schema (avoiding zod leakage in the emitted `.d.ts`)

### Build and packaging
- **Package subpaths** added to `package.json` exports:
  - `@tableau/mcp-server/features/featureGateProvider` → types-only condition
  - `@tableau/mcp-server/telemetry/telemetryProvider` → types-only condition
- **New `tsconfig.providers.json`**: declaration-only build config (`emitDeclarationOnly`) for the two provider modules
- All build scripts (`build`, `build:dev`, `build:desktop`, `build:combined`) now emit the provider `.d.ts` files via `tsc --project tsconfig.providers.json`
- `Dockerfile` updated to copy `tsconfig.providers.json` into the builder stage
- Version bumped to `2.24.0`

### Internal refactoring and cleanup
- **Removed unused telemetry schema**: `telemetryAttributesSchema` and its compile-time sync guard were deleted from `src/telemetry/types.ts` (the schema was never used for runtime validation; `TelemetryAttributes` is now hand-written in the public contract)
- **Import updates**: Internal consumers (`init.ts`, `noop.ts`, `serverFeatureGate.ts`, test files) now import provider types directly from the new leaf modules instead of from `types.ts`
- **Dead re-export removed**: `export type { FeatureGateProvider }` removed from `src/features/init.ts` (redundant; consumers should import from the leaf)
- **Lint/format fixes**: Applied import-sort and prettier to touched files

## Why

`tabhf-mcp-svc` (and other custom-provider deployments) currently hand-mirror `FeatureGateProvider` / `TelemetryProvider` locally, which silently drifts from the server's real contract. Exporting the interfaces as stable, versioned types gives one source of truth across repos without exposing the server's internal config schemas or zod dependencies.

The "narrow dedicated module" design ensures:
- Each interface lives in a single, self-contained file
- Emitted `.d.ts` files have zero imports (fully self-contained)
- Runtime imports of these subpaths fail by design (types-only condition)

## Testing / Verification

- ✅ All build variants succeed: `npm run build`, `build:dev`, `build:desktop`, `build:combined`
- ✅ Both emitted `.d.ts` are dependency-free (verified: zero `import`/`export … from` statements)
- ✅ `npx tsc --noEmit` clean (both main `tsconfig.json` and `tsconfig.providers.json`)
- ✅ Full unit suite passes: **2076/2076** (140 test files)
- ✅ Consumer proof (separate project, `moduleResolution: node16`, `skipLibCheck: false`, installed from packed tarball): correct `implements` compiles; wrong signature / missing method errors with `TS2416` / `TS2420` — confirming the types flow, not `any`

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

Additive only — no existing export or behavior changes.

## Related Issues

W-23337643

## Checklist

- [x] I have updated the version in the package.json file (bumped to `2.24.0`).
- [ ] I have made any necessary changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works (consumer-side type proof; existing suite green)
- [x] New and existing unit tests pass locally with my changes
- [x] I have documented any breaking changes in the PR description (none — additive)

## Notes for Reviewers

- Consumers must use `moduleResolution` `node16` / `nodenext` / `bundler` to resolve subpath exports.
- Only the `"types"` condition is exported (no runtime entry) — these subpaths are for `import type` only.
- The telemetry attributes schema was removed because it was never used for runtime validation; `TelemetryAttributes` is now a simple hand-written type in the public contract.
