### PR TITLE
W60 night 2: cost/P0 package + single-pass dashboard-auto-apply

### DIFF
--- a/src/config.desktop.ts
+++ b/src/config.desktop.ts
@@ -5,6 +5,13 @@ import { parseNumber } from './utils/parseNumber.js';
 
 export class Config extends BaseConfig {
   agentApiClientConfig: AgentApiClientConfig;
+  /**
+   * Which set of desktop tools to register (W60 spike lever 1 / preamble P1). Normalized
+   * (trim + lowercase). '' (unset) or 'full' registers the full set; 'demo' registers the
+   * slim fast-path + escalation-fallback set; any other value falls back to full with a
+   * logged warning. Slimming the registered surface cuts per-turn schema tokens/latency.
+   */
+  toolProfile: string;
 
   /**
    * When true, the desktop server talks to Tableau Desktop's new "External Client API"
@@ -26,6 +33,7 @@ export class Config extends BaseConfig {
       AGENT_API_POLL_INTERVAL_MS: agentApiPollIntervalMs,
       TABLEAU_EXTERNAL_API: externalApi,
       TABLEAU_EXTERNAL_API_DISCOVERY_DIR: externalApiDiscoveryDir,
+      TOOL_PROFILE: toolProfile,
     } = cleansedVars;
 
     if (this.transport !== 'stdio') {
@@ -34,6 +42,7 @@ export class Config extends BaseConfig {
 
     this.externalApiEnabled = externalApi === '1' || externalApi === 'true';
     this.externalApiDiscoveryDir = externalApiDiscoveryDir || undefined;
+    this.toolProfile = (toolProfile ?? '').trim().toLowerCase();
 
     this.agentApiClientConfig = {
       agentApiBase: agentApiBase ?? 'http://127.0.0.1:8765/api/v1',

--- a/src/desktop/templates/injectTemplateCore.test.ts
+++ b/src/desktop/templates/injectTemplateCore.test.ts
@@ -1,0 +1,126 @@
+// Colocated tests for the pure inject core (removeSameNamedWorksheet +
+// buildInjectedWorkbookXml). These exercise the REAL functions (no mocks) — the
+// sibling injectTemplate.test.ts mocks injectTemplate, so a real round-trip can
+// only live here. Cases ported from the W60 adversary probe (P0-3 double-quote,
+// P2-7 attribute-order) plus a reserialization round-trip.
+import { buildInjectedWorkbookXml, removeSameNamedWorksheet } from './injectTemplateCore.js';
+
+describe('removeSameNamedWorksheet — quote-agnostic strip (adversary P0-3)', () => {
+  it('strips a double-quoted worksheet + window (the serializer emits double quotes)', () => {
+    const workbookXml = [
+      '<workbook><worksheets><worksheet name="Sales">OLD BODY</worksheet></worksheets>',
+      '<windows><window class="worksheet" name="Sales"/></windows></workbook>',
+    ].join('');
+
+    const out = removeSameNamedWorksheet(workbookXml, 'Sales');
+
+    expect(out).not.toContain('OLD BODY');
+    expect(out).not.toContain('<window class="worksheet" name="Sales"/>');
+  });
+
+  it('still strips a single-quoted worksheet + window (Desktop-native shape)', () => {
+    const workbookXml = [
+      "<workbook><worksheets><worksheet name='Sales'>OLD BODY</worksheet></worksheets>",
+      "<windows><window class='worksheet' name='Sales'/></windows></workbook>",
+    ].join('');
+
+    const out = removeSameNamedWorksheet(workbookXml, 'Sales');
+
+    expect(out).not.toContain('OLD BODY');
+    expect(out).not.toContain("<window class='worksheet' name='Sales'/>");
+  });
+});
+
+describe('removeSameNamedWorksheet — attribute-order tolerant window strip (adversary P2-7)', () => {
+  it('strips a <window> whose "active" attribute sorts before "class"', () => {
+    const workbookXml = [
+      "<workbook><worksheets><worksheet name='Sales'>OLD BODY</worksheet></worksheets>",
+      "<windows><window active='true' class='worksheet' maximized='true' name='Sales'/></windows>",
+      '</workbook>',
+    ].join('');
+
+    const out = removeSameNamedWorksheet(workbookXml, 'Sales');
+
+    expect(out).not.toContain('OLD BODY');
+    expect(out).not.toContain('name=');
+    // The <window> ENTRY is gone; the <windows> container legitimately survives, so
+    // match the entry element boundary (`<window\b`) rather than the `<window` substring.
+    expect(out).not.toMatch(/<window\b/);
+  });
+
+  it('strips a double-quoted, attribute-reordered window (both defeats combined)', () => {
+    const workbookXml = [
+      '<workbook><worksheets><worksheet name="Sales">OLD BODY</worksheet></worksheets>',
+      '<windows><window active="true" class="worksheet" name="Sales"/></windows></workbook>',
+    ].join('');
+
+    const out = removeSameNamedWorksheet(workbookXml, 'Sales');
+
+    expect(out).not.toContain('OLD BODY');
+    expect(out).not.toMatch(/<window\b/);
+  });
+});
+
+describe('removeSameNamedWorksheet — dashboard-zone fail-safe holds for double quotes too', () => {
+  it('leaves a double-quoted workbook untouched when a dashboard zone references the sheet', () => {
+    const workbookXml = [
+      '<workbook><worksheets><worksheet name="Sales">BODY</worksheet></worksheets>',
+      '<dashboards><dashboard name="D1"><zones><zone name="Sales" x="0"/></zones></dashboard></dashboards>',
+      '</workbook>',
+    ].join('');
+
+    const out = removeSameNamedWorksheet(workbookXml, 'Sales');
+
+    expect(out).toBe(workbookXml);
+  });
+});
+
+describe('buildInjectedWorkbookXml — reserialization round-trip (adversary P0-3)', () => {
+  const templateXml = [
+    "<?xml version='1.0'?><workbook>",
+    "<worksheets><worksheet name='{{TITLE}}'><table/></worksheet></worksheets>",
+    "<windows><window class='worksheet' name='{{TITLE}}'/></windows>",
+    '</workbook>',
+  ].join('');
+
+  const initialWorkbookXml = [
+    "<?xml version='1.0'?><workbook>",
+    "<worksheets><worksheet name='Keep'><table/></worksheet></worksheets>",
+    "<windows><window class='worksheet' name='Keep'/></windows>",
+    '</workbook>',
+  ].join('');
+
+  it('applying the same title twice leaves exactly one worksheet + window for it', () => {
+    const cycle1 = buildInjectedWorkbookXml({
+      workbookXml: initialWorkbookXml,
+      templateXml,
+      title: 'Sales',
+      sheetType: 'worksheet',
+      applyNonce: 'cycle-1',
+    });
+    expect(cycle1.ok).toBe(true);
+    if (!cycle1.ok) return;
+
+    // Cycle 1's output is what this pipeline re-reads on the 2nd apply — and it is
+    // double-quoted (fast-xml-parser XMLBuilder default), the exact case the old
+    // single-quote regex silently no-oped on.
+    expect(cycle1.xml).toContain('<worksheet name="Sales">');
+
+    const cycle2 = buildInjectedWorkbookXml({
+      workbookXml: cycle1.xml,
+      templateXml,
+      title: 'Sales',
+      sheetType: 'worksheet',
+      applyNonce: 'cycle-2',
+    });
+    expect(cycle2.ok).toBe(true);
+    if (!cycle2.ok) return;
+
+    const worksheetCount = (cycle2.xml.match(/<worksheet name="Sales">/g) ?? []).length;
+    expect(worksheetCount).toBe(1);
+    const windowCount = (cycle2.xml.match(/<window[^>]*name="Sales"/g) ?? []).length;
+    expect(windowCount).toBe(1);
+    // The unrelated sheet is preserved across both cycles.
+    expect(cycle2.xml).toContain('name="Keep"');
+  });
+});

--- a/src/desktop/templates/injectTemplateCore.ts
+++ b/src/desktop/templates/injectTemplateCore.ts
@@ -73,18 +73,30 @@ export type InjectTemplateCoreResult = { ok: true; xml: string } | { ok: false; 
 export function removeSameNamedWorksheet(workbookXml: string, title: string): string {
   const escaped = escapeXml(title);
   const nameAttr = escaped.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  const worksheetRe = new RegExp(`[ \\t]*<worksheet name='${nameAttr}'>[\\s\\S]*?</worksheet>\\n?`);
+  // Quote-agnostic (['"]): this pipeline's own serializer (parser.ts fast-xml-parser
+  // XMLBuilder, default quoteChar `"`) emits DOUBLE-quoted attributes, so a second apply
+  // over once-reserialized XML must still match — a single-quote-only regex silently
+  // no-ops the strip and the "Name (1)" pile-up returns (adversary P0-3).
+  const worksheetRe = new RegExp(
+    `[ \\t]*<worksheet name=['"]${nameAttr}['"]>[\\s\\S]*?</worksheet>\\n?`,
+  );
   if (!worksheetRe.test(workbookXml)) {
     return workbookXml;
   }
-  // Referenced by a dashboard zone? Leave it alone (fail-safe to Desktop dedup).
-  const zoneRe = new RegExp(`<zone [^>]*name='${nameAttr}'`);
+  // Referenced by a dashboard zone? Leave it alone (fail-safe to Desktop dedup). This
+  // check MUST also be quote-agnostic: on reserialized double-quoted XML a single-quote
+  // zone regex would miss the reference and strip a dashboard's member sheet.
+  const zoneRe = new RegExp(`<zone [^>]*name=['"]${nameAttr}['"]`);
   if (zoneRe.test(workbookXml)) {
     return workbookXml;
   }
   let out = workbookXml.replace(worksheetRe, '');
+  // Attribute-order tolerant (lookaheads, not a hardcoded `class='worksheet'` first):
+  // the serializer/Desktop may emit an attribute that sorts before `class` (e.g.
+  // `active`), which defeated the old anchored form (adversary P2-7). Match any
+  // <window> tag that carries BOTH class=worksheet AND the target name, in any order.
   const windowRe = new RegExp(
-    `[ \\t]*<window class='worksheet'[^>]*name='${nameAttr}'[^>]*(?:/>|>[\\s\\S]*?</window>)\\n?`,
+    `[ \\t]*<window\\b(?=[^>]*\\bclass=['"]worksheet['"])(?=[^>]*\\bname=['"]${nameAttr}['"])[^>]*(?:/>|>[\\s\\S]*?</window>)\\n?`,
   );
   out = out.replace(windowRe, '');
   return out;

--- a/src/desktop/validation/rules/connectionsNotAuthorable.test.ts
+++ b/src/desktop/validation/rules/connectionsNotAuthorable.test.ts
@@ -1,0 +1,166 @@
+import fs from 'fs';
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+
+import { runValidation } from '../registry.js';
+import { connectionsNotAuthorableRule } from './connectionsNotAuthorable.js';
+
+const LIVE_READBACK_FIXTURE = path.join(
+  process.cwd(),
+  'src',
+  'desktop',
+  'binder',
+  'fixtures',
+  'superstore-scratch-ref.xml',
+);
+
+describe('connections-not-authorable rule', () => {
+  it('a bare hand-authored excel-direct connection (copied from a .tds, not federated) is rejected', () => {
+    // The known-bad shape from tableau-oracle-connection-xml.md: a <connection> copied
+    // straight from a .tds, not wrapped in <named-connections>/federated.
+    const xml = `<?xml version="1.0"?>
+<workbook>
+  <datasources>
+    <datasource name="my-data">
+      <connection class="excel-direct" cleaning="no" compat="no" dataRefreshTime=""
+        filename="/Users/me/Documents/sales.xls" interpretationMode="0" password="" server="" validate="no" />
+    </datasource>
+  </datasources>
+</workbook>`;
+    const issues = connectionsNotAuthorableRule.validate(xml);
+    expect(issues.length).toBeGreaterThan(0);
+    expect(issues.every((i) => i.severity === 'error')).toBe(true);
+    expect(issues[0].message).toContain('connections-not-authorable');
+    expect(issues[0].message).toContain('Do not retry');
+    expect(issues[0].message).not.toMatch(/^FIX/i);
+  });
+
+  it('a federated wrapper with a fabricated (non-Desktop-minted) named-connection id is rejected', () => {
+    const xml = `<?xml version="1.0"?>
+<workbook>
+  <datasources>
+    <datasource name="my-data">
+      <connection class="federated">
+        <named-connections>
+          <named-connection caption="Sales" name="excel-direct.myconnection1">
+            <connection class="excel-direct" filename="/Users/me/Documents/sales.xls" />
+          </named-connection>
+        </named-connections>
+      </connection>
+    </datasource>
+  </datasources>
+</workbook>`;
+    const issues = connectionsNotAuthorableRule.validate(xml);
+    expect(issues.length).toBeGreaterThan(0);
+    expect(issues[0].xpath).toContain('excel-direct.myconnection1');
+  });
+
+  it('a federated wrapper with a Desktop-minted named-connection id passes', () => {
+    const xml = `<?xml version="1.0"?>
+<workbook>
+  <datasources>
+    <datasource name="my-data">
+      <connection class="federated">
+        <named-connections>
+          <named-connection caption="Sales" name="excel-direct.0ozsbj20cdelf51evvdk71kugqg0">
+            <connection class="excel-direct" filename="/Users/me/Documents/sales.xls" />
+          </named-connection>
+        </named-connections>
+      </connection>
+    </datasource>
+  </datasources>
+</workbook>`;
+    expect(connectionsNotAuthorableRule.validate(xml)).toEqual([]);
+  });
+
+  it('a fragment with no <connection> element at all is never flagged', () => {
+    const xml = `<?xml version="1.0"?>
+<worksheet name="Sheet 1">
+  <table>
+    <view />
+  </table>
+</worksheet>`;
+    expect(connectionsNotAuthorableRule.validate(xml)).toEqual([]);
+  });
+
+  it('the real live-readback fixture (genuine Desktop connection shape) is never rejected', () => {
+    const xml = fs.readFileSync(LIVE_READBACK_FIXTURE, 'utf8');
+    const issues = connectionsNotAuthorableRule.validate(xml);
+    expect(
+      issues,
+      `unexpected rejection of a genuine live-readback fixture: ${JSON.stringify(issues)}`,
+    ).toEqual([]);
+  });
+
+  it('a live-readback round-trip (unmodified connections, re-applied as-is) is never rejected via runValidation', () => {
+    const xml = fs.readFileSync(LIVE_READBACK_FIXTURE, 'utf8');
+    const result = runValidation(xml, 'workbook');
+    const offenders = result.issues.filter((i) => i.ruleId === 'connections-not-authorable');
+    expect(offenders).toEqual([]);
+  });
+
+  it('is registered for the workbook and datasource contexts, not worksheet/dashboard', () => {
+    expect(connectionsNotAuthorableRule.contexts).toEqual(['workbook', 'datasource']);
+  });
+
+  it('fires through runValidation(xml, "workbook") end-to-end, terminally (invalid → not just a warning)', () => {
+    const xml = `<?xml version="1.0"?>
+<workbook>
+  <datasources>
+    <datasource name="my-data">
+      <connection class="excel-direct" filename="/Users/me/Documents/sales.xls" />
+    </datasource>
+  </datasources>
+</workbook>`;
+    const result = runValidation(xml, 'workbook');
+    expect(result.valid).toBe(false);
+    expect(result.issues.some((i) => i.ruleId === 'connections-not-authorable')).toBe(true);
+  });
+
+  it('does not fire in the worksheet or dashboard contexts (out of scope by design)', () => {
+    const xml = `<?xml version="1.0"?>
+<workbook>
+  <datasources>
+    <datasource name="my-data">
+      <connection class="excel-direct" filename="/Users/me/Documents/sales.xls" />
+    </datasource>
+  </datasources>
+</workbook>`;
+    const worksheetResult = runValidation(xml, 'worksheet');
+    const dashboardResult = runValidation(xml, 'dashboard');
+    expect(worksheetResult.issues.some((i) => i.ruleId === 'connections-not-authorable')).toBe(
+      false,
+    );
+    expect(dashboardResult.issues.some((i) => i.ruleId === 'connections-not-authorable')).toBe(
+      false,
+    );
+  });
+});
+
+describe('connections-not-authorable — bundled template corpus never self-rejects', () => {
+  const XML_DIR = path.join(
+    process.cwd(),
+    'src',
+    'desktop',
+    'data',
+    'data-visualization-templates-xml',
+  );
+  const xmlFiles = fs.readdirSync(XML_DIR).filter((f) => f.endsWith('.xml'));
+
+  it('discovers a non-empty shipped template corpus', () => {
+    expect(xmlFiles.length).toBeGreaterThan(0);
+  });
+
+  it.each(xmlFiles)(
+    'runValidation(%s, "workbook") reports zero connections-not-authorable issues',
+    (file) => {
+      const xml = fs.readFileSync(path.join(XML_DIR, file), 'utf8');
+      const result = runValidation(xml, 'workbook');
+      const offenders = result.issues.filter((i) => i.ruleId === 'connections-not-authorable');
+      expect(
+        offenders,
+        `${file}: template must not self-reject on connections-not-authorable`,
+      ).toEqual([]);
+    },
+  );
+});

--- a/src/desktop/validation/rules/connectionsNotAuthorable.ts
+++ b/src/desktop/validation/rules/connectionsNotAuthorable.ts
@@ -1,0 +1,111 @@
+/**
+ * Validation rule: connections-not-authorable
+ *
+ * Terminal, non-retryable preflight rejection for hand-authored (or structurally
+ * modified) `<connection>` XML — the tmcp half of the Southard containment redesign
+ * (~/.claude/state/w60-southard-containment-spec.md §3 layer 3, task card #2).
+ *
+ * WHY: Tableau Desktop only accepts the connection SHAPE it serializes itself on a
+ * live readback — a modern datasource is `<connection class="federated">` wrapping
+ * `<named-connections><named-connection name="<protocol>.<Desktop-minted-id>">` around
+ * the real per-protocol `<connection class="excel-direct"|"hyper"|...>`. A model that
+ * hand-authors (or copies from a .tds) a bare `<connection class="excel-direct" .../>`
+ * directly under `<datasource>` — or fabricates a `named-connection` name instead of
+ * using Desktop's own minted id — produces XML that LOOKS plausible but fails at
+ * connect time (confirmed product behavior, see
+ * ~/.claude/projects/-Users-mattfilbert--claude/memory/tableau-oracle-connection-xml.md:
+ * "Adding protocol to the list of known bad protocols", connection construction fails
+ * in-proc before any file I/O — the shape is invalid, not the data).
+ *
+ * Every other preflight rule in this framework is retryable: its `message`/`suggestion`
+ * are "FIX lines" the agent is instructed (server.desktop.ts's DESKTOP_INSTRUCTIONS) to
+ * patch and re-apply. THIS rule is deliberately NOT phrased that way — there is no XML
+ * fix that makes a hand-authored connection accept; the only correct next step is
+ * "guide the user to Desktop's Connect pane, then re-read the workbook" (do NOT retry).
+ * Structural, not a true diff against a live baseline: `ValidationRule.validate(xml)` is
+ * pure over one XML string (no baseline plumbing exists in this framework and none is
+ * added here), so this rule detects "does this look like something Desktop emits" rather
+ * than "did this connection change since the last read". That is sufficient for both
+ * required outcomes: an unmodified live-readback round-trip (byte-identical shape) is
+ * NEVER rejected, and a hand-authored/copied-from-.tds connection (which cannot
+ * reproduce Desktop's opaque id-minting scheme) IS rejected.
+ */
+import { DOMParser } from '@xmldom/xmldom';
+import * as xpath from 'xpath';
+
+import type { ValidationIssue, ValidationRule } from '../types.js';
+
+/**
+ * Desktop mints `named-connection` names as `<protocol>.<opaque-lowercase-id>`, e.g.
+ * `excel-direct.0ozsbj20cdelf51evvdk71kugqg0` (28-char id, observed on a live readback).
+ * No agent or hand-authored XML can reproduce this scheme, so a name outside it is a
+ * reliable hand-authored signal — never a false positive on genuine Desktop output.
+ */
+const NAMED_CONNECTION_ID_RE = /^[a-z][a-z0-9_-]*\.[0-9a-z]{16,}$/;
+
+const TERMINAL_MESSAGE =
+  'connections-not-authorable: Data connections cannot be created or rewritten via XML apply. ' +
+  "Do not retry. Guide the user to Desktop's Connect pane, then re-read the workbook.";
+
+const TERMINAL_SUGGESTION =
+  'Do not retry with a different connection attribute shape — there is no XML fix. Tell the user ' +
+  "to open Desktop's Connect pane and add/repair the connection there, then call get-workbook-xml " +
+  'again once it is connected.';
+
+function issueFor(xpathHint: string): ValidationIssue {
+  return {
+    ruleId: 'connections-not-authorable',
+    severity: 'error',
+    message: TERMINAL_MESSAGE,
+    xpath: xpathHint,
+    suggestion: TERMINAL_SUGGESTION,
+  };
+}
+
+export const connectionsNotAuthorableRule: ValidationRule = {
+  id: 'connections-not-authorable',
+  description:
+    'Rejects hand-authored or structurally invalid <connection> XML with a terminal, ' +
+    'non-retryable error — only the exact shape Desktop itself serializes on a live ' +
+    'readback (federated + named-connection with a Desktop-minted id) ever applies.',
+  contexts: ['workbook', 'datasource'],
+
+  validate(xml: string): ValidationIssue[] {
+    let doc: Document;
+    try {
+      const parser = new DOMParser({ errorHandler: () => {} });
+      doc = parser.parseFromString(xml.trim() || '<empty/>', 'text/xml') as unknown as Document;
+    } catch {
+      // Malformed XML is reported by well-formed-xml; this rule has nothing to say.
+      return [];
+    }
+
+    const issues: ValidationIssue[] = [];
+
+    // 1. A bare/legacy connection directly under <datasource> that is NOT the modern
+    // federated wrapper — exactly the hand-authored-from-.tds shape (known-bad).
+    const bareConnections = xpath.select(
+      "//datasource/connection[not(@class='federated')]",
+      doc as unknown as Node,
+    ) as Element[];
+    for (const conn of bareConnections) {
+      const cls = conn.getAttribute('class') ?? '(none)';
+      issues.push(issueFor(`//datasource/connection[@class='${cls}']`));
+    }
+
+    // 2. A federated wrapper is present, but a named-connection's `name` was NOT minted
+    // by Desktop (fabricated, guessed, or otherwise hand-edited).
+    const namedConnections = xpath.select(
+      '//named-connection[@name]',
+      doc as unknown as Node,
+    ) as Element[];
+    for (const nc of namedConnections) {
+      const name = nc.getAttribute('name') ?? '';
+      if (!NAMED_CONNECTION_ID_RE.test(name)) {
+        issues.push(issueFor(`//named-connection[@name='${name}']`));
+      }
+    }
+
+    return issues;
+  },
+};

--- a/src/desktop/validation/rules/rules.ts
+++ b/src/desktop/validation/rules/rules.ts
@@ -1,5 +1,11 @@
 import { calcFieldNamesRule } from './calcFieldNames.js';
+import { connectionsNotAuthorableRule } from './connectionsNotAuthorable.js';
 import { invalidDerivationStringRule } from './invalidDerivationString.js';
 import { wellFormedXmlRule } from './wellFormedXml.js';
 
-export const validationRules = [wellFormedXmlRule, calcFieldNamesRule, invalidDerivationStringRule];
+export const validationRules = [
+  wellFormedXmlRule,
+  calcFieldNamesRule,
+  invalidDerivationStringRule,
+  connectionsNotAuthorableRule,
+];

--- a/src/server.desktop.test.ts
+++ b/src/server.desktop.test.ts
@@ -1,4 +1,7 @@
-import { DesktopMcpServer } from './server.desktop.js';
+import * as loggerModule from './logging/logger.js';
+import { DEMO_TOOL_PROFILE, DesktopMcpServer, selectToolsForProfile } from './server.desktop.js';
+import { DesktopTool } from './tools/desktop/tool.js';
+import { desktopToolNames } from './tools/desktop/toolName.js';
 import { desktopToolFactories } from './tools/desktop/tools.js';
 import { Provider } from './utils/provider.js';
 
@@ -23,6 +26,80 @@ describe('DesktopMcpServer', () => {
         expect.any(Function),
       );
     }
+  });
+});
+
+describe('selectToolsForProfile (TOOL_PROFILE, W60 spike lever 1 / preamble P1)', () => {
+  const allTools = (): Array<DesktopTool<any>> =>
+    desktopToolFactories.map((toolFactory) => toolFactory(new DesktopMcpServer()));
+
+  it('every slim-profile name is a real desktop tool name', () => {
+    for (const name of DEMO_TOOL_PROFILE) {
+      expect(desktopToolNames).toContain(name);
+    }
+  });
+
+  it('TOOL_PROFILE=demo registers exactly the slim set (nothing more, nothing less)', () => {
+    const selected = selectToolsForProfile(allTools(), 'demo');
+    expect(new Set(selected.map((t) => t.name))).toEqual(DEMO_TOOL_PROFILE);
+    // The escalation-fallback chain the preamble-hunt requires must survive the slim.
+    for (const fallback of [
+      'bind-template',
+      'get-workbook-xml',
+      'inject-template',
+      'apply-workbook',
+      'apply-worksheet',
+    ]) {
+      expect(selected.map((t) => t.name)).toContain(fallback);
+    }
+  });
+
+  it('unset ("") profile returns the full set unchanged, byte-identical order', () => {
+    const tools = allTools();
+    const selected = selectToolsForProfile(tools, '');
+    expect(selected).toBe(tools);
+    expect(selected.map((t) => t.name)).toEqual(tools.map((t) => t.name));
+  });
+
+  it('explicit "full" profile returns the full set unchanged', () => {
+    const tools = allTools();
+    expect(selectToolsForProfile(tools, 'full')).toBe(tools);
+  });
+
+  it('an unknown profile value falls back to the full set and logs a warning', () => {
+    const logSpy = vi.spyOn(loggerModule, 'log').mockImplementation(() => {});
+    const tools = allTools();
+    const selected = selectToolsForProfile(tools, 'bogus');
+    expect(selected).toBe(tools);
+    expect(logSpy).toHaveBeenCalledWith(expect.objectContaining({ level: 'warning' }));
+  });
+});
+
+describe('DesktopMcpServer TOOL_PROFILE env wiring', () => {
+  afterEach(() => {
+    // Reset to the unset (full) state so later tests in this file are unaffected.
+    vi.stubEnv('TOOL_PROFILE', '');
+  });
+
+  it('registers only the slim set end-to-end when TOOL_PROFILE=demo', async () => {
+    vi.stubEnv('TOOL_PROFILE', 'demo');
+    const server = getServer();
+    await server.registerTools();
+
+    const registeredNames = vi
+      .mocked(server.mcpServer.registerTool)
+      .mock.calls.map((call) => call[0]);
+    expect(new Set(registeredNames)).toEqual(DEMO_TOOL_PROFILE);
+  });
+
+  it('registers the full set when TOOL_PROFILE is unset', async () => {
+    const server = getServer();
+    await server.registerTools();
+
+    const registeredNames = vi
+      .mocked(server.mcpServer.registerTool)
+      .mock.calls.map((call) => call[0]);
+    expect(registeredNames.length).toBe(desktopToolFactories.length);
   });
 });
 

--- a/src/server.desktop.ts
+++ b/src/server.desktop.ts
@@ -17,12 +17,62 @@ import { log } from './logging/logger.js';
 import { ClientInfo, Server } from './server.js';
 import { DesktopTool } from './tools/desktop/tool.js';
 import { TableauDesktopRequestHandlerExtra } from './tools/desktop/toolContext.js';
+import { DesktopToolName } from './tools/desktop/toolName.js';
 import { desktopToolFactories } from './tools/desktop/tools.js';
 import { getDirname } from './utils/getDirname';
 import { Provider } from './utils/provider.js';
 
 const serverName = 'tableau-desktop-mcp';
 const serverVersion = pkg.version;
+
+/**
+ * Slim demo tool set (W60 spike lever 1 / preamble-hunt P1): registering ~10 tools instead
+ * of the full 42 shrinks the serialized schema surface (~15-25k → ~4-5k tokens), which the
+ * preamble-hunt measured as the single biggest per-turn latency win (−4.5 to −5.5s/chart)
+ * and a per-turn token/cost reduction. Reconciled from BOTH source lists: the spike's
+ * fast-path/coordination tools (bind-template, list-instances, list-available-fields,
+ * list-worksheets, apply-workbook, batch-create-and-cache-sheets, build-and-apply-dashboard)
+ * UNION the preamble-hunt's escalation-fallback chain it insists must stay
+ * (get-workbook-xml, inject-template, apply-worksheet — apply-workbook/list-instances/
+ * list-worksheets already overlap). Without the fallback chain the propose/escalate paths
+ * (per DESKTOP_INSTRUCTIONS) would have no tools to route to.
+ */
+export const DEMO_TOOL_PROFILE: ReadonlySet<DesktopToolName> = new Set<DesktopToolName>([
+  'bind-template',
+  'list-instances',
+  'list-worksheets',
+  'list-available-fields',
+  'apply-workbook',
+  'get-workbook-xml',
+  'inject-template',
+  'apply-worksheet',
+  'batch-create-and-cache-sheets',
+  'build-and-apply-dashboard',
+]);
+
+/**
+ * Select the tools to register for a given TOOL_PROFILE value (already normalized by
+ * Config: trim + lowercase). 'demo' → the slim {@link DEMO_TOOL_PROFILE} subset; '' (unset)
+ * or 'full' → the full set unchanged (same array reference — byte-identical behavior); any
+ * other value → full set + a logged warning. Pure and side-effect-free apart from the
+ * warning log, so the selection can be unit-tested without the server or env.
+ */
+export function selectToolsForProfile<T extends { name: DesktopToolName }>(
+  tools: T[],
+  profile: string,
+): T[] {
+  if (profile === 'demo') {
+    return tools.filter((tool) => DEMO_TOOL_PROFILE.has(tool.name));
+  }
+  if (profile !== '' && profile !== 'full') {
+    log({
+      message: `Unknown TOOL_PROFILE "${profile}" — registering the full tool set.`,
+      level: 'warning',
+      logger: 'DesktopMcpServer',
+    });
+  }
+  return tools;
+}
 
 const DATA_ROOTS = [
   join(getDirname(), 'desktop', 'data'),
@@ -111,7 +161,7 @@ export class DesktopMcpServer extends Server {
 
   protected _getToolsToRegister = async (): Promise<Array<DesktopTool<any>>> => {
     const allTools = desktopToolFactories.map((toolFactory) => toolFactory(this));
-    return allTools;
+    return selectToolsForProfile(allTools, getDesktopConfig().toolProfile);
   };
 
   private _registerKnowledgeResources = (): void => {

--- a/src/server.desktop.ts
+++ b/src/server.desktop.ts
@@ -39,6 +39,7 @@ const serverVersion = pkg.version;
  */
 export const DEMO_TOOL_PROFILE: ReadonlySet<DesktopToolName> = new Set<DesktopToolName>([
   'bind-template',
+  'dashboard-auto-apply',
   'list-instances',
   'list-worksheets',
   'list-available-fields',
@@ -93,7 +94,9 @@ const DESKTOP_INSTRUCTIONS = `You are controlling Tableau Desktop.
 
 For a plain chart ask (bar, column, line, treemap, waterfall, scatter, filled map, KPI, funnel, box plot), FIRST call bind-template with the user's ask and auto_apply: true — a confident bind renders the chart in ONE call (~2s server-side, no further tool calls). On propose/escalate, fall back to the general authoring tools (get-workbook-xml -> edit -> apply-workbook, or inject-template for a known template).
 
-Every session-scoped tool call needs the session id from list-instances — except bind-template, which auto-resolves the session when exactly one Desktop instance is running.
+For a dashboard ask with 2-6 charts (e.g. "a dashboard with sales by region and profit by category"), FIRST call dashboard-auto-apply with one { ask, title? } per chart and a dashboardName — it binds and composes every chart into one dashboard in ONE call. If any ask fails to deterministically bind, nothing is applied and each ask's outcome is returned; fall back to bind-template per chart, or build-and-apply-dashboard for KPI strips / custom zone layouts.
+
+Every session-scoped tool call needs the session id from list-instances — except bind-template and dashboard-auto-apply, which auto-resolve the session when exactly one Desktop instance is running.
 
 If an apply is rejected by preflight validation, fix the XML per the FIX lines in the error and re-apply. Prefer file mode for large workbooks.`;
 

--- a/src/tools/desktop/binder/bindTemplate.test.ts
+++ b/src/tools/desktop/binder/bindTemplate.test.ts
@@ -423,8 +423,9 @@ describe('bindTemplateTool auto_apply gate', () => {
     expect(typeof body.phase_ms.bind).toBe('number');
     expect(typeof body.phase_ms.inject).toBe('number');
     expect(typeof body.phase_ms.apply).toBe('number');
-    // Bound args stay intact for the client.
-    expect(body.args.template_name).toBe('bar-basic');
+    // W60 response-shape trim (P4): the applied:true fast-path drops the args echo — the
+    // manual second call it enabled never happens on success.
+    expect(body.args).toBeUndefined();
 
     expect(buildInjectedWorkbookXml).toHaveBeenCalledTimes(1);
     expect(buildInjectedWorkbookXml).toHaveBeenCalledWith(
@@ -439,6 +440,36 @@ describe('bindTemplateTool auto_apply gate', () => {
     );
     // Exactly one apply dispatch (the collapsed 4-call chain becomes one tool call).
     expect(executeCommand).toHaveBeenCalledTimes(1);
+  });
+
+  it('applied:true returns ONLY the trimmed fast-path shape (W60 P4 response-shape trim)', async () => {
+    const { getExecutor } = setupAutoApplyMocks();
+
+    const result = await getToolResult({
+      session: '1',
+      ask: 'bar chart of Sales by Region',
+      auto_apply: true,
+      getExecutor,
+    });
+
+    invariant(result.content[0].type === 'text');
+    const body = JSON.parse(result.content[0].text) as Record<string, unknown>;
+    // Keep only what a successful apply needs; drop args + the ~170-token
+    // apply_instruction + apply_hint + used_llm (dead weight on the success fast path).
+    expect(Object.keys(body).sort()).toEqual([
+      'applied',
+      'guidance',
+      'phase_ms',
+      'sheet_name',
+      'status',
+    ]);
+    expect(body.status).toBe('bound');
+    expect(body.apply_instruction).toBeUndefined();
+    expect(body.apply_hint).toBeUndefined();
+    expect(body.used_llm).toBeUndefined();
+    // Guidance collapses to one short line, not the verbose manual-chain instruction.
+    expect(typeof body.guidance).toBe('string');
+    expect((body.guidance as string).length).toBeLessThan(200);
   });
 
   it('auto_apply=true NEVER applies a Call-2 proposal (used_llm) even with a fast-path manifest', async () => {
@@ -559,6 +590,10 @@ describe('bindTemplateTool auto_apply graceful fallback', () => {
     expect(body.apply_error).toContain('not well-formed');
     // The bind is never lost — args are intact for the manual fallback chain.
     expect(body.args).toEqual(boundResult.status === 'bound' ? boundResult.args : undefined);
+    // P1-5 contrast: inject/validation/apply failures did NOT stem from a stale
+    // workbook, so the "fall back to the manual chain using the returned args" guidance
+    // is correct here and must be retained (only the events-dirty branch drops it).
+    expect(String(body.guidance)).toMatch(/manual chain/i);
     // Apply is not attempted once inject fails.
     expect(executeCommand).not.toHaveBeenCalled();
   });
@@ -696,6 +731,47 @@ describe('bindTemplateTool auto_apply — events-clean gate (W60 blind-spot #1)'
     expect(String(body.apply_error)).toMatch(/user changed the workbook.*3 event/);
     expect(body.args).toBeDefined(); // the bind survives — agent can re-get and retry
     expect(executeCommand).not.toHaveBeenCalled(); // the apply dispatch was suppressed
+  });
+
+  it('anchors the events sequence BEFORE reading the workbook (P1 race fix)', async () => {
+    // The self-review / adversary P1-4 finding: with the anchor captured AFTER the read,
+    // a user edit landing in the (read, anchor] window gets sequence <= anchor and is
+    // excluded by the strict `since` filter → silently reverted by the whole-document
+    // apply. Pin the real call order (not independent mocks): the anchor getEvents must
+    // fire before getWorkbookXml.
+    const { getEvents, getExecutor } = setupAutoApplyMocks({ userEventsDuringBind: 0 });
+    await getToolResult({
+      session: '1',
+      ask: 'bar chart of Sales by Region',
+      auto_apply: true,
+      getExecutor,
+    });
+
+    const anchorOrder = getEvents.mock.invocationCallOrder[0];
+    const readOrder = vi.mocked(getWorkbookXmlModule.getWorkbookXml).mock.invocationCallOrder[0];
+    expect(anchorOrder).toBeLessThan(readOrder);
+  });
+
+  it('refuses without inviting a manual re-apply of the stale pre-edit args (P1-5)', async () => {
+    // events-dirty branch: the returned args were computed against the pre-edit
+    // workbook. Guidance must NOT offer "apply the returned args manually" — that would
+    // reopen the exact race the gate just avoided. Re-running bind-template (fresh read)
+    // is the only safe option here.
+    const { getExecutor } = setupAutoApplyMocks({ userEventsDuringBind: 2 });
+    const result = await getToolResult({
+      session: '1',
+      ask: 'bar chart of Sales by Region',
+      auto_apply: true,
+      getExecutor,
+    });
+    invariant(result.content[0].type === 'text');
+    const body = JSON.parse(result.content[0].text) as Record<string, unknown>;
+    expect(body.applied).toBe(false);
+    expect(String(body.apply_error)).not.toMatch(/apply the returned args manually/i);
+    expect(String(body.guidance)).not.toMatch(/using the returned args/i);
+    expect(String(body.guidance)).toMatch(/re-run bind-template/i);
+    // The bind still survives so the agent can re-get and retry deliberately.
+    expect(body.args).toBeDefined();
   });
 
   it('applies when the workbook is events-clean (0 user events since the read)', async () => {

--- a/src/tools/desktop/binder/bindTemplate.ts
+++ b/src/tools/desktop/binder/bindTemplate.ts
@@ -73,13 +73,31 @@ const paramsSchema = {
  * present: `applied` + either `sheet_name`/`phase_ms` (success) or `apply_error`
  * (graceful fallback — the bound `args` are still intact).
  */
-type BindTemplateToolResult = BinderResult & {
+type BindTemplateToolResultBase = BinderResult & {
   guidance: string;
   applied?: boolean;
   sheet_name?: string;
   phase_ms?: { bind: number; inject: number; apply: number };
   apply_error?: string;
 };
+
+/**
+ * Trimmed shape returned ONLY on applied:true fast-path success (W60 spike lever 5 /
+ * preamble P4). It keeps just what a rendered success needs and drops the args echo, the
+ * ~170-token apply_instruction, apply_hint, and used_llm — those exist to enable a manual
+ * second call that never happens once the server-side apply succeeds. The FULL shape is
+ * preserved on applied:false / propose / escalate / error (the graceful-fallback contract
+ * is sacred — the fallback chain still needs the bound args).
+ */
+type AppliedFastPathResult = {
+  status: 'bound';
+  applied: true;
+  sheet_name: string;
+  phase_ms: { bind: number; inject: number; apply: number };
+  guidance: string;
+};
+
+type BindTemplateToolResult = BindTemplateToolResultBase | AppliedFastPathResult;
 
 /** Escalation reasons that route back to the general (non-fast-path) authoring flow. */
 const TIER2_REASONS: ReadonlySet<EscalateReason> = new Set<EscalateReason>([
@@ -194,11 +212,24 @@ function describeApplyError(
 
 type BoundResult = Extract<BinderResult, { status: 'bound' }>;
 
-/** Build the graceful-fallback result: the bound args are intact + why apply didn't run. */
-function applyFallback(base: BindTemplateToolResult, apply_error: string): BindTemplateToolResult {
+/**
+ * Build the graceful-fallback result: the bound args are intact + why apply didn't run.
+ * Default guidance points at the manual inject/apply chain using the returned args — that
+ * is correct for inject/validation/apply failures (the workbook was not the problem). The
+ * events-dirty branch passes a custom `guidance` that DROPS the "apply the returned args
+ * manually" alternative, because there the args are stale pre-edit values and re-applying
+ * them would revert the user's changes (adversary P1-5).
+ */
+function applyFallback(
+  base: BindTemplateToolResultBase,
+  apply_error: string,
+  guidance?: string,
+): BindTemplateToolResultBase {
   return {
     ...base,
-    guidance: `Server-side auto-apply did not complete (${apply_error}). The bound args are intact — fall back to the manual chain: get-workbook-xml → inject-template → apply-workbook using the returned args.`,
+    guidance:
+      guidance ??
+      `Server-side auto-apply did not complete (${apply_error}). The bound args are intact — fall back to the manual chain: get-workbook-xml → inject-template → apply-workbook using the returned args.`,
     applied: false,
     apply_error,
   };
@@ -222,7 +253,7 @@ async function performAutoApply({
   eventsAnchor,
 }: {
   res: BoundResult;
-  base: BindTemplateToolResult;
+  base: BindTemplateToolResultBase;
   workbookXml: string;
   session: string;
   executor: ToolExecutor;
@@ -245,7 +276,14 @@ async function performAutoApply({
       return applyFallback(
         base,
         `user changed the workbook during the bind (${events.value.count} event(s) since read) — ` +
-          're-run bind-template for a fresh read, or apply the returned args manually after reviewing',
+          're-run bind-template for a fresh read',
+        // Events-dirty guidance DROPS the manual-apply alternative (P1-5): the bound args
+        // were computed against the pre-edit workbook, so re-applying them would revert
+        // the user's changes — the only safe recovery is a fresh read via bind-template.
+        'Server-side auto-apply was refused: the user changed the workbook after it was read ' +
+          `(${events.value.count} event(s) since read). Re-run bind-template so it reads the ` +
+          'current workbook — do NOT re-apply the returned args, they were computed against ' +
+          'the pre-edit workbook and would revert their changes.',
       );
     }
   }
@@ -283,9 +321,12 @@ async function performAutoApply({
     return applyFallback(base, `apply failed: ${describeApplyError(applyResult.error)}`);
   }
 
+  // W60 response-shape trim (P4): on success, return ONLY the trimmed fast-path shape —
+  // drop the args echo, apply_instruction, apply_hint, and used_llm from `base`. Those
+  // enable a manual second call that never happens once the apply succeeds.
   return {
-    ...base,
-    guidance: `Applied server-side: injected template "${args.template_name}" and applied worksheet "${args.title}" to the live workbook via the validated apply path (bind ${bindMs}ms, inject ${injectMs}ms, apply ${applyMs}ms).`,
+    status: res.status,
+    guidance: `Applied "${args.title}" to the live workbook (bind ${bindMs}ms, inject ${injectMs}ms, apply ${applyMs}ms).`,
     applied: true,
     sheet_name: args.title,
     phase_ms: { bind: bindMs, inject: injectMs, apply: applyMs },
@@ -333,23 +374,33 @@ export const getBindTemplateTool = (server: DesktopMcpServer): DesktopTool<typeo
           // Phase timing (only reported when auto_apply performs). The bind phase
           // subsumes the live workbook read since server-side they are one step.
           const bindStart = Date.now();
-          const xmlResult = await getWorkbookXml({ executor, signal: extra.signal });
-          if (xmlResult.isErr()) {
-            return new DesktopCommandExecutionError(xmlResult.error).toErr();
-          }
 
-          // Events-clean anchor (W60 blind-spot #1): apply is whole-document
-          // last-writer-wins, so a user edit made in Desktop between this read and
-          // the auto-apply would be silently reverted. Anchor the event sequence
-          // now; performAutoApply refuses to apply over a dirty workbook. Best-
-          // effort: an executor without event support proceeds (surfaced in the
-          // result as events_gate 'unavailable') rather than disabling auto_apply.
+          // Events-clean anchor (W60 blind-spot #1 / adversary P1-4) — captured BEFORE
+          // the read. The apply is whole-document last-writer-wins, so a user edit made
+          // in Desktop between the read and the auto-apply would be silently reverted.
+          // Anchoring AFTER the read (the original bug) left any edit landing in the
+          // (read, anchor] window with sequence <= anchor, excluded by the strict `since`
+          // filter → count 0 → silently overwritten. Anchoring before the read makes that
+          // window checkable; worst case is now an over-cautious refusal (safe fallback),
+          // never a silent overwrite.
+          //
+          // Caveat verified (offline, no live Desktop): the read issues only
+          // `save-underlying-metadata` via getWorkbookXml — a metadata serialization/read
+          // that emits no counted document event. Counted events are user `doc:*`
+          // mutations (see checkForUserChanges tests), so a pre-read anchor does not
+          // false-trip the gate. Best-effort: an executor without event support proceeds
+          // rather than disabling auto_apply (Athena residual).
           let eventsAnchor: number | undefined;
           if (auto_apply === true) {
             const anchor = await executor.getEvents({ signal: extra.signal });
             if (anchor.isOk()) {
               eventsAnchor = anchor.value.latest_sequence;
             }
+          }
+
+          const xmlResult = await getWorkbookXml({ executor, signal: extra.signal });
+          if (xmlResult.isErr()) {
+            return new DesktopCommandExecutionError(xmlResult.error).toErr();
           }
 
           // SEAM: source manifests through bundledIntelligenceProvider (never raw
@@ -373,7 +424,7 @@ export const getBindTemplateTool = (server: DesktopMcpServer): DesktopTool<typeo
           });
           const bindMs = Date.now() - bindStart;
 
-          const base: BindTemplateToolResult = { ...res, guidance: buildGuidance(res) };
+          const base: BindTemplateToolResultBase = { ...res, guidance: buildGuidance(res) };
 
           // ── Auto-apply gate (defense in depth) ───────────────────────────
           // Only a deterministic Call-1 bind (used_llm === false) of a fast-path-

--- a/src/tools/desktop/binder/bindTemplate.ts
+++ b/src/tools/desktop/binder/bindTemplate.ts
@@ -169,8 +169,11 @@ function buildGuidance(res: BinderResult): string {
  * instance is running. 0 or 2+ instances fail closed with an instance-listing error
  * so the caller must pick one — this deletes the list-instances turn from the common
  * single-Desktop case without ever guessing between multiple instances.
+ *
+ * Exported for reuse by dashboard-auto-apply (W60), which needs the identical
+ * fail-closed session resolution — no reason for a second implementation.
  */
-function resolveSession(session: string | undefined): Result<string, McpToolError> {
+export function resolveSession(session: string | undefined): Result<string, McpToolError> {
   if (session !== undefined) {
     return Ok(session);
   }

--- a/src/tools/desktop/dashboard/buildAndApplyDashboard.ts
+++ b/src/tools/desktop/dashboard/buildAndApplyDashboard.ts
@@ -15,26 +15,7 @@ import {
 } from '../../../errors/mcpToolError.js';
 import { DesktopMcpServer } from '../../../server.desktop.js';
 import { DesktopTool } from '../tool.js';
-
-const customZoneSchema = z.object({
-  worksheetName: z.string(),
-  x: z.number(),
-  y: z.number(),
-  width: z.number(),
-  height: z.number(),
-});
-
-const layoutSpecSchema = z.object({
-  kpis: z.array(z.string()).describe('Worksheet names for KPI strip'),
-  charts: z.array(z.string()).describe('Worksheet names for chart grid'),
-  layoutType: z.enum(['auto-grid', 'rows', 'columns', 'custom']).optional().default('auto-grid'),
-  gridColumns: z.number().optional().describe('Number of columns for auto-grid layout'),
-  kpiStripHeight: z
-    .number()
-    .optional()
-    .describe('KPI strip height as a percentage of total height (0-100)'),
-  customZones: z.array(customZoneSchema).optional(),
-});
+import { buildDashboardXml, computeZones, layoutSpecSchema } from './dashboardZones.js';
 
 const paramsSchema = {
   session: z.string().describe('Tableau instance Session ID from list-instances.'),
@@ -54,68 +35,6 @@ const paramsSchema = {
     .array(z.string())
     .describe('All worksheet names to register as viewpoints in the dashboard window.'),
 };
-
-const ZONE_STYLE = `<zone-style>
-            <format attr="border-color" value="#000000"/>
-            <format attr="border-style" value="none"/>
-            <format attr="border-width" value="0"/>
-            <format attr="margin" value="4"/>
-          </zone-style>`;
-
-function escapeXml(text: string): string {
-  return text
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&apos;');
-}
-
-type Zone =
-  | {
-      kind: 'text';
-      h: number;
-      id: number;
-      w: number;
-      x: number;
-      y: number;
-      text: string;
-      bold: string;
-      fontAlignment: string;
-      fontColor: string;
-      fontName: string;
-      fontSize: string;
-    }
-  | { kind: 'worksheet'; h: number; id: number; name: string; w: number; x: number; y: number };
-
-function buildZoneXml(zone: Zone): string {
-  if (zone.kind === 'text') {
-    return `<zone h="${zone.h}" id="${zone.id}" type-v2="text" w="${zone.w}" x="${zone.x}" y="${zone.y}">
-          <zone-text>
-            <formatted-text>
-              <run bold="${zone.bold}" fontalignment="${zone.fontAlignment}" fontcolor="${zone.fontColor}" fontname="${zone.fontName}" fontsize="${zone.fontSize}">${zone.text}</run>
-            </formatted-text>
-          </zone-text>
-          ${ZONE_STYLE}
-        </zone>`;
-  }
-  return `<zone h="${zone.h}" id="${zone.id}" name="${escapeXml(zone.name)}" w="${zone.w}" x="${zone.x}" y="${zone.y}">
-          ${ZONE_STYLE}
-        </zone>`;
-}
-
-function buildDashboardXml(dashboardName: string, zones: Zone[]): string {
-  const zonesXml = zones.map(buildZoneXml).join('\n        ');
-  return `<dashboard enable-sort-zone-taborder="true" name="${escapeXml(dashboardName)}">
-  <style/>
-  <size maxheight="1000" maxwidth="1400" minheight="1000" minwidth="1400" sizing-mode="fixed"/>
-  <zones>
-    <zone h="100000" id="9" type-v2="layout-basic" w="100000" x="0" y="0">
-        ${zonesXml}
-    </zone>
-  </zones>
-</dashboard>`;
-}
 
 const title = 'Build and Apply Dashboard';
 export const getBuildAndApplyDashboardTool = (
@@ -166,112 +85,9 @@ export const getBuildAndApplyDashboardTool = (
             ).toErr();
           }
 
-          // Build zones
-          const zones: Zone[] = [];
-          let nextId = 10;
-          let currentY = 0;
-
-          if (titleText) {
-            zones.push({
-              kind: 'text',
-              h: 8000,
-              id: nextId++,
-              w: 100000,
-              x: 0,
-              y: currentY,
-              text: escapeXml(titleText),
-              bold: 'true',
-              fontAlignment: '1',
-              fontColor: '#1f77b4',
-              fontName: 'Tableau Semibold',
-              fontSize: '16',
-            });
-            currentY += 8000;
-          }
-
-          const kpiStripHeightPct = layoutSpec.kpiStripHeight ?? 20;
-          const kpiStripHeight = Math.floor(100000 * (kpiStripHeightPct / 100));
-          const chartYOffset = layoutSpec.kpis.length > 0 ? currentY + kpiStripHeight : currentY;
-          const chartAreaHeight = 100000 - chartYOffset;
-
-          if (layoutSpec.kpis.length > 0) {
-            const kpiWidth = Math.floor(100000 / layoutSpec.kpis.length);
-            for (let i = 0; i < layoutSpec.kpis.length; i++) {
-              zones.push({
-                kind: 'worksheet',
-                h: kpiStripHeight,
-                id: nextId++,
-                name: layoutSpec.kpis[i],
-                w: kpiWidth,
-                x: i * kpiWidth,
-                y: currentY,
-              });
-            }
-          }
-
-          if (layoutSpec.charts.length > 0) {
-            const { layoutType, charts, gridColumns, customZones } = layoutSpec;
-
-            if (layoutType === 'custom' && customZones) {
-              for (const cz of customZones) {
-                if (charts.includes(cz.worksheetName)) {
-                  zones.push({
-                    kind: 'worksheet',
-                    h: cz.height,
-                    id: nextId++,
-                    name: cz.worksheetName,
-                    w: cz.width,
-                    x: cz.x,
-                    y: cz.y,
-                  });
-                }
-              }
-            } else if (layoutType === 'rows') {
-              const chartHeight = Math.floor(chartAreaHeight / charts.length);
-              for (let i = 0; i < charts.length; i++) {
-                zones.push({
-                  kind: 'worksheet',
-                  h: chartHeight,
-                  id: nextId++,
-                  name: charts[i],
-                  w: 100000,
-                  x: 0,
-                  y: chartYOffset + i * chartHeight,
-                });
-              }
-            } else if (layoutType === 'columns') {
-              const chartWidth = Math.floor(100000 / charts.length);
-              for (let i = 0; i < charts.length; i++) {
-                zones.push({
-                  kind: 'worksheet',
-                  h: chartAreaHeight,
-                  id: nextId++,
-                  name: charts[i],
-                  w: chartWidth,
-                  x: i * chartWidth,
-                  y: chartYOffset,
-                });
-              }
-            } else {
-              // auto-grid (default)
-              const cols = gridColumns ?? Math.min(2, charts.length);
-              const rows = Math.ceil(charts.length / cols);
-              const chartWidth = Math.floor(100000 / cols);
-              const chartHeight = Math.floor(chartAreaHeight / rows);
-              for (let i = 0; i < charts.length; i++) {
-                zones.push({
-                  kind: 'worksheet',
-                  h: chartHeight,
-                  id: nextId++,
-                  name: charts[i],
-                  w: chartWidth,
-                  x: (i % cols) * chartWidth,
-                  y: chartYOffset + Math.floor(i / cols) * chartHeight,
-                });
-              }
-            }
-          }
-
+          // Zone math lifted to dashboardZones.ts (W60 dashboard-auto-apply spec §5/Q2) so
+          // both this tool and dashboard-auto-apply share one builder. Zero behavior change.
+          const zones = computeZones(titleText, layoutSpec);
           const dashboardXml = buildDashboardXml(dashboardName, zones);
           const executor = await extra.getExecutor(session);
 

--- a/src/tools/desktop/dashboard/dashboardAutoApply.test.ts
+++ b/src/tools/desktop/dashboard/dashboardAutoApply.test.ts
@@ -1,0 +1,681 @@
+import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { Err, Ok } from 'ts-results-es';
+import { z } from 'zod';
+
+import type { BinderResult } from '../../../desktop/binder/binder.js';
+import * as binderModule from '../../../desktop/binder/binder.js';
+import type { TemplateManifest } from '../../../desktop/binder/manifest-types.js';
+import * as getWorkbookXmlModule from '../../../desktop/commands/workbook/getWorkbookXml.js';
+import * as injectViewpointsModule from '../../../desktop/commands/workbook/injectViewpoints.js';
+import { DesktopDiscoverer } from '../../../desktop/desktopDiscoverer.js';
+import { bundledIntelligenceProvider } from '../../../desktop/intelligence/provider.js';
+import * as xmlToJsonModule from '../../../desktop/libraries/workbook-serialization-converter/index.js';
+import * as injectTemplateModule from '../../../desktop/templates/injectTemplate.js';
+import { buildInjectedWorkbookXml } from '../../../desktop/templates/injectTemplateCore.js';
+import { getTemplatePath } from '../../../desktop/templates/templatePath.js';
+import * as validationRegistry from '../../../desktop/validation/registry.js';
+import { NoDesktopInstancesFoundError } from '../../../errors/mcpToolError.js';
+import { DesktopMcpServer } from '../../../server.desktop.js';
+import invariant from '../../../utils/invariant.js';
+import { Provider } from '../../../utils/provider.js';
+import { TableauDesktopToolContext } from '../toolContext.js';
+import { getMockRequestHandlerExtra } from '../toolContext.mock.js';
+import { DASHBOARD_ZONES_VIA_WORKBOOK, getDashboardAutoApplyTool } from './dashboardAutoApply.js';
+
+// Auto-mock the live-read + inject/apply boundaries. Partial-mock binder.js and
+// injectTemplateCore.js so their pure exports (escapeXml, DERIVATION_* etc.) stay real
+// while only the impure/heavy entry points are stubbed — mirrors bindTemplate.test.ts.
+vi.mock('../../../desktop/commands/workbook/getWorkbookXml.js');
+vi.mock('../../../desktop/commands/workbook/injectViewpoints.js');
+vi.mock('../../../desktop/templates/injectTemplate.js');
+vi.mock('../../../desktop/binder/binder.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../desktop/binder/binder.js')>();
+  return { ...actual, bindTemplate: vi.fn() };
+});
+vi.mock('../../../desktop/templates/injectTemplateCore.js', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../../../desktop/templates/injectTemplateCore.js')>();
+  return { ...actual, buildInjectedWorkbookXml: vi.fn() };
+});
+vi.mock('../../../desktop/desktopDiscoverer.js');
+vi.mock('../../../desktop/libraries/workbook-serialization-converter/index.js');
+vi.mock('../../../desktop/templates/templatePath.js');
+vi.mock('../../../desktop/validation/registry.js');
+vi.mock('fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('fs')>();
+  return {
+    ...actual,
+    default: (actual as unknown as { default?: typeof actual }).default ?? actual,
+    readFileSync: vi.fn((path: unknown, ...rest: unknown[]) => {
+      if (typeof path === 'string' && path.includes('mock-templates')) {
+        return '<template/>';
+      }
+      return (actual.readFileSync as (...a: unknown[]) => unknown)(path, ...rest);
+    }),
+    writeFileSync: vi.fn(),
+  };
+});
+
+const XML = '<?xml version="1.0"?><workbook><windows></windows></workbook>';
+
+function boundResultFor(templateName: string, title: string): BinderResult {
+  return {
+    status: 'bound',
+    used_llm: false,
+    apply_hint: 'worksheet-path',
+    apply_instruction: 'Create a sheet, substitute the fragment, then apply-worksheet.',
+    args: {
+      template_name: templateName,
+      title,
+      sheet_type: 'worksheet',
+      template_parameters: { DATASOURCE: 'Superstore' },
+      field_mapping: { cat: '[Region]', val: '[Sales]' },
+    },
+  };
+}
+
+const boundA = boundResultFor('bar-basic', 'Sales by Region');
+const boundB = boundResultFor('line-basic', 'Profit by Month');
+
+const proposeResult: BinderResult = {
+  status: 'propose',
+  llm_input: { ask: 'weird ask', candidate_templates: [], fields: [] } as unknown as Extract<
+    BinderResult,
+    { status: 'propose' }
+  >['llm_input'],
+  output_schema: { type: 'object' },
+};
+
+const escalateResult: BinderResult = {
+  status: 'escalate',
+  reason: 'field-not-found',
+  blockers: [{ code: 'field-not-found', slot_id: 'val', detail: 'No field named "Revenue".' }],
+};
+
+describe('dashboardAutoApplyTool', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should create a tool instance with correct properties', () => {
+    const tool = getDashboardAutoApplyTool(new DesktopMcpServer());
+    expect(tool.name).toBe('dashboard-auto-apply');
+    expect(tool.paramsSchema).toMatchObject({
+      session: expect.any(Object),
+      asks: expect.any(Object),
+      dashboardName: expect.any(Object),
+      title: expect.any(Object),
+      layout: expect.any(Object),
+    });
+    expect(tool.annotations).toMatchObject({ readOnlyHint: false, destructiveHint: true });
+  });
+
+  it('the live probe verdict is PASS — primary single-dispatch mode is the shipped default', () => {
+    // W60 zones-live-probe (2026-07-08, session 18055): a fully zone-populated
+    // dashboard node survived a single workbook-level apply on readback. Pin the
+    // verdict so a future edit cannot silently flip back to fallback mode.
+    expect(DASHBOARD_ZONES_VIA_WORKBOOK).toBe(true);
+  });
+
+  it('asks length 1 is refused at the schema layer', async () => {
+    const tool = getDashboardAutoApplyTool(new DesktopMcpServer());
+    const schema = z.object(await Provider.from(tool.paramsSchema));
+    expect(
+      schema.safeParse({
+        asks: [{ ask: 'bar chart of Sales by Region' }],
+        dashboardName: 'D',
+      }).success,
+    ).toBe(false);
+  });
+
+  it('asks length 7 is refused at the schema layer', async () => {
+    const tool = getDashboardAutoApplyTool(new DesktopMcpServer());
+    const schema = z.object(await Provider.from(tool.paramsSchema));
+    const asks = Array.from({ length: 7 }, (_, i) => ({ ask: `chart ${i}` }));
+    expect(schema.safeParse({ asks, dashboardName: 'D' }).success).toBe(false);
+  });
+
+  it('asks length 2 and 6 are accepted at the schema layer', async () => {
+    const tool = getDashboardAutoApplyTool(new DesktopMcpServer());
+    const schema = z.object(await Provider.from(tool.paramsSchema));
+    expect(
+      schema.safeParse({ asks: [{ ask: 'a' }, { ask: 'b' }], dashboardName: 'D' }).success,
+    ).toBe(true);
+    const six = Array.from({ length: 6 }, (_, i) => ({ ask: `chart ${i}` }));
+    expect(schema.safeParse({ asks: six, dashboardName: 'D' }).success).toBe(true);
+  });
+});
+
+/**
+ * Wire the happy-path seams for a dashboard-auto-apply call over `binds` (default 2
+ * asks). Mirrors bindTemplate.test.ts's setupAutoApplyMocks: the apply leg runs the
+ * REAL validated `loadWorkbookXml` path (real runValidation via a mocked registry
+ * result, real executor dispatch) so preflight is never bypassed; only the boundaries
+ * (read, bind, inject-core, template path, dashboard/viewpoint injectors) are mocked.
+ */
+function setupMocks({
+  binds = [boundA, boundB],
+  fastPathEligible = true,
+  inject = { ok: true as const, xml: XML },
+  validationValid = true,
+  dispatch = Ok({ command_id: 'cmd-1', status: 'completed', submitted_at: '', result: {} }),
+  userEventsDuringBatch = 0,
+  existingDashboards = [] as string[],
+}: {
+  binds?: BinderResult[];
+  fastPathEligible?: boolean;
+  inject?: { ok: true; xml: string } | { ok: false; issues: string[] };
+  validationValid?: boolean;
+  dispatch?: ReturnType<typeof Ok> | ReturnType<typeof Err>;
+  userEventsDuringBatch?: number | 'unsupported';
+  existingDashboards?: string[];
+} = {}): {
+  executeCommand: ReturnType<typeof vi.fn>;
+  getEvents: ReturnType<typeof vi.fn>;
+  getExecutor: ReturnType<typeof vi.fn>;
+  bindSpy: ReturnType<typeof vi.fn>;
+} {
+  const dashboardsXml = existingDashboards
+    .map((n) => `<dashboard name="${n}"><zones/></dashboard>`)
+    .join('');
+  const workbookXml = `<?xml version="1.0"?><workbook><dashboards>${dashboardsXml}</dashboards><windows></windows></workbook>`;
+
+  vi.spyOn(getWorkbookXmlModule, 'getWorkbookXml').mockResolvedValue(Ok(workbookXml));
+  const bindSpy = vi.mocked(binderModule.bindTemplate);
+  let call = 0;
+  bindSpy.mockImplementation(async () => binds[call++ % binds.length]);
+
+  const templateNames = [
+    ...new Set(binds.filter((b) => b.status === 'bound').map((b) => b.args.template_name)),
+  ];
+  vi.spyOn(bundledIntelligenceProvider, 'listTemplateManifests').mockReturnValue(
+    templateNames.map(
+      (template) =>
+        ({ template, fast_path_eligible: fastPathEligible }) as unknown as TemplateManifest,
+    ),
+  );
+  vi.mocked(getTemplatePath).mockReturnValue('/mock-templates/tpl.xml');
+  vi.mocked(buildInjectedWorkbookXml).mockReturnValue(inject);
+  vi.mocked(injectTemplateModule.injectTemplate).mockImplementation(
+    (wb: string) => wb, // pass currentXml through unchanged; the wrapper content is asserted via the spy call args
+  );
+  vi.spyOn(injectViewpointsModule, 'injectViewpoints').mockImplementation((wb: string) => wb);
+
+  vi.mocked(xmlToJsonModule.xmlToJson).mockImplementation(() => {
+    throw new Error('force text path');
+  });
+  vi.mocked(validationRegistry.runValidation).mockReturnValue(
+    validationValid
+      ? { valid: true, issues: [] }
+      : { valid: false, issues: [{ ruleId: 'r', severity: 'error', message: 'boom' }] },
+  );
+
+  const executeCommand = vi.fn().mockResolvedValue(dispatch);
+  const getEvents =
+    userEventsDuringBatch === 'unsupported'
+      ? vi.fn().mockResolvedValue(Err('events unsupported on this transport'))
+      : vi
+          .fn()
+          .mockResolvedValueOnce(Ok({ events: [], latest_sequence: 41, count: 0 }))
+          .mockResolvedValue(
+            Ok({
+              events: Array.from({ length: userEventsDuringBatch as number }, (_, i) => ({
+                id: i,
+              })),
+              latest_sequence: 41 + (userEventsDuringBatch as number),
+              count: userEventsDuringBatch,
+            }),
+          );
+  const getExecutor = vi.fn().mockResolvedValue({ executeCommand, getEvents });
+  return { executeCommand, getEvents, getExecutor, bindSpy };
+}
+
+async function getToolResult({
+  session,
+  asks,
+  dashboardName = 'Sales Dashboard',
+  title,
+  getExecutor,
+}: {
+  session?: string;
+  asks: Array<{ ask: string; title?: string }>;
+  dashboardName?: string;
+  title?: string;
+  getExecutor?: TableauDesktopToolContext['getExecutor'];
+}): Promise<CallToolResult> {
+  const tool = getDashboardAutoApplyTool(new DesktopMcpServer());
+  const callback = await Provider.from(tool.callback);
+  const mockExecutor: TableauDesktopToolContext['getExecutor'] =
+    getExecutor ?? vi.fn().mockResolvedValue({});
+  const extra = { ...getMockRequestHandlerExtra(), getExecutor: mockExecutor };
+  return await callback({ session, asks, dashboardName, title, layout: undefined }, extra);
+}
+
+describe('dashboardAutoApplyTool happy path', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('applies exactly once (one read, one dispatch) and returns the trimmed success shape', async () => {
+    const { executeCommand, getExecutor } = setupMocks();
+
+    const result = await getToolResult({
+      session: '1',
+      asks: [{ ask: 'bar chart of Sales by Region' }, { ask: 'line chart of Profit by Month' }],
+      getExecutor,
+    });
+
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+    const body = JSON.parse(result.content[0].text);
+    expect(body.applied).toBe(true);
+    expect(body.dashboard).toBe('Sales Dashboard');
+    expect(body.sheets).toEqual([
+      { title: 'Sales by Region', template_name: 'bar-basic' },
+      { title: 'Profit by Month', template_name: 'line-basic' },
+    ]);
+    expect(typeof body.phase_ms.read).toBe('number');
+    expect(typeof body.phase_ms.bind).toBe('number');
+    expect(typeof body.phase_ms.inject).toBe('number');
+    expect(typeof body.phase_ms.apply).toBe('number');
+    expect(Object.keys(body).sort()).toEqual([
+      'applied',
+      'dashboard',
+      'guidance',
+      'phase_ms',
+      'sheets',
+    ]);
+
+    expect(vi.mocked(getWorkbookXmlModule.getWorkbookXml)).toHaveBeenCalledTimes(1);
+    expect(executeCommand).toHaveBeenCalledTimes(1);
+  });
+
+  it('injects the dashboard wrapper with zones referencing every resolved title', async () => {
+    const { getExecutor } = setupMocks();
+
+    await getToolResult({
+      session: '1',
+      asks: [{ ask: 'bar chart of Sales by Region' }, { ask: 'line chart of Profit by Month' }],
+      title: 'My Dashboard',
+      getExecutor,
+    });
+
+    expect(injectTemplateModule.injectTemplate).toHaveBeenCalledTimes(1);
+    const [, wrapperXml, sheetType] = vi.mocked(injectTemplateModule.injectTemplate).mock.calls[0];
+    expect(sheetType).toBe('dashboard');
+    expect(wrapperXml).toContain('<zone');
+    expect(wrapperXml).toContain('name="Sales by Region"');
+    expect(wrapperXml).toContain('name="Profit by Month"');
+    expect(wrapperXml).toContain('type-v2="text"'); // title zone present
+
+    expect(injectViewpointsModule.injectViewpoints).toHaveBeenCalledWith(
+      expect.any(String),
+      'Sales Dashboard',
+      ['Sales by Region', 'Profit by Month'],
+    );
+  });
+
+  it('honors a per-ask title override in the resolved zone/viewpoint titles', async () => {
+    const { getExecutor } = setupMocks();
+
+    await getToolResult({
+      session: '1',
+      asks: [
+        { ask: 'bar chart of Sales by Region', title: 'Custom A' },
+        { ask: 'line chart of Profit by Month' },
+      ],
+      getExecutor,
+    });
+
+    expect(injectViewpointsModule.injectViewpoints).toHaveBeenCalledWith(
+      expect.any(String),
+      'Sales Dashboard',
+      ['Custom A', 'Profit by Month'],
+    );
+  });
+
+  it('pristine-read regression: every ask is bound against the IDENTICAL pristine workbookXml', async () => {
+    const { getExecutor, bindSpy } = setupMocks();
+
+    await getToolResult({
+      session: '1',
+      asks: [{ ask: 'bar chart of Sales by Region' }, { ask: 'line chart of Profit by Month' }],
+      getExecutor,
+    });
+
+    expect(bindSpy).toHaveBeenCalledTimes(2);
+    const xmls = bindSpy.mock.calls.map((c) => (c[0] as { workbookXml: string }).workbookXml);
+    expect(xmls[0]).toBe(xmls[1]);
+    expect(xmls[0]).toContain('<workbook>');
+  });
+
+  it('runs preflight validation BEFORE dispatching the apply', async () => {
+    const { executeCommand, getExecutor } = setupMocks();
+
+    await getToolResult({
+      session: '1',
+      asks: [{ ask: 'bar chart of Sales by Region' }, { ask: 'line chart of Profit by Month' }],
+      getExecutor,
+    });
+
+    expect(validationRegistry.runValidation).toHaveBeenCalledTimes(1);
+    expect(executeCommand).toHaveBeenCalledTimes(1);
+    const validationOrder = vi.mocked(validationRegistry.runValidation).mock.invocationCallOrder[0];
+    const dispatchOrder = executeCommand.mock.invocationCallOrder[0];
+    expect(validationOrder).toBeLessThan(dispatchOrder);
+  });
+
+  it('replaces a pre-existing same-named dashboard and reports it in `replaced`', async () => {
+    const { getExecutor } = setupMocks({ existingDashboards: ['Sales Dashboard'] });
+
+    const result = await getToolResult({
+      session: '1',
+      asks: [{ ask: 'bar chart of Sales by Region' }, { ask: 'line chart of Profit by Month' }],
+      getExecutor,
+    });
+
+    invariant(result.content[0].type === 'text');
+    const body = JSON.parse(result.content[0].text);
+    expect(body.applied).toBe(true);
+    expect(body.replaced).toEqual({ dashboard: 'Sales Dashboard', sheets: [] });
+  });
+});
+
+describe('dashboardAutoApplyTool all-or-nothing gate matrix', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('any ask "propose" refuses the whole batch — zero dispatches, every outcome intact', async () => {
+    const { executeCommand, getExecutor } = setupMocks({ binds: [boundA, proposeResult] });
+
+    const result = await getToolResult({
+      session: '1',
+      asks: [{ ask: 'bar chart of Sales by Region' }, { ask: 'something weird' }],
+      getExecutor,
+    });
+
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+    const body = JSON.parse(result.content[0].text);
+    expect(body.applied).toBe(false);
+    expect(body.results).toHaveLength(2);
+    expect(body.results[0].result.status).toBe('bound');
+    expect(body.results[1].result.status).toBe('propose');
+    expect(executeCommand).not.toHaveBeenCalled();
+  });
+
+  it('any ask "escalate" refuses the whole batch — zero dispatches', async () => {
+    const { executeCommand, getExecutor } = setupMocks({ binds: [boundA, escalateResult] });
+
+    const result = await getToolResult({
+      session: '1',
+      asks: [{ ask: 'bar chart of Sales by Region' }, { ask: 'weird revenue ask' }],
+      getExecutor,
+    });
+
+    invariant(result.content[0].type === 'text');
+    const body = JSON.parse(result.content[0].text);
+    expect(body.applied).toBe(false);
+    expect(body.results[1].result.reason).toBe('field-not-found');
+    expect(executeCommand).not.toHaveBeenCalled();
+  });
+
+  it('mutation-proof: a bound-but-used_llm:true result (impossible via Call-1, simulated via mock) refuses the batch', async () => {
+    const usedLlmBound: BinderResult = {
+      ...(boundA as Extract<BinderResult, { status: 'bound' }>),
+      used_llm: true,
+    };
+    const { executeCommand, getExecutor } = setupMocks({ binds: [usedLlmBound, boundB] });
+
+    const result = await getToolResult({
+      session: '1',
+      asks: [{ ask: 'bar chart of Sales by Region' }, { ask: 'line chart of Profit by Month' }],
+      getExecutor,
+    });
+
+    invariant(result.content[0].type === 'text');
+    const body = JSON.parse(result.content[0].text);
+    expect(body.applied).toBe(false);
+    expect(executeCommand).not.toHaveBeenCalled();
+  });
+
+  it('mutation-proof: a bound result whose manifest is not fast_path_eligible refuses the batch', async () => {
+    const { executeCommand, getExecutor } = setupMocks({ fastPathEligible: false });
+
+    const result = await getToolResult({
+      session: '1',
+      asks: [{ ask: 'bar chart of Sales by Region' }, { ask: 'line chart of Profit by Month' }],
+      getExecutor,
+    });
+
+    invariant(result.content[0].type === 'text');
+    const body = JSON.parse(result.content[0].text);
+    expect(body.applied).toBe(false);
+    expect(executeCommand).not.toHaveBeenCalled();
+  });
+
+  it('events-dirty pre-dispatch refuses the whole batch with P1-5 guidance, zero dispatches', async () => {
+    const { executeCommand, getExecutor } = setupMocks({ userEventsDuringBatch: 3 });
+
+    const result = await getToolResult({
+      session: '1',
+      asks: [{ ask: 'bar chart of Sales by Region' }, { ask: 'line chart of Profit by Month' }],
+      getExecutor,
+    });
+
+    invariant(result.content[0].type === 'text');
+    const body = JSON.parse(result.content[0].text);
+    expect(body.applied).toBe(false);
+    expect(String(body.apply_error)).toMatch(/user changed the workbook.*3 event/);
+    expect(String(body.guidance)).toMatch(/re-run dashboard-auto-apply/i);
+    expect(executeCommand).not.toHaveBeenCalled();
+  });
+
+  it('gate is best-effort: an executor without event support still applies', async () => {
+    const { executeCommand, getExecutor } = setupMocks({ userEventsDuringBatch: 'unsupported' });
+
+    const result = await getToolResult({
+      session: '1',
+      asks: [{ ask: 'bar chart of Sales by Region' }, { ask: 'line chart of Profit by Month' }],
+      getExecutor,
+    });
+
+    invariant(result.content[0].type === 'text');
+    const body = JSON.parse(result.content[0].text);
+    expect(body.applied).toBe(true);
+    expect(executeCommand).toHaveBeenCalled();
+  });
+
+  it('inject failure on ask 2 of 2 refuses the whole batch — zero dispatches, diagnostics intact', async () => {
+    const { executeCommand, getExecutor } = setupMocks({
+      inject: { ok: false, issues: ['not well-formed'] },
+    });
+
+    const result = await getToolResult({
+      session: '1',
+      asks: [{ ask: 'bar chart of Sales by Region' }, { ask: 'line chart of Profit by Month' }],
+      getExecutor,
+    });
+
+    invariant(result.content[0].type === 'text');
+    const body = JSON.parse(result.content[0].text);
+    expect(body.applied).toBe(false);
+    expect(String(body.apply_error)).toContain('inject failed');
+    expect(body.results).toHaveLength(2);
+    expect(body.results[0].result.status).toBe('bound');
+    expect(executeCommand).not.toHaveBeenCalled();
+  });
+
+  it('preflight validation failure aborts the apply — zero dispatches', async () => {
+    const { executeCommand, getExecutor } = setupMocks({ validationValid: false });
+
+    const result = await getToolResult({
+      session: '1',
+      asks: [{ ask: 'bar chart of Sales by Region' }, { ask: 'line chart of Profit by Month' }],
+      getExecutor,
+    });
+
+    invariant(result.content[0].type === 'text');
+    const body = JSON.parse(result.content[0].text);
+    expect(body.applied).toBe(false);
+    expect(String(body.apply_error)).toContain('preflight validation failed');
+    expect(executeCommand).not.toHaveBeenCalled();
+  });
+
+  it('duplicate resolved titles within the batch refuse — zero dispatches, indices named', async () => {
+    const dup = boundResultFor('bar-basic', 'Same Title');
+    const dup2 = boundResultFor('line-basic', 'Same Title');
+    const { executeCommand, getExecutor } = setupMocks({ binds: [dup, dup2] });
+
+    const result = await getToolResult({
+      session: '1',
+      asks: [{ ask: 'bar chart' }, { ask: 'line chart' }],
+      getExecutor,
+    });
+
+    invariant(result.content[0].type === 'text');
+    const body = JSON.parse(result.content[0].text);
+    expect(body.applied).toBe(false);
+    expect(String(body.guidance)).toMatch(/Duplicate resolved title/);
+    expect(String(body.guidance)).toMatch(/\[0, 1\]/);
+    expect(executeCommand).not.toHaveBeenCalled();
+  });
+
+  it('a title referenced by an existing dashboard zone refuses — zero dispatches', async () => {
+    const { executeCommand, getExecutor } = setupMocks();
+    // A DIFFERENT existing dashboard's zone already references "Sales by Region".
+    vi.spyOn(getWorkbookXmlModule, 'getWorkbookXml').mockResolvedValue(
+      Ok(
+        '<?xml version="1.0"?><workbook><dashboards><dashboard name="Other"><zones><zone name="Sales by Region"/></zones></dashboard></dashboards><windows></windows></workbook>',
+      ),
+    );
+
+    const result = await getToolResult({
+      session: '1',
+      asks: [{ ask: 'bar chart of Sales by Region' }, { ask: 'line chart of Profit by Month' }],
+      getExecutor,
+    });
+
+    invariant(result.content[0].type === 'text');
+    const body = JSON.parse(result.content[0].text);
+    expect(body.applied).toBe(false);
+    expect(String(body.apply_error)).toMatch(/referenced by existing dashboard zone/);
+    expect(executeCommand).not.toHaveBeenCalled();
+  });
+
+  it('replacing the SAME-named dashboard does not self-collide with the zone-reference guard', async () => {
+    // The dashboard we are about to replace references "Sales by Region" itself — that
+    // must NOT trip the "referenced by an existing dashboard" refusal (Q1).
+    const { executeCommand, getExecutor } = setupMocks({ existingDashboards: ['Sales Dashboard'] });
+    vi.spyOn(getWorkbookXmlModule, 'getWorkbookXml').mockResolvedValue(
+      Ok(
+        '<?xml version="1.0"?><workbook><dashboards><dashboard name="Sales Dashboard"><zones><zone name="Sales by Region"/></zones></dashboard></dashboards><windows></windows></workbook>',
+      ),
+    );
+
+    const result = await getToolResult({
+      session: '1',
+      asks: [{ ask: 'bar chart of Sales by Region' }, { ask: 'line chart of Profit by Month' }],
+      getExecutor,
+    });
+
+    invariant(result.content[0].type === 'text');
+    const body = JSON.parse(result.content[0].text);
+    expect(body.applied).toBe(true);
+    expect(executeCommand).toHaveBeenCalledTimes(1);
+  });
+
+  it('a resolved title matching an already-existing worksheet is reported as replaced', async () => {
+    const { getExecutor } = setupMocks();
+    vi.spyOn(getWorkbookXmlModule, 'getWorkbookXml').mockResolvedValue(
+      Ok(
+        '<?xml version="1.0"?><workbook><worksheets><worksheet name="Sales by Region"></worksheet></worksheets><dashboards></dashboards><windows></windows></workbook>',
+      ),
+    );
+
+    const result = await getToolResult({
+      session: '1',
+      asks: [{ ask: 'bar chart of Sales by Region' }, { ask: 'line chart of Profit by Month' }],
+      getExecutor,
+    });
+
+    invariant(result.content[0].type === 'text');
+    const body = JSON.parse(result.content[0].text);
+    expect(body.applied).toBe(true);
+    expect(body.replaced.sheets).toEqual(['Sales by Region']);
+  });
+});
+
+describe('dashboardAutoApplyTool session-default-when-unique', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function mockInstances(pids: number[]): void {
+    const map = new Map(pids.map((pid) => [pid, { pid }]));
+    vi.mocked(DesktopDiscoverer).mockImplementation(
+      () => ({ getInstances: () => map }) as unknown as DesktopDiscoverer,
+    );
+  }
+
+  it('resolves the session automatically when exactly one Desktop instance is running', async () => {
+    mockInstances([4242]);
+    const { getExecutor } = setupMocks();
+
+    const result = await getToolResult({
+      asks: [{ ask: 'bar chart of Sales by Region' }, { ask: 'line chart of Profit by Month' }],
+      getExecutor,
+    });
+
+    expect(result.isError).toBe(false);
+    expect(getExecutor).toHaveBeenCalledWith('4242');
+  });
+
+  it('fails closed listing instances when 2+ Desktop instances are running (no read, no bind)', async () => {
+    mockInstances([11, 22]);
+    const getExecutor = vi.fn().mockResolvedValue({});
+    const getWorkbookXmlSpy = vi.spyOn(getWorkbookXmlModule, 'getWorkbookXml');
+
+    const result = await getToolResult({
+      asks: [{ ask: 'bar chart of Sales by Region' }, { ask: 'line chart of Profit by Month' }],
+      getExecutor,
+    });
+
+    expect(result.isError).toBe(true);
+    invariant(result.content[0].type === 'text');
+    expect(result.content[0].text).toContain('Multiple Tableau Desktop instances are running');
+    expect(getExecutor).not.toHaveBeenCalled();
+    expect(getWorkbookXmlSpy).not.toHaveBeenCalled();
+  });
+
+  it('fails closed when no Desktop instance is running', async () => {
+    mockInstances([]);
+    const getExecutor = vi.fn().mockResolvedValue({});
+
+    const result = await getToolResult({
+      asks: [{ ask: 'bar chart of Sales by Region' }, { ask: 'line chart of Profit by Month' }],
+      getExecutor,
+    });
+
+    expect(result.isError).toBe(true);
+    invariant(result.content[0].type === 'text');
+    expect(result.content[0].text).toBe(new NoDesktopInstancesFoundError().message);
+    expect(getExecutor).not.toHaveBeenCalled();
+  });
+
+  it('an explicit session always wins (discovery is never consulted)', async () => {
+    mockInstances([11, 22]);
+    const { getExecutor } = setupMocks();
+
+    const result = await getToolResult({
+      session: '7',
+      asks: [{ ask: 'bar chart of Sales by Region' }, { ask: 'line chart of Profit by Month' }],
+      getExecutor,
+    });
+
+    expect(result.isError).toBe(false);
+    expect(getExecutor).toHaveBeenCalledWith('7');
+    expect(DesktopDiscoverer).not.toHaveBeenCalled();
+  });
+});

--- a/src/tools/desktop/dashboard/dashboardAutoApply.ts
+++ b/src/tools/desktop/dashboard/dashboardAutoApply.ts
@@ -1,0 +1,504 @@
+// W60 single-pass dashboard-auto-apply: collapses the proven 5-call / 6-Desktop-apply
+// dashboard composition (bind-template x N + batch-create-and-cache-sheets +
+// build-and-apply-dashboard) into ONE MCP call with exactly one Desktop apply dispatch
+// on the primary path. See ~/.claude/state/w60-dashboard-singlepass-spec.md for the full
+// design (§2 architecture, §4 the five design questions, §7 test plan).
+//
+// Every mutation stays IN-MEMORY over one pristine workbook read until the single
+// loadWorkbookXml dispatch (§4-Q3): a bind failure, inject failure, batch-preflight
+// refusal, events-dirty re-check, or preflight validation failure all short-circuit
+// BEFORE Desktop is touched. Nothing here is partially applied on the primary path.
+
+import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { randomUUID } from 'crypto';
+import { readFileSync } from 'fs';
+import { Ok } from 'ts-results-es';
+import { z } from 'zod';
+
+import { type BinderResult, bindTemplate } from '../../../desktop/binder/binder.js';
+import type { TemplateManifest } from '../../../desktop/binder/manifest-types.js';
+import { getWorkbookXml } from '../../../desktop/commands/workbook/getWorkbookXml.js';
+import { injectViewpoints } from '../../../desktop/commands/workbook/injectViewpoints.js';
+import { loadDashboardXml } from '../../../desktop/commands/workbook/loadDashboardXml.js';
+import {
+  loadWorkbookXml,
+  type LoadWorkbookXmlError,
+} from '../../../desktop/commands/workbook/loadWorkbookXml.js';
+import { bundledIntelligenceProvider } from '../../../desktop/intelligence/provider.js';
+import { deleteDashboard, listWorkbookDashboards } from '../../../desktop/metadata/dashboards.js';
+import { injectTemplate } from '../../../desktop/templates/injectTemplate.js';
+import {
+  buildInjectedWorkbookXml,
+  escapeXml,
+} from '../../../desktop/templates/injectTemplateCore.js';
+import { getTemplatePath } from '../../../desktop/templates/templatePath.js';
+import { ExecuteCommandError } from '../../../desktop/toolExecutor/toolExecutor.js';
+import { DesktopCommandExecutionError } from '../../../errors/mcpToolError.js';
+import { DesktopMcpServer } from '../../../server.desktop.js';
+import { getExceptionMessage } from '../../../utils/getExceptionMessage.js';
+import { resolveSession } from '../binder/bindTemplate.js';
+import { DesktopTool } from '../tool.js';
+import { buildDashboardXml, computeZones } from './dashboardZones.js';
+
+/**
+ * Whether a fully zone-populated `<dashboard>` node injected as part of a single
+ * workbook-level `load-underlying-metadata` apply renders correctly on readback (the
+ * spec's "one live unknown", §2). Set from the W60 live probe (2026-07-08, session
+ * 18055): a 2-worksheet auto-grid dashboard was injected into one workbook-level apply
+ * and `tableau-get-dashboard` readback showed the exact zone tree (worksheet refs,
+ * w/h/x/y tiling) intact — NOT stripped to a basic empty layout. PASS → primary mode.
+ * One `if` at the dispatch step flips this to fallback mode (a second `loadDashboardXml`
+ * dispatch, §2 "Probe fails") without touching the rest of the flow — never a
+ * user-facing flag.
+ */
+export const DASHBOARD_ZONES_VIA_WORKBOOK = true;
+
+const MIN_ASKS = 2;
+const MAX_ASKS = 6;
+
+const askSchema = z.object({
+  ask: z
+    .string()
+    .min(1)
+    .describe("Natural-language chart request, e.g. 'bar chart of Sales by Region'."),
+  title: z
+    .string()
+    .min(1)
+    .max(80)
+    .optional()
+    .describe('Optional title override for this sheet (default: the deterministic bind title).'),
+});
+
+const layoutSchema = z.object({
+  layoutType: z
+    .enum(['auto-grid', 'rows', 'columns'])
+    .optional()
+    .default('auto-grid')
+    .describe('Dashboard grid layout. v1 does not support custom zones or a KPI strip.'),
+  gridColumns: z.number().optional().describe('Number of columns for auto-grid layout.'),
+});
+
+const paramsSchema = {
+  session: z
+    .string()
+    .optional()
+    .describe(
+      'Tableau instance Session ID from list-instances. Optional: when omitted and exactly one Desktop instance is running, it is resolved automatically; with 0 or 2+ instances the tool fails closed and lists the instances.',
+    ),
+  asks: z
+    .array(askSchema)
+    .min(MIN_ASKS)
+    .max(MAX_ASKS)
+    .describe(
+      `2-${MAX_ASKS} chart asks to bind and compose into one dashboard. Every ask must deterministically bind (Call-1, no proposal) or the whole batch is refused with each ask's outcome intact.`,
+    ),
+  dashboardName: z.string().min(1).describe('Name of the dashboard to build and apply.'),
+  title: z.string().optional().describe('Optional title text zone at the top of the dashboard.'),
+  layout: layoutSchema.optional().describe('Dashboard layout options (default: auto-grid).'),
+};
+
+/** One ask's outcome, tagged with its position and original ask text for diagnostics. */
+type AskOutcome = { index: number; ask: string; result: BinderResult };
+
+type DashboardAutoApplyRefusalResult = {
+  applied: false;
+  results: AskOutcome[];
+  guidance: string;
+  apply_error?: string;
+};
+
+type Replaced = { dashboard?: string; sheets: string[] };
+
+type DashboardAutoApplySuccessResult = {
+  applied: true;
+  dashboard: string;
+  sheets: Array<{ title: string; template_name: string }>;
+  phase_ms: { read: number; bind: number; inject: number; apply: number };
+  guidance: string;
+  replaced?: Replaced;
+};
+
+type DashboardAutoApplyPartialResult = {
+  applied: 'partial';
+  dashboard: string;
+  sheets: Array<{ title: string; template_name: string }>;
+  apply_error: string;
+  guidance: string;
+  replaced?: Replaced;
+};
+
+type DashboardAutoApplyToolResult =
+  | DashboardAutoApplyRefusalResult
+  | DashboardAutoApplySuccessResult
+  | DashboardAutoApplyPartialResult;
+
+/** Human-readable detail for a loadWorkbookXml failure (mirrors bindTemplate.ts). */
+function describeApplyError(
+  error:
+    | { type: 'execute-command-error'; error: ExecuteCommandError }
+    | { type: 'load-workbook-xml-error'; error: LoadWorkbookXmlError },
+): string {
+  if (error.type === 'load-workbook-xml-error') {
+    const inner = error.error;
+    if (inner.type === 'validation-failed') {
+      return `preflight validation failed: ${inner.issues.map((i) => i.message).join('; ')}`;
+    }
+    return 'invalid workbook XML';
+  }
+  return `workbook load command failed: ${JSON.stringify(error.error)}`;
+}
+
+function refusal(
+  results: AskOutcome[],
+  guidance: string,
+  apply_error?: string,
+): Ok<DashboardAutoApplyToolResult> {
+  return new Ok({ applied: false, results, guidance, ...(apply_error ? { apply_error } : {}) });
+}
+
+/** Quote-agnostic (matches injectTemplateCore.ts's own conventions): true when `title`
+ * already names a `<worksheet>` element in `workbookXml`. */
+function hasWorksheetNamed(workbookXml: string, title: string): boolean {
+  const nameAttr = escapeXml(title).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return new RegExp(`<worksheet name=['"]${nameAttr}['"]>`).test(workbookXml);
+}
+
+/** True when `title` is referenced by a `<zone name="...">` in ANY dashboard already in
+ * `workbookXml` — mirrors injectTemplateCore.ts's own zoneRe (injectTemplateCore.ts:89),
+ * duplicated here (not imported — that file is off-limits, in-flight in another lane). */
+function isReferencedByDashboardZone(workbookXml: string, title: string): boolean {
+  const nameAttr = escapeXml(title).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return new RegExp(`<zone [^>]*name=['"]${nameAttr}['"]`).test(workbookXml);
+}
+
+const title = 'Build a Dashboard From N Asks in One Call (Fast Path)';
+
+export const getDashboardAutoApplyTool = (
+  server: DesktopMcpServer,
+): DesktopTool<typeof paramsSchema> => {
+  const dashboardAutoApplyTool = new DesktopTool({
+    server,
+    name: 'dashboard-auto-apply',
+    title,
+    description: [
+      'Bind 2-6 chart asks to checked-in templates and compose them into one new (or replaced) dashboard, applied to the live workbook in ONE call.',
+      "Every ask must deterministically bind (bind-template Call-1, no-LLM); if any ask does not, NOTHING is applied and every ask's full bind-template-shaped outcome is returned so you can fall back to the per-chart flow (bind-template with auto_apply, or propose/escalate resolution).",
+      "All-or-nothing: a duplicate title, a title already referenced by an existing dashboard's zone, a mid-flight user edit, or a preflight validation failure all refuse the WHOLE batch before anything is dispatched to Desktop.",
+      'On success returns the trimmed shape { applied:true, dashboard, sheets, phase_ms, guidance } — call list-worksheets / get-dashboard-xml if you need the full XML.',
+    ].join(' '),
+    paramsSchema,
+    annotations: {
+      title,
+      readOnlyHint: false,
+      openWorldHint: false,
+      destructiveHint: true,
+      idempotentHint: false,
+    },
+    callback: async (
+      { session, asks, dashboardName, title: titleText, layout },
+      extra,
+    ): Promise<CallToolResult> => {
+      return await dashboardAutoApplyTool.logAndExecute<DashboardAutoApplyToolResult>({
+        extra,
+        args: { session, asks, dashboardName, title: titleText, layout },
+        callback: async () => {
+          const sessionResult = resolveSession(session);
+          if (sessionResult.isErr()) {
+            return sessionResult.error.toErr();
+          }
+          const resolvedSession = sessionResult.value;
+          const executor = await extra.getExecutor(resolvedSession);
+
+          // ── Events anchor (pre-read) — identical rationale to bindTemplate.ts's
+          // pre-bind anchor: capturing BEFORE the read makes the (read, apply] window
+          // checkable, so a mid-flight user edit is refused (safe) rather than silently
+          // reverted by the whole-document apply.
+          let eventsAnchor: number | undefined;
+          const anchor = await executor.getEvents({ signal: extra.signal });
+          if (anchor.isOk()) {
+            eventsAnchor = anchor.value.latest_sequence;
+          }
+
+          const readStart = Date.now();
+          const xmlResult = await getWorkbookXml({ executor, signal: extra.signal });
+          if (xmlResult.isErr()) {
+            return new DesktopCommandExecutionError(xmlResult.error).toErr();
+          }
+          const pristineXml = xmlResult.value;
+          const readMs = Date.now() - readStart;
+
+          // SEAM: same provider as bind-template / propose-template / validate-proposal.
+          const manifests = new Map(
+            bundledIntelligenceProvider
+              .listTemplateManifests()
+              .map((m): [string, TemplateManifest] => [m.template, m]),
+          );
+
+          // ── Bind ALL N against the SAME pristine XML (never a bind-mutated copy —
+          // this is the unit-level pin for the w60-portability-live.md sequential-
+          // degradation finding: every ask sees identical workbookXml).
+          const bindStart = Date.now();
+          const outcomes: AskOutcome[] = [];
+          for (let i = 0; i < asks.length; i++) {
+            // Sequential await (not Promise.all): keeps bind ordering deterministic for
+            // the pristine-read spy test; costs ~0.1-0.3s total at N<=6 (spec §6).
+            const result = await bindTemplate({
+              ask: asks[i].ask,
+              workbookXml: pristineXml,
+              manifests,
+            });
+            outcomes.push({ index: i, ask: asks[i].ask, result });
+          }
+          const bindMs = Date.now() - bindStart;
+
+          const notBound = outcomes.filter((o) => o.result.status !== 'bound');
+          if (notBound.length > 0) {
+            return refusal(
+              outcomes,
+              'One or more asks did not deterministically bind (Call-1, no-LLM). Nothing was applied to ' +
+                'the live workbook. Each ask carries its own bind-template-shaped outcome below: for ' +
+                '"propose", fill its output_schema and call bind-template again; for "escalate", follow its ' +
+                'guidance. Once every ask binds, retry dashboard-auto-apply, or fall back to the per-chart ' +
+                'bind-template(auto_apply:true) flow using each already-bound ask.',
+            );
+          }
+
+          // ── Defense-in-depth gate matrix (mirrors bindTemplate.ts:434-440 verbatim,
+          // per-ask): Call-1 only (never passed a proposal here, so used_llm===false is
+          // structurally guaranteed by binder.ts, but asserted explicitly — flipping
+          // either half of this check must fail a test, same discipline as w60-auto-apply).
+          const notFastPath = outcomes.filter((o) => {
+            const r = o.result;
+            if (r.status !== 'bound') return false;
+            const manifest = manifests.get(r.args.template_name);
+            return r.used_llm !== false || manifest?.fast_path_eligible !== true;
+          });
+          if (notFastPath.length > 0) {
+            return refusal(
+              outcomes,
+              'One or more bound asks are not eligible for server-side auto-apply (used_llm or ' +
+                'fast_path_eligible gate failed). Nothing was applied. Fall back to the per-chart flow.',
+            );
+          }
+
+          // ── Resolve titles (per-ask override, else the bind's own escaped title) and
+          // refuse in-batch duplicates BEFORE touching the workbook (Q1).
+          const resolvedTitles: string[] = outcomes.map((o, i) => {
+            const bound = o.result as Extract<BinderResult, { status: 'bound' }>;
+            const override = asks[i].title;
+            return override !== undefined ? escapeXml(override) : bound.args.title;
+          });
+          const seen = new Map<string, number[]>();
+          resolvedTitles.forEach((t, i) => seen.set(t, [...(seen.get(t) ?? []), i]));
+          const dupes = [...seen.entries()].filter(([, idxs]) => idxs.length > 1);
+          if (dupes.length > 0) {
+            const detail = dupes
+              .map(([t, idxs]) => `"${t}" at indices [${idxs.join(', ')}]`)
+              .join('; ');
+            return refusal(
+              outcomes,
+              `Duplicate resolved title(s) within the batch: ${detail}. Give each ask a distinct 'title' ` +
+                'and retry — nothing was applied.',
+              `duplicate title(s): ${detail}`,
+            );
+          }
+
+          // ── Replace semantics for the dashboard itself (Q1): delete first so the
+          // zone-reference safety check below never self-collides with the dashboard
+          // we are about to regenerate.
+          let currentXml = pristineXml;
+          const replaced: Replaced = { sheets: [] };
+          if (listWorkbookDashboards(currentXml).includes(dashboardName)) {
+            currentXml = deleteDashboard(currentXml, dashboardName);
+            replaced.dashboard = dashboardName;
+          }
+
+          // ── Batch refusal: a resolved title already referenced by a DIFFERENT
+          // existing dashboard's zone (Q1). Silent Desktop dedup-to-"Name (1)" would
+          // wire OUR new dashboard's zones/viewpoints to the OLD sheet — loud refusal
+          // beats a silently wrong dashboard.
+          const zoneCollisions = resolvedTitles.filter((t) =>
+            isReferencedByDashboardZone(currentXml, t),
+          );
+          if (zoneCollisions.length > 0) {
+            const detail = zoneCollisions.map((t) => `"${t}"`).join(', ');
+            return refusal(
+              outcomes,
+              `Resolved title(s) ${detail} are already referenced by another existing dashboard's zone. ` +
+                'Applying this batch would silently rewire that dashboard to a replaced sheet. Rename the ' +
+                "ask's title and retry — nothing was applied.",
+              `title referenced by existing dashboard zone: ${detail}`,
+            );
+          }
+
+          // ── Sequential in-memory injects (worksheets), each its own applyNonce
+          // (mirrors bindTemplate.ts:296-307). Any failure refuses the WHOLE batch —
+          // nothing is dispatched (Q3).
+          const injectStart = Date.now();
+          const sheets: Array<{ title: string; template_name: string }> = [];
+          for (let i = 0; i < outcomes.length; i++) {
+            const bound = outcomes[i].result as Extract<BinderResult, { status: 'bound' }>;
+            const resolvedTitle = resolvedTitles[i];
+            if (hasWorksheetNamed(currentXml, resolvedTitle)) {
+              replaced.sheets.push(resolvedTitle);
+            }
+            let templateXml: string;
+            try {
+              templateXml = readFileSync(getTemplatePath(bound.args.template_name), 'utf-8');
+            } catch (err) {
+              return refusal(
+                outcomes,
+                `Could not read template "${bound.args.template_name}" for ask index ${i}: ` +
+                  `${getExceptionMessage(err)}. Nothing was applied.`,
+                `template read failed: ${getExceptionMessage(err)}`,
+              );
+            }
+            const applyNonce = `${resolvedSession}:${Date.now()}:${randomUUID()}`;
+            let injected: ReturnType<typeof buildInjectedWorkbookXml>;
+            try {
+              injected = buildInjectedWorkbookXml({
+                workbookXml: currentXml,
+                templateXml,
+                title: resolvedTitle,
+                sheetType: 'worksheet',
+                templateParameters: bound.args.template_parameters,
+                fieldMapping: bound.args.field_mapping,
+                applyNonce,
+              });
+            } catch (err) {
+              return refusal(
+                outcomes,
+                `Inject failed for ask index ${i} ("${resolvedTitle}"): ${getExceptionMessage(err)}. ` +
+                  'Nothing was applied to the live workbook.',
+                `inject failed: ${getExceptionMessage(err)}`,
+              );
+            }
+            if (!injected.ok) {
+              return refusal(
+                outcomes,
+                `Inject failed for ask index ${i} ("${resolvedTitle}"): ${injected.issues.join('; ')}. ` +
+                  'Nothing was applied to the live workbook.',
+                `inject failed: ${injected.issues.join('; ')}`,
+              );
+            }
+            currentXml = injected.xml;
+            sheets.push({ title: resolvedTitle, template_name: bound.args.template_name });
+          }
+
+          // ── Dashboard node injection with zones already populated (primary mode) or
+          // a minimal layout-basic placeholder (fallback mode) — the "one live unknown"
+          // the probe decided (§2). Either way ONE wrapper inject + ONE viewpoints call.
+          const zones = DASHBOARD_ZONES_VIA_WORKBOOK
+            ? computeZones(titleText, {
+                kpis: [],
+                charts: resolvedTitles,
+                layoutType: layout?.layoutType ?? 'auto-grid',
+                gridColumns: layout?.gridColumns,
+              })
+            : [];
+          const dashboardXml = buildDashboardXml(dashboardName, zones);
+          const wrapperXml = `<workbook><dashboards>${dashboardXml}</dashboards><windows><window class="dashboard" name="${escapeXml(dashboardName)}"/></windows></workbook>`;
+          try {
+            currentXml = injectTemplate(currentXml, wrapperXml, 'dashboard');
+          } catch (err) {
+            return refusal(
+              outcomes,
+              `Dashboard injection failed: ${getExceptionMessage(err)}. Nothing was applied.`,
+              `dashboard inject failed: ${getExceptionMessage(err)}`,
+            );
+          }
+          currentXml = injectViewpoints(currentXml, dashboardName, resolvedTitles);
+          const injectMs = Date.now() - injectStart;
+
+          // ── Events re-check pre-dispatch (P1-5): a user edit between the anchor and
+          // now refuses the WHOLE batch — the binds/injects were computed against the
+          // pre-edit workbook, so applying them would silently revert the user's changes.
+          if (eventsAnchor !== undefined) {
+            const events = await executor.getEvents({
+              signal: extra.signal,
+              sinceSequence: eventsAnchor,
+            });
+            if (events.isOk() && events.value.count > 0) {
+              return refusal(
+                outcomes,
+                'Server-side auto-apply was refused: the user changed the workbook after it was read ' +
+                  `(${events.value.count} event(s) since read). Re-run dashboard-auto-apply so it reads the ` +
+                  'current workbook — do NOT re-apply, the binds were computed against the pre-edit workbook ' +
+                  'and re-applying could revert their changes.',
+                `user changed the workbook during the batch (${events.value.count} event(s) since read)`,
+              );
+            }
+          }
+
+          // ── ONE dispatch (primary mode) — the ONLY doc that ever reaches Desktop,
+          // the same runValidation workbook preflight guarantee every apply path has.
+          const applyStart = Date.now();
+          const applyResult = await loadWorkbookXml({
+            xml: currentXml,
+            executor,
+            signal: extra.signal,
+          });
+          if (applyResult.isErr()) {
+            return refusal(
+              outcomes,
+              `Server-side auto-apply did not complete (${describeApplyError(applyResult.error)}). Nothing ` +
+                'was applied — fall back to the per-chart bind-template(auto_apply:true) flow using each ' +
+                "ask's bound args.",
+              describeApplyError(applyResult.error),
+            );
+          }
+          const applyMs = Date.now() - applyStart;
+
+          if (!DASHBOARD_ZONES_VIA_WORKBOOK) {
+            // Fallback mode (§2 "Probe fails"): the workbook (worksheets + minimal empty
+            // dashboard) is already live; a second dispatch lays in the real zones. A
+            // failure here is a REAL partial window (Q3) — the dashboard exists with a
+            // valid empty layout, coherent and recoverable via build-and-apply-dashboard.
+            const realZones = computeZones(titleText, {
+              kpis: [],
+              charts: resolvedTitles,
+              layoutType: layout?.layoutType ?? 'auto-grid',
+              gridColumns: layout?.gridColumns,
+            });
+            const zonesXml = buildDashboardXml(dashboardName, realZones);
+            const dashboardApply = await loadDashboardXml({
+              dashboardName,
+              xml: zonesXml,
+              executor,
+              signal: extra.signal,
+            });
+            if (dashboardApply.isErr()) {
+              const err = dashboardApply.error;
+              const message =
+                err.type === 'load-dashboard-xml-error'
+                  ? JSON.stringify(err.error)
+                  : `workbook load command failed: ${JSON.stringify(err.error)}`;
+              return new Ok({
+                applied: 'partial',
+                dashboard: dashboardName,
+                sheets,
+                apply_error: message,
+                guidance:
+                  `The workbook (sheets + an empty "${dashboardName}" dashboard) was applied, but laying ` +
+                  `in the zones failed (${message}). Re-issue the zones via build-and-apply-dashboard — the ` +
+                  'dashboard exists with a valid empty layout, nothing is corrupted.',
+                ...(replaced.dashboard || replaced.sheets.length > 0 ? { replaced } : {}),
+              });
+            }
+          }
+
+          return new Ok({
+            applied: true,
+            dashboard: dashboardName,
+            sheets,
+            phase_ms: { read: readMs, bind: bindMs, inject: injectMs, apply: applyMs },
+            guidance: `Applied "${dashboardName}" (${sheets.length} sheet(s)) to the live workbook (read ${readMs}ms, bind ${bindMs}ms, inject ${injectMs}ms, apply ${applyMs}ms).`,
+            ...(replaced.dashboard || replaced.sheets.length > 0 ? { replaced } : {}),
+          });
+        },
+      });
+    },
+  });
+
+  return dashboardAutoApplyTool;
+};

--- a/src/tools/desktop/dashboard/dashboardZones.test.ts
+++ b/src/tools/desktop/dashboard/dashboardZones.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildDashboardXml, computeZones, type LayoutSpec, type Zone } from './dashboardZones.js';
+
+// Characterization suite (W60 spec §5/Q2, §7 test-plan item 1): this module is a
+// byte-for-byte extraction of buildAndApplyDashboard.ts's inline zone-computation
+// callback body. buildAndApplyDashboard.ts now imports computeZones/buildDashboardXml
+// directly, so buildAndApplyDashboard.test.ts staying green (it asserts on the
+// serialized XML: `<zone`, `type-v2="text"`, kpiCount/chartCount/viewpointCount) is
+// itself the no-op-refactor proof. This suite locks the pure zone math independently.
+
+function spec(overrides: Partial<LayoutSpec> = {}): LayoutSpec {
+  return { kpis: [], charts: [], layoutType: 'auto-grid', ...overrides };
+}
+
+describe('computeZones — auto-grid', () => {
+  it('N=2 tiles two equal-width columns side by side, no overlap', () => {
+    const zones = computeZones(undefined, spec({ charts: ['A', 'B'] }));
+    expect(zones).toEqual([
+      { kind: 'worksheet', h: 100000, id: 10, name: 'A', w: 50000, x: 0, y: 0 },
+      { kind: 'worksheet', h: 100000, id: 11, name: 'B', w: 50000, x: 50000, y: 0 },
+    ]);
+  });
+
+  it('N=3 (default cols=2) wraps to 2 rows with the known cosmetic half-width gap', () => {
+    const zones = computeZones(undefined, spec({ charts: ['A', 'B', 'C'] }));
+    expect(zones.map((z) => (z.kind === 'worksheet' ? z.name : ''))).toEqual(['A', 'B', 'C']);
+    // Row 2 (chart C) starts at y=50000 (chartHeight = floor(100000/2)).
+    expect(zones[2]).toMatchObject({ x: 0, y: 50000, w: 50000 });
+  });
+
+  it('N=4 with gridColumns=4 produces one row of four equal columns', () => {
+    const zones = computeZones(undefined, spec({ charts: ['A', 'B', 'C', 'D'], gridColumns: 4 }));
+    expect(zones.every((z) => z.kind === 'worksheet' && z.h === 100000)).toBe(true);
+    expect(zones.map((z) => (z.kind === 'worksheet' ? z.x : -1))).toEqual([0, 25000, 50000, 75000]);
+  });
+
+  it('every zone id is unique and ascending from 10', () => {
+    const zones = computeZones(undefined, spec({ charts: ['A', 'B', 'C', 'D', 'E', 'F'] }));
+    const ids = zones.map((z) => z.id);
+    expect(ids).toEqual([10, 11, 12, 13, 14, 15]);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('zones tile [0,100000) without exceeding the canvas', () => {
+    for (const zone of computeZones(undefined, spec({ charts: ['A', 'B', 'C', 'D', 'E'] }))) {
+      if (zone.kind !== 'worksheet') continue;
+      expect(zone.x + zone.w).toBeLessThanOrEqual(100000);
+      expect(zone.y + zone.h).toBeLessThanOrEqual(100000);
+    }
+  });
+});
+
+describe('computeZones — rows / columns', () => {
+  it('rows: N charts stack full-width top to bottom', () => {
+    const zones = computeZones(undefined, spec({ charts: ['A', 'B', 'C'], layoutType: 'rows' }));
+    expect(zones.every((z) => z.kind === 'worksheet' && z.w === 100000)).toBe(true);
+    expect(zones.map((z) => (z.kind === 'worksheet' ? z.y : -1))).toEqual([0, 33333, 66666]);
+  });
+
+  it('columns: N charts sit side by side full-height', () => {
+    const zones = computeZones(undefined, spec({ charts: ['A', 'B'], layoutType: 'columns' }));
+    expect(zones.every((z) => z.kind === 'worksheet' && z.h === 100000)).toBe(true);
+    expect(zones.map((z) => (z.kind === 'worksheet' ? z.x : -1))).toEqual([0, 50000]);
+  });
+});
+
+describe('computeZones — title zone', () => {
+  it('an 8% title text zone is prepended and pushes the chart area down', () => {
+    const zones = computeZones('Q1 Sales', spec({ charts: ['A', 'B'] }));
+    expect(zones[0]).toMatchObject({ kind: 'text', h: 8000, id: 10, y: 0 });
+    const chartZones = zones.slice(1);
+    expect(chartZones.every((z) => z.kind === 'worksheet')).toBe(true);
+    // Chart area height is 100000 - 8000 = 92000, one row => each chart h=92000.
+    expect(chartZones[0]).toMatchObject({ h: 92000, y: 8000 });
+  });
+
+  it('no title text zone when title is omitted', () => {
+    const zones = computeZones(undefined, spec({ charts: ['A', 'B'] }));
+    expect(zones.every((z) => z.kind === 'worksheet')).toBe(true);
+  });
+});
+
+describe('computeZones — KPI strip (build-and-apply-dashboard only; unchanged behavior)', () => {
+  it('KPI zones tile the top strip before the chart grid', () => {
+    const zones = computeZones(undefined, spec({ kpis: ['K1', 'K2'], charts: ['A'] }));
+    const kpiZones = zones.filter(
+      (z) => z.kind === 'worksheet' && (z as Zone & { name: string }).name.startsWith('K'),
+    );
+    expect(kpiZones).toHaveLength(2);
+    expect(kpiZones[0]).toMatchObject({ y: 0, h: 20000 });
+    const chartZone = zones.find(
+      (z) => z.kind === 'worksheet' && (z as Zone & { name: string }).name === 'A',
+    );
+    expect(chartZone).toMatchObject({ y: 20000 });
+  });
+});
+
+describe('buildDashboardXml', () => {
+  it('wraps zones in the fixed 1400x1000 layout-basic dashboard shape', () => {
+    const zones = computeZones(undefined, spec({ charts: ['A', 'B'] }));
+    const xml = buildDashboardXml('My Dashboard', zones);
+    expect(xml).toContain('name="My Dashboard"');
+    expect(xml).toContain('maxwidth="1400"');
+    expect(xml).toContain('minheight="1000"');
+    expect(xml).toContain('type-v2="layout-basic"');
+    expect(xml).toContain('name="A"');
+    expect(xml).toContain('name="B"');
+  });
+
+  it('escapes a dashboard name with XML metacharacters', () => {
+    const xml = buildDashboardXml('A & B "Sales"', []);
+    expect(xml).toContain('A &amp; B &quot;Sales&quot;');
+  });
+
+  it('an empty zone list still produces a valid layout-basic wrapper', () => {
+    const xml = buildDashboardXml('Empty', []);
+    expect(xml).toContain('<zone h="100000" id="9" type-v2="layout-basic"');
+  });
+});

--- a/src/tools/desktop/dashboard/dashboardZones.ts
+++ b/src/tools/desktop/dashboard/dashboardZones.ts
@@ -1,0 +1,206 @@
+// Pure zone-computation module extracted byte-for-byte from
+// buildAndApplyDashboard.ts:58-118,169-273 (W60 single-pass dashboard-auto-apply spec, §5/Q2)
+// so both build-and-apply-dashboard (KPI strip + custom zones, unchanged behavior) and the new
+// dashboard-auto-apply tool (v1: auto-grid/rows/columns only, no KPIs/custom) share ONE zone
+// builder. No fs, no MCP — pure over its inputs so it is characterization-testable.
+
+import { z } from 'zod';
+
+export const customZoneSchema = z.object({
+  worksheetName: z.string(),
+  x: z.number(),
+  y: z.number(),
+  width: z.number(),
+  height: z.number(),
+});
+
+export const layoutSpecSchema = z.object({
+  kpis: z.array(z.string()).describe('Worksheet names for KPI strip'),
+  charts: z.array(z.string()).describe('Worksheet names for chart grid'),
+  layoutType: z.enum(['auto-grid', 'rows', 'columns', 'custom']).optional().default('auto-grid'),
+  gridColumns: z.number().optional().describe('Number of columns for auto-grid layout'),
+  kpiStripHeight: z
+    .number()
+    .optional()
+    .describe('KPI strip height as a percentage of total height (0-100)'),
+  customZones: z.array(customZoneSchema).optional(),
+});
+
+export type LayoutSpec = z.infer<typeof layoutSpecSchema>;
+
+const ZONE_STYLE = `<zone-style>
+            <format attr="border-color" value="#000000"/>
+            <format attr="border-style" value="none"/>
+            <format attr="border-width" value="0"/>
+            <format attr="margin" value="4"/>
+          </zone-style>`;
+
+export function escapeXml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+export type Zone =
+  | {
+      kind: 'text';
+      h: number;
+      id: number;
+      w: number;
+      x: number;
+      y: number;
+      text: string;
+      bold: string;
+      fontAlignment: string;
+      fontColor: string;
+      fontName: string;
+      fontSize: string;
+    }
+  | { kind: 'worksheet'; h: number; id: number; name: string; w: number; x: number; y: number };
+
+export function buildZoneXml(zone: Zone): string {
+  if (zone.kind === 'text') {
+    return `<zone h="${zone.h}" id="${zone.id}" type-v2="text" w="${zone.w}" x="${zone.x}" y="${zone.y}">
+          <zone-text>
+            <formatted-text>
+              <run bold="${zone.bold}" fontalignment="${zone.fontAlignment}" fontcolor="${zone.fontColor}" fontname="${zone.fontName}" fontsize="${zone.fontSize}">${zone.text}</run>
+            </formatted-text>
+          </zone-text>
+          ${ZONE_STYLE}
+        </zone>`;
+  }
+  return `<zone h="${zone.h}" id="${zone.id}" name="${escapeXml(zone.name)}" w="${zone.w}" x="${zone.x}" y="${zone.y}">
+          ${ZONE_STYLE}
+        </zone>`;
+}
+
+export function buildDashboardXml(dashboardName: string, zones: Zone[]): string {
+  const zonesXml = zones.map(buildZoneXml).join('\n        ');
+  return `<dashboard enable-sort-zone-taborder="true" name="${escapeXml(dashboardName)}">
+  <style/>
+  <size maxheight="1000" maxwidth="1400" minheight="1000" minwidth="1400" sizing-mode="fixed"/>
+  <zones>
+    <zone h="100000" id="9" type-v2="layout-basic" w="100000" x="0" y="0">
+        ${zonesXml}
+    </zone>
+  </zones>
+</dashboard>`;
+}
+
+/**
+ * Compute the zone tree for a dashboard from an optional title and a layout spec —
+ * lifted verbatim (same math, same zone-id sequencing) from
+ * buildAndApplyDashboard.ts's inline callback body so both tools produce
+ * byte-identical XML via {@link buildDashboardXml}.
+ */
+export function computeZones(titleText: string | undefined, layoutSpec: LayoutSpec): Zone[] {
+  const zones: Zone[] = [];
+  let nextId = 10;
+  let currentY = 0;
+
+  if (titleText) {
+    zones.push({
+      kind: 'text',
+      h: 8000,
+      id: nextId++,
+      w: 100000,
+      x: 0,
+      y: currentY,
+      text: escapeXml(titleText),
+      bold: 'true',
+      fontAlignment: '1',
+      fontColor: '#1f77b4',
+      fontName: 'Tableau Semibold',
+      fontSize: '16',
+    });
+    currentY += 8000;
+  }
+
+  const kpiStripHeightPct = layoutSpec.kpiStripHeight ?? 20;
+  const kpiStripHeight = Math.floor(100000 * (kpiStripHeightPct / 100));
+  const chartYOffset = layoutSpec.kpis.length > 0 ? currentY + kpiStripHeight : currentY;
+  const chartAreaHeight = 100000 - chartYOffset;
+
+  if (layoutSpec.kpis.length > 0) {
+    const kpiWidth = Math.floor(100000 / layoutSpec.kpis.length);
+    for (let i = 0; i < layoutSpec.kpis.length; i++) {
+      zones.push({
+        kind: 'worksheet',
+        h: kpiStripHeight,
+        id: nextId++,
+        name: layoutSpec.kpis[i],
+        w: kpiWidth,
+        x: i * kpiWidth,
+        y: currentY,
+      });
+    }
+  }
+
+  if (layoutSpec.charts.length > 0) {
+    const { layoutType, charts, gridColumns, customZones } = layoutSpec;
+
+    if (layoutType === 'custom' && customZones) {
+      for (const cz of customZones) {
+        if (charts.includes(cz.worksheetName)) {
+          zones.push({
+            kind: 'worksheet',
+            h: cz.height,
+            id: nextId++,
+            name: cz.worksheetName,
+            w: cz.width,
+            x: cz.x,
+            y: cz.y,
+          });
+        }
+      }
+    } else if (layoutType === 'rows') {
+      const chartHeight = Math.floor(chartAreaHeight / charts.length);
+      for (let i = 0; i < charts.length; i++) {
+        zones.push({
+          kind: 'worksheet',
+          h: chartHeight,
+          id: nextId++,
+          name: charts[i],
+          w: 100000,
+          x: 0,
+          y: chartYOffset + i * chartHeight,
+        });
+      }
+    } else if (layoutType === 'columns') {
+      const chartWidth = Math.floor(100000 / charts.length);
+      for (let i = 0; i < charts.length; i++) {
+        zones.push({
+          kind: 'worksheet',
+          h: chartAreaHeight,
+          id: nextId++,
+          name: charts[i],
+          w: chartWidth,
+          x: i * chartWidth,
+          y: chartYOffset,
+        });
+      }
+    } else {
+      // auto-grid (default)
+      const cols = gridColumns ?? Math.min(2, charts.length);
+      const rows = Math.ceil(charts.length / cols);
+      const chartWidth = Math.floor(100000 / cols);
+      const chartHeight = Math.floor(chartAreaHeight / rows);
+      for (let i = 0; i < charts.length; i++) {
+        zones.push({
+          kind: 'worksheet',
+          h: chartHeight,
+          id: nextId++,
+          name: charts[i],
+          w: chartWidth,
+          x: (i % cols) * chartWidth,
+          y: chartYOffset + Math.floor(i / cols) * chartHeight,
+        });
+      }
+    }
+  }
+
+  return zones;
+}

--- a/src/tools/desktop/toolName.ts
+++ b/src/tools/desktop/toolName.ts
@@ -26,6 +26,7 @@ export const desktopToolNames = [
   'search-workbook-examples',
   'execute-tableau-command',
   'bind-template',
+  'dashboard-auto-apply',
   'list-templates',
   'propose-template',
   'validate-proposal',

--- a/src/tools/desktop/tools.ts
+++ b/src/tools/desktop/tools.ts
@@ -14,6 +14,7 @@ import { getPlanDashboardCreationTool } from './coordination/planDashboardCreati
 import { getApplyDashboardTool } from './dashboard/applyDashboard.js';
 import { getApplyDashboardWithViewpointsTool } from './dashboard/applyDashboardWithViewpoints.js';
 import { getBuildAndApplyDashboardTool } from './dashboard/buildAndApplyDashboard.js';
+import { getDashboardAutoApplyTool } from './dashboard/dashboardAutoApply.js';
 import { getGetDashboardGuideTool } from './dashboard/getDashboardGuide.js';
 import { getGetDashboardXmlTool } from './dashboard/getDashboardXml.js';
 import { getAddFieldToColsTool } from './fields/addFieldToCols.js';
@@ -69,6 +70,7 @@ export const desktopToolFactories = [
   getSearchWorkbookExamplesTool,
   getExecuteTableauCommandTool,
   getBindTemplateTool,
+  getDashboardAutoApplyTool,
   getListTemplatesTool,
   getProposeTemplateTool,
   getValidateProposalTool,


### PR DESCRIPTION
Two commits cherry-picked from the local wave30 lineage onto current feature/authoring (post #456/#458).

**cost/P0 package** (a172ebb2)
- `TOOL_PROFILE=demo` slim 10-tool registration (unset/full = byte-identical; unknown values warn + fall back)
- events-anchor-before-read fix for the P1-4 race (user edits in the read window are no longer silently reverted)
- trimmed `applied:true` fast-path response shape (full shape kept on all non-applied paths)
- quote-agnostic + attribute-order-tolerant same-name strip in injectTemplateCore — fixes the second-apply "Name (1)" self-sabotage (P0-3/P2-7); events-dirty fallback guidance no longer suggests re-applying stale args (P1-5)

**dashboard-auto-apply** (2f4553ae)
- new single-pass multi-chart dashboard tool: one workbook read, N in-memory binds against pristine XML, one events-gated apply (was 5 calls / 9.3s live)
- zone math extracted to pure `dashboardZones.ts`; `buildAndApplyDashboard` refactored to consume it, zero behavior change; lockstep-core untouched
- batch preflight refuses duplicate titles / collisions with existing dashboards' zones; all-or-nothing (zero dispatches on refusal)
- `DASHBOARD_ZONES_VIA_WORKBOOK=true` verified by live probe (zone tree survives a whole-workbook apply intact; pristine state restored after)
- `connections-not-authorable` terminal validation rule — hand-authored `<connection>` XML now fails non-retryably instead of looping

**Evidence:** on this base: vitest 2761/2761, tsc clean. Original lineage: full agent-check green both commits (known pre-existing lint debt in an untracked script excluded).

**Note for #433:** once this lands, `dashboardAutoApply`/binder template reads should move to the SEA-aware `readTemplate()` seam introduced there; also flagged on that PR — binder manifests (`manifest.ts:140,160`) still read from disk, so the SEA binary isn't yet self-contained for the bind fast path.

*Opened by MattGPT (Matt's Claude Code automation) on Matt Filbert's behalf.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)