### PR TITLE
desktop: route table as data — DESKTOP_INSTRUCTIONS generated from a typed table + data-question stop rule

### DIFF
--- a/src/desktop/routeTable.test.ts
+++ b/src/desktop/routeTable.test.ts
@@ -1,3 +1,4 @@
+import { desktopToolNames } from '../tools/desktop/toolName.js';
 import {
   DESKTOP_ROUTE_TABLE,
   DesktopInstructionRoute,
@@ -8,6 +9,17 @@ import {
 const routes = DESKTOP_ROUTE_TABLE.filter(
   (entry): entry is DesktopInstructionRoute => entry.kind === 'route',
 );
+
+// WHY: boundary guards keep 'apply-dashboard' from matching inside 'build-and-apply-dashboard'.
+const toolMentionsInFirstMentionOrder = (text: string): string[] =>
+  desktopToolNames
+    .map((tool) => ({
+      tool,
+      index: text.search(new RegExp(`(?<![a-z0-9-])${tool}(?![a-z0-9-])`)),
+    }))
+    .filter(({ index }) => index !== -1)
+    .sort((a, b) => a.index - b.index)
+    .map(({ tool }) => tool);
 
 describe('DESKTOP_ROUTE_TABLE', () => {
   it('entry ids are unique', () => {
@@ -30,12 +42,14 @@ describe('DESKTOP_ROUTE_TABLE', () => {
     expect(renderInstructionEntry(route)).toBe(`For ${route.trigger}, ${route.action}`);
   });
 
-  it.each(routes)('route "$id" rendered block names every tool in its sequence', (route) => {
-    const rendered = renderInstructionEntry(route);
-    for (const tool of route.toolSequence) {
-      expect(rendered).toContain(tool);
-    }
-  });
+  it.each(routes)(
+    'route "$id" toolSequence lists exactly the tools its rendered block names, in first-mention order',
+    (route) => {
+      expect(toolMentionsInFirstMentionOrder(renderInstructionEntry(route))).toEqual([
+        ...route.toolSequence,
+      ]);
+    },
+  );
 
   it.each(routes)('route "$id" rendered block states each stop condition verbatim', (route) => {
     const rendered = renderInstructionEntry(route);

--- a/src/desktop/routeTable.test.ts
+++ b/src/desktop/routeTable.test.ts
@@ -1,0 +1,53 @@
+import {
+  DESKTOP_ROUTE_TABLE,
+  DesktopInstructionRoute,
+  generateDesktopInstructions,
+  renderInstructionEntry,
+} from './routeTable.js';
+
+const routes = DESKTOP_ROUTE_TABLE.filter(
+  (entry): entry is DesktopInstructionRoute => entry.kind === 'route',
+);
+
+describe('DESKTOP_ROUTE_TABLE', () => {
+  it('entry ids are unique', () => {
+    const ids = DESKTOP_ROUTE_TABLE.map((entry) => entry.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('contains the plain-chart and dashboard routes', () => {
+    expect(routes.map((route) => route.id)).toEqual(
+      expect.arrayContaining(['plain-chart', 'dashboard']),
+    );
+  });
+
+  it.each(routes)('route "$id" declares a tool sequence and stop conditions', (route) => {
+    expect(route.toolSequence.length).toBeGreaterThan(0);
+    expect(route.stopConditions.length).toBeGreaterThan(0);
+  });
+
+  it.each(routes)('route "$id" renders as "For <trigger>, <action>"', (route) => {
+    expect(renderInstructionEntry(route)).toBe(`For ${route.trigger}, ${route.action}`);
+  });
+
+  it.each(routes)('route "$id" rendered block names every tool in its sequence', (route) => {
+    const rendered = renderInstructionEntry(route);
+    for (const tool of route.toolSequence) {
+      expect(rendered).toContain(tool);
+    }
+  });
+
+  it.each(routes)('route "$id" rendered block states each stop condition verbatim', (route) => {
+    const rendered = renderInstructionEntry(route);
+    for (const stopCondition of route.stopConditions) {
+      expect(rendered).toContain(stopCondition);
+    }
+  });
+});
+
+describe('generateDesktopInstructions', () => {
+  it('renders every entry in table order, one paragraph each, separated by blank lines', () => {
+    const generated = generateDesktopInstructions(DESKTOP_ROUTE_TABLE);
+    expect(generated.split('\n\n')).toEqual(DESKTOP_ROUTE_TABLE.map(renderInstructionEntry));
+  });
+});

--- a/src/desktop/routeTable.test.ts
+++ b/src/desktop/routeTable.test.ts
@@ -15,9 +15,9 @@ describe('DESKTOP_ROUTE_TABLE', () => {
     expect(new Set(ids).size).toBe(ids.length);
   });
 
-  it('contains the plain-chart and dashboard routes', () => {
+  it('contains the plain-chart, dashboard, and data-value deflection routes', () => {
     expect(routes.map((route) => route.id)).toEqual(
-      expect.arrayContaining(['plain-chart', 'dashboard']),
+      expect.arrayContaining(['plain-chart', 'dashboard', 'data-value-question']),
     );
   });
 

--- a/src/desktop/routeTable.ts
+++ b/src/desktop/routeTable.ts
@@ -59,6 +59,16 @@ export const DESKTOP_ROUTE_TABLE: readonly DesktopInstructionEntry[] = [
     ],
   },
   {
+    kind: 'route',
+    id: 'data-value-question',
+    trigger: 'a data-value question ("what was revenue in Q3?")',
+    action:
+      'do NOT answer with a number — this server cannot read data values. Say so, then offer the chart that would show it (a plain chart ask via bind-template) instead.',
+    toolSequence: ['bind-template'],
+    stopConditions: ['do NOT answer with a number — this server cannot read data values'],
+    requiredEvidence: [],
+  },
+  {
     kind: 'prose',
     id: 'session-resolution',
     text: 'Every session-scoped tool call needs the session id from list-instances — except bind-template and dashboard-auto-apply, which auto-resolve the session when exactly one Desktop instance is running.',

--- a/src/desktop/routeTable.ts
+++ b/src/desktop/routeTable.ts
@@ -1,0 +1,79 @@
+import { DesktopToolName } from '../tools/desktop/toolName.js';
+
+// WHY: product routing used to live as free prose in DESKTOP_INSTRUCTIONS and drifted
+// silently (the A1 dashboard-row incident); routes are data here so tests can pin each
+// route's tool sequence and stop conditions and any edit shows up as a reviewable diff.
+export type DesktopInstructionRoute = {
+  readonly kind: 'route';
+  readonly id: string;
+  readonly trigger: string;
+  readonly action: string;
+  readonly toolSequence: readonly DesktopToolName[];
+  readonly stopConditions: readonly string[];
+  readonly requiredEvidence: readonly string[];
+};
+
+export type DesktopInstructionProse = {
+  readonly kind: 'prose';
+  readonly id: string;
+  readonly text: string;
+};
+
+export type DesktopInstructionEntry = DesktopInstructionRoute | DesktopInstructionProse;
+
+export const DESKTOP_ROUTE_TABLE: readonly DesktopInstructionEntry[] = [
+  {
+    kind: 'prose',
+    id: 'preamble',
+    text: 'You are controlling Tableau Desktop.',
+  },
+  {
+    kind: 'route',
+    id: 'plain-chart',
+    trigger:
+      'a plain chart ask (bar, column, line, treemap, waterfall, scatter, filled map, KPI, funnel, box plot)',
+    action:
+      "FIRST call bind-template with the user's ask and auto_apply: true — a confident bind renders the chart in ONE call (~2s server-side, no further tool calls). On propose/escalate, fall back to the general authoring tools (get-workbook-xml -> edit -> apply-workbook, or inject-template for a known template).",
+    toolSequence: ['bind-template', 'get-workbook-xml', 'apply-workbook', 'inject-template'],
+    stopConditions: [
+      'a confident bind renders the chart in ONE call (~2s server-side, no further tool calls)',
+      'On propose/escalate, fall back to the general authoring tools',
+    ],
+    requiredEvidence: [
+      "bind-template success: { status: 'bound', applied: true, sheet_name, phase_ms }",
+    ],
+  },
+  {
+    kind: 'route',
+    id: 'dashboard',
+    trigger:
+      'a dashboard ask with 2-6 charts (e.g. "a dashboard with sales by region and profit by category")',
+    action:
+      "FIRST call dashboard-auto-apply with one { ask, title? } per chart and a dashboardName — it binds and composes every chart into one dashboard in ONE call. If any ask fails to deterministically bind, nothing is applied and each ask's outcome is returned; fall back to bind-template per chart, or build-and-apply-dashboard for KPI strips / custom zone layouts.",
+    toolSequence: ['dashboard-auto-apply', 'bind-template', 'build-and-apply-dashboard'],
+    stopConditions: [
+      "If any ask fails to deterministically bind, nothing is applied and each ask's outcome is returned",
+    ],
+    requiredEvidence: [
+      'dashboard-auto-apply success: { applied: true, dashboard, sheets: [{ title, template_name }], phase_ms }',
+    ],
+  },
+  {
+    kind: 'prose',
+    id: 'session-resolution',
+    text: 'Every session-scoped tool call needs the session id from list-instances — except bind-template and dashboard-auto-apply, which auto-resolve the session when exactly one Desktop instance is running.',
+  },
+  {
+    kind: 'prose',
+    id: 'preflight-rejection',
+    text: 'If an apply is rejected by preflight validation, fix the XML per the FIX lines in the error and re-apply. Prefer file mode for large workbooks.',
+  },
+];
+
+export function renderInstructionEntry(entry: DesktopInstructionEntry): string {
+  return entry.kind === 'prose' ? entry.text : `For ${entry.trigger}, ${entry.action}`;
+}
+
+export function generateDesktopInstructions(table: readonly DesktopInstructionEntry[]): string {
+  return table.map(renderInstructionEntry).join('\n\n');
+}

--- a/src/server.desktop.test.ts
+++ b/src/server.desktop.test.ts
@@ -1,6 +1,11 @@
 import * as configModule from './config.desktop.js';
 import * as loggerModule from './logging/logger.js';
-import { DEMO_TOOL_PROFILE, DesktopMcpServer, selectToolsForProfile } from './server.desktop.js';
+import {
+  DEMO_TOOL_PROFILE,
+  DESKTOP_INSTRUCTIONS,
+  DesktopMcpServer,
+  selectToolsForProfile,
+} from './server.desktop.js';
 import { DesktopTool } from './tools/desktop/tool.js';
 import { desktopToolNames } from './tools/desktop/toolName.js';
 import { desktopToolFactories } from './tools/desktop/tools.js';
@@ -47,6 +52,21 @@ describe('DesktopMcpServer', () => {
     } finally {
       spy.mockRestore();
     }
+  });
+});
+
+describe('DESKTOP_INSTRUCTIONS (generated from DESKTOP_ROUTE_TABLE)', () => {
+  // Snapshot-style pin: any route-table edit must surface here as a reviewable diff.
+  it('matches the pinned instructions string', () => {
+    expect(DESKTOP_INSTRUCTIONS).toBe(`You are controlling Tableau Desktop.
+
+For a plain chart ask (bar, column, line, treemap, waterfall, scatter, filled map, KPI, funnel, box plot), FIRST call bind-template with the user's ask and auto_apply: true — a confident bind renders the chart in ONE call (~2s server-side, no further tool calls). On propose/escalate, fall back to the general authoring tools (get-workbook-xml -> edit -> apply-workbook, or inject-template for a known template).
+
+For a dashboard ask with 2-6 charts (e.g. "a dashboard with sales by region and profit by category"), FIRST call dashboard-auto-apply with one { ask, title? } per chart and a dashboardName — it binds and composes every chart into one dashboard in ONE call. If any ask fails to deterministically bind, nothing is applied and each ask's outcome is returned; fall back to bind-template per chart, or build-and-apply-dashboard for KPI strips / custom zone layouts.
+
+Every session-scoped tool call needs the session id from list-instances — except bind-template and dashboard-auto-apply, which auto-resolve the session when exactly one Desktop instance is running.
+
+If an apply is rejected by preflight validation, fix the XML per the FIX lines in the error and re-apply. Prefer file mode for large workbooks.`);
   });
 });
 

--- a/src/server.desktop.test.ts
+++ b/src/server.desktop.test.ts
@@ -64,6 +64,8 @@ For a plain chart ask (bar, column, line, treemap, waterfall, scatter, filled ma
 
 For a dashboard ask with 2-6 charts (e.g. "a dashboard with sales by region and profit by category"), FIRST call dashboard-auto-apply with one { ask, title? } per chart and a dashboardName — it binds and composes every chart into one dashboard in ONE call. If any ask fails to deterministically bind, nothing is applied and each ask's outcome is returned; fall back to bind-template per chart, or build-and-apply-dashboard for KPI strips / custom zone layouts.
 
+For a data-value question ("what was revenue in Q3?"), do NOT answer with a number — this server cannot read data values. Say so, then offer the chart that would show it (a plain chart ask via bind-template) instead.
+
 Every session-scoped tool call needs the session id from list-instances — except bind-template and dashboard-auto-apply, which auto-resolve the session when exactly one Desktop instance is running.
 
 If an apply is rejected by preflight validation, fix the XML per the FIX lines in the error and re-apply. Prefer file mode for large workbooks.`);

--- a/src/server.desktop.ts
+++ b/src/server.desktop.ts
@@ -11,6 +11,7 @@ import pkg from '../package.json';
 import { getDesktopConfig } from './config.desktop.js';
 import { DATA_ROOT, readResourceAsset, RESOURCES_ROOT } from './desktop/assets.js';
 import { listKnowledgeResources, readKnowledgeResource } from './desktop/knowledge/index.js';
+import { DESKTOP_ROUTE_TABLE, generateDesktopInstructions } from './desktop/routeTable.js';
 import { SessionManager } from './desktop/sessionManager.js';
 import { log } from './logging/logger.js';
 import { ClientInfo, Server } from './server.js';
@@ -78,16 +79,9 @@ export { DATA_ROOT, RESOURCES_ROOT };
 
 // Routing guidance every connecting client receives at initialize (W60 adoption P5 —
 // the demo build previously shipped NO instructions, so skill-less clients got zero
-// routing and the template fast path stayed dark in real sessions).
-const DESKTOP_INSTRUCTIONS = `You are controlling Tableau Desktop.
-
-For a plain chart ask (bar, column, line, treemap, waterfall, scatter, filled map, KPI, funnel, box plot), FIRST call bind-template with the user's ask and auto_apply: true — a confident bind renders the chart in ONE call (~2s server-side, no further tool calls). On propose/escalate, fall back to the general authoring tools (get-workbook-xml -> edit -> apply-workbook, or inject-template for a known template).
-
-For a dashboard ask with 2-6 charts (e.g. "a dashboard with sales by region and profit by category"), FIRST call dashboard-auto-apply with one { ask, title? } per chart and a dashboardName — it binds and composes every chart into one dashboard in ONE call. If any ask fails to deterministically bind, nothing is applied and each ask's outcome is returned; fall back to bind-template per chart, or build-and-apply-dashboard for KPI strips / custom zone layouts.
-
-Every session-scoped tool call needs the session id from list-instances — except bind-template and dashboard-auto-apply, which auto-resolve the session when exactly one Desktop instance is running.
-
-If an apply is rejected by preflight validation, fix the XML per the FIX lines in the error and re-apply. Prefer file mode for large workbooks.`;
+// routing and the template fast path stayed dark in real sessions). Generated from the
+// typed route table so route edits are pinned by tests instead of drifting as prose.
+export const DESKTOP_INSTRUCTIONS = generateDesktopInstructions(DESKTOP_ROUTE_TABLE);
 
 export class DesktopMcpServer extends Server {
   private readonly sessionManager = new SessionManager();


### PR DESCRIPTION
## Intent

Product routing in `server.desktop.ts` used to live as hand-maintained prose and drifted silently (the A1 dashboard-row incident). This PR makes routes plain data — id, trigger, ordered tool sequence, stop conditions, required evidence — and generates `DESKTOP_INSTRUCTIONS` from that table. Generated output was verified byte-identical to `feature/authoring`'s current prose on the source branch (confirmed again here via the pinned snapshot test in `server.desktop.test.ts`). Tests pin the table↔prose relationship bidirectionally, including tool-mention order, so any route edit surfaces as a reviewable diff instead of silent drift.

Same delivery pattern as #459: a cherry-picked delta branch onto `origin/feature/authoring`, not the full working branch (which carries weeks of unrelated in-flight work).

## What's included

- `route table as data: DESKTOP_INSTRUCTIONS generated from a typed route table` — introduces `src/desktop/routeTable.ts` (typed `DESKTOP_ROUTE_TABLE` + `generateDesktopInstructions`) and rewires `server.desktop.ts` to generate `DESKTOP_INSTRUCTIONS` from it instead of a hand-written string.
- `data-question stop rule: deflection route for data-value questions (M10)` — adds one new route-table entry: for data-value questions ("what was revenue in Q3?"), deflect instead of fabricating a number, and point at the plain-chart route instead. No new tools, no added LLM turns.
- `route table tests: pin prose->toolSequence direction and first-mention order` — replaces the one-directional (toolSequence → prose) containment check with a bidirectional check: extract tool-name tokens from the rendered block (boundary-guarded against nested names like `apply-dashboard` inside `build-and-apply-dashboard`) and assert equality with `toolSequence` in first-mention order.

## Semantic deltas vs. `feature/authoring` today

None beyond the intended new content. `feature/authoring`'s current `DESKTOP_INSTRUCTIONS` (plain-chart route, dashboard route via `dashboard-auto-apply`, session-resolution, preflight-rejection) is byte-identical to what the route table generates for those same entries — confirmed by the pinned snapshot test. The only behavioral addition is the new data-value-question deflection route. All tool names the table references (`bind-template`, `get-workbook-xml`, `apply-workbook`, `inject-template`, `dashboard-auto-apply`, `build-and-apply-dashboard`, `list-instances`) already exist on `feature/authoring` (via merged #459), so no route adaptation was needed — all three commits cherry-picked clean with zero conflicts.

## Validation

In a worktree on `claude/w61-route-table` (base `origin/feature/authoring`, 3 commits ahead):

- `npm ci`
- `bash scripts/agent-check` → `== agent-check: ALL GREEN (4 checks) ==` (lint, typecheck, unit tests, lockstep-core hash gate)
- `npx vitest run src/server.desktop.test.ts src/desktop/routeTable.test.ts` → 2 files, 25 tests passed, including the pinned `DESKTOP_INSTRUCTIONS` snapshot test

Full suite: 208 test files / 2814 tests passed.

## Context

Part of the W61 "two-voice" control-layer slate: enforcement/receipts on existing seams, no new LLM voices, no added turns.

---

*Prepared and posted by Claude ("MattGPT") on Matt's behalf.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)