### PR TITLE
desktop: reject whole-workbook docs whose dashboards reference omitted worksheets

### DIFF
--- a/src/desktop/commands/workbook/loadDashboardXml.test.ts
+++ b/src/desktop/commands/workbook/loadDashboardXml.test.ts
@@ -261,6 +261,25 @@ describe('loadDashboardXml (External Client API transport, TABLEAU_EXTERNAL_API 
     expect(applied).not.toContain('<worksheet');
   });
 
+  it('does not reject a per-dashboard apply whose minimal document omits live worksheets referenced by zones', async () => {
+    const dashboardXml = `<dashboard name='${dashboardName}'><zones><zone name='Sheet 1' /></zones></dashboard>`;
+    const { executor, calls } = dispatchingExecutor(
+      liveWorkbook(['Sales Dashboard', 'Other DB'], ['Sheet 1']),
+    );
+
+    const result = await loadDashboardXml({
+      dashboardName,
+      xml: dashboardXml,
+      executor,
+      signal: mockSignal,
+    });
+
+    expect(result.isOk()).toBe(true);
+    const applyCall = calls.find((c) => c.command === 'load-underlying-metadata');
+    expect(applyCall?.args?.text).toContain('name="Sheet 1"');
+    expect(applyCall?.args?.text).not.toContain('<worksheet');
+  });
+
   it('should apply a minimal document for a brand-new dashboard', async () => {
     const { executor, calls } = dispatchingExecutor(liveWorkbook(['Some Other DB']));
 

--- a/src/desktop/commands/workbook/loadWorkbookXml.validation.test.ts
+++ b/src/desktop/commands/workbook/loadWorkbookXml.validation.test.ts
@@ -1,0 +1,38 @@
+import invariant from '../../../utils/invariant.js';
+import { LocalExecutor } from '../../toolExecutor/localToolExecutor.js';
+import { loadWorkbookXml } from './loadWorkbookXml.js';
+
+describe('loadWorkbookXml validation preflight', () => {
+  it('rejects a whole-workbook document whose dashboard references an omitted worksheet', async () => {
+    const executor = { executeCommand: vi.fn() } as unknown as LocalExecutor;
+
+    const result = await loadWorkbookXml({
+      xml:
+        "<?xml version='1.0'?><workbook>" +
+        "<worksheets><worksheet name='Included Sheet'><table /></worksheet></worksheets>" +
+        "<dashboards><dashboard name='Executive Dashboard'><zones>" +
+        "<zone h='100000' id='3' type-v2='layout-basic' w='100000' x='0' y='0'>" +
+        "<zone h='98000' id='4' name='Missing Sheet' w='98000' x='1000' y='1000' />" +
+        '</zone></zones></dashboard></dashboards>' +
+        '</workbook>',
+      executor,
+      signal: new AbortController().signal,
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      invariant(result.error.type === 'load-workbook-xml-error');
+      invariant(result.error.error.type === 'validation-failed');
+      expect(result.error.error.issues).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            ruleId: 'dashboard-zones-reference-included-worksheets',
+            severity: 'error',
+            message: expect.stringContaining('Missing Sheet'),
+          }),
+        ]),
+      );
+    }
+    expect(executor.executeCommand).not.toHaveBeenCalled();
+  });
+});

--- a/src/desktop/validation/rules/dashboardZonesReferenceIncludedWorksheets.test.ts
+++ b/src/desktop/validation/rules/dashboardZonesReferenceIncludedWorksheets.test.ts
@@ -1,0 +1,146 @@
+import { runValidation } from '../registry.js';
+import { dashboardZonesReferenceIncludedWorksheetsRule } from './dashboardZonesReferenceIncludedWorksheets.js';
+
+const RULE_ID = 'dashboard-zones-reference-included-worksheets';
+
+describe('dashboard-zones-reference-included-worksheets rule', () => {
+  it('is registered only for the workbook context', () => {
+    expect(dashboardZonesReferenceIncludedWorksheetsRule.contexts).toEqual(['workbook']);
+  });
+
+  it('rejects a whole-workbook document when a dashboard zone references an omitted worksheet', () => {
+    const result = runValidation(
+      workbookXml({
+        worksheets: ['Included Sheet'],
+        dashboards: [
+          {
+            name: 'Executive Dashboard',
+            zones: ["<zone h='98000' id='4' name='Missing Sheet' w='98000' x='1000' y='1000' />"],
+          },
+        ],
+      }),
+      'workbook',
+    );
+
+    const errors = result.issues.filter((i) => i.ruleId === RULE_ID && i.severity === 'error');
+    expect(result.valid).toBe(false);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toContain('Executive Dashboard');
+    expect(errors[0].message).toContain('Missing Sheet');
+    expect(errors[0].message).toContain('include the worksheet in the document or remove the zone');
+  });
+
+  it('allows a whole-workbook document when dashboard zones reference included worksheets', () => {
+    const result = runValidation(
+      workbookXml({
+        worksheets: ['Sales Trend', 'Region Count'],
+        dashboards: [
+          {
+            name: 'Health Dash',
+            zones: [
+              "<zone h='98000' id='4' name='Sales Trend' w='49000' x='500' y='1000' />",
+              "<zone h='98000' id='5' name='Region Count' w='49000' x='50500' y='1000' />",
+            ],
+          },
+        ],
+      }),
+      'workbook',
+    );
+
+    expect(result.issues.filter((i) => i.ruleId === RULE_ID)).toEqual([]);
+  });
+
+  it('reports each missing worksheet referenced across multiple dashboards and zones', () => {
+    const result = runValidation(
+      workbookXml({
+        worksheets: ['Included Sheet'],
+        dashboards: [
+          {
+            name: 'Regional Dashboard',
+            zones: [
+              "<zone h='49000' id='4' name='Included Sheet' w='49000' x='500' y='1000' />",
+              "<zone h='49000' id='5' name='Missing Regional' w='49000' x='50500' y='1000' />",
+            ],
+          },
+          {
+            name: 'Executive Dashboard',
+            zones: ["<zone h='98000' id='6' name='Missing Executive' w='98000' x='1000' y='1000' />"],
+          },
+        ],
+      }),
+      'workbook',
+    );
+
+    const messages = result.issues
+      .filter((i) => i.ruleId === RULE_ID)
+      .map((i) => i.message);
+    expect(messages).toHaveLength(2);
+    expect(messages).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('Missing Regional'),
+        expect.stringContaining('Missing Executive'),
+      ]),
+    );
+  });
+
+  it('ignores dashboard zone types that do not reference worksheets', () => {
+    const result = runValidation(
+      workbookXml({
+        worksheets: ['Sales Trend'],
+        dashboards: [
+          {
+            name: 'Mixed Dashboard',
+            zones: [
+              "<zone h='100000' id='3' type-v2='layout-basic' w='100000' x='0' y='0'>",
+              "<zone h='20000' id='4' type-v2='text' w='98000' x='1000' y='1000'><zone-text><formatted-text><run>Title</run></formatted-text></zone-text></zone>",
+              "<zone h='20000' id='5' type-v2='blank' w='98000' x='1000' y='25000' />",
+              "<zone h='20000' id='6' name='Sales Trend' w='98000' x='1000' y='50000' />",
+              '</zone>',
+            ],
+          },
+        ],
+      }),
+      'workbook',
+    );
+
+    expect(result.issues.filter((i) => i.ruleId === RULE_ID)).toEqual([]);
+  });
+
+  it('does not run against the dashboard validation context used by per-dashboard apply', () => {
+    const result = runValidation(
+      workbookXml({
+        worksheets: [],
+        dashboards: [
+          {
+            name: 'Executive Dashboard',
+            zones: ["<zone h='98000' id='4' name='Live Sheet' w='98000' x='1000' y='1000' />"],
+          },
+        ],
+      }),
+      'dashboard',
+    );
+
+    expect(result.issues.filter((i) => i.ruleId === RULE_ID)).toEqual([]);
+  });
+});
+
+function workbookXml({
+  worksheets,
+  dashboards,
+}: {
+  worksheets: string[];
+  dashboards: Array<{ name: string; zones: string[] }>;
+}): string {
+  const worksheetXml = worksheets
+    .map((name) => `<worksheet name='${name}'><table /></worksheet>`)
+    .join('');
+  const dashboardXml = dashboards
+    .map(
+      ({ name, zones }) =>
+        `<dashboard name='${name}'><zones><zone h='100000' id='3' type-v2='layout-basic' w='100000' x='0' y='0'>${zones.join(
+          '',
+        )}</zone></zones></dashboard>`,
+    )
+    .join('');
+  return `<?xml version='1.0'?><workbook><worksheets>${worksheetXml}</worksheets><dashboards>${dashboardXml}</dashboards></workbook>`;
+}

--- a/src/desktop/validation/rules/dashboardZonesReferenceIncludedWorksheets.ts
+++ b/src/desktop/validation/rules/dashboardZonesReferenceIncludedWorksheets.ts
@@ -1,0 +1,86 @@
+/**
+ * Validation rule: dashboard-zones-reference-included-worksheets
+ *
+ * Whole-workbook apply is authoritative: sheets omitted from the document are pruned
+ * after the workbook POST. A document that keeps a dashboard while omitting a
+ * worksheet referenced by one of that dashboard's sheet zones cannot converge because
+ * Tableau silently refuses to delete worksheets still referenced by live dashboard zones.
+ *
+ * Scope is deliberately workbook-only. Per-dashboard applies post minimal workbook
+ * documents that omit worksheets by design; those live worksheets are preserved by the
+ * upsert-only path and must not be rejected by this whole-workbook consistency check.
+ */
+import { DOMParser } from '@xmldom/xmldom';
+import * as xpath from 'xpath';
+
+import type { ValidationIssue, ValidationRule } from '../types.js';
+
+function issueFor(dashboardName: string, worksheetName: string): ValidationIssue {
+  return {
+    ruleId: 'dashboard-zones-reference-included-worksheets',
+    severity: 'error',
+    message:
+      `Dashboard "${dashboardName}" references worksheet "${worksheetName}" from a zone, ` +
+      'but that worksheet is omitted from this whole-workbook document; include the worksheet ' +
+      'in the document or remove the zone.',
+    xpath: `//dashboard[@name=${JSON.stringify(dashboardName)}]//zone[@name=${JSON.stringify(
+      worksheetName,
+    )}]`,
+    suggestion: 'Include the worksheet in the document or remove the zone.',
+  };
+}
+
+export const dashboardZonesReferenceIncludedWorksheetsRule: ValidationRule = {
+  id: 'dashboard-zones-reference-included-worksheets',
+  description:
+    'Rejects whole-workbook documents whose dashboard sheet zones reference worksheets omitted from <worksheets>.',
+  contexts: ['workbook'],
+
+  validate(xml: string): ValidationIssue[] {
+    let doc: Document;
+    try {
+      const parser = new DOMParser({ errorHandler: () => {} });
+      doc = parser.parseFromString(xml.trim() || '<empty/>', 'text/xml') as unknown as Document;
+    } catch {
+      // Malformed XML is reported by well-formed-xml; this rule has nothing to say.
+      return [];
+    }
+
+    const worksheetNames = new Set(
+      (xpath.select('//worksheets/worksheet[@name]', doc as unknown as Node) as Element[])
+        .map((worksheet) => worksheet.getAttribute('name'))
+        .filter((name): name is string => !!name),
+    );
+
+    const dashboards = xpath.select(
+      '//dashboards/dashboard[@name]',
+      doc as unknown as Node,
+    ) as Element[];
+    const issues: ValidationIssue[] = [];
+    const seen = new Set<string>();
+
+    for (const dashboard of dashboards) {
+      const dashboardName = dashboard.getAttribute('name');
+      if (!dashboardName) continue;
+
+      // Worksheet zones are represented as <zone name="Worksheet Name" .../>. Layout,
+      // text, and blank zones carry type-v2 and do not name worksheets.
+      const worksheetZones = xpath.select(
+        './/zone[@name and not(@type-v2)]',
+        dashboard as unknown as Node,
+      ) as Element[];
+
+      for (const zone of worksheetZones) {
+        const worksheetName = zone.getAttribute('name');
+        if (!worksheetName || worksheetNames.has(worksheetName)) continue;
+
+        const key = `${dashboardName}\u0000${worksheetName}`;
+        if (seen.has(key)) continue;
+        seen.add(key);
+        issues.push(issueFor(dashboardName, worksheetName));
+      }
+    }
+
+    return issues;
+  },
+};

--- a/src/desktop/validation/rules/rules.ts
+++ b/src/desktop/validation/rules/rules.ts
@@ -1,5 +1,6 @@
 import { calcFieldNamesRule } from './calcFieldNames.js';
 import { connectionsNotAuthorableRule } from './connectionsNotAuthorable.js';
+import { dashboardZonesReferenceIncludedWorksheetsRule } from './dashboardZonesReferenceIncludedWorksheets.js';
 import { invalidDerivationStringRule } from './invalidDerivationString.js';
 import { qualifiedNameBracketsRule } from './qualifiedNameBrackets.js';
 import { wellFormedXmlRule } from './wellFormedXml.js';
@@ -9,5 +10,6 @@ export const validationRules = [
   calcFieldNamesRule,
   invalidDerivationStringRule,
   connectionsNotAuthorableRule,
+  dashboardZonesReferenceIncludedWorksheetsRule,
   qualifiedNameBracketsRule,
 ];


### PR DESCRIPTION
Fast-follow from the #467 review thread (per the discussion with @lauren-jacksonSFDC's review bot: a genuinely dangling zone ref "can only come from the POST body itself" — this rule guards exactly that input, pre-POST).

**What:** new validation rule `dashboard-zones-reference-included-worksheets`. A whole-workbook document that keeps a dashboard whose sheet zones reference a worksheet omitted from `<worksheets>` is rejected with a clear issue (dashboard name, missing worksheet, remedy) instead of silently diverging — post-#467, such a doc can't converge because Tableau silently refuses to prune a worksheet still referenced by a live dashboard zone, and the apply would report Ok while live ≠ doc.

**Scoping (the load-bearing part):** the rule runs only in the `workbook` validation context. Per-sheet applies (`loadWorksheetXml`/`loadDashboardXml`) post minimal docs that omit live worksheets by design — those paths are explicitly not affected, with tests proving both sides: the violation is caught on the authoritative whole-workbook apply and NOT raised on a per-dashboard minimal-doc apply.

**Validation:** `tsc --noEmit` clean, full suite 3,111 passed / 222 files, lint clean. Zone shape derived from repo fixtures (`orphan-zone-drifted.xml`) and `dashboardZones.ts` (sheet zones carry `name`, layout/text zones carry `type-v2`).

Minion-built, Fable-verified. Posted under the MattGPT automation persona on @mattcfilbert's behalf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)