### PR TITLE
@W-23202034: Prevent sign-out teardown from masking the real REST error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "2.25.0",
+  "version": "2.25.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "2.25.0",
+      "version": "2.25.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.7.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "2.25.0",
+  "version": "2.25.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/src/restApiInstance.test.ts
+++ b/src/restApiInstance.test.ts
@@ -187,6 +187,58 @@ describe('restApiInstance', () => {
       expect(restApi.signOut).not.toHaveBeenCalled();
     });
 
+    // W-23202034: a sign-out failure during teardown must not mask the callback's real result or
+    // error. A throw in the `finally` sign-out would otherwise replace whatever the callback
+    // returned/threw — e.g. a 404 from a missing resource surfacing to the caller as the sign-out's
+    // 401. Sign-out is best-effort cleanup; its failure is swallowed and logged.
+    it('should not let a sign-out failure mask the callback error', async () => {
+      vi.stubEnv('AUTH', 'pat');
+
+      const callbackError = new Error('Request failed with status code 404');
+
+      await expect(
+        useRestApi({
+          config: getConfig(),
+          requestId: mockRequestId,
+          server: new WebMcpServer(),
+          tableauAuthInfo: undefined,
+          jwtScopes: [],
+          signal: new AbortController().signal,
+          callback: (restApi) => {
+            // Simulate the ephemeral session being torn down: sign-out now rejects (e.g. 401).
+            vi.mocked(restApi.signOut).mockRejectedValueOnce(
+              new Error('Request failed with status code 401'),
+            );
+            // The real failure the caller cares about.
+            return Promise.reject(callbackError);
+          },
+        }),
+        // The caller must see the callback's 404, NOT the sign-out's 401.
+      ).rejects.toBe(callbackError);
+    });
+
+    it('should not let a sign-out failure mask a successful callback result', async () => {
+      vi.stubEnv('AUTH', 'pat');
+
+      const result = await useRestApi({
+        config: getConfig(),
+        requestId: mockRequestId,
+        server: new WebMcpServer(),
+        tableauAuthInfo: undefined,
+        jwtScopes: [],
+        signal: new AbortController().signal,
+        callback: (restApi) => {
+          vi.mocked(restApi.signOut).mockRejectedValueOnce(
+            new Error('Request failed with status code 401'),
+          );
+          return Promise.resolve('ok');
+        },
+      });
+
+      // A best-effort sign-out failure is swallowed; the successful result still reaches the caller.
+      expect(result).toBe('ok');
+    });
+
     it('should set credentials when using Passthrough auth', async () => {
       vi.stubEnv('AUTH', 'pat');
 

--- a/src/restApiInstance.ts
+++ b/src/restApiInstance.ts
@@ -166,8 +166,24 @@ export const useRestApi = async <T>(
       // Tableau REST sessions for 'pat' and 'direct-trust' are intentionally ephemeral.
       // Sessions for 'oauth' and 'passthrough' are not. Signing out would invalidate the session,
       // preventing the access token from being reused for subsequent requests.
-      await restApi.signOut();
-      log({ message: 'Signed out of Tableau REST API', level: 'debug', logger: 'auth' });
+      //
+      // Isolate the sign-out so a teardown failure can NEVER mask the callback's real result or
+      // error. A throw inside `finally` replaces whatever the `try` was returning or throwing, so an
+      // un-caught sign-out error would clobber the real outcome — e.g. a callback that 404s on a
+      // missing resource surfaces to the caller as the sign-out's 401 once the session is torn down
+      // (W-23202034). Swallow-and-log instead: sign-out is best-effort cleanup, and the ephemeral
+      // session expires on its own regardless.
+      try {
+        await restApi.signOut();
+        log({ message: 'Signed out of Tableau REST API', level: 'debug', logger: 'auth' });
+      } catch (error) {
+        log({
+          message: `Failed to sign out of Tableau REST API: ${getExceptionMessage(error)}`,
+          level: 'warning',
+          logger: 'auth',
+          data: error,
+        });
+      }
     }
   }
 };


### PR DESCRIPTION
## What

Fixes **W-23202034** — `delete-workbook` (and any web tool) returned a misleading **401** to the caller when the target LUID does not exist, instead of the real **404**.

## Root cause

`useRestApi` (`src/restApiInstance.ts`) signs out ephemeral (`pat` / `direct-trust`) sessions in a `finally` block:

```ts
try {
  return await callback(restApi);
} finally {
  if (signOutWhenCompleted) {
    await restApi.signOut();   // ← un-isolated
  }
}
```

A `throw` inside `finally` **replaces** whatever the `try` was returning or throwing. So when the callback 404s on a missing resource and the subsequent `signOut()` fails (401) on the now-torn-down session, the sign-out's **401 clobbers the real 404**. The caller sees 401.

The all-zeros-vs-real-shaped LUID difference in the original report was a red herring — it only changed *which* path tore the session down first. The defect is the un-isolated teardown; the fix covers every trigger.

## Fix

Isolate the sign-out in its own `try/catch` and swallow-and-log any failure at `warning`. Sign-out is best-effort cleanup (the ephemeral session expires on its own regardless), so its failure must never mask the callback's real result or error.

```ts
try {
  await restApi.signOut();
  log({ message: 'Signed out of Tableau REST API', level: 'debug', logger: 'auth' });
} catch (error) {
  log({
    message: `Failed to sign out of Tableau REST API: ${getExceptionMessage(error)}`,
    level: 'warning',
    logger: 'auth',
    data: error,
  });
}
```

The callback's result or error now always reaches the caller intact.

## Tests

Two unit cases added to `src/restApiInstance.test.ts`:
- `should not let a sign-out failure mask the callback error` — injects `callback → reject(404)` + `signOut → reject(401)`, asserts the caller receives the **404**, not the 401.
- `should not let a sign-out failure mask a successful callback result` — a successful result survives a failing sign-out.

Both **fail without the fix, pass with it** (verified by stashing the fix). The forced-failure run emits the exact swallowed line — `Failed to sign out of Tableau REST API: Request failed with status code 401` at level `warning`.

- Full unit suite: **2212/2212** pass · `tsc --noEmit` clean · eslint clean · prettier clean.
- Version bumped **2.25.0 → 2.25.1**.

## Live verification (tmcp-tester, isolated server)

Verified on a **dedicated isolated http server (port 39271)** — the running dev servers were left untouched. Nonexistent LUID `00000000-0000-0000-0000-000000000000` only; `delete-workbook` **preview** (confirm omitted) 404s on the access-check read **before any mutation**, so no real content was ever tagged or deleted.

| # | Test | Result | Observed |
|---|------|--------|----------|
| 1 | Pre-fix live repro (v2.25.0) | **INCONCLUSIVE** (5/5 runs) | caller saw `Request failed with status code 404` — the mask did **not** trigger: live `signOut` succeeded, so the 404 survived even pre-fix |
| 2a | Post-fix live (v2.25.1), nonexistent LUID | **PASS** | caller sees `Request failed with status code 404` (correct real status) |
| 2b | Post-fix swallowed-signout `warning` in log | N/A live | `signOut` succeeded live too (no warning emitted) — the warning path is proven deterministically by the unit test |
| 3 | Healthy-session regression | **PASS** | `list-workbooks` OK; `get-workbook` on a real Superstore LUID returned correct id + name — healthy sign-out path intact |
| 4 | Registration | **PASS** | `delete-workbook` present in `tools/list` |

**Caveat (expected):** the pre-fix live **401** could not be reproduced. With a fresh PAT sign-in per call, `signOut` reliably succeeds, so the `finally`-sign-out never throws and the 404 is never masked in that environment — pre-fix **and** post-fix both return 404 live. The bug is session-teardown-timing dependent (the mask fires only when `signOut` itself 401s). This is exactly why the **unit tier is the authoritative proof** — it injects the sign-out failure deterministically. **e2e is not added**: a live e2e cannot force the teardown failure, so it would pass identically before and after the fix and prove nothing.

**Verdict: PASS — fix correct and non-regressive.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
