### PR TITLE
desktop: switch External Client API route surface from /v1/ to /v0/

### DIFF
--- a/src/desktop/externalApi/externalApiClient.test.ts
+++ b/src/desktop/externalApi/externalApiClient.test.ts
@@ -23,7 +23,7 @@ describe('ExternalApiClient', () => {
     await server.close();
   });
 
-  it('reports liveness from GET /v1/health', async () => {
+  it('reports liveness from GET /v0/health', async () => {
     const result = await client.health();
     expect(result.isOk()).toBe(true);
     expect(result.unwrap().healthy).toBe(true);
@@ -68,7 +68,7 @@ describe('ExternalApiClient', () => {
   });
 
   it('maps a 415 unsupported-content-type problem response', async () => {
-    server.setOverride('POST /v1/workbook/document', {
+    server.setOverride('POST /v0/workbook/document', {
       status: 415,
       body: JSON.stringify({ code: 'unsupported-content-type', title: 'unsupported-content-type' }),
     });

--- a/src/desktop/externalApi/externalApiToolExecutor.test.ts
+++ b/src/desktop/externalApi/externalApiToolExecutor.test.ts
@@ -56,7 +56,7 @@ describe('ExternalApiToolExecutor', () => {
   });
 
   describe('executeCommand routing', () => {
-    it('routes save-underlying-metadata to GET /v1/workbook/document', async () => {
+    it('routes save-underlying-metadata to GET /v0/workbook/document', async () => {
       const executor = new ExternalApiToolExecutor({ discover: () => [instanceFor(server)] });
       await executor.start();
 
@@ -73,10 +73,10 @@ describe('ExternalApiToolExecutor', () => {
 
       const last = server.requests.at(-1);
       expect(last?.method).toBe('GET');
-      expect(last?.path).toBe('/v1/workbook/document');
+      expect(last?.path).toBe('/v0/workbook/document');
     });
 
-    it('routes load-underlying-metadata (text) to POST /v1/workbook/document', async () => {
+    it('routes load-underlying-metadata (text) to POST /v0/workbook/document', async () => {
       const executor = new ExternalApiToolExecutor({ discover: () => [instanceFor(server)] });
       await executor.start();
 
@@ -93,11 +93,11 @@ describe('ExternalApiToolExecutor', () => {
 
       const last = server.requests.at(-1);
       expect(last?.method).toBe('POST');
-      expect(last?.path).toBe('/v1/workbook/document');
+      expect(last?.path).toBe('/v0/workbook/document');
       expect(last?.body).toBe(xml);
     });
 
-    it('routes any other command to POST /v1/app:invokeCommand', async () => {
+    it('routes any other command to POST /v0/app:invokeCommand', async () => {
       const executor = new ExternalApiToolExecutor({ discover: () => [instanceFor(server)] });
       await executor.start();
 
@@ -114,7 +114,7 @@ describe('ExternalApiToolExecutor', () => {
 
       const last = server.requests.at(-1);
       expect(last?.method).toBe('POST');
-      expect(last?.path).toBe('/v1/app:invokeCommand');
+      expect(last?.path).toBe('/v0/app:invokeCommand');
     });
 
     it('maps a failed operation envelope to a command-failed error', async () => {

--- a/src/desktop/externalApi/externalApiToolExecutor.ts
+++ b/src/desktop/externalApi/externalApiToolExecutor.ts
@@ -18,9 +18,9 @@ import {
   ProblemResponse,
 } from './types.js';
 
-/** The single "get whole workbook document" command, routed to GET /v1/workbook/document. */
+/** The single "get whole workbook document" command, routed to GET /v0/workbook/document. */
 const SAVE_UNDERLYING_METADATA = 'save-underlying-metadata';
-/** The single "apply whole workbook document" command, routed to POST /v1/workbook/document. */
+/** The single "apply whole workbook document" command, routed to POST /v0/workbook/document. */
 const LOAD_UNDERLYING_METADATA = 'load-underlying-metadata';
 
 const LOGGER = 'ExternalApiToolExecutor';
@@ -57,9 +57,9 @@ type RawOutcome = {
  *
  * Command surface → endpoint mapping (thin, verified against localToolExecutor's
  * command shapes):
- *   - `tabui:save-underlying-metadata` (is-json !== true) → GET  /v1/workbook/document
- *   - `tabui:load-underlying-metadata` (with `text`)      → POST /v1/workbook/document
- *   - everything else                                     → POST /v1/app:invokeCommand
+ *   - `tabui:save-underlying-metadata` (is-json !== true) → GET  /v0/workbook/document
+ *   - `tabui:load-underlying-metadata` (with `text`)      → POST /v0/workbook/document
+ *   - everything else                                     → POST /v0/app:invokeCommand
  *     (the API resolves the SAME legacy command registry, so params pass through as-is)
  *
  * On a 401 (stale discovery file) the executor rescans discovery exactly once and

--- a/src/desktop/externalApi/types.ts
+++ b/src/desktop/externalApi/types.ts
@@ -12,15 +12,15 @@ import { z } from 'zod';
 
 /** Route paths served by the running Desktop loopback host. */
 export const EXTERNAL_API_ROUTES = {
-  health: '/v1/health',
-  app: '/v1/app',
-  workbookDocument: '/v1/workbook/document',
-  invokeCommand: '/v1/app:invokeCommand',
+  health: '/v0/health',
+  app: '/v0/app',
+  workbookDocument: '/v0/workbook/document',
+  invokeCommand: '/v0/app:invokeCommand',
   openapi: '/openapi.json',
   oauthProtectedResource: '/.well-known/oauth-protected-resource',
 } as const;
 
-/** Response headers on `GET /v1/workbook/document`. Matched case-insensitively. */
+/** Response headers on `GET /v0/workbook/document`. Matched case-insensitively. */
 export const HEADER_APPLICATION_VERSION = 'x-tableau-application-version';
 export const HEADER_XSD_PAYLOAD_VERSION = 'x-tableau-xsd-payload-version';
 
@@ -74,8 +74,8 @@ export const problemResponseSchema = z
 export type ProblemResponse = z.infer<typeof problemResponseSchema>;
 
 /**
- * Operation envelope returned by `POST /v1/workbook/document` and
- * `POST /v1/app:invokeCommand`. `result` is captured on success; `state` +
+ * Operation envelope returned by `POST /v0/workbook/document` and
+ * `POST /v0/app:invokeCommand`. `result` is captured on success; `state` +
  * `createdAt`/`completedAt` (ISO8601-Z) describe the operation lifecycle.
  */
 export const operationEnvelopeSchema = z


### PR DESCRIPTION
## Description

Switches the desktop MCP's External Client API route surface from `/v1/` to `/v0/`, matching the monolith change that renames the served route paths (monolith PR sf-analyticscloud/monolith#59424).

The single functional change is in `EXTERNAL_API_ROUTES` (`src/desktop/externalApi/types.ts`): `health`, `app`, `workbookDocument`, and `invokeCommand` now point at `/v0/…`. The unversioned `openapi` and `oauthProtectedResource` paths are unchanged, matching the monolith. The remaining edits are consistency updates to doc comments and test path literals/assertions.

## Motivation and Context

The desktop MCP does not discover routes dynamically — it hardcodes them and builds each request as `baseUrl + route`, where `baseUrl` (from the discovery file) carries no path prefix. Once Desktop serves `/v0/`, every MCP call (health, get/apply workbook document, invokeCommand) would hit the old `/v1/` path and 404. This realigns the client with the served surface.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

Breaking in the sense that it is a **lockstep** change with Desktop: MCP on `/v0/` must not run against an old `/v1/` Desktop build, or every call 404s. Land it alongside the Desktop build that ships `/v0/`.

## How Has This Been Tested?

- `npx vitest run src/desktop/externalApi src/desktop/commands/workbook` — 128/129 pass. The one failure (`discovery.test.ts` "newest-first by startedAt") is pre-existing and unrelated: it fails identically with these changes stashed (a Windows path-handling issue in the test, not the routes).
- `npx tsc --noEmit` — clean.

## Related Issues

- Monolith counterpart: sf-analyticscloud/monolith#59424 (@W-23262641)

## Checklist

- [ ] I have updated the version in the package.json file by using `npm run version`.
- [ ] I have made any necessary changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works — existing contract tests updated to the new paths
- [x] New and existing unit tests pass locally with my changes
- [x] I have documented any breaking changes in the PR description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
