### PR TITLE
@W-23202054: Stop get-stale-content-report from silently ignoring invalid projectIds

### DIFF
--- a/docs/docs/tools/admin-insights/get-stale-content-report.md
+++ b/docs/docs/tools/admin-insights/get-stale-content-report.md
@@ -4,35 +4,38 @@ sidebar_position: 3
 
 # Get Stale Content Report
 
-Builds a deterministic report of stale Tableau Cloud content (workbooks and published
-datasources) by querying the Admin Insights `Site Content` datasource — which exposes a
-`Last Accessed At` field per item — applying the staleness threshold server-side, and returning
-already-filtered rows.
+Builds a deterministic report of stale Tableau Cloud content (workbooks and published datasources)
+by querying the Admin Insights `Site Content` datasource — which exposes a `Last Accessed At` field
+per item — applying the staleness threshold server-side, and returning already-filtered rows.
 
-The server applies the threshold comparison, optional project filter, and sort. Clients receive
-only items where days since last use exceed the threshold. **No client-side math is required.**
+The server applies the threshold comparison, optional project filter, and sort. Clients receive only
+items where days since last use exceed the threshold. **No client-side math is required.**
 
-The tool is admin-only — it is registered only when `ADMIN_TOOLS_ENABLED=true`, and at request
-time it verifies the caller's site role and rejects anything below
-`SiteAdministratorCreator` / `SiteAdministratorExplorer` / `ServerAdministrator`.
+The tool is admin-only — it is registered only when `ADMIN_TOOLS_ENABLED=true`, and at request time
+it verifies the caller's site role and rejects anything below `SiteAdministratorCreator` /
+`SiteAdministratorExplorer` / `ServerAdministrator`.
 
 ## APIs called
 
-- [Query Datasource (VDS)](https://help.tableau.com/current/api/vizql-data-service/en-us/reference/index.html#tag/HeadlessBI/operation/QueryDatasource) — single VDS call against the `Site Content` Admin Insights datasource
-- [Query Data Sources (REST)](https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref_data_sources.htm#query_data_sources) — used internally to resolve the `Site Content` dataset LUID
-- [Query Projects (REST)](https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref_projects.htm#query_projects) — used internally to resolve project LUIDs to names when a project scope is set
-- [Get User on Site (REST)](https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref_users_and_groups.htm#get_user_on_site) — used internally for the admin gate
+- [Query Datasource (VDS)](https://help.tableau.com/current/api/vizql-data-service/en-us/reference/index.html#tag/HeadlessBI/operation/QueryDatasource)
+  — single VDS call against the `Site Content` Admin Insights datasource
+- [Query Data Sources (REST)](https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref_data_sources.htm#query_data_sources)
+  — used internally to resolve the `Site Content` dataset LUID
+- [Query Projects (REST)](https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref_projects.htm#query_projects)
+  — used internally to resolve project LUIDs to names when a project scope is set
+- [Get User on Site (REST)](https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref_users_and_groups.htm#get_user_on_site)
+  — used internally for the admin gate
 
 ## Optional arguments
 
 ### `minAgeDays`
 
-Minimum days since last access for content to be considered stale. The server applies the
-condition `daysSinceLastUse > minAgeDays` (strict greater-than).
+Minimum days since last access for content to be considered stale. The server applies the condition
+`daysSinceLastUse > minAgeDays` (strict greater-than).
 
 If omitted, falls back to the server-configured threshold
-[`STALE_CONTENT_MIN_AGE_DAYS`](../../configuration/mcp-config/env-vars.md), which defaults to
-`90` — the Tableau Cloud TS Events lookback ceiling.
+[`STALE_CONTENT_MIN_AGE_DAYS`](../../configuration/mcp-config/env-vars.md), which defaults to `90` —
+the Tableau Cloud TS Events lookback ceiling.
 
 Range: `1`–`3650`.
 
@@ -50,6 +53,13 @@ If omitted, falls back to the server-configured
 [`INCLUDE_PROJECT_IDS`](../../configuration/mcp-config/env-vars.md) bound (if any). When both are
 set, the final scope is the intersection.
 
+Any requested LUID that does not exist on the site, or that falls outside the server-configured
+`INCLUDE_PROJECT_IDS` bound, is **ignored and reported** in `mcp.warnings` (rather than silently
+dropped). Each warning has `type: "PROJECT_IDS_IGNORED"`, a `reason` of `unknown-on-site` or
+`not-permitted-by-config`, and the list of ignored LUIDs. If **none** of the requested LUIDs resolve
+to a valid, permitted project, the tool returns an **empty report** (`rows: []`,
+`totalStaleItems: 0`) with the warning — it never widens to the full site.
+
 Example: `["af59ee84-a375-4cb4-84b9-eaa7864f59fb"]`
 
 <hr />
@@ -64,14 +74,14 @@ Example: `["Datasource"]`
 ## Notes and caveats
 
 - The Tableau-managed `Admin Insights` project is **excluded by design** — its datasources are
-  admin-owned and refreshed by Tableau, not user content. The exclusion is enforced as a
-  server-side VDS filter on `Item Parent Project Name`.
-- `Last Accessed At` is `null` for items that have never been accessed. The report ages those
-  items from `Created At` instead and flags them with `neverAccessed: true`.
+  admin-owned and refreshed by Tableau, not user content. The exclusion is enforced as a server-side
+  VDS filter on `Item Parent Project Name`.
+- `Last Accessed At` is `null` for items that have never been accessed. The report ages those items
+  from `Created At` instead and flags them with `neverAccessed: true`.
 - Rows are sorted descending by `daysSinceLastUse`, then by `size`.
 - Tableau Cloud `Last Accessed At` is populated whenever the underlying `TS Events` access stream
-  records an access — items beyond the 90-day Cloud event lookback may show `null` even if they
-  were accessed earlier. Items with `daysSinceLastUse ≥ 90` should be interpreted accordingly.
+  records an access — items beyond the 90-day Cloud event lookback may show `null` even if they were
+  accessed earlier. Items with `daysSinceLastUse ≥ 90` should be interpreted accordingly.
 
 ## Example result
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "2.25.1",
+  "version": "2.25.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "2.25.1",
+      "version": "2.25.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.7.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "2.25.1",
+  "version": "2.25.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/src/tools/web/adminInsights/getStaleContentReport.test.ts
+++ b/src/tools/web/adminInsights/getStaleContentReport.test.ts
@@ -1,6 +1,7 @@
 import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { Err, Ok } from 'ts-results-es';
 
+import { OverridableConfig } from '../../../overridableConfig.js';
 import { WebMcpServer } from '../../../server.web.js';
 import { Provider } from '../../../utils/provider.js';
 import { getMockRequestHandlerExtra } from '../toolContext.mock.js';
@@ -308,36 +309,140 @@ describe('buildSiteContentQuery', () => {
 });
 
 describe('resolveProjectScopeIds', () => {
-  it('returns null when no scope is set', () => {
-    const ids = exportedForTesting.resolveProjectScopeIds({
+  it('returns null scope with no out-of-scope IDs when no scope is set', () => {
+    const resolution = exportedForTesting.resolveProjectScopeIds({
       argProjectIds: undefined,
       boundedProjectIds: null,
     });
-    expect(ids).toBeNull();
+    expect(resolution.scopeIds).toBeNull();
+    expect(resolution.boundedOutOfScopeIds).toEqual([]);
   });
 
   it('returns the arg LUIDs when no bounded context is set', () => {
-    const ids = exportedForTesting.resolveProjectScopeIds({
+    const resolution = exportedForTesting.resolveProjectScopeIds({
       argProjectIds: ['p-1', 'p-2'],
       boundedProjectIds: null,
     });
-    expect(ids).toEqual(['p-1', 'p-2']);
+    expect(resolution.scopeIds).toEqual(['p-1', 'p-2']);
+    expect(resolution.boundedOutOfScopeIds).toEqual([]);
   });
 
-  it('returns the intersection when both arg and bounded context are set', () => {
-    const ids = exportedForTesting.resolveProjectScopeIds({
+  it('returns the intersection and reports the bounded out-of-scope IDs', () => {
+    const resolution = exportedForTesting.resolveProjectScopeIds({
       argProjectIds: ['p-1', 'p-other'],
       boundedProjectIds: new Set(['p-1', 'p-allowed']),
     });
-    expect(ids).toEqual(['p-1']);
+    expect(resolution.scopeIds).toEqual(['p-1']);
+    expect(resolution.boundedOutOfScopeIds).toEqual(['p-other']);
   });
 
-  it('falls back to bounded context when arg is omitted', () => {
-    const ids = exportedForTesting.resolveProjectScopeIds({
+  it('falls back to bounded context (no out-of-scope IDs) when arg is omitted', () => {
+    const resolution = exportedForTesting.resolveProjectScopeIds({
       argProjectIds: undefined,
       boundedProjectIds: new Set(['p-bounded']),
     });
-    expect(ids).toEqual(['p-bounded']);
+    expect(resolution.scopeIds).toEqual(['p-bounded']);
+    expect(resolution.boundedOutOfScopeIds).toEqual([]);
+  });
+});
+
+describe('buildProjectIdWarnings', () => {
+  it('returns no warnings when nothing was dropped', () => {
+    expect(
+      exportedForTesting.buildProjectIdWarnings({
+        boundedOutOfScopeIds: [],
+        unknownProjectIds: [],
+      }),
+    ).toEqual([]);
+  });
+
+  it('emits one unknown-on-site warning listing the unknown IDs', () => {
+    const warnings = exportedForTesting.buildProjectIdWarnings({
+      boundedOutOfScopeIds: [],
+      unknownProjectIds: ['bad-1', 'bad-2'],
+    });
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toMatchObject({
+      type: 'PROJECT_IDS_IGNORED',
+      severity: 'WARNING',
+      reason: 'unknown-on-site',
+      ignoredProjectIds: ['bad-1', 'bad-2'],
+    });
+    expect(warnings[0].message).toContain('bad-1');
+    expect(warnings[0].message).toContain('bad-2');
+  });
+
+  it('emits one not-permitted-by-config warning listing the out-of-scope IDs', () => {
+    const warnings = exportedForTesting.buildProjectIdWarnings({
+      boundedOutOfScopeIds: ['p-2'],
+      unknownProjectIds: [],
+    });
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toMatchObject({
+      reason: 'not-permitted-by-config',
+      ignoredProjectIds: ['p-2'],
+    });
+  });
+
+  it('emits both reasons (max two entries) when both drop paths fire', () => {
+    const warnings = exportedForTesting.buildProjectIdWarnings({
+      boundedOutOfScopeIds: ['p-2'],
+      unknownProjectIds: ['bad-1'],
+    });
+    expect(warnings).toHaveLength(2);
+    expect(warnings.map((w) => w.reason).sort()).toEqual([
+      'not-permitted-by-config',
+      'unknown-on-site',
+    ]);
+  });
+});
+
+describe('resolveProjectIdsToNames', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clearStaleContentReportCache();
+    mocks.mockQueryProjects.mockResolvedValue({
+      pagination: { pageNumber: 1, pageSize: 1000, totalAvailable: 2 },
+      projects: [
+        { id: 'p-1', name: 'Finance' },
+        { id: 'p-2', name: 'Sales' },
+      ],
+    });
+  });
+
+  const restApi = {
+    siteId: 'site-test',
+    projectsMethods: { queryProjects: mocks.mockQueryProjects },
+  } as unknown as Parameters<typeof exportedForTesting.resolveProjectIdsToNames>[0]['restApi'];
+
+  it('returns matched names with no unknown IDs when all resolve', async () => {
+    const result = await exportedForTesting.resolveProjectIdsToNames({
+      restApi,
+      projectIds: ['p-1', 'p-2'],
+    });
+    expect(result.isOk()).toBe(true);
+    expect(result.unwrap().names.sort()).toEqual(['Finance', 'Sales']);
+    expect(result.unwrap().unknownIds).toEqual([]);
+  });
+
+  it('reports the unknown IDs that matched no site project', async () => {
+    const result = await exportedForTesting.resolveProjectIdsToNames({
+      restApi,
+      projectIds: ['p-1', 'nonexistent'],
+    });
+    expect(result.isOk()).toBe(true);
+    expect(result.unwrap().names).toEqual(['Finance']);
+    expect(result.unwrap().unknownIds).toEqual(['nonexistent']);
+  });
+
+  it('reports all IDs as unknown when none match', async () => {
+    const result = await exportedForTesting.resolveProjectIdsToNames({
+      restApi,
+      projectIds: ['bad-1', 'bad-2'],
+    });
+    expect(result.isOk()).toBe(true);
+    expect(result.unwrap().names).toEqual([]);
+    expect(result.unwrap().unknownIds).toEqual(['bad-1', 'bad-2']);
   });
 });
 
@@ -557,16 +662,144 @@ describe('get-stale-content-report tool', () => {
     expect(projectFilters).toHaveLength(1);
     expect(projectFilters[0].exclude).toBe(false);
   });
+
+  it('warns on partially-invalid projectIds and scopes to the valid subset (unknown-on-site)', async () => {
+    const { Ok } = await import('ts-results-es');
+    mocks.mockQueryDatasource.mockResolvedValueOnce(Ok({ data: [] }));
+
+    // Site has p-1 (Finance) and p-2 (Sales); 'nonexistent' matches nothing.
+    const result = await getToolResult({ minAgeDays: 90, projectIds: ['p-1', 'nonexistent'] });
+
+    expect(result.isError).toBeFalsy();
+
+    // Filter still applied for the valid project.
+    expect(mocks.mockQueryDatasource).toHaveBeenCalledTimes(1);
+    const vdsCall = mocks.mockQueryDatasource.mock.calls[0][0];
+    const filters = vdsCall.query.filters as Array<{
+      field?: { fieldCaption?: string };
+      filterType?: string;
+      values?: string[];
+      exclude?: boolean;
+    }>;
+    const includeFilter = filters.find(
+      (f) => f.field?.fieldCaption === 'Item Parent Project Name' && f.exclude === false,
+    );
+    expect(includeFilter?.values).toEqual(['Finance']);
+
+    const payload = parsePayload(result);
+    expect(payload.mcp?.warnings).toHaveLength(1);
+    expect(payload.mcp?.warnings?.[0]).toMatchObject({
+      type: 'PROJECT_IDS_IGNORED',
+      severity: 'WARNING',
+      reason: 'unknown-on-site',
+      ignoredProjectIds: ['nonexistent'],
+    });
+  });
+
+  it('returns an empty report (never the full site) when ALL projectIds are invalid (widening guard — W-23202054)', async () => {
+    const result = await getToolResult({ minAgeDays: 90, projectIds: ['bad-1', 'bad-2'] });
+
+    expect(result.isError).toBeFalsy();
+
+    // Core regression assertion: the widening guard must short-circuit BEFORE any
+    // Site Content query runs, so the unscoped full-site query can never fire.
+    expect(mocks.mockQueryDatasource).not.toHaveBeenCalled();
+
+    const payload = parsePayload(result);
+    expect(payload.rows).toEqual([]);
+    expect(payload.totalStaleItems).toBe(0);
+    expect(payload.totalStaleSizeBytes).toBe(0);
+    expect(payload.thresholdDays).toBe(90);
+    expect(payload.mcp?.warnings).toHaveLength(1);
+    expect(payload.mcp?.warnings?.[0]).toMatchObject({
+      reason: 'unknown-on-site',
+      ignoredProjectIds: ['bad-1', 'bad-2'],
+    });
+  });
+
+  it('warns (not-permitted-by-config) and scopes to the permitted subset when an ID is outside the bounded context', async () => {
+    const { Ok } = await import('ts-results-es');
+    mocks.mockQueryDatasource.mockResolvedValueOnce(Ok({ data: [] }));
+
+    // Server bounded context permits only p-1; caller requests p-1 + p-2.
+    const result = await getToolResult({
+      minAgeDays: 90,
+      projectIds: ['p-1', 'p-2'],
+      includeProjectIds: 'p-1',
+    });
+
+    expect(result.isError).toBeFalsy();
+
+    const vdsCall = mocks.mockQueryDatasource.mock.calls[0][0];
+    const filters = vdsCall.query.filters as Array<{
+      field?: { fieldCaption?: string };
+      values?: string[];
+      exclude?: boolean;
+    }>;
+    const includeFilter = filters.find(
+      (f) => f.field?.fieldCaption === 'Item Parent Project Name' && f.exclude === false,
+    );
+    expect(includeFilter?.values).toEqual(['Finance']);
+
+    const payload = parsePayload(result);
+    expect(payload.mcp?.warnings).toHaveLength(1);
+    expect(payload.mcp?.warnings?.[0]).toMatchObject({
+      reason: 'not-permitted-by-config',
+      ignoredProjectIds: ['p-2'],
+    });
+  });
+
+  it('omits the mcp key entirely when all projectIds are valid (back-compat)', async () => {
+    const { Ok } = await import('ts-results-es');
+    mocks.mockQueryDatasource.mockResolvedValueOnce(Ok({ data: [] }));
+
+    const result = await getToolResult({ minAgeDays: 90, projectIds: ['p-1', 'p-2'] });
+
+    expect(result.isError).toBeFalsy();
+    const payload = parsePayload(result);
+    expect('mcp' in payload).toBe(false);
+  });
 });
+
+type StaleReportPayload = {
+  thresholdDays: number;
+  totalStaleItems: number;
+  totalStaleSizeBytes: number;
+  rows: Array<{ itemId: string }>;
+  mcp?: {
+    warnings: Array<{
+      type: string;
+      severity: string;
+      reason: string;
+      ignoredProjectIds: string[];
+      message: string;
+    }>;
+  };
+};
+
+function parsePayload(result: CallToolResult): StaleReportPayload {
+  if (result.content[0].type !== 'text') {
+    throw new Error('expected text content');
+  }
+  return JSON.parse(result.content[0].text) as StaleReportPayload;
+}
 
 async function getToolResult(params: {
   minAgeDays?: number;
   projectIds?: string[];
+  includeProjectIds?: string;
 }): Promise<CallToolResult> {
   const tool = getGetStaleContentReportTool(new WebMcpServer());
   const callback = await Provider.from(tool.callback);
+  const extra = getMockRequestHandlerExtra();
+  if (params.includeProjectIds !== undefined) {
+    // Drive the server bounded context (INCLUDE_PROJECT_IDS) → boundedContext.projectIds.
+    extra.getConfigWithOverrides = vi
+      .fn()
+      .mockResolvedValue(new OverridableConfig({ INCLUDE_PROJECT_IDS: params.includeProjectIds }));
+  }
   return await callback(
     { minAgeDays: params.minAgeDays, projectIds: params.projectIds, itemTypes: undefined },
-    getMockRequestHandlerExtra(),
+    extra,
   );
 }

--- a/src/tools/web/adminInsights/getStaleContentReport.test.ts
+++ b/src/tools/web/adminInsights/getStaleContentReport.test.ts
@@ -352,6 +352,7 @@ describe('buildProjectIdWarnings', () => {
       exportedForTesting.buildProjectIdWarnings({
         boundedOutOfScopeIds: [],
         unknownProjectIds: [],
+        hasRemainingScope: true,
       }),
     ).toEqual([]);
   });
@@ -360,6 +361,7 @@ describe('buildProjectIdWarnings', () => {
     const warnings = exportedForTesting.buildProjectIdWarnings({
       boundedOutOfScopeIds: [],
       unknownProjectIds: ['bad-1', 'bad-2'],
+      hasRemainingScope: true,
     });
     expect(warnings).toHaveLength(1);
     expect(warnings[0]).toMatchObject({
@@ -376,24 +378,48 @@ describe('buildProjectIdWarnings', () => {
     const warnings = exportedForTesting.buildProjectIdWarnings({
       boundedOutOfScopeIds: ['p-2'],
       unknownProjectIds: [],
+      hasRemainingScope: true,
     });
     expect(warnings).toHaveLength(1);
     expect(warnings[0]).toMatchObject({
       reason: 'not-permitted-by-config',
       ignoredProjectIds: ['p-2'],
     });
+    // Env-var name (INCLUDE_PROJECT_IDS) is not leaked into caller-facing output.
+    expect(warnings[0].message).not.toContain('INCLUDE_PROJECT_IDS');
   });
 
   it('emits both reasons (max two entries) when both drop paths fire', () => {
     const warnings = exportedForTesting.buildProjectIdWarnings({
       boundedOutOfScopeIds: ['p-2'],
       unknownProjectIds: ['bad-1'],
+      hasRemainingScope: true,
     });
     expect(warnings).toHaveLength(2);
     expect(warnings.map((w) => w.reason).sort()).toEqual([
       'not-permitted-by-config',
       'unknown-on-site',
     ]);
+  });
+
+  it('says a valid subset was scoped to when some scope remains', () => {
+    const warnings = exportedForTesting.buildProjectIdWarnings({
+      boundedOutOfScopeIds: [],
+      unknownProjectIds: ['bad-1'],
+      hasRemainingScope: true,
+    });
+    expect(warnings[0].message).toContain('remaining valid projects');
+  });
+
+  it('says an empty report was returned (never the full site) when no scope remains', () => {
+    const warnings = exportedForTesting.buildProjectIdWarnings({
+      boundedOutOfScopeIds: [],
+      unknownProjectIds: ['bad-1', 'bad-2'],
+      hasRemainingScope: false,
+    });
+    // The all-invalid message must not imply a valid subset existed.
+    expect(warnings[0].message).not.toContain('remaining valid projects');
+    expect(warnings[0].message).toContain('empty report');
   });
 });
 
@@ -715,6 +741,9 @@ describe('get-stale-content-report tool', () => {
       reason: 'unknown-on-site',
       ignoredProjectIds: ['bad-1', 'bad-2'],
     });
+    // The warning must not imply a valid subset was scoped to — it must say the report is empty.
+    expect(payload.mcp?.warnings?.[0].message).toContain('empty report');
+    expect(payload.mcp?.warnings?.[0].message).not.toContain('remaining valid projects');
   });
 
   it('warns (not-permitted-by-config) and scopes to the permitted subset when an ID is outside the bounded context', async () => {

--- a/src/tools/web/adminInsights/getStaleContentReport.ts
+++ b/src/tools/web/adminInsights/getStaleContentReport.ts
@@ -32,7 +32,10 @@ const paramsSchema = {
     .optional()
     .describe(
       'Optional list of project LUIDs to scope the report to. ' +
-        'If omitted, returns all projects the caller can access.',
+        'If omitted, returns all projects the caller can access. ' +
+        'Any requested LUID that is unknown on the site or outside the server-configured ' +
+        'scope is reported in `mcp.warnings` and ignored; if none of the requested LUIDs ' +
+        'resolve, an empty report (0 rows) is returned — never the full site.',
     ),
   itemTypes: z
     .array(z.enum(['Workbook', 'Datasource']))
@@ -78,6 +81,18 @@ const siteContentRowSchema = z
   .passthrough();
 
 type SiteContentRow = z.infer<typeof siteContentRowSchema>;
+
+// Structured warning attached to a successful result when some requested projectIds were
+// ignored. Follows the `mcp.warnings` convention established by query-datasource
+// (see ContextFilterWarning in validators/validateContextFilters.ts). At most two entries
+// are produced — one per `reason`.
+type StaleReportWarning = {
+  type: 'PROJECT_IDS_IGNORED';
+  severity: 'WARNING';
+  message: string;
+  ignoredProjectIds: string[];
+  reason: 'unknown-on-site' | 'not-permitted-by-config';
+};
 
 const MS_PER_DAY = 1000 * 60 * 60 * 24;
 
@@ -149,7 +164,7 @@ and the REST API rejects it (404). \`itemLuid\` is \`null\` only on older sites 
       const configWithOverrides = await extra.getConfigWithOverrides();
       const thresholdDays = minAgeDays ?? configWithOverrides.staleContentMinAgeDays;
       const types = itemTypes ?? ['Workbook', 'Datasource'];
-      const requestedProjectIds = resolveProjectScopeIds({
+      const { scopeIds: requestedProjectIds, boundedOutOfScopeIds } = resolveProjectScopeIds({
         argProjectIds: projectIds,
         boundedProjectIds: configWithOverrides.boundedContext.projectIds,
       });
@@ -168,6 +183,7 @@ and the REST API rejects it (404). \`itemLuid\` is \`null\` only on older sites 
               }
 
               let projectNameScope: ReadonlyArray<string> | null = null;
+              let unknownProjectIds: ReadonlyArray<string> = [];
               if (requestedProjectIds) {
                 const namesResult = await resolveProjectIdsToNames({
                   restApi,
@@ -176,7 +192,27 @@ and the REST API rejects it (404). \`itemLuid\` is \`null\` only on older sites 
                 if (namesResult.isErr()) {
                   return namesResult;
                 }
-                projectNameScope = namesResult.value;
+                projectNameScope = namesResult.value.names;
+                unknownProjectIds = namesResult.value.unknownIds;
+              }
+
+              const warnings = buildProjectIdWarnings({
+                boundedOutOfScopeIds,
+                unknownProjectIds,
+              });
+
+              // Widening guard (core fix for W-23202054): a scope WAS requested but nothing
+              // resolved to a real project name. Do NOT fall through to buildSiteContentQuery,
+              // which would emit the unscoped full-site query. Return an empty report + the
+              // warnings so a fully-invalid scope can never silently widen to the whole site.
+              if (requestedProjectIds && projectNameScope && projectNameScope.length === 0) {
+                return new Ok({
+                  thresholdDays,
+                  totalStaleItems: 0,
+                  totalStaleSizeBytes: 0,
+                  rows: [] as StaleContentRow[],
+                  ...(warnings.length > 0 ? { mcp: { warnings } } : {}),
+                });
               }
 
               const siteContentResult = await executeAdminInsightsQuery({
@@ -204,6 +240,7 @@ and the REST API rejects it (404). \`itemLuid\` is \`null\` only on older sites 
                 totalStaleItems: rows.length,
                 totalStaleSizeBytes: rows.reduce((sum, r) => sum + (r.size ?? 0), 0),
                 rows,
+                ...(warnings.length > 0 ? { mcp: { warnings } } : {}),
               });
             },
           });
@@ -280,11 +317,12 @@ async function resolveProjectIdsToNames({
 }: {
   restApi: RestApi;
   projectIds: ReadonlyArray<string>;
-}): Promise<Result<string[], McpToolError>> {
+}): Promise<Result<{ names: string[]; unknownIds: string[] }, McpToolError>> {
   const idSet = new Set(projectIds);
   const cache = getProjectNameCache();
 
-  // Cache hit: every requested ID is in the cache.
+  // Cache hit: every requested ID is in the cache. An all-hit means every requested ID
+  // resolved to a real project name, so there are no unknown IDs.
   const cachedNames = new Set<string>();
   let allHit = true;
   for (const id of idSet) {
@@ -296,7 +334,7 @@ async function resolveProjectIdsToNames({
     cachedNames.add(name);
   }
   if (allHit) {
-    return new Ok(Array.from(cachedNames));
+    return new Ok({ names: Array.from(cachedNames), unknownIds: [] });
   }
 
   // Cache miss for at least one ID: refresh the full project list for this site.
@@ -314,14 +352,19 @@ async function resolveProjectIdsToNames({
   });
 
   const out = new Set<string>();
+  const matchedIds = new Set<string>();
   for (const p of projects) {
     cache.set(`${restApi.siteId}:${p.id}`, p.name);
     if (idSet.has(p.id)) {
       out.add(p.name);
+      matchedIds.add(p.id);
     }
   }
 
-  return new Ok(Array.from(out));
+  // Requested IDs that matched no site project — silently dropped before W-23202054.
+  const unknownIds = projectIds.filter((id) => !matchedIds.has(id));
+
+  return new Ok({ names: Array.from(out), unknownIds });
 }
 
 // Lazy-initialized cache to avoid module-level parseNumber call.
@@ -345,23 +388,71 @@ function getProjectNameCache(): ExpiringMap<string, string> {
   return projectNameCache;
 }
 
+type ProjectScopeResolution = {
+  // null = no scope requested (all projects the caller can access).
+  scopeIds: ReadonlyArray<string> | null;
+  // Requested IDs dropped because they fall outside the server INCLUDE_PROJECT_IDS bound.
+  boundedOutOfScopeIds: ReadonlyArray<string>;
+};
+
 function resolveProjectScopeIds({
   argProjectIds,
   boundedProjectIds,
 }: {
   argProjectIds: ReadonlyArray<string> | undefined;
   boundedProjectIds: Set<string> | null;
-}): ReadonlyArray<string> | null {
+}): ProjectScopeResolution {
   if (argProjectIds && argProjectIds.length > 0) {
     if (boundedProjectIds) {
-      return argProjectIds.filter((id) => boundedProjectIds.has(id));
+      return {
+        scopeIds: argProjectIds.filter((id) => boundedProjectIds.has(id)),
+        boundedOutOfScopeIds: argProjectIds.filter((id) => !boundedProjectIds.has(id)),
+      };
     }
-    return [...argProjectIds];
+    return { scopeIds: [...argProjectIds], boundedOutOfScopeIds: [] };
   }
   if (boundedProjectIds) {
-    return Array.from(boundedProjectIds);
+    return { scopeIds: Array.from(boundedProjectIds), boundedOutOfScopeIds: [] };
   }
-  return null;
+  return { scopeIds: null, boundedOutOfScopeIds: [] };
+}
+
+// Assembles at most two structured warnings — one for IDs unknown on the site, one for IDs
+// dropped by the server-configured bounded context — for attachment to the successful result.
+function buildProjectIdWarnings({
+  boundedOutOfScopeIds,
+  unknownProjectIds,
+}: {
+  boundedOutOfScopeIds: ReadonlyArray<string>;
+  unknownProjectIds: ReadonlyArray<string>;
+}): StaleReportWarning[] {
+  const warnings: StaleReportWarning[] = [];
+
+  if (unknownProjectIds.length > 0) {
+    warnings.push({
+      type: 'PROJECT_IDS_IGNORED',
+      severity: 'WARNING',
+      message:
+        `The following requested projectIds do not exist on this site and were ignored: ${unknownProjectIds.join(', ')}. ` +
+        'The report was scoped to the remaining valid projects.',
+      ignoredProjectIds: [...unknownProjectIds],
+      reason: 'unknown-on-site',
+    });
+  }
+
+  if (boundedOutOfScopeIds.length > 0) {
+    warnings.push({
+      type: 'PROJECT_IDS_IGNORED',
+      severity: 'WARNING',
+      message:
+        `The following requested projectIds are outside the server-configured project scope (INCLUDE_PROJECT_IDS) and were ignored: ${boundedOutOfScopeIds.join(', ')}. ` +
+        'The report was scoped to the remaining permitted projects.',
+      ignoredProjectIds: [...boundedOutOfScopeIds],
+      reason: 'not-permitted-by-config',
+    });
+  }
+
+  return warnings;
 }
 
 export function computeStaleRows({
@@ -464,5 +555,7 @@ export function clearStaleContentReportCache(): void {
 export const exportedForTesting = {
   buildSiteContentQuery,
   resolveProjectScopeIds,
+  resolveProjectIdsToNames,
+  buildProjectIdWarnings,
   parseSize,
 };

--- a/src/tools/web/adminInsights/getStaleContentReport.ts
+++ b/src/tools/web/adminInsights/getStaleContentReport.ts
@@ -196,9 +196,14 @@ and the REST API rejects it (404). \`itemLuid\` is \`null\` only on older sites 
                 unknownProjectIds = namesResult.value.unknownIds;
               }
 
+              // Did any requested project survive both drop paths? Drives the warning wording:
+              // if nothing remains, the report is empty and the message must say so rather than
+              // implying a valid subset was scoped to.
+              const hasRemainingScope = !!(projectNameScope && projectNameScope.length > 0);
               const warnings = buildProjectIdWarnings({
                 boundedOutOfScopeIds,
                 unknownProjectIds,
+                hasRemainingScope,
               });
 
               // Widening guard (core fix for W-23202054): a scope WAS requested but nothing
@@ -418,15 +423,23 @@ function resolveProjectScopeIds({
 }
 
 // Assembles at most two structured warnings — one for IDs unknown on the site, one for IDs
-// dropped by the server-configured bounded context — for attachment to the successful result.
+// dropped by the server-configured project scope — for attachment to the successful result.
+// `hasRemainingScope` branches the wording: when no requested project survived, the message must
+// tell the caller the report is empty rather than implying a valid subset was scoped to — that
+// false premise is exactly the silent-widening confusion this fix targets.
 function buildProjectIdWarnings({
   boundedOutOfScopeIds,
   unknownProjectIds,
+  hasRemainingScope,
 }: {
   boundedOutOfScopeIds: ReadonlyArray<string>;
   unknownProjectIds: ReadonlyArray<string>;
+  hasRemainingScope: boolean;
 }): StaleReportWarning[] {
   const warnings: StaleReportWarning[] = [];
+  const outcome = hasRemainingScope
+    ? 'The report was scoped to the remaining valid projects.'
+    : 'None of the requested projectIds resolved to a project you can report on; an empty report (0 rows) was returned instead of the full site.';
 
   if (unknownProjectIds.length > 0) {
     warnings.push({
@@ -434,7 +447,7 @@ function buildProjectIdWarnings({
       severity: 'WARNING',
       message:
         `The following requested projectIds do not exist on this site and were ignored: ${unknownProjectIds.join(', ')}. ` +
-        'The report was scoped to the remaining valid projects.',
+        outcome,
       ignoredProjectIds: [...unknownProjectIds],
       reason: 'unknown-on-site',
     });
@@ -445,8 +458,8 @@ function buildProjectIdWarnings({
       type: 'PROJECT_IDS_IGNORED',
       severity: 'WARNING',
       message:
-        `The following requested projectIds are outside the server-configured project scope (INCLUDE_PROJECT_IDS) and were ignored: ${boundedOutOfScopeIds.join(', ')}. ` +
-        'The report was scoped to the remaining permitted projects.',
+        `The following requested projectIds are outside this server's configured project scope and were ignored: ${boundedOutOfScopeIds.join(', ')}. ` +
+        outcome,
       ignoredProjectIds: [...boundedOutOfScopeIds],
       reason: 'not-permitted-by-config',
     });


### PR DESCRIPTION
## Bug (W-23202054, P3)

`get-stale-content-report` accepts a `projectIds` list to scope the report. Two resolution paths silently dropped requested IDs, and the worst case silently **widened the report to the entire site**:

1. `resolveProjectScopeIds` dropped IDs outside the server's bounded context (`INCLUDE_PROJECT_IDS`) with no signal.
2. `resolveProjectIdsToNames` intersected requested IDs against real site projects; IDs matching no project vanished.

When **every** requested ID was invalid, `projectNameScope` collapsed to `[]`, and `buildSiteContentQuery` treated an empty scope identically to "no scope requested" → the `else` branch emits the unscoped full-site query. A typo in a project scope silently returned **all site content** — the opposite of what the caller asked for.

## Fix

- **Track dropped IDs** through both resolution paths, distinguishing `unknown-on-site` from `not-permitted-by-config`, and surface them in `mcp.warnings` (reusing the result convention from `query-datasource`).
- **Widening guard (core fix):** when a scope was requested but nothing resolved to a real project name, return an **empty report (0 rows) + warnings** — never fall through to the unscoped full-site query.
- **Back-compat:** no `mcp` key is emitted when all requested IDs are valid; the clean result shape is unchanged.

## Test coverage

Unit (`getStaleContentReport.test.ts`, 37/37 pass):
- **Partial-invalid** — scoped to the valid subset, one `unknown-on-site` warning listing the ignored ID; filter still applied for the valid project.
- **All-invalid (widening-guard regression)** — `rows: []`, totals 0, and **asserts `mockQueryDatasource` was NOT called** (proves no full-site query fires).
- **Bounded-context drop** — `not-permitted-by-config` warning for the out-of-scope ID.
- **All-valid back-compat** — no `mcp` key present.
- Direct unit tests for the new `resolveProjectScopeIds` / `resolveProjectIdsToNames` return shapes and `buildProjectIdWarnings`.

Full suite: 2223/2223 pass · `tsc --noEmit` clean · eslint + prettier clean.

**E2E: N/A** — the existing prompt-level e2e cannot deterministically force an invalid-ID site condition; this is a resolver-level fix owned by the unit tier. The all-invalid unit test is the authoritative regression proof (deterministic, fails without the guard, passes with it).

## Version

Patch bump 2.25.1 → 2.25.2 (CI version-bump-check gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)