### PR TITLE
desktop: rework per-sheet commands for the External Client API + additive-POST workaround

### DIFF
--- a/src/desktop/commands/workbook/applyMutex.ts
+++ b/src/desktop/commands/workbook/applyMutex.ts
@@ -1,0 +1,16 @@
+// BAND-AID: whole-workbook and per-sheet applies mutate the live document via a
+// read → delete → POST sequence. Two applies overlapping (e.g. rapid back-to-back binds)
+// race on tabdoc:delete-sheet — the second tries to delete a sheet the first already
+// removed, which fails and pops a Tableau error dialog. Serialize every mutating apply
+// through this single chain so they run one at a time. Remove once the API applies atomically.
+let tail: Promise<unknown> = Promise.resolve();
+
+export function withApplyLock<T>(fn: () => Promise<T>): Promise<T> {
+  const run = tail.then(fn, fn);
+  // Keep the chain alive even if this run rejects, without surfacing an unhandled rejection.
+  tail = run.then(
+    () => undefined,
+    () => undefined,
+  );
+  return run;
+}

--- a/src/desktop/commands/workbook/deleteLiveSheet.ts
+++ b/src/desktop/commands/workbook/deleteLiveSheet.ts
@@ -1,0 +1,49 @@
+import { Err, Ok, Result } from 'ts-results-es';
+
+import { listWorkbookDashboards } from '../../metadata/dashboards.js';
+import { listSheets } from '../../metadata/sheets.js';
+import {
+  ExecuteCommandError,
+  WithExecutorAndAbortSignal,
+} from '../../toolExecutor/toolExecutor.js';
+import { getWorkbookXml } from './getWorkbookXml.js';
+
+// Deletes a live worksheet or dashboard via tabdoc:delete-sheet so a following additive workbook
+// POST re-adds the edited copy without a name-collision duplicate. A no-op when the sheet is absent,
+// so applying a brand-new sheet is safe.
+export async function deleteLiveSheet({
+  sheetName,
+  executor,
+  signal,
+}: { sheetName: string } & WithExecutorAndAbortSignal): Promise<Result<void, ExecuteCommandError>> {
+  const workbookResult = await getWorkbookXml({ executor, signal });
+  if (workbookResult.isErr()) {
+    return workbookResult;
+  }
+
+  let present: boolean;
+  try {
+    present =
+      listSheets(workbookResult.value).includes(sheetName) ||
+      listWorkbookDashboards(workbookResult.value).includes(sheetName);
+  } catch (error) {
+    return Err({ type: 'invalid-response', error });
+  }
+
+  if (!present) {
+    return Ok.EMPTY;
+  }
+
+  const result = await executor.executeCommand({
+    namespace: 'tabdoc',
+    command: 'delete-sheet',
+    args: { Sheet: sheetName },
+    signal,
+  });
+
+  if (result.isErr()) {
+    return result;
+  }
+
+  return Ok.EMPTY;
+}

--- a/src/desktop/commands/workbook/derivationPreflight.test.ts
+++ b/src/desktop/commands/workbook/derivationPreflight.test.ts
@@ -10,15 +10,27 @@
 import { Ok } from 'ts-results-es';
 
 import invariant from '../../../utils/invariant.js';
-import * as xmlToJsonModule from '../../libraries/workbook-serialization-converter/index.js';
 import { LocalExecutor } from '../../toolExecutor/localToolExecutor.js';
 import { loadWorkbookXml } from './loadWorkbookXml.js';
 import { loadWorksheetXml } from './loadWorksheetXml.js';
 
-vi.mock('fs');
-vi.mock('../../libraries/workbook-serialization-converter/index.js');
-
 const mockSignal = new AbortController().signal;
+
+// Executor that serves the live workbook on the save-underlying-metadata fetch and acks
+// every other command, so the multi-call apply-worksheet flow (fetch → delete → apply) runs.
+function dispatchingExecutor(workbookXml: string): LocalExecutor {
+  const executeCommand = vi.fn(async (params: any) => {
+    if (params.command === 'save-underlying-metadata') {
+      return Ok({
+        command_id: 'cmd-get',
+        status: 'completed',
+        parsedResult: { text: workbookXml },
+      });
+    }
+    return Ok({ command_id: 'cmd-ok', status: 'completed', submitted_at: '' });
+  });
+  return { executeCommand } as unknown as LocalExecutor;
+}
 
 function workbookWithDerivation(derivation: string): string {
   return `<?xml version="1.0" encoding="UTF-8"?>
@@ -81,21 +93,16 @@ describe('derivation preflight — apply-workbook path', () => {
   });
 
   it('sends a canonical derivation through to Tableau (positive control)', async () => {
-    vi.spyOn(xmlToJsonModule, 'xmlToJson').mockReturnValue('{"workbook": {}}');
-
-    const executeCommand = vi
-      .fn()
-      .mockResolvedValue(Ok({ command_id: 'cmd-1', status: 'completed', submitted_at: '' }));
-    const mockExecutor = { executeCommand } as unknown as LocalExecutor;
+    const executor = dispatchingExecutor(workbookWithDerivation('Month-Trunc'));
 
     const result = await loadWorkbookXml({
       xml: workbookWithDerivation('Month-Trunc'),
-      executor: mockExecutor,
+      executor,
       signal: mockSignal,
     });
 
     expect(result.isOk()).toBe(true);
-    expect(executeCommand).toHaveBeenCalled();
+    expect(executor.executeCommand).toHaveBeenCalled();
   });
 });
 
@@ -129,19 +136,16 @@ describe('derivation preflight — apply-worksheet path', () => {
   });
 
   it('sends a canonical derivation through to Tableau (positive control)', async () => {
-    const executeCommand = vi
-      .fn()
-      .mockResolvedValue(Ok({ command_id: 'cmd-1', status: 'completed', submitted_at: '' }));
-    const mockExecutor = { executeCommand } as unknown as LocalExecutor;
+    const executor = dispatchingExecutor(workbookWithDerivation('Month-Trunc'));
 
     const result = await loadWorksheetXml({
       worksheetName: 'Sheet 1',
       xml: worksheetWithDerivation('Month-Trunc'),
-      executor: mockExecutor,
+      executor,
       signal: mockSignal,
     });
 
     expect(result.isOk()).toBe(true);
-    expect(executeCommand).toHaveBeenCalled();
+    expect(executor.executeCommand).toHaveBeenCalled();
   });
 });

--- a/src/desktop/commands/workbook/getDashboardXml.test.ts
+++ b/src/desktop/commands/workbook/getDashboardXml.test.ts
@@ -6,6 +6,25 @@ import { getDashboardXml } from './getDashboardXml.js';
 
 vi.mock('../../toolExecutor/localToolExecutor.js');
 
+function workbookWith(dashboardNames: string[]): string {
+  const dashboards = dashboardNames
+    .map((name) => `<dashboard name='${name}'><zones /></dashboard>`)
+    .join('');
+  return `<?xml version='1.0'?><workbook><dashboards>${dashboards}</dashboards></workbook>`;
+}
+
+function executorReturning(text: string): LocalExecutor {
+  return {
+    executeCommand: vi.fn().mockResolvedValue(
+      Ok({
+        command_id: 'cmd-123',
+        status: 'completed',
+        parsedResult: { text },
+      }),
+    ),
+  } as unknown as LocalExecutor;
+}
+
 describe('getDashboardXml', () => {
   const mockSignal = new AbortController().signal;
   const dashboardName = 'Sales Dashboard';
@@ -14,17 +33,8 @@ describe('getDashboardXml', () => {
     vi.clearAllMocks();
   });
 
-  it('should successfully return dashboard XML', async () => {
-    const mockXml = '<dashboard name="Sales Dashboard"><zones></zones></dashboard>';
-    const mockExecutor = {
-      executeCommand: vi.fn().mockResolvedValue(
-        Ok({
-          command_id: 'cmd-123',
-          status: 'completed',
-          parsedResult: { dashboardXml: mockXml },
-        }),
-      ),
-    } as unknown as LocalExecutor;
+  it('should slice the requested dashboard out of the whole-workbook document', async () => {
+    const mockExecutor = executorReturning(workbookWith(['Sales Dashboard', 'Other Dashboard']));
 
     const result = await getDashboardXml({
       dashboardName,
@@ -34,22 +44,24 @@ describe('getDashboardXml', () => {
 
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {
-      expect(result.value).toBe(mockXml);
+      expect(result.value).toContain('<dashboard');
+      expect(result.value).toContain('name="Sales Dashboard"');
+      expect(result.value).not.toContain('Other Dashboard');
     }
 
     expect(mockExecutor.executeCommand).toHaveBeenCalledWith({
       namespace: 'tabui',
-      command: 'save-dashboard',
-      args: { dashboardName },
+      command: 'save-underlying-metadata',
+      args: { 'is-json': false },
       schema: expect.any(Object),
       signal: mockSignal,
     });
   });
 
-  it('should return error when executeCommand fails', async () => {
+  it('should return execute-command-error when the workbook fetch fails', async () => {
     const error = {
       type: 'command-failed' as const,
-      error: { code: 'ERROR', message: 'Dashboard not found' },
+      error: { code: 'ERROR', message: 'Fetch failed' },
     };
     const mockExecutor = {
       executeCommand: vi.fn().mockResolvedValue(Err(error)),
@@ -68,16 +80,8 @@ describe('getDashboardXml', () => {
     }
   });
 
-  it('should return no-dashboard-found error when response contains no dashboard element', async () => {
-    const mockExecutor = {
-      executeCommand: vi.fn().mockResolvedValue(
-        Ok({
-          command_id: 'cmd-123',
-          status: 'completed',
-          parsedResult: { dashboardXml: '<empty></empty>' },
-        }),
-      ),
-    } as unknown as LocalExecutor;
+  it('should return no-dashboard-found when the workbook has no matching dashboard', async () => {
+    const mockExecutor = executorReturning(workbookWith(['Some Other Dashboard']));
 
     const result = await getDashboardXml({
       dashboardName,
@@ -91,51 +95,5 @@ describe('getDashboardXml', () => {
       expect(result.error.error.type).toBe('no-dashboard-found');
       expect(result.error.error.message).toContain(dashboardName);
     }
-  });
-
-  it('should return multiple-dashboards-found error when response contains more than one dashboard', async () => {
-    const mockXml = '<workbook><dashboard name="D1"/><dashboard name="D2"/></workbook>';
-    const mockExecutor = {
-      executeCommand: vi.fn().mockResolvedValue(
-        Ok({
-          command_id: 'cmd-123',
-          status: 'completed',
-          parsedResult: { dashboardXml: mockXml },
-        }),
-      ),
-    } as unknown as LocalExecutor;
-
-    const result = await getDashboardXml({
-      dashboardName,
-      executor: mockExecutor,
-      signal: mockSignal,
-    });
-
-    expect(result.isErr()).toBe(true);
-    if (result.isErr()) {
-      invariant(result.error.type === 'get-dashboard-xml-error');
-      expect(result.error.error.type).toBe('multiple-dashboards-found');
-      expect(result.error.error.message).toContain('2');
-    }
-  });
-
-  it('should pass dashboardName as arg to save-dashboard command', async () => {
-    const mockExecutor = {
-      executeCommand: vi.fn().mockResolvedValue(
-        Ok({
-          command_id: 'cmd-123',
-          status: 'completed',
-          parsedResult: { dashboardXml: '<dashboard name="My DB"/>' },
-        }),
-      ),
-    } as unknown as LocalExecutor;
-
-    await getDashboardXml({ dashboardName: 'My DB', executor: mockExecutor, signal: mockSignal });
-
-    expect(mockExecutor.executeCommand).toHaveBeenCalledWith(
-      expect.objectContaining({
-        args: { dashboardName: 'My DB' },
-      }),
-    );
   });
 });

--- a/src/desktop/commands/workbook/getDashboardXml.ts
+++ b/src/desktop/commands/workbook/getDashboardXml.ts
@@ -1,10 +1,11 @@
 import { Err, Ok, Result } from 'ts-results-es';
-import { z } from 'zod';
 
+import { extractDashboardXml } from '../../metadata/dashboards.js';
 import {
   ExecuteCommandError,
   WithExecutorAndAbortSignal,
 } from '../../toolExecutor/toolExecutor.js';
+import { getWorkbookXml } from './getWorkbookXml.js';
 
 export type GetDashboardXmlError = (
   | { type: 'no-dashboard-found' }
@@ -22,39 +23,22 @@ export async function getDashboardXml({
     | { type: 'get-dashboard-xml-error'; error: GetDashboardXmlError }
   >
 > {
-  const result = await executor.executeCommand({
-    namespace: 'tabui',
-    command: 'save-dashboard',
-    args: {
-      dashboardName,
-    },
-    schema: z.object({
-      dashboardXml: z.string(),
-    }),
-    signal,
-  });
-
-  if (result.isErr()) {
-    return Err({ type: 'execute-command-error', error: result.error });
+  const workbookResult = await getWorkbookXml({ executor, signal });
+  if (workbookResult.isErr()) {
+    return Err({ type: 'execute-command-error', error: workbookResult.error });
   }
 
-  const dashboardXml = result.value.parsedResult.dashboardXml;
-  const dashboardCount = (dashboardXml.match(/<dashboard/g) || []).length;
+  let dashboardXml: string | null;
+  try {
+    dashboardXml = extractDashboardXml(workbookResult.value, dashboardName);
+  } catch (error) {
+    return Err({ type: 'execute-command-error', error: { type: 'invalid-response', error } });
+  }
 
-  if (dashboardCount === 0) {
+  if (dashboardXml === null) {
     return Err({
       type: 'get-dashboard-xml-error',
       error: { type: 'no-dashboard-found', message: `No dashboard found for "${dashboardName}".` },
-    });
-  }
-
-  if (dashboardCount > 1) {
-    return Err({
-      type: 'get-dashboard-xml-error',
-      error: {
-        type: 'multiple-dashboards-found',
-        message: `${dashboardCount} dashboards found instead of 1.`,
-      },
     });
   }
 

--- a/src/desktop/commands/workbook/getWorksheetXml.test.ts
+++ b/src/desktop/commands/workbook/getWorksheetXml.test.ts
@@ -6,6 +6,25 @@ import { getWorksheetXml } from './getWorksheetXml.js';
 
 vi.mock('../../toolExecutor/localToolExecutor.js');
 
+function workbookWith(worksheetNames: string[]): string {
+  const worksheets = worksheetNames
+    .map((name) => `<worksheet name='${name}'><table><rows /></table></worksheet>`)
+    .join('');
+  return `<?xml version='1.0'?><workbook><worksheets>${worksheets}</worksheets></workbook>`;
+}
+
+function executorReturning(text: string): LocalExecutor {
+  return {
+    executeCommand: vi.fn().mockResolvedValue(
+      Ok({
+        command_id: 'cmd-123',
+        status: 'completed',
+        parsedResult: { text },
+      }),
+    ),
+  } as unknown as LocalExecutor;
+}
+
 describe('getWorksheetXml', () => {
   const mockSignal = new AbortController().signal;
   const worksheetName = 'Sheet 1';
@@ -14,19 +33,8 @@ describe('getWorksheetXml', () => {
     vi.clearAllMocks();
   });
 
-  it('should successfully return worksheet XML', async () => {
-    const mockXml = '<worksheet name="Sheet 1"><table></table></worksheet>';
-    const mockExecutor = {
-      executeCommand: vi.fn().mockResolvedValue(
-        Ok({
-          command_id: 'cmd-123',
-          status: 'completed',
-          parsedResult: {
-            worksheetXml: mockXml,
-          },
-        }),
-      ),
-    } as unknown as LocalExecutor;
+  it('should slice the requested worksheet out of the whole-workbook document', async () => {
+    const mockExecutor = executorReturning(workbookWith(['Sheet 1', 'Sheet 2']));
 
     const result = await getWorksheetXml({
       worksheetName,
@@ -36,22 +44,24 @@ describe('getWorksheetXml', () => {
 
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {
-      expect(result.value).toBe(mockXml);
+      expect(result.value).toContain('<worksheet');
+      expect(result.value).toContain('name="Sheet 1"');
+      expect(result.value).not.toContain('Sheet 2');
     }
 
     expect(mockExecutor.executeCommand).toHaveBeenCalledWith({
       namespace: 'tabui',
-      command: 'save-worksheet',
-      args: { worksheetName },
+      command: 'save-underlying-metadata',
+      args: { 'is-json': false },
       schema: expect.any(Object),
       signal: mockSignal,
     });
   });
 
-  it('should return error when executeCommand fails', async () => {
+  it('should return execute-command-error when the workbook fetch fails', async () => {
     const error = {
       type: 'command-failed' as const,
-      error: { code: 'ERROR', message: 'Worksheet not found' },
+      error: { code: 'ERROR', message: 'Fetch failed' },
     };
     const mockExecutor = {
       executeCommand: vi.fn().mockResolvedValue(Err(error)),
@@ -70,18 +80,8 @@ describe('getWorksheetXml', () => {
     }
   });
 
-  it('should return no-worksheet-found error when response contains no worksheet element', async () => {
-    const mockExecutor = {
-      executeCommand: vi.fn().mockResolvedValue(
-        Ok({
-          command_id: 'cmd-123',
-          status: 'completed',
-          parsedResult: {
-            worksheetXml: '<empty></empty>',
-          },
-        }),
-      ),
-    } as unknown as LocalExecutor;
+  it('should return no-worksheet-found when the workbook has no matching worksheet', async () => {
+    const mockExecutor = executorReturning(workbookWith(['Some Other Sheet']));
 
     const result = await getWorksheetXml({
       worksheetName,
@@ -97,83 +97,18 @@ describe('getWorksheetXml', () => {
     }
   });
 
-  it('should return multiple-worksheets-found error when response contains more than one worksheet', async () => {
-    const mockXml = '<workbook><worksheet name="Sheet 1"/><worksheet name="Sheet 2"/></workbook>';
-    const mockExecutor = {
-      executeCommand: vi.fn().mockResolvedValue(
-        Ok({
-          command_id: 'cmd-123',
-          status: 'completed',
-          parsedResult: {
-            worksheetXml: mockXml,
-          },
-        }),
-      ),
-    } as unknown as LocalExecutor;
+  it('should handle worksheet names with special characters', async () => {
+    const mockExecutor = executorReturning(workbookWith(['Sales &amp; Data']));
 
     const result = await getWorksheetXml({
-      worksheetName,
-      executor: mockExecutor,
-      signal: mockSignal,
-    });
-
-    expect(result.isErr()).toBe(true);
-    if (result.isErr()) {
-      invariant(result.error.type === 'get-worksheet-xml-error');
-      expect(result.error.error.type).toBe('multiple-worksheets-found');
-      expect(result.error.error.message).toContain('2');
-    }
-  });
-
-  it('should pass worksheetName as arg to save-worksheet command', async () => {
-    const mockExecutor = {
-      executeCommand: vi.fn().mockResolvedValue(
-        Ok({
-          command_id: 'cmd-123',
-          status: 'completed',
-          parsedResult: {
-            worksheetXml: '<worksheet name="My Sheet"/>',
-          },
-        }),
-      ),
-    } as unknown as LocalExecutor;
-
-    await getWorksheetXml({
-      worksheetName: 'My Sheet',
-      executor: mockExecutor,
-      signal: mockSignal,
-    });
-
-    expect(mockExecutor.executeCommand).toHaveBeenCalledWith(
-      expect.objectContaining({
-        args: { worksheetName: 'My Sheet' },
-      }),
-    );
-  });
-
-  it('should handle XML with special characters', async () => {
-    const mockXml = '<worksheet name="Sales &amp; Data"><formula>&lt;SUM&gt;</formula></worksheet>';
-    const mockExecutor = {
-      executeCommand: vi.fn().mockResolvedValue(
-        Ok({
-          command_id: 'cmd-123',
-          status: 'completed',
-          parsedResult: {
-            worksheetXml: mockXml,
-          },
-        }),
-      ),
-    } as unknown as LocalExecutor;
-
-    const result = await getWorksheetXml({
-      worksheetName,
+      worksheetName: 'Sales & Data',
       executor: mockExecutor,
       signal: mockSignal,
     });
 
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {
-      expect(result.value).toContain('&amp;');
+      expect(result.value).toContain('Sales &amp; Data');
     }
   });
 });

--- a/src/desktop/commands/workbook/getWorksheetXml.ts
+++ b/src/desktop/commands/workbook/getWorksheetXml.ts
@@ -1,10 +1,11 @@
 import { Err, Ok, Result } from 'ts-results-es';
-import { z } from 'zod';
 
+import { extractSheetXml } from '../../metadata/sheets.js';
 import {
   ExecuteCommandError,
   WithExecutorAndAbortSignal,
 } from '../../toolExecutor/toolExecutor.js';
+import { getWorkbookXml } from './getWorkbookXml.js';
 
 export type GetWorksheetXmlError = (
   | { type: 'no-worksheet-found' }
@@ -22,39 +23,22 @@ export async function getWorksheetXml({
     | { type: 'get-worksheet-xml-error'; error: GetWorksheetXmlError }
   >
 > {
-  const result = await executor.executeCommand({
-    namespace: 'tabui',
-    command: 'save-worksheet',
-    args: {
-      worksheetName,
-    },
-    schema: z.object({
-      worksheetXml: z.string(),
-    }),
-    signal,
-  });
-
-  if (result.isErr()) {
-    return Err({ type: 'execute-command-error', error: result.error });
+  const workbookResult = await getWorkbookXml({ executor, signal });
+  if (workbookResult.isErr()) {
+    return Err({ type: 'execute-command-error', error: workbookResult.error });
   }
 
-  const worksheetXml = result.value.parsedResult.worksheetXml;
-  const worksheetCount = (worksheetXml.match(/<worksheet/g) || []).length;
+  let worksheetXml: string | null;
+  try {
+    worksheetXml = extractSheetXml(workbookResult.value, worksheetName);
+  } catch (error) {
+    return Err({ type: 'execute-command-error', error: { type: 'invalid-response', error } });
+  }
 
-  if (worksheetCount === 0) {
+  if (worksheetXml === null) {
     return Err({
       type: 'get-worksheet-xml-error',
       error: { type: 'no-worksheet-found', message: `No worksheet found for ${worksheetName}.` },
-    });
-  }
-
-  if (worksheetCount > 1) {
-    return Err({
-      type: 'get-worksheet-xml-error',
-      error: {
-        type: 'multiple-worksheets-found',
-        message: `${worksheetCount} worksheets found instead of 1.`,
-      },
     });
   }
 

--- a/src/desktop/commands/workbook/listDashboards.test.ts
+++ b/src/desktop/commands/workbook/listDashboards.test.ts
@@ -5,6 +5,25 @@ import { listDashboards } from './listDashboards.js';
 
 vi.mock('../../toolExecutor/localToolExecutor.js');
 
+function workbookWith(dashboardNames: string[]): string {
+  const dashboards = dashboardNames
+    .map((name) => `<dashboard name='${name}'><zones /></dashboard>`)
+    .join('');
+  return `<?xml version='1.0'?><workbook><dashboards>${dashboards}</dashboards></workbook>`;
+}
+
+function executorReturning(text: string): LocalExecutor {
+  return {
+    executeCommand: vi.fn().mockResolvedValue(
+      Ok({
+        command_id: 'cmd-123',
+        status: 'completed',
+        parsedResult: { text },
+      }),
+    ),
+  } as unknown as LocalExecutor;
+}
+
 describe('listDashboards', () => {
   const mockSignal = new AbortController().signal;
 
@@ -12,21 +31,8 @@ describe('listDashboards', () => {
     vi.clearAllMocks();
   });
 
-  it('should successfully return list of dashboards', async () => {
-    const mockExecutor = {
-      executeCommand: vi.fn().mockResolvedValue(
-        Ok({
-          command_id: 'cmd-123',
-          status: 'completed',
-          parsedResult: {
-            dashboards: JSON.stringify({
-              count: 2,
-              dashboards: [{ name: 'Sales Dashboard' }, { name: 'Executive Summary' }],
-            }),
-          },
-        }),
-      ),
-    } as unknown as LocalExecutor;
+  it('should return dashboard names sliced from the whole-workbook document', async () => {
+    const mockExecutor = executorReturning(workbookWith(['Sales Dashboard', 'Executive Summary']));
 
     const result = await listDashboards({ executor: mockExecutor, signal: mockSignal });
 
@@ -40,40 +46,25 @@ describe('listDashboards', () => {
 
     expect(mockExecutor.executeCommand).toHaveBeenCalledWith({
       namespace: 'tabui',
-      command: 'list-dashboards',
+      command: 'save-underlying-metadata',
+      args: { 'is-json': false },
       schema: expect.any(Object),
       signal: mockSignal,
     });
   });
 
   it('should return empty list when no dashboards exist', async () => {
-    const mockExecutor = {
-      executeCommand: vi.fn().mockResolvedValue(
-        Ok({
-          command_id: 'cmd-123',
-          status: 'completed',
-          parsedResult: {
-            dashboards: JSON.stringify({
-              count: 0,
-              dashboards: [],
-            }),
-          },
-        }),
-      ),
-    } as unknown as LocalExecutor;
+    const mockExecutor = executorReturning('<?xml version="1.0"?><workbook></workbook>');
 
     const result = await listDashboards({ executor: mockExecutor, signal: mockSignal });
 
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {
-      expect(result.value).toEqual({
-        count: 0,
-        dashboards: [],
-      });
+      expect(result.value).toEqual({ count: 0, dashboards: [] });
     }
   });
 
-  it('should return error when executeCommand fails', async () => {
+  it('should return error when the workbook fetch fails', async () => {
     const error = { type: 'command-timed-out' as const, error: 'Command timeout' };
     const mockExecutor = {
       executeCommand: vi.fn().mockResolvedValue(Err(error)),
@@ -87,43 +78,8 @@ describe('listDashboards', () => {
     }
   });
 
-  it('should return error when JSON parsing fails', async () => {
-    const mockExecutor = {
-      executeCommand: vi.fn().mockResolvedValue(
-        Ok({
-          command_id: 'cmd-123',
-          status: 'completed',
-          parsedResult: {
-            dashboards: 'not valid json',
-          },
-        }),
-      ),
-    } as unknown as LocalExecutor;
-
-    const result = await listDashboards({ executor: mockExecutor, signal: mockSignal });
-
-    expect(result.isErr()).toBe(true);
-    if (result.isErr()) {
-      expect(result.error.type).toBe('invalid-response');
-    }
-  });
-
-  it('should return error when schema validation fails', async () => {
-    const mockExecutor = {
-      executeCommand: vi.fn().mockResolvedValue(
-        Ok({
-          command_id: 'cmd-123',
-          status: 'completed',
-          parsedResult: {
-            dashboards: JSON.stringify({
-              // Wrong structure - dashboards is not an array
-              count: 'invalid',
-              dashboards: 'not-an-array',
-            }),
-          },
-        }),
-      ),
-    } as unknown as LocalExecutor;
+  it('should return invalid-response when the workbook XML cannot be parsed', async () => {
+    const mockExecutor = executorReturning('not valid xml <<<');
 
     const result = await listDashboards({ executor: mockExecutor, signal: mockSignal });
 
@@ -134,24 +90,9 @@ describe('listDashboards', () => {
   });
 
   it('should handle dashboard names with special characters', async () => {
-    const mockExecutor = {
-      executeCommand: vi.fn().mockResolvedValue(
-        Ok({
-          command_id: 'cmd-123',
-          status: 'completed',
-          parsedResult: {
-            dashboards: JSON.stringify({
-              count: 3,
-              dashboards: [
-                { name: 'Dashboard & Analysis' },
-                { name: 'Sales: Q1-Q4' },
-                { name: "CEO's Report" },
-              ],
-            }),
-          },
-        }),
-      ),
-    } as unknown as LocalExecutor;
+    const mockExecutor = executorReturning(
+      workbookWith(['Dashboard &amp; Analysis', 'Sales: Q1-Q4', 'CEO&apos;s Report']),
+    );
 
     const result = await listDashboards({ executor: mockExecutor, signal: mockSignal });
 

--- a/src/desktop/commands/workbook/listDashboards.ts
+++ b/src/desktop/commands/workbook/listDashboards.ts
@@ -1,15 +1,11 @@
 import { Err, Ok, Result } from 'ts-results-es';
-import { z } from 'zod';
 
+import { listWorkbookDashboards } from '../../metadata/dashboards.js';
 import {
   ExecuteCommandError,
   WithExecutorAndAbortSignal,
 } from '../../toolExecutor/toolExecutor.js';
-
-const dashboardNamesSchema = z.object({
-  count: z.number(),
-  dashboards: z.array(z.object({ name: z.string() })),
-});
+import { getWorkbookXml } from './getWorkbookXml.js';
 
 export async function listDashboards({ executor, signal }: WithExecutorAndAbortSignal): Promise<
   Result<
@@ -20,33 +16,20 @@ export async function listDashboards({ executor, signal }: WithExecutorAndAbortS
     ExecuteCommandError
   >
 > {
-  const result = await executor.executeCommand({
-    namespace: 'tabui',
-    command: 'list-dashboards',
-    schema: z.object({
-      dashboards: z.string(),
-    }),
-    signal,
-  });
-
-  if (result.isErr()) {
-    return result;
+  const workbookResult = await getWorkbookXml({ executor, signal });
+  if (workbookResult.isErr()) {
+    return workbookResult;
   }
 
-  let dashboards: unknown;
+  let dashboards: Array<string>;
   try {
-    dashboards = JSON.parse(result.value.parsedResult.dashboards || '[]');
-  } catch (e) {
-    return Err({ type: 'invalid-response', error: e });
-  }
-
-  const dashboardsResult = dashboardNamesSchema.safeParse(dashboards);
-  if (!dashboardsResult.success) {
-    return Err({ type: 'invalid-response', error: dashboardsResult.error });
+    dashboards = listWorkbookDashboards(workbookResult.value);
+  } catch (error) {
+    return Err({ type: 'invalid-response', error });
   }
 
   return Ok({
-    count: dashboardsResult.data.dashboards.length,
-    dashboards: dashboardsResult.data.dashboards.map((dashboard) => dashboard.name),
+    count: dashboards.length,
+    dashboards,
   });
 }

--- a/src/desktop/commands/workbook/listWorksheets.test.ts
+++ b/src/desktop/commands/workbook/listWorksheets.test.ts
@@ -5,6 +5,25 @@ import { listWorksheets } from './listWorksheets.js';
 
 vi.mock('../../toolExecutor/localToolExecutor.js');
 
+function workbookWith(worksheetNames: string[]): string {
+  const worksheets = worksheetNames
+    .map((name) => `<worksheet name='${name}'><table /></worksheet>`)
+    .join('');
+  return `<?xml version='1.0'?><workbook><worksheets>${worksheets}</worksheets></workbook>`;
+}
+
+function executorReturning(text: string): LocalExecutor {
+  return {
+    executeCommand: vi.fn().mockResolvedValue(
+      Ok({
+        command_id: 'cmd-123',
+        status: 'completed',
+        parsedResult: { text },
+      }),
+    ),
+  } as unknown as LocalExecutor;
+}
+
 describe('listWorksheets', () => {
   const mockSignal = new AbortController().signal;
 
@@ -12,21 +31,8 @@ describe('listWorksheets', () => {
     vi.clearAllMocks();
   });
 
-  it('should successfully return list of worksheets', async () => {
-    const mockExecutor = {
-      executeCommand: vi.fn().mockResolvedValue(
-        Ok({
-          command_id: 'cmd-123',
-          status: 'completed',
-          parsedResult: {
-            worksheets: JSON.stringify({
-              count: 3,
-              worksheets: [{ name: 'Sheet 1' }, { name: 'Sales' }, { name: 'Analysis' }],
-            }),
-          },
-        }),
-      ),
-    } as unknown as LocalExecutor;
+  it('should return worksheet names sliced from the whole-workbook document', async () => {
+    const mockExecutor = executorReturning(workbookWith(['Sheet 1', 'Sales', 'Analysis']));
 
     const result = await listWorksheets({ executor: mockExecutor, signal: mockSignal });
 
@@ -40,40 +46,25 @@ describe('listWorksheets', () => {
 
     expect(mockExecutor.executeCommand).toHaveBeenCalledWith({
       namespace: 'tabui',
-      command: 'list-worksheets',
+      command: 'save-underlying-metadata',
+      args: { 'is-json': false },
       schema: expect.any(Object),
       signal: mockSignal,
     });
   });
 
   it('should return empty list when no worksheets exist', async () => {
-    const mockExecutor = {
-      executeCommand: vi.fn().mockResolvedValue(
-        Ok({
-          command_id: 'cmd-123',
-          status: 'completed',
-          parsedResult: {
-            worksheets: JSON.stringify({
-              count: 0,
-              worksheets: [],
-            }),
-          },
-        }),
-      ),
-    } as unknown as LocalExecutor;
+    const mockExecutor = executorReturning('<?xml version="1.0"?><workbook></workbook>');
 
     const result = await listWorksheets({ executor: mockExecutor, signal: mockSignal });
 
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {
-      expect(result.value).toEqual({
-        count: 0,
-        worksheets: [],
-      });
+      expect(result.value).toEqual({ count: 0, worksheets: [] });
     }
   });
 
-  it('should return error when executeCommand fails', async () => {
+  it('should return error when the workbook fetch fails', async () => {
     const error = { type: 'command-failed' as const, error: { code: 'ERROR', message: 'Failed' } };
     const mockExecutor = {
       executeCommand: vi.fn().mockResolvedValue(Err(error)),
@@ -87,63 +78,8 @@ describe('listWorksheets', () => {
     }
   });
 
-  it('should return error when JSON parsing fails', async () => {
-    const mockExecutor = {
-      executeCommand: vi.fn().mockResolvedValue(
-        Ok({
-          command_id: 'cmd-123',
-          status: 'completed',
-          parsedResult: {
-            worksheets: 'invalid json {',
-          },
-        }),
-      ),
-    } as unknown as LocalExecutor;
-
-    const result = await listWorksheets({ executor: mockExecutor, signal: mockSignal });
-
-    expect(result.isErr()).toBe(true);
-    if (result.isErr()) {
-      expect(result.error.type).toBe('invalid-response');
-    }
-  });
-
-  it('should return error when schema validation fails', async () => {
-    const mockExecutor = {
-      executeCommand: vi.fn().mockResolvedValue(
-        Ok({
-          command_id: 'cmd-123',
-          status: 'completed',
-          parsedResult: {
-            worksheets: JSON.stringify({
-              // Missing required fields
-              invalid: 'data',
-            }),
-          },
-        }),
-      ),
-    } as unknown as LocalExecutor;
-
-    const result = await listWorksheets({ executor: mockExecutor, signal: mockSignal });
-
-    expect(result.isErr()).toBe(true);
-    if (result.isErr()) {
-      expect(result.error.type).toBe('invalid-response');
-    }
-  });
-
-  it('should handle empty worksheets string', async () => {
-    const mockExecutor = {
-      executeCommand: vi.fn().mockResolvedValue(
-        Ok({
-          command_id: 'cmd-123',
-          status: 'completed',
-          parsedResult: {
-            worksheets: '',
-          },
-        }),
-      ),
-    } as unknown as LocalExecutor;
+  it('should return invalid-response when the workbook XML cannot be parsed', async () => {
+    const mockExecutor = executorReturning('this is not xml <<<');
 
     const result = await listWorksheets({ executor: mockExecutor, signal: mockSignal });
 

--- a/src/desktop/commands/workbook/listWorksheets.test.ts
+++ b/src/desktop/commands/workbook/listWorksheets.test.ts
@@ -2,6 +2,7 @@ import { Err, Ok } from 'ts-results-es';
 
 import { LocalExecutor } from '../../toolExecutor/localToolExecutor.js';
 import { listWorksheets } from './listWorksheets.js';
+import { SCRATCH_PREFIX } from './loadWorkbookXml.js';
 
 vi.mock('../../toolExecutor/localToolExecutor.js');
 
@@ -51,6 +52,19 @@ describe('listWorksheets', () => {
       schema: expect.any(Object),
       signal: mockSignal,
     });
+  });
+
+  it('hides the additive-POST scratch sheet from the list', async () => {
+    const mockExecutor = executorReturning(
+      workbookWith(['Sheet 1', `${SCRATCH_PREFIX}abc123`, 'Sales']),
+    );
+
+    const result = await listWorksheets({ executor: mockExecutor, signal: mockSignal });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toEqual({ count: 2, worksheets: ['Sheet 1', 'Sales'] });
+    }
   });
 
   it('should return empty list when no worksheets exist', async () => {

--- a/src/desktop/commands/workbook/listWorksheets.ts
+++ b/src/desktop/commands/workbook/listWorksheets.ts
@@ -6,6 +6,7 @@ import {
   WithExecutorAndAbortSignal,
 } from '../../toolExecutor/toolExecutor.js';
 import { getWorkbookXml } from './getWorkbookXml.js';
+import { SCRATCH_PREFIX } from './loadWorkbookXml.js';
 
 export async function listWorksheets({ executor, signal }: WithExecutorAndAbortSignal): Promise<
   Result<
@@ -23,7 +24,9 @@ export async function listWorksheets({ executor, signal }: WithExecutorAndAbortS
 
   let worksheets: Array<string>;
   try {
-    worksheets = listSheets(workbookResult.value);
+    worksheets = listSheets(workbookResult.value).filter(
+      (name) => !name.startsWith(SCRATCH_PREFIX),
+    );
   } catch (error) {
     return Err({ type: 'invalid-response', error });
   }

--- a/src/desktop/commands/workbook/listWorksheets.ts
+++ b/src/desktop/commands/workbook/listWorksheets.ts
@@ -1,15 +1,11 @@
 import { Err, Ok, Result } from 'ts-results-es';
-import { z } from 'zod';
 
+import { listSheets } from '../../metadata/sheets.js';
 import {
   ExecuteCommandError,
   WithExecutorAndAbortSignal,
 } from '../../toolExecutor/toolExecutor.js';
-
-const worksheetNamesSchema = z.object({
-  count: z.number(),
-  worksheets: z.array(z.object({ name: z.string() })),
-});
+import { getWorkbookXml } from './getWorkbookXml.js';
 
 export async function listWorksheets({ executor, signal }: WithExecutorAndAbortSignal): Promise<
   Result<
@@ -20,33 +16,20 @@ export async function listWorksheets({ executor, signal }: WithExecutorAndAbortS
     ExecuteCommandError
   >
 > {
-  const result = await executor.executeCommand({
-    namespace: 'tabui',
-    command: 'list-worksheets',
-    schema: z.object({
-      worksheets: z.string(),
-    }),
-    signal,
-  });
-
-  if (result.isErr()) {
-    return result;
+  const workbookResult = await getWorkbookXml({ executor, signal });
+  if (workbookResult.isErr()) {
+    return workbookResult;
   }
 
-  let worksheets: unknown;
+  let worksheets: Array<string>;
   try {
-    worksheets = JSON.parse(result.value.parsedResult.worksheets || '[]');
-  } catch (e) {
-    return Err({ type: 'invalid-response', error: e });
-  }
-
-  const worksheetsResult = worksheetNamesSchema.safeParse(worksheets);
-  if (!worksheetsResult.success) {
-    return Err({ type: 'invalid-response', error: worksheetsResult.error });
+    worksheets = listSheets(workbookResult.value);
+  } catch (error) {
+    return Err({ type: 'invalid-response', error });
   }
 
   return Ok({
-    count: worksheetsResult.data.worksheets.length,
-    worksheets: worksheetsResult.data.worksheets.map((worksheet) => worksheet.name),
+    count: worksheets.length,
+    worksheets,
   });
 }

--- a/src/desktop/commands/workbook/loadDashboardXml.test.ts
+++ b/src/desktop/commands/workbook/loadDashboardXml.test.ts
@@ -5,37 +5,91 @@ import { loadDashboardXml } from './loadDashboardXml.js';
 
 vi.mock('../../toolExecutor/localToolExecutor.js');
 
+const dashboardName = 'Sales Dashboard';
+const validXml = `<dashboard name='${dashboardName}'><zones></zones></dashboard>`;
+
+function liveWorkbook(dashboardNames: string[], worksheetNames: string[] = ['Sheet 1']): string {
+  const worksheets = worksheetNames
+    .map((name) => `<worksheet name='${name}'><table /></worksheet>`)
+    .join('');
+  const dashboards = dashboardNames
+    .map((name) => `<dashboard name='${name}'><zones /></dashboard>`)
+    .join('');
+  const windows = dashboardNames
+    .map((name) => `<window class='dashboard' name='${name}' />`)
+    .join('');
+  return `<?xml version='1.0'?><workbook><worksheets>${worksheets}</worksheets><dashboards>${dashboards}</dashboards><windows>${windows}</windows></workbook>`;
+}
+
+function dispatchingExecutor(workbookXml: string): {
+  executor: LocalExecutor;
+  calls: Array<{ namespace: string; command: string; args?: Record<string, unknown> }>;
+} {
+  const calls: Array<{ namespace: string; command: string; args?: Record<string, unknown> }> = [];
+  const executeCommand = vi.fn(async (params: any) => {
+    calls.push({ namespace: params.namespace, command: params.command, args: params.args });
+    if (params.command === 'save-underlying-metadata') {
+      return Ok({
+        command_id: 'cmd-get',
+        status: 'completed',
+        parsedResult: { text: workbookXml },
+      });
+    }
+    return Ok({ command_id: 'cmd-ok', status: 'completed', submitted_at: '' });
+  });
+  return { executor: { executeCommand } as unknown as LocalExecutor, calls };
+}
+
 describe('loadDashboardXml', () => {
   const mockSignal = new AbortController().signal;
-  const dashboardName = 'Sales Dashboard';
-  const validXml = '<dashboard name="Sales Dashboard"><zones></zones></dashboard>';
 
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it('should successfully load dashboard XML', async () => {
-    const mockExecutor = {
-      executeCommand: vi
-        .fn()
-        .mockResolvedValue(Ok({ command_id: 'cmd-123', status: 'completed', submitted_at: '' })),
-    } as unknown as LocalExecutor;
+  it('should delete the live dashboard then apply a minimal document that omits worksheets', async () => {
+    const { executor, calls } = dispatchingExecutor(
+      liveWorkbook(['Sales Dashboard', 'Other DB'], ['Sheet 1']),
+    );
 
     const result = await loadDashboardXml({
       dashboardName,
       xml: validXml,
-      executor: mockExecutor,
+      executor,
       signal: mockSignal,
     });
 
     expect(result.isOk()).toBe(true);
-    expect(mockExecutor.executeCommand).toHaveBeenCalledWith(
-      expect.objectContaining({
-        namespace: 'tabui',
-        command: 'load-dashboard',
-        args: { dashboardName, dashboardXml: validXml },
-      }),
-    );
+
+    const deleteCall = calls.find((c) => c.command === 'delete-sheet');
+    expect(deleteCall).toEqual({
+      namespace: 'tabdoc',
+      command: 'delete-sheet',
+      args: { Sheet: dashboardName },
+    });
+
+    const applyCall = calls.find((c) => c.command === 'load-underlying-metadata');
+    expect(applyCall?.namespace).toBe('tabui');
+    const applied = applyCall?.args?.text as string;
+    expect(applied).toContain('name="Sales Dashboard"');
+    expect(applied).not.toContain('Other DB');
+    // Worksheets are stripped so the additive POST does not duplicate them.
+    expect(applied).not.toContain('<worksheet');
+  });
+
+  it('should skip the delete when the dashboard does not yet exist', async () => {
+    const { executor, calls } = dispatchingExecutor(liveWorkbook(['Some Other DB']));
+
+    const result = await loadDashboardXml({
+      dashboardName,
+      xml: validXml,
+      executor,
+      signal: mockSignal,
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(calls.find((c) => c.command === 'delete-sheet')).toBeUndefined();
+    expect(calls.find((c) => c.command === 'load-underlying-metadata')).toBeDefined();
   });
 
   it('should return invalid-xml error when xml is empty', async () => {
@@ -51,7 +105,9 @@ describe('loadDashboardXml', () => {
     expect(result.isErr()).toBe(true);
     if (result.isErr()) {
       expect(result.error.type).toBe('load-dashboard-xml-error');
-      expect(result.error.error.type).toBe('invalid-xml');
+      if (result.error.type === 'load-dashboard-xml-error') {
+        expect(result.error.error.type).toBe('invalid-xml');
+      }
     }
     expect(mockExecutor.executeCommand).not.toHaveBeenCalled();
   });
@@ -69,16 +125,18 @@ describe('loadDashboardXml', () => {
     expect(result.isErr()).toBe(true);
     if (result.isErr()) {
       expect(result.error.type).toBe('load-dashboard-xml-error');
-      expect(result.error.error.type).toBe('validation-failed');
-      if (result.error.error.type === 'validation-failed') {
-        expect(result.error.error.issues.length).toBeGreaterThan(0);
-        expect(result.error.error.issues[0].ruleId).toBe('well-formed-xml');
+      if (result.error.type === 'load-dashboard-xml-error') {
+        expect(result.error.error.type).toBe('validation-failed');
+        if (result.error.error.type === 'validation-failed') {
+          expect(result.error.error.issues.length).toBeGreaterThan(0);
+          expect(result.error.error.issues[0].ruleId).toBe('well-formed-xml');
+        }
       }
     }
     expect(mockExecutor.executeCommand).not.toHaveBeenCalled();
   });
 
-  it('should return error when executeCommand fails', async () => {
+  it('should return error when the workbook fetch fails', async () => {
     const error = {
       type: 'command-failed' as const,
       error: { code: 'ERROR', message: 'Failed', recoverable: false },
@@ -97,26 +155,24 @@ describe('loadDashboardXml', () => {
     expect(result.isErr()).toBe(true);
     if (result.isErr()) {
       expect(result.error.type).toBe('execute-command-error');
-      expect(result.error.error).toEqual(error);
+      if (result.error.type === 'execute-command-error') {
+        expect(result.error.error).toEqual(error);
+      }
     }
   });
 
   it('should pass the abort signal to executeCommand', async () => {
     const customSignal = new AbortController().signal;
-    const mockExecutor = {
-      executeCommand: vi
-        .fn()
-        .mockResolvedValue(Ok({ command_id: 'cmd-123', status: 'completed', submitted_at: '' })),
-    } as unknown as LocalExecutor;
+    const { executor } = dispatchingExecutor(liveWorkbook(['Sales Dashboard']));
 
     await loadDashboardXml({
       dashboardName,
       xml: validXml,
-      executor: mockExecutor,
+      executor,
       signal: customSignal,
     });
 
-    expect(mockExecutor.executeCommand).toHaveBeenCalledWith(
+    expect(executor.executeCommand).toHaveBeenCalledWith(
       expect.objectContaining({ signal: customSignal }),
     );
   });

--- a/src/desktop/commands/workbook/loadDashboardXml.ts
+++ b/src/desktop/commands/workbook/loadDashboardXml.ts
@@ -9,6 +9,7 @@ import {
 } from '../../toolExecutor/toolExecutor.js';
 import { runValidation } from '../../validation/registry.js';
 import { ValidationIssue } from '../../validation/types.js';
+import { withApplyLock } from './applyMutex.js';
 import { deleteLiveSheet } from './deleteLiveSheet.js';
 import { getWorkbookXml } from './getWorkbookXml.js';
 import { applyWorkbookText } from './loadWorkbookXml.js';
@@ -66,36 +67,38 @@ export async function loadDashboardXml({
     });
   }
 
-  const workbookResult = await getWorkbookXml({ executor, signal });
-  if (workbookResult.isErr()) {
-    return Err({ type: 'execute-command-error', error: workbookResult.error });
-  }
+  return withApplyLock(async () => {
+    const workbookResult = await getWorkbookXml({ executor, signal });
+    if (workbookResult.isErr()) {
+      return Err({ type: 'execute-command-error', error: workbookResult.error });
+    }
 
-  let minimalDoc: string;
-  try {
-    minimalDoc = buildMinimalDashboardDoc(workbookResult.value, dashboardName, xml);
-  } catch (error) {
-    return Err({ type: 'execute-command-error', error: { type: 'invalid-response', error } });
-  }
+    let minimalDoc: string;
+    try {
+      minimalDoc = buildMinimalDashboardDoc(workbookResult.value, dashboardName, xml);
+    } catch (error) {
+      return Err({ type: 'execute-command-error', error: { type: 'invalid-response', error } });
+    }
 
-  const deleteResult = await deleteLiveSheet({ sheetName: dashboardName, executor, signal });
-  if (deleteResult.isErr()) {
-    return Err({ type: 'execute-command-error', error: deleteResult.error });
-  }
+    const deleteResult = await deleteLiveSheet({ sheetName: dashboardName, executor, signal });
+    if (deleteResult.isErr()) {
+      return Err({ type: 'execute-command-error', error: deleteResult.error });
+    }
 
-  const applyResult = await applyWorkbookText({ xml: minimalDoc, executor, signal });
-  if (applyResult.isErr()) {
-    return Err({ type: 'execute-command-error', error: applyResult.error });
-  }
+    const applyResult = await applyWorkbookText({ xml: minimalDoc, executor, signal });
+    if (applyResult.isErr()) {
+      return Err({ type: 'execute-command-error', error: applyResult.error });
+    }
 
-  log({
-    level: 'info',
-    message: 'load-dashboard completed',
-    logger: 'dashboardCommands',
-    data: { dashboardName },
+    log({
+      level: 'info',
+      message: 'load-dashboard completed',
+      logger: 'dashboardCommands',
+      data: { dashboardName },
+    });
+
+    return Ok.EMPTY;
   });
-
-  return Ok.EMPTY;
 }
 
 function sanitize(value: unknown): unknown {

--- a/src/desktop/commands/workbook/loadDashboardXml.ts
+++ b/src/desktop/commands/workbook/loadDashboardXml.ts
@@ -2,12 +2,16 @@ import { Err, Ok, Result } from 'ts-results-es';
 
 import { log } from '../../../logging/logger.js';
 import { sanitizeValue } from '../../../logging/sanitize.js';
+import { buildMinimalDashboardDoc } from '../../metadata/dashboards.js';
 import {
   ExecuteCommandError,
   WithExecutorAndAbortSignal,
 } from '../../toolExecutor/toolExecutor.js';
 import { runValidation } from '../../validation/registry.js';
 import { ValidationIssue } from '../../validation/types.js';
+import { deleteLiveSheet } from './deleteLiveSheet.js';
+import { getWorkbookXml } from './getWorkbookXml.js';
+import { applyWorkbookText } from './loadWorkbookXml.js';
 
 export type LoadDashboardXmlError =
   | { type: 'invalid-xml' }
@@ -62,28 +66,33 @@ export async function loadDashboardXml({
     });
   }
 
-  const result = await executor.executeCommand({
-    namespace: 'tabui',
-    command: 'load-dashboard',
-    signal,
-    args: {
-      dashboardName,
-      dashboardXml: xml,
-    },
-  });
+  const workbookResult = await getWorkbookXml({ executor, signal });
+  if (workbookResult.isErr()) {
+    return Err({ type: 'execute-command-error', error: workbookResult.error });
+  }
 
-  if (result.isErr()) {
-    return Err({ type: 'execute-command-error', error: result.error });
+  let minimalDoc: string;
+  try {
+    minimalDoc = buildMinimalDashboardDoc(workbookResult.value, dashboardName, xml);
+  } catch (error) {
+    return Err({ type: 'execute-command-error', error: { type: 'invalid-response', error } });
+  }
+
+  const deleteResult = await deleteLiveSheet({ sheetName: dashboardName, executor, signal });
+  if (deleteResult.isErr()) {
+    return Err({ type: 'execute-command-error', error: deleteResult.error });
+  }
+
+  const applyResult = await applyWorkbookText({ xml: minimalDoc, executor, signal });
+  if (applyResult.isErr()) {
+    return Err({ type: 'execute-command-error', error: applyResult.error });
   }
 
   log({
     level: 'info',
     message: 'load-dashboard completed',
     logger: 'dashboardCommands',
-    data: {
-      dashboardName,
-      commandId: result.value.command_id,
-    },
+    data: { dashboardName },
   });
 
   return Ok.EMPTY;

--- a/src/desktop/commands/workbook/loadWorkbookXml.test.ts
+++ b/src/desktop/commands/workbook/loadWorkbookXml.test.ts
@@ -1,148 +1,75 @@
-import { writeFileSync } from 'fs';
 import { Err, Ok } from 'ts-results-es';
 
 import invariant from '../../../utils/invariant.js';
-import * as xmlToJsonModule from '../../libraries/workbook-serialization-converter/index.js';
 import { LocalExecutor } from '../../toolExecutor/localToolExecutor.js';
 import * as validationRegistry from '../../validation/registry.js';
 import { loadWorkbookXml } from './loadWorkbookXml.js';
 
-vi.mock('fs');
 vi.mock('../../toolExecutor/localToolExecutor.js');
-vi.mock('../../libraries/workbook-serialization-converter/index.js');
 vi.mock('../../validation/registry.js');
+
+const validXml =
+  '<?xml version="1.0"?><workbook>' +
+  '<worksheets><worksheet name="Sheet 1"><table /></worksheet></worksheets>' +
+  '</workbook>';
+
+// Executor that records every dispatched command so the scratch-reset sequence
+// (save-underlying-metadata fetch → new-worksheet → delete-sheet* → load-underlying-metadata →
+// delete-sheet scratch) is assertable. The fetch returns `liveXml` as the live workbook.
+function dispatchingExecutor(liveXml: string = validXml): {
+  executor: LocalExecutor;
+  calls: Array<{ namespace: string; command: string; args?: Record<string, unknown> }>;
+} {
+  const calls: Array<{ namespace: string; command: string; args?: Record<string, unknown> }> = [];
+  const executeCommand = vi.fn(async (params: any) => {
+    calls.push({ namespace: params.namespace, command: params.command, args: params.args });
+    if (params.command === 'save-underlying-metadata') {
+      return Ok({ command_id: 'cmd-get', status: 'completed', parsedResult: { text: liveXml } });
+    }
+    return Ok({ command_id: 'cmd', status: 'completed', submitted_at: '' });
+  });
+  return { executor: { executeCommand } as unknown as LocalExecutor, calls };
+}
 
 describe('loadWorkbookXml', () => {
   const mockSignal = new AbortController().signal;
-  const validXml = '<?xml version="1.0"?><workbook><worksheets></worksheets></workbook>';
 
   beforeEach(() => {
     vi.clearAllMocks();
-    // Default mock for validation - passes
     vi.spyOn(validationRegistry, 'runValidation').mockReturnValue({ valid: true, issues: [] });
   });
 
-  it('should successfully load workbook XML via filepath', async () => {
-    const mockJson = '{"workbook": {}}';
-    vi.spyOn(xmlToJsonModule, 'xmlToJson').mockReturnValue(mockJson);
+  it('resets colliding sheets behind a scratch sheet, then applies via the text POST', async () => {
+    const { executor, calls } = dispatchingExecutor();
 
-    const mockExecutor = {
-      executeCommand: vi.fn().mockResolvedValue(
-        Ok({
-          command_id: 'cmd-123',
-          status: 'completed',
-          submitted_at: '',
-        }),
-      ),
-    } as unknown as LocalExecutor;
-
-    const result = await loadWorkbookXml({
-      xml: validXml,
-      executor: mockExecutor,
-      signal: mockSignal,
-    });
+    const result = await loadWorkbookXml({ xml: validXml, executor, signal: mockSignal });
 
     expect(result.isOk()).toBe(true);
 
-    expect(mockExecutor.executeCommand).toHaveBeenCalledWith(
-      expect.objectContaining({
-        namespace: 'tabui',
-        command: 'load-underlying-metadata',
-        args: expect.objectContaining({
-          filepath: expect.stringContaining('workbook-apply'),
-        }),
-      }),
+    const scratchAdd = calls.find((c) => c.command === 'new-worksheet');
+    expect(scratchAdd?.namespace).toBe('tabdoc');
+    const scratchName = scratchAdd?.args?.NewSheet as string;
+    expect(scratchName).toMatch(/^mcpApplyScratch[a-zA-Z0-9]+$/);
+
+    // The doc's own sheet is deleted before the POST so the additive merge can re-add it cleanly.
+    expect(calls.some((c) => c.command === 'delete-sheet' && c.args?.Sheet === 'Sheet 1')).toBe(
+      true,
     );
-    expect(writeFileSync).toHaveBeenCalledWith(expect.stringContaining('.json'), mockJson, 'utf-8');
-  });
 
-  it('should fallback to text mode when XML to JSON conversion fails', async () => {
-    vi.spyOn(xmlToJsonModule, 'xmlToJson').mockImplementation(() => {
-      throw new Error('Conversion failed');
-    });
-
-    const mockExecutor = {
-      executeCommand: vi.fn().mockResolvedValue(
-        Ok({
-          command_id: 'cmd-123',
-          status: 'completed',
-          submitted_at: '',
-          parsedResult: {
-            status: 'completed',
-          },
-        }),
-      ),
-    } as unknown as LocalExecutor;
-
-    const result = await loadWorkbookXml({
-      xml: validXml,
-      executor: mockExecutor,
-      signal: mockSignal,
-    });
-
-    expect(result.isOk()).toBe(true);
-
-    // Should call with text argument instead
-    expect(mockExecutor.executeCommand).toHaveBeenCalledWith(
-      expect.objectContaining({
-        args: expect.objectContaining({
-          text: validXml,
-        }),
-      }),
+    // POST happens after the deletes and before the scratch is removed.
+    const postIdx = calls.findIndex((c) => c.command === 'load-underlying-metadata');
+    const scratchDeleteIdx = calls.findIndex(
+      (c) => c.command === 'delete-sheet' && c.args?.Sheet === scratchName,
     );
-  });
-
-  it('should fallback to text mode when filepath load fails', async () => {
-    const mockJson = '{"workbook": {}}';
-    vi.spyOn(xmlToJsonModule, 'xmlToJson').mockReturnValue(mockJson);
-
-    const mockExecutor = {
-      executeCommand: vi
-        .fn()
-        .mockResolvedValueOnce(
-          Err({
-            type: 'command-failed',
-            error: { code: 'ERROR', message: 'Failed to load', recoverable: false },
-          }),
-        )
-        .mockResolvedValueOnce(
-          Ok({
-            command_id: 'cmd-124',
-            status: 'completed',
-            submitted_at: '',
-            parsedResult: {
-              status: 'completed',
-            },
-          }),
-        ),
-    } as unknown as LocalExecutor;
-
-    const result = await loadWorkbookXml({
-      xml: validXml,
-      executor: mockExecutor,
-      signal: mockSignal,
-    });
-
-    expect(result.isOk()).toBe(true);
-    expect(mockExecutor.executeCommand).toHaveBeenCalledTimes(2);
-    // Second call should be text mode
-    expect(mockExecutor.executeCommand).toHaveBeenLastCalledWith(
-      expect.objectContaining({
-        args: expect.objectContaining({
-          text: validXml,
-        }),
-      }),
-    );
+    expect(postIdx).toBeGreaterThan(0);
+    expect(scratchDeleteIdx).toBeGreaterThan(postIdx);
+    expect(calls[postIdx].args).toEqual({ text: validXml });
   });
 
   it('should return error when XML is invalid', async () => {
-    const invalidXml = 'not xml';
-
-    const mockExecutor = {} as unknown as LocalExecutor;
-
     const result = await loadWorkbookXml({
-      xml: invalidXml,
-      executor: mockExecutor,
+      xml: 'not xml',
+      executor: {} as unknown as LocalExecutor,
       signal: mockSignal,
     });
 
@@ -154,9 +81,11 @@ describe('loadWorkbookXml', () => {
   });
 
   it('should return error when XML is empty', async () => {
-    const mockExecutor = {} as unknown as LocalExecutor;
-
-    const result = await loadWorkbookXml({ xml: '', executor: mockExecutor, signal: mockSignal });
+    const result = await loadWorkbookXml({
+      xml: '',
+      executor: {} as unknown as LocalExecutor,
+      signal: mockSignal,
+    });
 
     expect(result.isErr()).toBe(true);
     if (result.isErr()) {
@@ -167,20 +96,12 @@ describe('loadWorkbookXml', () => {
   it('should return error when validation fails', async () => {
     vi.spyOn(validationRegistry, 'runValidation').mockReturnValue({
       valid: false,
-      issues: [
-        {
-          ruleId: 'test-rule',
-          severity: 'error',
-          message: 'Invalid structure',
-        },
-      ],
+      issues: [{ ruleId: 'test-rule', severity: 'error', message: 'Invalid structure' }],
     });
-
-    const mockExecutor = {} as unknown as LocalExecutor;
 
     const result = await loadWorkbookXml({
       xml: validXml,
-      executor: mockExecutor,
+      executor: {} as unknown as LocalExecutor,
       signal: mockSignal,
     });
 
@@ -191,40 +112,18 @@ describe('loadWorkbookXml', () => {
     }
   });
 
-  it('should return error when text mode load fails', async () => {
-    vi.spyOn(xmlToJsonModule, 'xmlToJson').mockImplementation(() => {
-      throw new Error('Conversion failed');
-    });
-
-    const mockExecutor = {
-      executeCommand: vi.fn().mockResolvedValue(
-        Err({
-          type: 'command-failed',
-          error: { code: 'ERROR', message: 'Failed to load', recoverable: false },
-        }),
-      ),
-    } as unknown as LocalExecutor;
-
-    const result = await loadWorkbookXml({
-      xml: validXml,
-      executor: mockExecutor,
-      signal: mockSignal,
-    });
-
-    expect(result.isErr()).toBe(true);
-    if (result.isErr()) {
-      expect(result.error.type).toBe('execute-command-error');
-    }
-  });
-
-  it('should return error when executeCommand fails', async () => {
-    const mockJson = '{"workbook": {}}';
-    vi.spyOn(xmlToJsonModule, 'xmlToJson').mockReturnValue(mockJson);
-
+  it('should return execute-command-error when the apply POST fails', async () => {
     const error = { type: 'command-timed-out' as const, error: 'Timeout' };
-    const mockExecutor = {
-      executeCommand: vi.fn().mockResolvedValue(Err(error)),
-    } as unknown as LocalExecutor;
+    const executeCommand = vi.fn(async (params: any) => {
+      if (params.command === 'save-underlying-metadata') {
+        return Ok({ command_id: 'cmd-get', status: 'completed', parsedResult: { text: validXml } });
+      }
+      if (params.command === 'load-underlying-metadata') {
+        return Err(error);
+      }
+      return Ok({ command_id: 'cmd', status: 'completed', submitted_at: '' });
+    });
+    const mockExecutor = { executeCommand } as unknown as LocalExecutor;
 
     const result = await loadWorkbookXml({
       xml: validXml,
@@ -234,102 +133,47 @@ describe('loadWorkbookXml', () => {
 
     expect(result.isErr()).toBe(true);
     if (result.isErr()) {
-      expect(result.error.type).toBe('execute-command-error');
+      invariant(result.error.type === 'execute-command-error');
       expect(result.error.error).toEqual(error);
     }
-  });
-
-  it('should use provided filepath when specified', async () => {
-    const mockJson = '{"workbook": {}}';
-    const customFilePath = '/custom/path/workbook.json';
-    vi.spyOn(xmlToJsonModule, 'xmlToJson').mockReturnValue(mockJson);
-
-    const mockExecutor = {
-      executeCommand: vi.fn().mockResolvedValue(
-        Ok({
-          command_id: 'cmd-123',
-          status: 'completed',
-          submitted_at: '',
-        }),
-      ),
-    } as unknown as LocalExecutor;
-
-    await loadWorkbookXml({
-      xml: validXml,
-      filePath: customFilePath,
-      executor: mockExecutor,
-      signal: mockSignal,
-    });
-
-    expect(writeFileSync).toHaveBeenCalledWith(customFilePath, mockJson, 'utf-8');
-    expect(mockExecutor.executeCommand).toHaveBeenCalledWith(
-      expect.objectContaining({
-        args: expect.objectContaining({
-          filepath: customFilePath,
-        }),
-      }),
+    // The scratch sheet is still cleaned up even after a failed POST.
+    const scratchAdd = (executeCommand.mock.calls as any[]).find(
+      ([p]) => p.command === 'new-worksheet',
     );
+    const scratchName = scratchAdd[0].args.NewSheet;
+    expect(
+      (executeCommand.mock.calls as any[]).some(
+        ([p]) => p.command === 'delete-sheet' && p.args?.Sheet === scratchName,
+      ),
+    ).toBe(true);
   });
 
-  it('should trim whitespace from XML', async () => {
-    const xmlWithWhitespace = `
-      ${validXml}
-    `;
-    const mockJson = '{"workbook": {}}';
-    vi.spyOn(xmlToJsonModule, 'xmlToJson').mockReturnValue(mockJson);
-
-    const mockExecutor = {
-      executeCommand: vi.fn().mockResolvedValue(
-        Ok({
-          command_id: 'cmd-123',
-          status: 'completed',
-          submitted_at: '',
-        }),
-      ),
-    } as unknown as LocalExecutor;
+  it('should trim whitespace from XML before validating and applying', async () => {
+    const { executor, calls } = dispatchingExecutor();
 
     const result = await loadWorkbookXml({
-      xml: xmlWithWhitespace,
-      executor: mockExecutor,
+      xml: `\n      ${validXml}\n    `,
+      executor,
       signal: mockSignal,
     });
 
     expect(result.isOk()).toBe(true);
     expect(validationRegistry.runValidation).toHaveBeenCalledWith(validXml, 'workbook');
+    const post = calls.find((c) => c.command === 'load-underlying-metadata');
+    expect(post?.args).toEqual({ text: validXml });
   });
 
   it('should proceed with warnings but not errors', async () => {
     vi.spyOn(validationRegistry, 'runValidation').mockReturnValue({
       valid: true,
-      issues: [
-        {
-          ruleId: 'test-rule',
-          severity: 'warning',
-          message: 'Deprecated element',
-        },
-      ],
+      issues: [{ ruleId: 'test-rule', severity: 'warning', message: 'Deprecated element' }],
     });
 
-    const mockJson = '{"workbook": {}}';
-    vi.spyOn(xmlToJsonModule, 'xmlToJson').mockReturnValue(mockJson);
+    const { executor, calls } = dispatchingExecutor();
 
-    const mockExecutor = {
-      executeCommand: vi.fn().mockResolvedValue(
-        Ok({
-          command_id: 'cmd-123',
-          status: 'completed',
-          submitted_at: '',
-        }),
-      ),
-    } as unknown as LocalExecutor;
-
-    const result = await loadWorkbookXml({
-      xml: validXml,
-      executor: mockExecutor,
-      signal: mockSignal,
-    });
+    const result = await loadWorkbookXml({ xml: validXml, executor, signal: mockSignal });
 
     expect(result.isOk()).toBe(true);
-    expect(mockExecutor.executeCommand).toHaveBeenCalled();
+    expect(calls.some((c) => c.command === 'load-underlying-metadata')).toBe(true);
   });
 });

--- a/src/desktop/commands/workbook/loadWorkbookXml.test.ts
+++ b/src/desktop/commands/workbook/loadWorkbookXml.test.ts
@@ -3,7 +3,7 @@ import { Err, Ok } from 'ts-results-es';
 import invariant from '../../../utils/invariant.js';
 import { LocalExecutor } from '../../toolExecutor/localToolExecutor.js';
 import * as validationRegistry from '../../validation/registry.js';
-import { loadWorkbookXml } from './loadWorkbookXml.js';
+import { loadWorkbookXml, SCRATCH_PREFIX } from './loadWorkbookXml.js';
 
 vi.mock('../../toolExecutor/localToolExecutor.js');
 vi.mock('../../validation/registry.js');
@@ -49,7 +49,7 @@ describe('loadWorkbookXml', () => {
     const scratchAdd = calls.find((c) => c.command === 'new-worksheet');
     expect(scratchAdd?.namespace).toBe('tabdoc');
     const scratchName = scratchAdd?.args?.NewSheet as string;
-    expect(scratchName).toMatch(/^mcpApplyScratch[a-zA-Z0-9]+$/);
+    expect(scratchName.startsWith(SCRATCH_PREFIX)).toBe(true);
 
     // The doc's own sheet is deleted before the POST so the additive merge can re-add it cleanly.
     expect(calls.some((c) => c.command === 'delete-sheet' && c.args?.Sheet === 'Sheet 1')).toBe(

--- a/src/desktop/commands/workbook/loadWorkbookXml.ts
+++ b/src/desktop/commands/workbook/loadWorkbookXml.ts
@@ -10,7 +10,12 @@ import {
 } from '../../toolExecutor/toolExecutor.js';
 import { runValidation } from '../../validation/registry.js';
 import { ValidationIssue } from '../../validation/types.js';
+import { withApplyLock } from './applyMutex.js';
 import { getWorkbookXml } from './getWorkbookXml.js';
+
+// Name prefix for the throwaway sheet the additive-POST workaround creates. Reads as a progress
+// label if it ever flashes in the UI. Callers listing sheets filter it so it never surfaces.
+export const SCRATCH_PREFIX = '...thinking-';
 
 export type LoadWorkbookXmlError =
   | { type: 'invalid-xml' }
@@ -58,7 +63,7 @@ export async function loadWorkbookXml({
     });
   }
 
-  const result = await resetAndApplyWorkbook({ xml, executor, signal });
+  const result = await withApplyLock(() => resetAndApplyWorkbook({ xml, executor, signal }));
   if (result.isErr()) {
     return Err({ type: 'execute-command-error', error: result.error });
   }
@@ -94,7 +99,16 @@ async function resetAndApplyWorkbook({
     return Err({ type: 'invalid-response', error });
   }
 
-  const scratchName = `mcpApplyScratch${generateUUID().replace(/[^a-zA-Z0-9]/g, '')}`;
+  // Sweep any scratch left over from a prior apply whose trailing delete no-op'd (Tableau silently
+  // refuses to delete the last sheet, and the post-POST doc may not have settled yet). Safe because
+  // the apply lock serializes us — no live apply owns a scratch right now, and real sheets remain.
+  for (const name of listSheets(liveResult.value)) {
+    if (name.startsWith(SCRATCH_PREFIX)) {
+      await deleteScratch(name, executor, signal);
+    }
+  }
+
+  const scratchName = `${SCRATCH_PREFIX}${generateUUID().replace(/[^a-zA-Z0-9]/g, '')}`;
   const addScratch = await executor.executeCommand({
     namespace: 'tabdoc',
     command: 'new-worksheet',
@@ -124,7 +138,8 @@ async function resetAndApplyWorkbook({
     return applied;
   }
 
-  return deleteScratch(scratchName, executor, signal);
+  await deleteScratch(scratchName, executor, signal);
+  return Ok.EMPTY;
 }
 
 async function deleteScratch(

--- a/src/desktop/commands/workbook/loadWorkbookXml.ts
+++ b/src/desktop/commands/workbook/loadWorkbookXml.ts
@@ -1,15 +1,16 @@
-import { writeFileSync } from 'fs';
 import { Err, Ok, Result } from 'ts-results-es';
 
 import { log } from '../../../logging/logger.js';
-import { DesktopCache } from '../../cache.js';
-import { xmlToJson } from '../../libraries/workbook-serialization-converter';
+import { listWorkbookDashboards } from '../../metadata/dashboards.js';
+import { generateUUID } from '../../metadata/parser.js';
+import { listSheets } from '../../metadata/sheets.js';
 import {
   ExecuteCommandError,
   WithExecutorAndAbortSignal,
 } from '../../toolExecutor/toolExecutor.js';
 import { runValidation } from '../../validation/registry.js';
 import { ValidationIssue } from '../../validation/types.js';
+import { getWorkbookXml } from './getWorkbookXml.js';
 
 export type LoadWorkbookXmlError =
   | { type: 'invalid-xml' }
@@ -17,10 +18,9 @@ export type LoadWorkbookXmlError =
 
 export async function loadWorkbookXml({
   xml,
-  filePath,
   executor,
   signal,
-}: { xml: string; filePath?: string } & WithExecutorAndAbortSignal): Promise<
+}: { xml: string } & WithExecutorAndAbortSignal): Promise<
   Result<
     void,
     | { type: 'execute-command-error'; error: ExecuteCommandError }
@@ -58,98 +58,97 @@ export async function loadWorkbookXml({
     });
   }
 
-  return loadUnderlyingMetadataByFilepath({ xml, executor, signal, filePath });
-}
-
-async function loadUnderlyingMetadataByFilepath({
-  xml,
-  filePath,
-  executor,
-  signal,
-}: {
-  xml: string;
-  filePath?: string;
-} & WithExecutorAndAbortSignal): Promise<
-  Result<void, { type: 'execute-command-error'; error: ExecuteCommandError }>
-> {
-  let jsonContent: string | undefined;
-
-  try {
-    jsonContent = xmlToJson(xml);
-  } catch (error) {
-    log({
-      level: 'warning',
-      message: 'XML→JSON conversion failed, falling back to text',
-      logger: 'workbookCommands',
-      data: {
-        error,
-      },
-    });
-
-    return loadUnderlyingMetadataByText({ xml, executor, signal });
-  }
-
-  const jsonPath =
-    filePath ||
-    new DesktopCache().getCacheFilePath({ prefix: 'workbook-apply', extension: 'json' });
-  writeFileSync(jsonPath, jsonContent, 'utf-8');
-
-  log({
-    level: 'info',
-    message: 'Converted XML→JSON for file-path load',
-    logger: 'workbookCommands',
-    data: {
-      xmlLength: xml.length,
-      jsonLength: jsonContent.length,
-      filePath: jsonPath,
-    },
-  });
-
-  const result = await executor.executeCommand({
-    namespace: 'tabui',
-    command: 'load-underlying-metadata',
-    signal,
-    args: {
-      filepath: jsonPath,
-    },
-  });
-
+  const result = await resetAndApplyWorkbook({ xml, executor, signal });
   if (result.isErr()) {
-    const { error } = result;
-    if (error.type === 'command-failed') {
-      log({
-        level: 'warning',
-        message: 'File-path approach did not complete, falling back to text',
-        logger: 'workbookCommands',
-        data: {
-          error: error.error,
-        },
-      });
-
-      return loadUnderlyingMetadataByText({ xml, executor, signal });
-    }
-
     return Err({ type: 'execute-command-error', error: result.error });
   }
-
-  log({
-    level: 'info',
-    message: 'load-underlying-metadata (filepath/JSON) completed',
-    logger: 'workbookCommands',
-  });
 
   return Ok.EMPTY;
 }
 
-async function loadUnderlyingMetadataByText({
+// TEMPORARY workaround for an External Client API bug: POST /v1/workbook/document is additive on
+// sheet-name collision (never overwrites), so re-posting a whole workbook re-adds every sheet it
+// already has as "(2)". The API fix + an expanded get/set surface are coming; remove this then.
+// The scratch sheet exists only so the delete loop never hits Tableau's refusal to delete the
+// last remaining sheet.
+async function resetAndApplyWorkbook({
   xml,
   executor,
   signal,
-}: {
-  xml: string;
-} & WithExecutorAndAbortSignal): Promise<
-  Result<void, { type: 'execute-command-error'; error: ExecuteCommandError }>
-> {
+}: { xml: string } & WithExecutorAndAbortSignal): Promise<Result<void, ExecuteCommandError>> {
+  const liveResult = await getWorkbookXml({ executor, signal });
+  if (liveResult.isErr()) {
+    return liveResult;
+  }
+
+  // Only sheets that are BOTH live and in the doc collide on the additive POST. Deleting a
+  // doc sheet that is not live yet errors; a live sheet absent from the doc is left to merge.
+  let colliding: Array<string>;
+  try {
+    const docNames = new Set([...listSheets(xml), ...listWorkbookDashboards(xml)]);
+    colliding = [
+      ...listSheets(liveResult.value),
+      ...listWorkbookDashboards(liveResult.value),
+    ].filter((name) => docNames.has(name));
+  } catch (error) {
+    return Err({ type: 'invalid-response', error });
+  }
+
+  const scratchName = `mcpApplyScratch${generateUUID().replace(/[^a-zA-Z0-9]/g, '')}`;
+  const addScratch = await executor.executeCommand({
+    namespace: 'tabdoc',
+    command: 'new-worksheet',
+    args: { NewSheet: scratchName },
+    signal,
+  });
+  if (addScratch.isErr()) {
+    return addScratch;
+  }
+
+  for (const name of colliding) {
+    const deleted = await executor.executeCommand({
+      namespace: 'tabdoc',
+      command: 'delete-sheet',
+      args: { Sheet: name },
+      signal,
+    });
+    if (deleted.isErr()) {
+      await deleteScratch(scratchName, executor, signal);
+      return deleted;
+    }
+  }
+
+  const applied = await applyWorkbookText({ xml, executor, signal });
+  if (applied.isErr()) {
+    await deleteScratch(scratchName, executor, signal);
+    return applied;
+  }
+
+  return deleteScratch(scratchName, executor, signal);
+}
+
+async function deleteScratch(
+  scratchName: string,
+  executor: WithExecutorAndAbortSignal['executor'],
+  signal: AbortSignal,
+): Promise<Result<void, ExecuteCommandError>> {
+  const result = await executor.executeCommand({
+    namespace: 'tabdoc',
+    command: 'delete-sheet',
+    args: { Sheet: scratchName },
+    signal,
+  });
+  if (result.isErr()) {
+    return result;
+  }
+  return Ok.EMPTY;
+}
+
+export async function applyWorkbookText({
+  xml,
+  executor,
+  signal,
+}: { xml: string } & WithExecutorAndAbortSignal): Promise<Result<void, ExecuteCommandError>> {
   const result = await executor.executeCommand({
     namespace: 'tabui',
     command: 'load-underlying-metadata',
@@ -160,19 +159,13 @@ async function loadUnderlyingMetadataByText({
   });
 
   if (result.isErr()) {
-    const { error } = result;
-    if (error.type === 'command-failed') {
-      log({
-        level: 'error',
-        message: 'load-underlying-metadata (text) failed',
-        logger: 'workbookCommands',
-        data: {
-          error,
-        },
-      });
-    }
-
-    return Err({ type: 'execute-command-error', error: result.error });
+    log({
+      level: 'error',
+      message: 'load-underlying-metadata (text) failed',
+      logger: 'workbookCommands',
+      data: { error: result.error },
+    });
+    return result;
   }
 
   log({
@@ -182,7 +175,6 @@ async function loadUnderlyingMetadataByText({
     data: {
       commandId: result.value.command_id,
       hasResult: !!result.value.result,
-      resultKeys: result.value.result ? Object.keys(result.value.result) : [],
     },
   });
 

--- a/src/desktop/commands/workbook/loadWorksheetXml.test.ts
+++ b/src/desktop/commands/workbook/loadWorksheetXml.test.ts
@@ -8,54 +8,95 @@ import { loadWorksheetXml } from './loadWorksheetXml.js';
 vi.mock('../../toolExecutor/localToolExecutor.js');
 vi.mock('../../validation/registry.js');
 
+const worksheetName = 'Sheet 1';
+const validXml = `<worksheet name='${worksheetName}'><table><rows /></table></worksheet>`;
+
+function liveWorkbook(worksheetNames: string[]): string {
+  const worksheets = worksheetNames
+    .map((name) => `<worksheet name='${name}'><table /></worksheet>`)
+    .join('');
+  const windows = worksheetNames
+    .map((name) => `<window class='worksheet' name='${name}' />`)
+    .join('');
+  return `<?xml version='1.0'?><workbook><worksheets>${worksheets}</worksheets><windows>${windows}</windows></workbook>`;
+}
+
+// Executor that dispatches by command, recording each call so the delete-then-apply
+// sequence can be asserted. `save-underlying-metadata` returns the live workbook.
+function dispatchingExecutor(workbookXml: string): {
+  executor: LocalExecutor;
+  calls: Array<{ namespace: string; command: string; args?: Record<string, unknown> }>;
+} {
+  const calls: Array<{ namespace: string; command: string; args?: Record<string, unknown> }> = [];
+  const executeCommand = vi.fn(async (params: any) => {
+    calls.push({ namespace: params.namespace, command: params.command, args: params.args });
+    if (params.command === 'save-underlying-metadata') {
+      return Ok({
+        command_id: 'cmd-get',
+        status: 'completed',
+        parsedResult: { text: workbookXml },
+      });
+    }
+    return Ok({ command_id: 'cmd-ok', status: 'completed', submitted_at: '' });
+  });
+  return { executor: { executeCommand } as unknown as LocalExecutor, calls };
+}
+
 describe('loadWorksheetXml', () => {
   const mockSignal = new AbortController().signal;
-  const worksheetName = 'Sheet 1';
-  const validXml = '<worksheet name="Sheet 1"><table></table></worksheet>';
 
   beforeEach(() => {
     vi.clearAllMocks();
     vi.spyOn(validationRegistry, 'runValidation').mockReturnValue({ valid: true, issues: [] });
   });
 
-  it('should successfully load worksheet XML', async () => {
-    const mockExecutor = {
-      executeCommand: vi.fn().mockResolvedValue(
-        Ok({
-          command_id: 'cmd-123',
-          status: 'completed',
-          submitted_at: '',
-        }),
-      ),
-    } as unknown as LocalExecutor;
+  it('should delete the live sheet then apply a minimal document for an existing sheet', async () => {
+    const { executor, calls } = dispatchingExecutor(liveWorkbook(['Sheet 1', 'Other']));
 
     const result = await loadWorksheetXml({
       worksheetName,
       xml: validXml,
-      executor: mockExecutor,
+      executor,
       signal: mockSignal,
     });
 
     expect(result.isOk()).toBe(true);
-    expect(mockExecutor.executeCommand).toHaveBeenCalledWith(
-      expect.objectContaining({
-        namespace: 'tabui',
-        command: 'load-worksheet',
-        args: {
-          worksheetName,
-          worksheetXml: validXml,
-        },
-      }),
-    );
+
+    const deleteCall = calls.find((c) => c.command === 'delete-sheet');
+    expect(deleteCall).toEqual({
+      namespace: 'tabdoc',
+      command: 'delete-sheet',
+      args: { Sheet: worksheetName },
+    });
+
+    const applyCall = calls.find((c) => c.command === 'load-underlying-metadata');
+    expect(applyCall?.namespace).toBe('tabui');
+    expect(typeof applyCall?.args?.text).toBe('string');
+    // The applied minimal doc carries the edited sheet but not the untouched "Other".
+    expect(applyCall?.args?.text).toContain('name="Sheet 1"');
+    expect(applyCall?.args?.text).not.toContain('Other');
   });
 
-  it('should return error when XML is invalid', async () => {
-    const mockExecutor = {} as unknown as LocalExecutor;
+  it('should skip the delete when the sheet does not yet exist (new sheet)', async () => {
+    const { executor, calls } = dispatchingExecutor(liveWorkbook(['Some Other Sheet']));
 
     const result = await loadWorksheetXml({
       worksheetName,
+      xml: validXml,
+      executor,
+      signal: mockSignal,
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(calls.find((c) => c.command === 'delete-sheet')).toBeUndefined();
+    expect(calls.find((c) => c.command === 'load-underlying-metadata')).toBeDefined();
+  });
+
+  it('should return error when XML is invalid', async () => {
+    const result = await loadWorksheetXml({
+      worksheetName,
       xml: 'not xml',
-      executor: mockExecutor,
+      executor: {} as unknown as LocalExecutor,
       signal: mockSignal,
     });
 
@@ -67,12 +108,10 @@ describe('loadWorksheetXml', () => {
   });
 
   it('should return error when XML is empty', async () => {
-    const mockExecutor = {} as unknown as LocalExecutor;
-
     const result = await loadWorksheetXml({
       worksheetName,
       xml: '',
-      executor: mockExecutor,
+      executor: {} as unknown as LocalExecutor,
       signal: mockSignal,
     });
 
@@ -88,12 +127,10 @@ describe('loadWorksheetXml', () => {
       issues: [{ ruleId: 'test-rule', severity: 'error', message: 'Invalid structure' }],
     });
 
-    const mockExecutor = {} as unknown as LocalExecutor;
-
     const result = await loadWorksheetXml({
       worksheetName,
       xml: validXml,
-      executor: mockExecutor,
+      executor: {} as unknown as LocalExecutor,
       signal: mockSignal,
     });
 
@@ -104,30 +141,7 @@ describe('loadWorksheetXml', () => {
     }
   });
 
-  it('should proceed with warnings but not errors', async () => {
-    vi.spyOn(validationRegistry, 'runValidation').mockReturnValue({
-      valid: true,
-      issues: [{ ruleId: 'test-rule', severity: 'warning', message: 'Deprecated element' }],
-    });
-
-    const mockExecutor = {
-      executeCommand: vi
-        .fn()
-        .mockResolvedValue(Ok({ command_id: 'cmd-123', status: 'completed', submitted_at: '' })),
-    } as unknown as LocalExecutor;
-
-    const result = await loadWorksheetXml({
-      worksheetName,
-      xml: validXml,
-      executor: mockExecutor,
-      signal: mockSignal,
-    });
-
-    expect(result.isOk()).toBe(true);
-    expect(mockExecutor.executeCommand).toHaveBeenCalled();
-  });
-
-  it('should return error when executeCommand fails', async () => {
+  it('should return execute-command-error when the workbook fetch fails', async () => {
     const error = {
       type: 'command-failed' as const,
       error: { code: 'ERROR', message: 'Failed', recoverable: false },
@@ -145,27 +159,8 @@ describe('loadWorksheetXml', () => {
 
     expect(result.isErr()).toBe(true);
     if (result.isErr()) {
-      expect(result.error.type).toBe('execute-command-error');
+      invariant(result.error.type === 'execute-command-error');
       expect(result.error.error).toEqual(error);
     }
-  });
-
-  it('should trim whitespace from XML', async () => {
-    const xmlWithWhitespace = `\n  ${validXml}\n`;
-    const mockExecutor = {
-      executeCommand: vi
-        .fn()
-        .mockResolvedValue(Ok({ command_id: 'cmd-123', status: 'completed', submitted_at: '' })),
-    } as unknown as LocalExecutor;
-
-    const result = await loadWorksheetXml({
-      worksheetName,
-      xml: xmlWithWhitespace,
-      executor: mockExecutor,
-      signal: mockSignal,
-    });
-
-    expect(result.isOk()).toBe(true);
-    expect(validationRegistry.runValidation).toHaveBeenCalledWith(validXml, 'worksheet');
   });
 });

--- a/src/desktop/commands/workbook/loadWorksheetXml.ts
+++ b/src/desktop/commands/workbook/loadWorksheetXml.ts
@@ -9,6 +9,7 @@ import {
 } from '../../toolExecutor/toolExecutor.js';
 import { runValidation } from '../../validation/registry.js';
 import { ValidationIssue } from '../../validation/types.js';
+import { withApplyLock } from './applyMutex.js';
 import { deleteLiveSheet } from './deleteLiveSheet.js';
 import { getWorkbookXml } from './getWorkbookXml.js';
 import { applyWorkbookText } from './loadWorkbookXml.js';
@@ -66,36 +67,38 @@ export async function loadWorksheetXml({
     });
   }
 
-  const workbookResult = await getWorkbookXml({ executor, signal });
-  if (workbookResult.isErr()) {
-    return Err({ type: 'execute-command-error', error: workbookResult.error });
-  }
+  return withApplyLock(async () => {
+    const workbookResult = await getWorkbookXml({ executor, signal });
+    if (workbookResult.isErr()) {
+      return Err({ type: 'execute-command-error', error: workbookResult.error });
+    }
 
-  let minimalDoc: string;
-  try {
-    minimalDoc = buildMinimalSheetDoc(workbookResult.value, worksheetName, xml);
-  } catch (error) {
-    return Err({ type: 'execute-command-error', error: { type: 'invalid-response', error } });
-  }
+    let minimalDoc: string;
+    try {
+      minimalDoc = buildMinimalSheetDoc(workbookResult.value, worksheetName, xml);
+    } catch (error) {
+      return Err({ type: 'execute-command-error', error: { type: 'invalid-response', error } });
+    }
 
-  const deleteResult = await deleteLiveSheet({ sheetName: worksheetName, executor, signal });
-  if (deleteResult.isErr()) {
-    return Err({ type: 'execute-command-error', error: deleteResult.error });
-  }
+    const deleteResult = await deleteLiveSheet({ sheetName: worksheetName, executor, signal });
+    if (deleteResult.isErr()) {
+      return Err({ type: 'execute-command-error', error: deleteResult.error });
+    }
 
-  const applyResult = await applyWorkbookText({ xml: minimalDoc, executor, signal });
-  if (applyResult.isErr()) {
-    return Err({ type: 'execute-command-error', error: applyResult.error });
-  }
+    const applyResult = await applyWorkbookText({ xml: minimalDoc, executor, signal });
+    if (applyResult.isErr()) {
+      return Err({ type: 'execute-command-error', error: applyResult.error });
+    }
 
-  log({
-    level: 'info',
-    message: 'load-worksheet completed',
-    logger: 'worksheetCommands',
-    data: { worksheetName },
+    log({
+      level: 'info',
+      message: 'load-worksheet completed',
+      logger: 'worksheetCommands',
+      data: { worksheetName },
+    });
+
+    return Ok.EMPTY;
   });
-
-  return Ok.EMPTY;
 }
 
 function sanitize(value: unknown): unknown {

--- a/src/desktop/commands/workbook/loadWorksheetXml.ts
+++ b/src/desktop/commands/workbook/loadWorksheetXml.ts
@@ -2,12 +2,16 @@ import { Err, Ok, Result } from 'ts-results-es';
 
 import { log } from '../../../logging/logger.js';
 import { sanitizeValue } from '../../../logging/sanitize.js';
+import { buildMinimalSheetDoc } from '../../metadata/sheets.js';
 import {
   ExecuteCommandError,
   WithExecutorAndAbortSignal,
 } from '../../toolExecutor/toolExecutor.js';
 import { runValidation } from '../../validation/registry.js';
 import { ValidationIssue } from '../../validation/types.js';
+import { deleteLiveSheet } from './deleteLiveSheet.js';
+import { getWorkbookXml } from './getWorkbookXml.js';
+import { applyWorkbookText } from './loadWorkbookXml.js';
 
 export type LoadWorksheetXmlError =
   | { type: 'invalid-xml' }
@@ -62,28 +66,33 @@ export async function loadWorksheetXml({
     });
   }
 
-  const result = await executor.executeCommand({
-    namespace: 'tabui',
-    command: 'load-worksheet',
-    signal,
-    args: {
-      worksheetName,
-      worksheetXml: xml,
-    },
-  });
+  const workbookResult = await getWorkbookXml({ executor, signal });
+  if (workbookResult.isErr()) {
+    return Err({ type: 'execute-command-error', error: workbookResult.error });
+  }
 
-  if (result.isErr()) {
-    return Err({ type: 'execute-command-error', error: result.error });
+  let minimalDoc: string;
+  try {
+    minimalDoc = buildMinimalSheetDoc(workbookResult.value, worksheetName, xml);
+  } catch (error) {
+    return Err({ type: 'execute-command-error', error: { type: 'invalid-response', error } });
+  }
+
+  const deleteResult = await deleteLiveSheet({ sheetName: worksheetName, executor, signal });
+  if (deleteResult.isErr()) {
+    return Err({ type: 'execute-command-error', error: deleteResult.error });
+  }
+
+  const applyResult = await applyWorkbookText({ xml: minimalDoc, executor, signal });
+  if (applyResult.isErr()) {
+    return Err({ type: 'execute-command-error', error: applyResult.error });
   }
 
   log({
     level: 'info',
     message: 'load-worksheet completed',
     logger: 'worksheetCommands',
-    data: {
-      worksheetName,
-      commandId: result.value.command_id,
-    },
+    data: { worksheetName },
   });
 
   return Ok.EMPTY;

--- a/src/desktop/metadata/dashboards.ts
+++ b/src/desktop/metadata/dashboards.ts
@@ -157,3 +157,50 @@ export function listWorkbookDashboards(workbookXml: string): string[] {
   const dashboards = normalizeArray(workbook.workbook?.dashboards?.dashboard);
   return dashboards.map((db) => db['@_name']).filter((name): name is string => !!name);
 }
+
+// Returns a standalone `<dashboard>` fragment (not a whole workbook), or null if absent.
+export function extractDashboardXml(workbookXml: string, dashboardName: string): string | null {
+  const workbook = parseXML(workbookXml);
+  const dashboard = findDashboard(workbook, dashboardName);
+  if (!dashboard) {
+    return null;
+  }
+  return serializeXML({ dashboard });
+}
+
+// Builds a whole-workbook document carrying only the one edited dashboard (and its window).
+// Worksheets are stripped: they stay live and the dashboard's zones still reference them by name,
+// whereas re-posting them would duplicate them. The workbook POST merges additively and never
+// overwrites, so the caller MUST delete the live dashboard first to avoid a uniquified "(2)" name.
+export function buildMinimalDashboardDoc(
+  workbookXml: string,
+  dashboardName: string,
+  editedDashboardXml: string,
+): string {
+  const workbook = parseXML(workbookXml);
+  const editedParsed = parseXML(editedDashboardXml);
+  const editedDashboard = normalizeArray(editedParsed.dashboard as ParsedDashboard | undefined)[0];
+  if (!editedDashboard || editedDashboard['@_name'] !== dashboardName) {
+    throw new Error(`Edited XML does not contain a <dashboard name="${dashboardName}">`);
+  }
+
+  if (workbook.workbook?.dashboards) {
+    workbook.workbook.dashboards.dashboard = editedDashboard;
+  }
+
+  if (workbook.workbook?.windows) {
+    const windows = normalizeArray(workbook.workbook.windows.window);
+    const targetWindow = windows.find(
+      (win) => win['@_class'] === 'dashboard' && win['@_name'] === dashboardName,
+    );
+    if (targetWindow) {
+      workbook.workbook.windows.window = targetWindow;
+    } else {
+      delete workbook.workbook.windows.window;
+    }
+  }
+
+  delete workbook.workbook?.worksheets;
+
+  return serializeXML(workbook);
+}

--- a/src/desktop/metadata/sheets.ts
+++ b/src/desktop/metadata/sheets.ts
@@ -112,3 +112,49 @@ export function listSheets(workbookXml: string): string[] {
   const worksheets = normalizeArray(workbook.workbook?.worksheets?.worksheet);
   return worksheets.map((ws) => ws['@_name']).filter((name): name is string => !!name);
 }
+
+// Returns a standalone `<worksheet>` fragment (not a whole workbook), or null if absent.
+export function extractSheetXml(workbookXml: string, sheetName: string): string | null {
+  const workbook = parseXML(workbookXml);
+  const worksheet = findWorksheet(workbook, sheetName);
+  if (!worksheet) {
+    return null;
+  }
+  return serializeXML({ worksheet });
+}
+
+// Builds a whole-workbook document carrying only the one edited worksheet (and its window).
+// The workbook POST merges additively and never overwrites, so the caller MUST delete the live
+// sheet first — otherwise the merge re-adds this one under a uniquified "(2)" name.
+export function buildMinimalSheetDoc(
+  workbookXml: string,
+  sheetName: string,
+  editedWorksheetXml: string,
+): string {
+  const workbook = parseXML(workbookXml);
+  const editedParsed = parseXML(editedWorksheetXml);
+  const editedWorksheet = normalizeArray(editedParsed.worksheet as ParsedWorksheet | undefined)[0];
+  if (!editedWorksheet || editedWorksheet['@_name'] !== sheetName) {
+    throw new Error(`Edited XML does not contain a <worksheet name="${sheetName}">`);
+  }
+
+  if (workbook.workbook?.worksheets) {
+    workbook.workbook.worksheets.worksheet = editedWorksheet;
+  }
+
+  if (workbook.workbook?.windows) {
+    const windows = normalizeArray(workbook.workbook.windows.window);
+    const targetWindow = windows.find(
+      (win) => win['@_class'] === 'worksheet' && win['@_name'] === sheetName,
+    );
+    if (targetWindow) {
+      workbook.workbook.windows.window = targetWindow;
+    } else {
+      delete workbook.workbook.windows.window;
+    }
+  }
+
+  delete workbook.workbook?.dashboards;
+
+  return serializeXML(workbook);
+}

--- a/src/server.desktop.test.ts
+++ b/src/server.desktop.test.ts
@@ -1,3 +1,4 @@
+import * as configModule from './config.desktop.js';
 import * as loggerModule from './logging/logger.js';
 import { DEMO_TOOL_PROFILE, DesktopMcpServer, selectToolsForProfile } from './server.desktop.js';
 import { DesktopTool } from './tools/desktop/tool.js';
@@ -25,6 +26,26 @@ describe('DesktopMcpServer', () => {
         },
         expect.any(Function),
       );
+    }
+  });
+
+  it('does not register check-for-user-changes on the External Client API transport', async () => {
+    const base = configModule.getDesktopConfig();
+    const spy = vi
+      .spyOn(configModule, 'getDesktopConfig')
+      .mockReturnValue({ ...base, externalApiEnabled: true });
+
+    try {
+      const server = getServer();
+      await server.registerTools();
+
+      const registeredNames = (
+        vi.mocked(server.mcpServer.registerTool).mock.calls as Array<[string, ...unknown[]]>
+      ).map(([name]) => name);
+      expect(registeredNames).not.toContain('check-for-user-changes');
+      expect(registeredNames).toContain('list-worksheets');
+    } finally {
+      spy.mockRestore();
     }
   });
 });

--- a/src/server.desktop.ts
+++ b/src/server.desktop.ts
@@ -14,6 +14,7 @@ import { listKnowledgeResources, readKnowledgeResource } from './desktop/knowled
 import { SessionManager } from './desktop/sessionManager.js';
 import { log } from './logging/logger.js';
 import { ClientInfo, Server } from './server.js';
+import { getCheckForUserChangesTool } from './tools/desktop/session/checkForUserChanges.js';
 import { DesktopTool } from './tools/desktop/tool.js';
 import { TableauDesktopRequestHandlerExtra } from './tools/desktop/toolContext.js';
 import { DesktopToolName } from './tools/desktop/toolName.js';
@@ -151,7 +152,12 @@ export class DesktopMcpServer extends Server {
   };
 
   protected _getToolsToRegister = async (): Promise<Array<DesktopTool<any>>> => {
-    const allTools = desktopToolFactories.map((toolFactory) => toolFactory(this));
+    // check-for-user-changes needs the events endpoint, which the External Client API does not
+    // expose; don't advertise a tool that can only return an error on that transport.
+    const factories = getDesktopConfig().externalApiEnabled
+      ? desktopToolFactories.filter((factory) => factory !== getCheckForUserChangesTool)
+      : desktopToolFactories;
+    const allTools = factories.map((toolFactory) => toolFactory(this));
     return selectToolsForProfile(allTools, getDesktopConfig().toolProfile);
   };
 

--- a/src/tools/desktop/binder/bindTemplate.test.ts
+++ b/src/tools/desktop/binder/bindTemplate.test.ts
@@ -438,8 +438,10 @@ describe('bindTemplateTool auto_apply gate', () => {
         applyNonce: expect.any(String),
       }),
     );
-    // Exactly one apply dispatch (the collapsed 4-call chain becomes one tool call).
-    expect(executeCommand).toHaveBeenCalledTimes(1);
+    // The additive-POST workaround dispatches the scratch-reset chain: add scratch →
+    // (delete colliding sheets — none here, XML has no sheets) → POST → delete scratch.
+    const dispatched = executeCommand.mock.calls.map(([p]) => p.command);
+    expect(dispatched).toEqual(['new-worksheet', 'load-underlying-metadata', 'delete-sheet']);
   });
 
   it('applied:true returns ONLY the trimmed fast-path shape (W60 P4 response-shape trim)', async () => {
@@ -556,11 +558,13 @@ describe('bindTemplateTool auto_apply gate', () => {
       getExecutor,
     });
 
-    expect(validationRegistry.runValidation).toHaveBeenCalledTimes(1);
     expect(validationRegistry.runValidation).toHaveBeenCalledWith('<workbook/>', 'workbook');
-    expect(executeCommand).toHaveBeenCalledTimes(1);
     const validationOrder = vi.mocked(validationRegistry.runValidation).mock.invocationCallOrder[0];
-    const dispatchOrder = executeCommand.mock.invocationCallOrder[0];
+    // The apply POST must dispatch AFTER preflight validation.
+    const postCallIdx = executeCommand.mock.calls.findIndex(
+      ([p]) => p.command === 'load-underlying-metadata',
+    );
+    const dispatchOrder = executeCommand.mock.invocationCallOrder[postCallIdx];
     expect(validationOrder).toBeLessThan(dispatchOrder);
   });
 });

--- a/src/tools/desktop/commands/executeTableauCommand.test.ts
+++ b/src/tools/desktop/commands/executeTableauCommand.test.ts
@@ -81,7 +81,7 @@ describe('executeTableauCommandTool', () => {
       .mockResolvedValue(new Ok({ command_id: 'c1', result: commandResult }));
     const extra = makeExtra(executeCommand);
 
-    const result = await getResult({ session: SESSION, command: 'tabui:save-workbook' }, extra);
+    const result = await getResult({ session: SESSION, command: 'tabdoc:save' }, extra);
 
     expect(result.isError).toBeFalsy();
     invariant(result.content[0].type === 'text');
@@ -93,7 +93,7 @@ describe('executeTableauCommandTool', () => {
     const executeCommand = vi.fn().mockResolvedValue(new Ok({ command_id: 'c1', result: null }));
     const extra = makeExtra(executeCommand);
 
-    const result = await getResult({ session: SESSION, command: 'tabui:save-workbook' }, extra);
+    const result = await getResult({ session: SESSION, command: 'tabdoc:save' }, extra);
 
     expect(result.isError).toBeFalsy();
     invariant(result.content[0].type === 'text');
@@ -119,7 +119,7 @@ describe('executeTableauCommandTool', () => {
     const executeCommand = vi.fn().mockResolvedValue(new Ok({ command_id: 'c1', result: null }));
     const extra = makeExtra(executeCommand);
 
-    await getResult({ session: SESSION, command: 'tabui:save-workbook' }, extra);
+    await getResult({ session: SESSION, command: 'tabdoc:save' }, extra);
 
     expect(executeCommand).toHaveBeenCalledWith(expect.objectContaining({ args: {} }));
   });
@@ -128,11 +128,11 @@ describe('executeTableauCommandTool', () => {
     const executeCommand = vi.fn().mockResolvedValue(new Ok({ command_id: 'c1', result: null }));
     const extra = makeExtra(executeCommand);
 
-    const result = await getResult({ session: SESSION, command: 'tabui:save-workbook' }, extra);
+    const result = await getResult({ session: SESSION, command: 'tabui:export-theme' }, extra);
 
     expect(result.isError).toBeFalsy();
     expect(executeCommand).toHaveBeenCalledWith(
-      expect.objectContaining({ namespace: 'tabui', command: 'save-workbook' }),
+      expect.objectContaining({ namespace: 'tabui', command: 'export-theme' }),
     );
   });
 });

--- a/src/tools/desktop/commands/executeTableauCommand.ts
+++ b/src/tools/desktop/commands/executeTableauCommand.ts
@@ -11,12 +11,12 @@ const paramsSchema = {
   command: z
     .string()
     .describe(
-      "Full command name in format 'namespace:command' (e.g., 'tabdoc:goto-sheet', 'tabui:save-workbook'). Use search-commands to find available commands.",
+      "Full command name in format 'namespace:command' (e.g., 'tabdoc:save', 'tabdoc:delete-sheet'). Use search-commands to find available commands.",
     ),
   args: z
     .record(z.any())
     .optional()
-    .describe("Command arguments as a JSON object (e.g., { 'sheet': 'Sheet1' })"),
+    .describe("Command arguments as a JSON object (e.g., { 'Sheet': 'Sheet 1' })"),
 };
 
 const title = 'Execute Tableau Command';
@@ -28,7 +28,7 @@ export const getExecuteTableauCommandTool = (
     name: 'execute-tableau-command',
     title,
     description:
-      "Execute an arbitrary Tableau command via the Agent API. Use search-commands to find available commands. Commands use the format 'namespace:command' (e.g., 'tabdoc:goto-sheet', 'tabui:save-workbook').",
+      "Execute an arbitrary registered Tableau Desktop command. Use search-commands to find available commands; a name not in the registry returns command-not-found. Commands use the format 'namespace:command' (e.g., 'tabdoc:save', 'tabdoc:delete-sheet').",
     paramsSchema,
     annotations: {
       title,

--- a/src/tools/desktop/dashboard/dashboardAutoApply.test.ts
+++ b/src/tools/desktop/dashboard/dashboardAutoApply.test.ts
@@ -286,8 +286,12 @@ describe('dashboardAutoApplyTool happy path', () => {
       'sheets',
     ]);
 
-    expect(vi.mocked(getWorkbookXmlModule.getWorkbookXml)).toHaveBeenCalledTimes(1);
-    expect(executeCommand).toHaveBeenCalledTimes(1);
+    // One read for the pristine bind; resetAndApplyWorkbook re-reads before the additive-POST
+    // workaround, so getWorkbookXml is called twice total. The apply dispatches the scratch-reset
+    // chain (new-worksheet → POST → delete-scratch) rather than a single command.
+    expect(vi.mocked(getWorkbookXmlModule.getWorkbookXml)).toHaveBeenCalledTimes(2);
+    const dispatched = executeCommand.mock.calls.map(([p]) => p.command);
+    expect(dispatched).toEqual(['new-worksheet', 'load-underlying-metadata', 'delete-sheet']);
   });
 
   it('injects the dashboard wrapper with zones referencing every resolved title', async () => {
@@ -359,9 +363,12 @@ describe('dashboardAutoApplyTool happy path', () => {
     });
 
     expect(validationRegistry.runValidation).toHaveBeenCalledTimes(1);
-    expect(executeCommand).toHaveBeenCalledTimes(1);
     const validationOrder = vi.mocked(validationRegistry.runValidation).mock.invocationCallOrder[0];
-    const dispatchOrder = executeCommand.mock.invocationCallOrder[0];
+    // The apply POST must dispatch AFTER preflight validation.
+    const postIdx = executeCommand.mock.calls.findIndex(
+      ([p]) => p.command === 'load-underlying-metadata',
+    );
+    const dispatchOrder = executeCommand.mock.invocationCallOrder[postIdx];
     expect(validationOrder).toBeLessThan(dispatchOrder);
   });
 
@@ -583,7 +590,7 @@ describe('dashboardAutoApplyTool all-or-nothing gate matrix', () => {
     invariant(result.content[0].type === 'text');
     const body = JSON.parse(result.content[0].text);
     expect(body.applied).toBe(true);
-    expect(executeCommand).toHaveBeenCalledTimes(1);
+    expect(executeCommand.mock.calls.map(([p]) => p.command)).toContain('load-underlying-metadata');
   });
 
   it('a resolved title matching an already-existing worksheet is reported as replaced', async () => {


### PR DESCRIPTION
## Description

Reworks the six Tableau Desktop per-sheet commands to work over the **External Client API ("Athena V0")** transport, whose command surface is whole-workbook-only, and works around an additive-POST duplication bug in that API.

**Reads** (`list-worksheets`, `list-dashboards`, `get-worksheet-xml`, `get-dashboard-xml`) now fetch the whole-workbook document (which already works via the typed `GET /v1/workbook/document` route) and slice out the requested names/subtrees client-side using the existing `src/desktop/metadata` helpers (added `extractSheetXml` / `extractDashboardXml`).

**Writes** (`apply-worksheet`, `apply-dashboard`) use a delete-then-POST-minimal sequence: fetch the workbook, build a document carrying only the edited sheet, `tabdoc:delete-sheet` the live copy, then POST. This avoids the additive-collision duplicate. Added `buildMinimalSheetDoc` / `buildMinimalDashboardDoc` and a shared `deleteLiveSheet` (a no-op when the sheet is absent, so applying a brand-new sheet is safe).

**Whole-workbook apply** (`loadWorkbookXml`, which backs `apply-workbook` and `bind-template` auto_apply) now runs a scratch-sheet reset before the additive POST: add a scratch worksheet (so deletes never hit Tableau's "can't delete the last sheet" refusal) → delete every worksheet/dashboard the doc re-posts → POST → delete the scratch. This eliminates the sheet-duplication that whole-workbook re-apply otherwise produced. The dead JSON/`{filepath}` load branch (which always 404s on this transport) was removed; apply now goes straight to the text POST.

**Cleanup:** `execute-tableau-command`'s description/examples no longer reference the Agent API or the non-existent `tabui:save-workbook` (now `tabdoc:save` / `tabdoc:delete-sheet`). `check-for-user-changes` is filtered out of tool registration on the External Client API transport, which has no events endpoint.

## Motivation and Context

Running the desktop MCP over the External Client API, the six per-sheet commands 404'd: they sent bespoke Agent-API verbs (`tabui:save-worksheet`, `list-worksheets`, `save-dashboard`, `load-worksheet`, …) that are not registered in the monolith `LegacyCommandRegistry`, so they fell through to `POST /v1/app:invokeCommand` and returned `command-not-found`. That API exposes only whole-workbook read/apply — there is no per-sheet route and no rename available — so the commands had to be reworked to slice/splice client-side.

Separately, `POST /v1/workbook/document` is additive on sheet-name collision (it never overwrites — a colliding name is re-added as `(2)`), so any whole-workbook re-apply duplicated every existing sheet. The duplication is being fixed in the API and the API surface is being expanded with real get/set operations; this workaround is temporary and marked as such in the code.

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

- Unit tests updated for every reworked command + new helpers; all workbook/metadata/binder/dashboard suites pass. Full suite green except two pre-existing timing/ordering flakes (`memo`, `discovery`) that also fail on the base branch.
- Verified live against a running Tableau Desktop instance over the External Client API: all six commands work; get→edit→apply round-trips land the edit; repeated whole-workbook and per-sheet applies leave the sheet/dashboard set stable with no duplication; `check-for-user-changes` is absent from the tool list.

## Related Issues

<!-- link the tracking issue -->

## Checklist

- [ ] I have updated the version in the package.json file by using `npm run version`.
- [x] I have made any necessary changes to the documentation (tool descriptions)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have documented any breaking changes in the PR description.
