### PR TITLE
desktop: prefix desktop log file names with desktop-mcp-

### DIFF
--- a/src/index.desktop.ts
+++ b/src/index.desktop.ts
@@ -16,7 +16,12 @@ async function startServer(): Promise<void> {
     ? config.defaultNotificationLevel
     : 'debug';
   if (config.loggers.has('fileLogger')) {
-    setFileLogger(new FileLogger({ logDirectory: config.fileLoggerDirectory }));
+    setFileLogger(
+      new FileLogger({
+        logDirectory: config.fileLoggerDirectory,
+        fileNamePrefix: 'desktop-mcp-',
+      }),
+    );
   }
 
   if (config.transport !== 'stdio') {

--- a/src/logging/fileLogger.test.ts
+++ b/src/logging/fileLogger.test.ts
@@ -59,6 +59,19 @@ describe('FileLogger', () => {
     expect(logObject.logger).toBe(logger);
   });
 
+  it('should prefix log file names when fileNamePrefix is set', async () => {
+    const prefixedLogger = new FileLogger({
+      logDirectory: testLogDirectory,
+      fileNamePrefix: 'desktop-mcp-',
+    });
+
+    await prefixedLogger.log({ message: 'Prefixed message', level: 'info', logger });
+
+    const files = readdirSync(testLogDirectory);
+    expect(files.length).toBe(1);
+    expect(files[0]).toMatch(/^desktop-mcp-.*\.log$/);
+  });
+
   it('should handle concurrent log writes to the same file', async () => {
     const message1 = 'First concurrent message';
     const message2 = 'Second concurrent message';

--- a/src/logging/fileLogger.ts
+++ b/src/logging/fileLogger.ts
@@ -16,10 +16,18 @@ export const getFileLogger = (): FileLogger | undefined => _fileLogger;
 
 export class FileLogger {
   private readonly _logDirectory: string;
+  private readonly _fileNamePrefix: string;
   private readonly _fileMutexes = new Map<string, Promise<void>>();
 
-  constructor({ logDirectory }: { logDirectory: string }) {
+  constructor({
+    logDirectory,
+    fileNamePrefix = '',
+  }: {
+    logDirectory: string;
+    fileNamePrefix?: string;
+  }) {
     this._logDirectory = logDirectory;
+    this._fileNamePrefix = fileNamePrefix;
 
     if (!existsSync(this._logDirectory)) {
       mkdirSync(this._logDirectory, { recursive: true });
@@ -29,7 +37,7 @@ export class FileLogger {
   async log(entry: LogEntry): Promise<void> {
     // Create a new log file each hour e.g. 2025-10-15T21-00-00-000Z.log
     const timestamp = new Date().toISOString();
-    const filename = `${new Date(new Date().setMinutes(0, 0, 0)).toISOString().replace(/[:.]/g, '-')}.log`;
+    const filename = `${this._fileNamePrefix}${new Date(new Date().setMinutes(0, 0, 0)).toISOString().replace(/[:.]/g, '-')}.log`;
     const logFilePath = join(this._logDirectory, filename);
 
     // Get or create a mutex for this specific log file


### PR DESCRIPTION
## Description

Renames desktop MCP log files so they're identifiable at a glance. The shared `FileLogger` wrote `<iso-hour>.log` (e.g. `2025-10-15T21-00-00-000Z.log`); the desktop variant now writes `desktop-mcp-<iso-hour>.log`.

- `fileLogger.ts`: add an optional `fileNamePrefix` (defaults to `''`, so default/combined variants are unchanged).
- `index.desktop.ts`: wire `fileNamePrefix: 'desktop-mcp-'` into the desktop `FileLogger`.
- `fileLogger.test.ts`: assert prefixed names match `desktop-mcp-*.log`.

Note: log files use the `.log` extension, not `.txt`.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Other: log file naming

## How Has This Been Tested?

- `npx vitest run src/logging/fileLogger.test.ts` — all pass, including the new prefix assertion.

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
