### PR TITLE
desktop: pin session to the launching Desktop, drop list-instances when pinned

### DIFF
--- a/src/config.desktop.test.ts
+++ b/src/config.desktop.test.ts
@@ -125,4 +125,25 @@ describe('DesktopConfig', () => {
       expect(new Config().externalApiDiscoveryDir).toBeUndefined();
     });
   });
+
+  describe('pinned Desktop session id', () => {
+    it('should be undefined by default', () => {
+      expect(new Config().desktopSessionId).toBeUndefined();
+    });
+
+    it('should read a numeric pid from TABLEAU_DESKTOP_SESSION_ID', () => {
+      vi.stubEnv('TABLEAU_DESKTOP_SESSION_ID', '4242');
+      expect(new Config().desktopSessionId).toBe('4242');
+    });
+
+    it('should ignore a blank value', () => {
+      vi.stubEnv('TABLEAU_DESKTOP_SESSION_ID', '');
+      expect(new Config().desktopSessionId).toBeUndefined();
+    });
+
+    it('should ignore a non-numeric value', () => {
+      vi.stubEnv('TABLEAU_DESKTOP_SESSION_ID', 'not-a-pid');
+      expect(new Config().desktopSessionId).toBeUndefined();
+    });
+  });
 });

--- a/src/config.desktop.ts
+++ b/src/config.desktop.ts
@@ -30,6 +30,14 @@ export class Config extends BaseConfig {
   /** Optional override for the External Client API discovery directory. */
   externalApiDiscoveryDir: string | undefined;
 
+  /**
+   * Session id (Desktop pid) the launching Tableau Desktop pinned via
+   * `TABLEAU_DESKTOP_SESSION_ID`. When set, every session-scoped tool defaults to
+   * this instance and `list-instances` is not registered, so the agent never has to
+   * discover which Desktop to control. Ignored unless it is a non-blank numeric pid.
+   */
+  desktopSessionId: string | undefined;
+
   constructor() {
     super();
 
@@ -42,6 +50,7 @@ export class Config extends BaseConfig {
       INLINE_XML_MAX_BYTES: inlineXmlMaxBytes,
       TABLEAU_EXTERNAL_API: externalApi,
       TABLEAU_EXTERNAL_API_DISCOVERY_DIR: externalApiDiscoveryDir,
+      TABLEAU_DESKTOP_SESSION_ID: desktopSessionId,
     } = cleansedVars;
 
     if (this.transport !== 'stdio') {
@@ -50,6 +59,8 @@ export class Config extends BaseConfig {
 
     this.externalApiEnabled = externalApi === '1' || externalApi === 'true';
     this.externalApiDiscoveryDir = externalApiDiscoveryDir || undefined;
+    this.desktopSessionId =
+      desktopSessionId && /^\d+$/.test(desktopSessionId) ? desktopSessionId : undefined;
     this.toolProfile = (toolProfile ?? '').trim().toLowerCase();
 
     this.inlineXmlMaxBytes = parseNumber(inlineXmlMaxBytes, {

--- a/src/desktop/externalApi/externalApiToolExecutor.test.ts
+++ b/src/desktop/externalApi/externalApiToolExecutor.test.ts
@@ -53,6 +53,24 @@ describe('ExternalApiToolExecutor', () => {
       await executor.start();
       expect(executor.isAvailable()).toBe(false);
     });
+
+    it('fails closed when a pinned pid is not among the discovered instances', async () => {
+      const executor = new ExternalApiToolExecutor({
+        pid: 12345,
+        discover: () => [instanceFor(server)], // pid 999 — not the pinned 12345
+      });
+      await executor.start();
+      expect(executor.isAvailable()).toBe(false);
+    });
+
+    it('connects to the pinned instance when its pid is present', async () => {
+      const executor = new ExternalApiToolExecutor({
+        pid: 999,
+        discover: () => [instanceFor(server)],
+      });
+      await executor.start();
+      expect(executor.isAvailable()).toBe(true);
+    });
   });
 
   describe('executeCommand routing', () => {
@@ -190,6 +208,35 @@ describe('ExternalApiToolExecutor', () => {
       expect(result.isOk()).toBe(true);
       expect(result.unwrap().parsedResult.text).toBe('<workbook><from-desktop /></workbook>');
       expect(discover).toHaveBeenCalledTimes(2);
+    });
+
+    it('fails closed when the pinned pid disappears on the 401 rescan instead of retargeting', async () => {
+      const other = await startMockExternalApiServer({
+        workbookXml: '<workbook><other /></workbook>',
+      });
+      try {
+        const discover = vi
+          .fn()
+          .mockReturnValueOnce([{ ...instanceFor(server, 'stale-token'), pid: 999 }])
+          .mockReturnValue([{ ...instanceFor(other, 'valid-token'), pid: 111 }]); // pinned pid 999 gone
+
+        const executor = new ExternalApiToolExecutor({ pid: 999, discover });
+        await executor.start();
+
+        const result = await executor.executeCommand({
+          namespace: 'tabui',
+          command: 'save-underlying-metadata',
+          args: { 'is-json': false },
+          schema: z.object({ text: z.string() }),
+          signal,
+        });
+
+        expect(result.isErr()).toBe(true);
+        expect(result.unwrapErr().type).toBe('unknown');
+        expect(other.requests).toHaveLength(0);
+      } finally {
+        await other.close();
+      }
     });
 
     it('gives up after a single rescan when the 401 persists', async () => {

--- a/src/desktop/externalApi/externalApiToolExecutor.test.ts
+++ b/src/desktop/externalApi/externalApiToolExecutor.test.ts
@@ -54,13 +54,26 @@ describe('ExternalApiToolExecutor', () => {
       expect(executor.isAvailable()).toBe(false);
     });
 
-    it('fails closed when a pinned pid is not among the discovered instances', async () => {
+    it('fails closed with a pid-named error when a pinned pid is not among the discovered instances', async () => {
       const executor = new ExternalApiToolExecutor({
         pid: 12345,
         discover: () => [instanceFor(server)], // pid 999 — not the pinned 12345
       });
       await executor.start();
       expect(executor.isAvailable()).toBe(false);
+
+      const result = await executor.executeCommand({
+        namespace: 'tabdoc',
+        command: 'undo',
+        signal,
+      });
+
+      expect(result.isErr()).toBe(true);
+      const error = result.unwrapErr();
+      expect(error.type).toBe('unknown');
+      if (error.type === 'unknown') {
+        expect(String(error.error)).toContain('pid 12345');
+      }
     });
 
     it('connects to the pinned instance when its pid is present', async () => {
@@ -232,7 +245,11 @@ describe('ExternalApiToolExecutor', () => {
         });
 
         expect(result.isErr()).toBe(true);
-        expect(result.unwrapErr().type).toBe('unknown');
+        const error = result.unwrapErr();
+        expect(error.type).toBe('unknown');
+        if (error.type === 'unknown') {
+          expect(String(error.error)).toContain('pid 999');
+        }
         expect(other.requests).toHaveLength(0);
       } finally {
         await other.close();

--- a/src/desktop/externalApi/externalApiToolExecutor.ts
+++ b/src/desktop/externalApi/externalApiToolExecutor.ts
@@ -198,9 +198,11 @@ export class ExternalApiToolExecutor extends ToolExecutor {
 
   private async resolveClient(): Promise<Result<ExternalApiClient, NoInstance>> {
     const instances = await this.deps.discover();
+    // A pinned pid must match exactly. Falling back to instances[0] here would silently
+    // retarget a different Desktop, which is the split-brain this pin exists to prevent.
     const chosen =
       this.deps.pid !== undefined
-        ? (instances.find((instance) => instance.pid === this.deps.pid) ?? instances[0])
+        ? instances.find((instance) => instance.pid === this.deps.pid)
         : instances[0];
 
     if (!chosen) {

--- a/src/desktop/externalApi/externalApiToolExecutor.ts
+++ b/src/desktop/externalApi/externalApiToolExecutor.ts
@@ -39,7 +39,7 @@ export type ExternalApiToolExecutorDeps = {
   ) => ExternalApiClient;
 };
 
-type NoInstance = { type: 'no-instance' };
+type NoInstance = { type: 'no-instance'; pinnedPid?: number };
 
 /** Normalized shape shared by document + invokeCommand responses. */
 type RawOutcome = {
@@ -207,7 +207,7 @@ export class ExternalApiToolExecutor extends ToolExecutor {
 
     if (!chosen) {
       this.client = undefined;
-      return Err({ type: 'no-instance' });
+      return Err({ type: 'no-instance', pinnedPid: this.deps.pid });
     }
 
     this.client = this.createClient(chosen);
@@ -360,7 +360,13 @@ function mapClientError(error: ExternalApiError | NoInstance): ExecuteCommandErr
     case 'network':
       return { type: 'unknown', error: error.error };
     case 'no-instance':
-      return { type: 'unknown', error: 'No External Client API instance available.' };
+      return {
+        type: 'unknown',
+        error:
+          error.pinnedPid !== undefined
+            ? `Pinned Tableau Desktop (pid ${error.pinnedPid}) is no longer running — relaunch the agent from the Desktop you want to control.`
+            : 'No External Client API instance available.',
+      };
   }
 }
 

--- a/src/desktop/routeTable.test.ts
+++ b/src/desktop/routeTable.test.ts
@@ -1,9 +1,11 @@
 import { desktopToolNames } from '../tools/desktop/toolName.js';
 import {
+  buildDesktopInstructions,
   DESKTOP_ROUTE_TABLE,
   DesktopInstructionRoute,
   generateDesktopInstructions,
   renderInstructionEntry,
+  SESSION_RESOLUTION_ID,
 } from './routeTable.js';
 
 const routes = DESKTOP_ROUTE_TABLE.filter(
@@ -63,5 +65,28 @@ describe('generateDesktopInstructions', () => {
   it('renders every entry in table order, one paragraph each, separated by blank lines', () => {
     const generated = generateDesktopInstructions(DESKTOP_ROUTE_TABLE);
     expect(generated.split('\n\n')).toEqual(DESKTOP_ROUTE_TABLE.map(renderInstructionEntry));
+  });
+});
+
+describe('buildDesktopInstructions', () => {
+  const sessionResolutionText = DESKTOP_ROUTE_TABLE.find(
+    (entry) => entry.id === SESSION_RESOLUTION_ID && entry.kind === 'prose',
+  );
+
+  it('keeps the session-resolution guidance when no session is pinned', () => {
+    const unpinned = buildDesktopInstructions({ sessionPinned: false });
+    expect(unpinned).toBe(generateDesktopInstructions(DESKTOP_ROUTE_TABLE));
+    expect(unpinned).toContain('list-instances');
+  });
+
+  it('drops the session-resolution guidance when a session is pinned', () => {
+    const pinned = buildDesktopInstructions({ sessionPinned: true });
+    expect(sessionResolutionText?.kind).toBe('prose');
+    if (sessionResolutionText?.kind === 'prose') {
+      expect(pinned).not.toContain(sessionResolutionText.text);
+    }
+    expect(pinned).not.toContain('list-instances');
+    // The other routes must survive the filter untouched.
+    expect(pinned).toContain('You are controlling Tableau Desktop.');
   });
 });

--- a/src/desktop/routeTable.ts
+++ b/src/desktop/routeTable.ts
@@ -21,6 +21,11 @@ export type DesktopInstructionProse = {
 
 export type DesktopInstructionEntry = DesktopInstructionRoute | DesktopInstructionProse;
 
+// The session-resolution prose points the agent at list-instances. When the launching
+// Desktop pins a session, that tool is unregistered, so this entry is dropped from the
+// instructions to avoid naming a tool the client cannot call.
+export const SESSION_RESOLUTION_ID = 'session-resolution';
+
 export const DESKTOP_ROUTE_TABLE: readonly DesktopInstructionEntry[] = [
   {
     kind: 'prose',
@@ -70,7 +75,7 @@ export const DESKTOP_ROUTE_TABLE: readonly DesktopInstructionEntry[] = [
   },
   {
     kind: 'prose',
-    id: 'session-resolution',
+    id: SESSION_RESOLUTION_ID,
     text: 'Every session-scoped tool call needs the session id from list-instances — except bind-template and dashboard-auto-apply, which auto-resolve the session when exactly one Desktop instance is running.',
   },
   {
@@ -86,4 +91,15 @@ export function renderInstructionEntry(entry: DesktopInstructionEntry): string {
 
 export function generateDesktopInstructions(table: readonly DesktopInstructionEntry[]): string {
   return table.map(renderInstructionEntry).join('\n\n');
+}
+
+/**
+ * Instructions for a given session-pinning state. When a session is pinned the
+ * agent never calls list-instances, so the session-resolution guidance is dropped.
+ */
+export function buildDesktopInstructions({ sessionPinned }: { sessionPinned: boolean }): string {
+  const table = sessionPinned
+    ? DESKTOP_ROUTE_TABLE.filter((entry) => entry.id !== SESSION_RESOLUTION_ID)
+    : DESKTOP_ROUTE_TABLE;
+  return generateDesktopInstructions(table);
 }

--- a/src/desktop/sessionResolution.test.ts
+++ b/src/desktop/sessionResolution.test.ts
@@ -1,0 +1,83 @@
+import * as configModule from '../config.desktop.js';
+import { DesktopDiscoverer } from './desktopDiscoverer.js';
+import * as externalDiscovery from './externalApi/discovery.js';
+import { resolveSession } from './sessionResolution.js';
+
+vi.mock('./desktopDiscoverer.js');
+
+function mockConfig(overrides: Partial<configModule.Config>): void {
+  const base = new configModule.Config();
+  vi.spyOn(configModule, 'getDesktopConfig').mockReturnValue({
+    ...base,
+    ...overrides,
+  } as configModule.Config);
+}
+
+function mockAgentApiInstances(pids: number[]): void {
+  const map = new Map(pids.map((pid) => [pid, { pid }]));
+  vi.mocked(DesktopDiscoverer).mockImplementation(
+    () => ({ getInstances: () => map }) as unknown as DesktopDiscoverer,
+  );
+}
+
+describe('resolveSession', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllEnvs();
+    vi.stubEnv('TABLEAU_MCP_TEST', 'true');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns an explicit session id verbatim, ahead of the pin and discovery', () => {
+    mockConfig({ desktopSessionId: '4242', externalApiEnabled: false });
+    const result = resolveSession('7');
+    expect(result.isOk()).toBe(true);
+    expect(result.unwrap()).toBe('7');
+  });
+
+  it('falls back to the pinned session id when no explicit session is given', () => {
+    mockConfig({ desktopSessionId: '4242', externalApiEnabled: false });
+    const result = resolveSession(undefined);
+    expect(result.isOk()).toBe(true);
+    expect(result.unwrap()).toBe('4242');
+  });
+
+  it('auto-resolves the unique Agent API instance when nothing is pinned', () => {
+    mockConfig({ desktopSessionId: undefined, externalApiEnabled: false });
+    mockAgentApiInstances([99]);
+    const result = resolveSession(undefined);
+    expect(result.isOk()).toBe(true);
+    expect(result.unwrap()).toBe('99');
+  });
+
+  it('fails closed when no instances are running and nothing is pinned', () => {
+    mockConfig({ desktopSessionId: undefined, externalApiEnabled: false });
+    mockAgentApiInstances([]);
+    expect(resolveSession(undefined).isErr()).toBe(true);
+  });
+
+  it('fails closed when multiple instances are running and nothing is pinned', () => {
+    mockConfig({ desktopSessionId: undefined, externalApiEnabled: false });
+    mockAgentApiInstances([1, 2]);
+    const result = resolveSession(undefined);
+    expect(result.isErr()).toBe(true);
+    expect(result.unwrapErr().getErrorText()).toContain('1, 2');
+  });
+
+  it('auto-resolves via External Client API discovery when that transport is active', () => {
+    mockConfig({
+      desktopSessionId: undefined,
+      externalApiEnabled: true,
+      externalApiDiscoveryDir: '/tmp/discovery',
+    });
+    vi.spyOn(externalDiscovery, 'discoverInstances').mockReturnValue([
+      { pid: 555 } as ReturnType<typeof externalDiscovery.discoverInstances>[number],
+    ]);
+    const result = resolveSession(undefined);
+    expect(result.isOk()).toBe(true);
+    expect(result.unwrap()).toBe('555');
+  });
+});

--- a/src/desktop/sessionResolution.test.ts
+++ b/src/desktop/sessionResolution.test.ts
@@ -31,18 +31,34 @@ describe('resolveSession', () => {
     vi.restoreAllMocks();
   });
 
-  it('returns an explicit session id verbatim, ahead of the pin and discovery', () => {
+  it('rejects an explicit session that conflicts with the pin', () => {
     mockConfig({ desktopSessionId: '4242', externalApiEnabled: false });
     const result = resolveSession('7');
-    expect(result.isOk()).toBe(true);
-    expect(result.unwrap()).toBe('7');
+    expect(result.isErr()).toBe(true);
+    const text = result.unwrapErr().getErrorText();
+    expect(text).toContain('4242');
+    expect(text).toContain('7');
   });
 
-  it('falls back to the pinned session id when no explicit session is given', () => {
+  it('honors an explicit session that matches the pin', () => {
+    mockConfig({ desktopSessionId: '4242', externalApiEnabled: false });
+    const result = resolveSession('4242');
+    expect(result.isOk()).toBe(true);
+    expect(result.unwrap()).toBe('4242');
+  });
+
+  it('uses the pinned session id when no explicit session is given', () => {
     mockConfig({ desktopSessionId: '4242', externalApiEnabled: false });
     const result = resolveSession(undefined);
     expect(result.isOk()).toBe(true);
     expect(result.unwrap()).toBe('4242');
+  });
+
+  it('returns an explicit session id verbatim when nothing is pinned', () => {
+    mockConfig({ desktopSessionId: undefined, externalApiEnabled: false });
+    const result = resolveSession('7');
+    expect(result.isOk()).toBe(true);
+    expect(result.unwrap()).toBe('7');
   });
 
   it('auto-resolves the unique Agent API instance when nothing is pinned', () => {

--- a/src/desktop/sessionResolution.ts
+++ b/src/desktop/sessionResolution.ts
@@ -6,8 +6,11 @@ import {
   McpToolError,
   NoDesktopInstancesFoundError,
 } from '../errors/mcpToolError.js';
+import { DesktopToolName } from '../tools/desktop/toolName.js';
 import { DesktopDiscoverer } from './desktopDiscoverer.js';
 import { discoverInstances } from './externalApi/discovery.js';
+
+const LIST_INSTANCES_TOOL: DesktopToolName = 'list-instances';
 
 /**
  * Resolve which Tableau Desktop session (pid) a session-scoped tool should target.
@@ -42,7 +45,7 @@ export function resolveSession(session: string | undefined): Result<string, McpT
   if (pids.length > 1) {
     return Err(
       new ArgsValidationError(
-        `Multiple Tableau Desktop instances are running (session IDs: ${pids.join(', ')}). Specify which one to use via the 'session' parameter (see list-instances for details).`,
+        `Multiple Tableau Desktop instances are running (session IDs: ${pids.join(', ')}). Specify which one to use via the 'session' parameter (see ${LIST_INSTANCES_TOOL} for details).`,
       ),
     );
   }

--- a/src/desktop/sessionResolution.ts
+++ b/src/desktop/sessionResolution.ts
@@ -16,9 +16,12 @@ const LIST_INSTANCES_TOOL: DesktopToolName = 'list-instances';
  * Resolve which Tableau Desktop session (pid) a session-scoped tool should target.
  *
  * Precedence:
- *   1. Explicit `session` arg — the caller always wins.
- *   2. `config.desktopSessionId` — the launching Desktop pinned itself via
- *      `TABLEAU_DESKTOP_SESSION_ID`, so the agent never needs list-instances.
+ *   1. `config.desktopSessionId` — when the launching Desktop pinned itself via
+ *      `TABLEAU_DESKTOP_SESSION_ID`, the pin is an invariant: it always wins, and an
+ *      explicit `session` naming a different Desktop is rejected rather than honored.
+ *      (list-instances is hidden when pinned, so any conflicting explicit session can
+ *      only be stale model context.)
+ *   2. Explicit `session` arg — when unpinned, the caller chooses.
  *   3. Auto-resolve when exactly one Desktop instance is running. 0 or 2+ instances
  *      fail closed with an instance-listing error rather than guessing.
  *
@@ -26,13 +29,20 @@ const LIST_INSTANCES_TOOL: DesktopToolName = 'list-instances';
  * differently, so step 3 reads whichever the active transport uses.
  */
 export function resolveSession(session: string | undefined): Result<string, McpToolError> {
-  if (session !== undefined) {
-    return Ok(session);
-  }
-
   const config = getDesktopConfig();
   if (config.desktopSessionId !== undefined) {
+    if (session !== undefined && session !== config.desktopSessionId) {
+      return Err(
+        new ArgsValidationError(
+          `This agent is pinned to Tableau Desktop (pid ${config.desktopSessionId}), but session '${session}' was requested. Omit the 'session' parameter — the pinned Desktop is used automatically.`,
+        ),
+      );
+    }
     return Ok(config.desktopSessionId);
+  }
+
+  if (session !== undefined) {
+    return Ok(session);
   }
 
   const pids = config.externalApiEnabled

--- a/src/desktop/sessionResolution.ts
+++ b/src/desktop/sessionResolution.ts
@@ -1,0 +1,51 @@
+import { Err, Ok, Result } from 'ts-results-es';
+
+import { getDesktopConfig } from '../config.desktop.js';
+import {
+  ArgsValidationError,
+  McpToolError,
+  NoDesktopInstancesFoundError,
+} from '../errors/mcpToolError.js';
+import { DesktopDiscoverer } from './desktopDiscoverer.js';
+import { discoverInstances } from './externalApi/discovery.js';
+
+/**
+ * Resolve which Tableau Desktop session (pid) a session-scoped tool should target.
+ *
+ * Precedence:
+ *   1. Explicit `session` arg — the caller always wins.
+ *   2. `config.desktopSessionId` — the launching Desktop pinned itself via
+ *      `TABLEAU_DESKTOP_SESSION_ID`, so the agent never needs list-instances.
+ *   3. Auto-resolve when exactly one Desktop instance is running. 0 or 2+ instances
+ *      fail closed with an instance-listing error rather than guessing.
+ *
+ * Transport-aware: the External Client API and the legacy Agent API discover instances
+ * differently, so step 3 reads whichever the active transport uses.
+ */
+export function resolveSession(session: string | undefined): Result<string, McpToolError> {
+  if (session !== undefined) {
+    return Ok(session);
+  }
+
+  const config = getDesktopConfig();
+  if (config.desktopSessionId !== undefined) {
+    return Ok(config.desktopSessionId);
+  }
+
+  const pids = config.externalApiEnabled
+    ? discoverInstances({ discoveryDir: config.externalApiDiscoveryDir }).map((i) => i.pid)
+    : Array.from(new DesktopDiscoverer().getInstances().values()).map((i) => i.pid);
+
+  if (pids.length === 0) {
+    return Err(new NoDesktopInstancesFoundError());
+  }
+  if (pids.length > 1) {
+    return Err(
+      new ArgsValidationError(
+        `Multiple Tableau Desktop instances are running (session IDs: ${pids.join(', ')}). Specify which one to use via the 'session' parameter (see list-instances for details).`,
+      ),
+    );
+  }
+
+  return Ok(String(pids[0]));
+}

--- a/src/server.desktop.test.ts
+++ b/src/server.desktop.test.ts
@@ -56,6 +56,36 @@ describe('DesktopMcpServer', () => {
       spy.mockRestore();
     }
   });
+
+  it('does not register list-instances when a Desktop session is pinned', async () => {
+    const base = configModule.getDesktopConfig();
+    const spy = vi
+      .spyOn(configModule, 'getDesktopConfig')
+      .mockReturnValue({ ...base, desktopSessionId: '4242' });
+
+    try {
+      const server = getServer();
+      await server.registerTools();
+
+      const registeredNames = (
+        vi.mocked(server.mcpServer.registerTool).mock.calls as Array<[string, ...unknown[]]>
+      ).map(([name]) => name);
+      expect(registeredNames).not.toContain('list-instances');
+      expect(registeredNames).toContain('list-worksheets');
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('registers list-instances when no Desktop session is pinned', async () => {
+    const server = getServer();
+    await server.registerTools();
+
+    const registeredNames = (
+      vi.mocked(server.mcpServer.registerTool).mock.calls as Array<[string, ...unknown[]]>
+    ).map(([name]) => name);
+    expect(registeredNames).toContain('list-instances');
+  });
 });
 
 describe('DESKTOP_INSTRUCTIONS (generated from DESKTOP_ROUTE_TABLE)', () => {
@@ -175,7 +205,6 @@ describe('DesktopMcpServer TOOL_PROFILE env wiring', () => {
     expect(registeredNames.length).toBe(desktopToolFactories.length);
   });
 });
-
 
 function getServer(): DesktopMcpServer {
   const server = new DesktopMcpServer();

--- a/src/server.desktop.ts
+++ b/src/server.desktop.ts
@@ -11,11 +11,12 @@ import pkg from '../package.json';
 import { getDesktopConfig } from './config.desktop.js';
 import { DATA_ROOT, readResourceAsset, RESOURCES_ROOT } from './desktop/assets.js';
 import { listKnowledgeResources, readKnowledgeResource } from './desktop/knowledge/index.js';
-import { DESKTOP_ROUTE_TABLE, generateDesktopInstructions } from './desktop/routeTable.js';
+import { buildDesktopInstructions } from './desktop/routeTable.js';
 import { SessionManager } from './desktop/sessionManager.js';
 import { log } from './logging/logger.js';
 import { ClientInfo, Server } from './server.js';
 import { getCheckForUserChangesTool } from './tools/desktop/session/checkForUserChanges.js';
+import { getListInstancesTool } from './tools/desktop/session/listInstances.js';
 import { DesktopTool } from './tools/desktop/tool.js';
 import { TableauDesktopRequestHandlerExtra } from './tools/desktop/toolContext.js';
 import { DesktopToolName } from './tools/desktop/toolName.js';
@@ -81,13 +82,21 @@ export { DATA_ROOT, RESOURCES_ROOT };
 // the demo build previously shipped NO instructions, so skill-less clients got zero
 // routing and the template fast path stayed dark in real sessions). Generated from the
 // typed route table so route edits are pinned by tests instead of drifting as prose.
-export const DESKTOP_INSTRUCTIONS = generateDesktopInstructions(DESKTOP_ROUTE_TABLE);
+export const DESKTOP_INSTRUCTIONS = buildDesktopInstructions({ sessionPinned: false });
 
 export class DesktopMcpServer extends Server {
   private readonly sessionManager = new SessionManager();
 
   constructor({ mcpServer, clientInfo }: { mcpServer?: McpServer; clientInfo?: ClientInfo } = {}) {
-    super({ mcpServer, clientInfo, serverName, serverVersion, instructions: DESKTOP_INSTRUCTIONS });
+    super({
+      mcpServer,
+      clientInfo,
+      serverName,
+      serverVersion,
+      instructions: buildDesktopInstructions({
+        sessionPinned: getDesktopConfig().desktopSessionId !== undefined,
+      }),
+    });
   }
 
   registerResources = async (): Promise<void> => {
@@ -146,13 +155,25 @@ export class DesktopMcpServer extends Server {
   };
 
   protected _getToolsToRegister = async (): Promise<Array<DesktopTool<any>>> => {
+    const config = getDesktopConfig();
+    const excluded = new Set<(server: DesktopMcpServer) => DesktopTool<any>>();
+
     // check-for-user-changes needs the events endpoint, which the External Client API does not
     // expose; don't advertise a tool that can only return an error on that transport.
-    const factories = getDesktopConfig().externalApiEnabled
-      ? desktopToolFactories.filter((factory) => factory !== getCheckForUserChangesTool)
-      : desktopToolFactories;
+    if (config.externalApiEnabled) {
+      excluded.add(getCheckForUserChangesTool);
+    }
+
+    // When the launching Desktop pinned a session, every tool defaults to it, so
+    // list-instances has nothing to add — dropping it keeps the agent from ever
+    // spending a turn discovering which instance to control.
+    if (config.desktopSessionId !== undefined) {
+      excluded.add(getListInstancesTool);
+    }
+
+    const factories = desktopToolFactories.filter((factory) => !excluded.has(factory));
     const allTools = factories.map((toolFactory) => toolFactory(this));
-    return selectToolsForProfile(allTools, getDesktopConfig().toolProfile);
+    return selectToolsForProfile(allTools, config.toolProfile);
   };
 
   private _registerKnowledgeResources = (): void => {

--- a/src/tools/desktop/binder/bindTemplate.ts
+++ b/src/tools/desktop/binder/bindTemplate.ts
@@ -1,6 +1,6 @@
 import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { randomUUID } from 'crypto';
-import { Err, Ok, Result } from 'ts-results-es';
+import { Ok } from 'ts-results-es';
 import { z } from 'zod';
 
 import {
@@ -18,17 +18,12 @@ import {
   loadWorkbookXml,
   type LoadWorkbookXmlError,
 } from '../../../desktop/commands/workbook/loadWorkbookXml.js';
-import { DesktopDiscoverer } from '../../../desktop/desktopDiscoverer.js';
 import { bundledIntelligenceProvider } from '../../../desktop/intelligence/provider.js';
+import { resolveSession } from '../../../desktop/sessionResolution.js';
 import { buildInjectedWorkbookXml } from '../../../desktop/templates/injectTemplateCore.js';
 import { readTemplate } from '../../../desktop/templates/templatePath.js';
 import { ExecuteCommandError, ToolExecutor } from '../../../desktop/toolExecutor/toolExecutor.js';
-import {
-  ArgsValidationError,
-  DesktopCommandExecutionError,
-  type McpToolError,
-  NoDesktopInstancesFoundError,
-} from '../../../errors/mcpToolError.js';
+import { DesktopCommandExecutionError } from '../../../errors/mcpToolError.js';
 import { DesktopMcpServer } from '../../../server.desktop.js';
 import { getExceptionMessage } from '../../../utils/getExceptionMessage.js';
 import { DesktopTool } from '../tool.js';
@@ -166,40 +161,6 @@ function buildGuidance(res: BinderResult): string {
     case 'escalate':
       return renderEscalationGuidance(res.reason, res.blockers);
   }
-}
-
-/**
- * Session-default-when-unique (bind-template only): with an explicit `session` the
- * caller always wins; with none, resolve automatically ONLY when exactly one Desktop
- * instance is running. 0 or 2+ instances fail closed with an instance-listing error
- * so the caller must pick one — this deletes the list-instances turn from the common
- * single-Desktop case without ever guessing between multiple instances.
- *
- * Exported for reuse by dashboard-auto-apply (W60), which needs the identical
- * fail-closed session resolution — no reason for a second implementation.
- */
-export function resolveSession(session: string | undefined): Result<string, McpToolError> {
-  if (session !== undefined) {
-    return Ok(session);
-  }
-
-  const instances = new DesktopDiscoverer().getInstances();
-  if (instances.size === 0) {
-    return Err(new NoDesktopInstancesFoundError());
-  }
-  if (instances.size > 1) {
-    const ids = Array.from(instances.values())
-      .map((i) => i.pid)
-      .join(', ');
-    return Err(
-      new ArgsValidationError(
-        `Multiple Tableau Desktop instances are running (session IDs: ${ids}). Specify which one to use via the 'session' parameter (see list-instances for details).`,
-      ),
-    );
-  }
-
-  const [only] = Array.from(instances.values());
-  return Ok(String(only.pid));
 }
 
 /** Human-readable detail for a loadWorkbookXml failure, used in the apply-error text. */

--- a/src/tools/desktop/binder/proposeTemplate.ts
+++ b/src/tools/desktop/binder/proposeTemplate.ts
@@ -15,6 +15,7 @@ import {
   bundledIntelligenceProvider,
   type ProviderStatus,
 } from '../../../desktop/intelligence/provider.js';
+import { resolveSession } from '../../../desktop/sessionResolution.js';
 import { DesktopCommandExecutionError } from '../../../errors/mcpToolError.js';
 import { DesktopMcpServer } from '../../../server.desktop.js';
 import { DesktopTool } from '../tool.js';
@@ -32,7 +33,7 @@ import { DesktopTool } from '../tool.js';
 // exactly [...loadManifests().values()], so re-keying by m.template reproduces it.
 
 const paramsSchema = {
-  session: z.string().describe('Session ID from list-instances.'),
+  session: z.string().optional().describe('Session ID; optional if pinned or unique.'),
   ask: z.string().describe('Natural-language chart request.'),
 };
 
@@ -102,7 +103,12 @@ export const getProposeTemplateTool = (
         extra,
         args: { session, ask },
         callback: async () => {
-          const executor = await extra.getExecutor(session);
+          const sessionResult = resolveSession(session);
+          if (sessionResult.isErr()) {
+            return sessionResult.error.toErr();
+          }
+          const resolvedSession = sessionResult.value;
+          const executor = await extra.getExecutor(resolvedSession);
           const xmlResult = await getWorkbookXml({ executor, signal: extra.signal });
           if (xmlResult.isErr()) {
             return new DesktopCommandExecutionError(xmlResult.error).toErr();

--- a/src/tools/desktop/binder/validateProposal.ts
+++ b/src/tools/desktop/binder/validateProposal.ts
@@ -16,6 +16,7 @@ import {
   bundledIntelligenceProvider,
   type ProviderStatus,
 } from '../../../desktop/intelligence/provider.js';
+import { resolveSession } from '../../../desktop/sessionResolution.js';
 import { DesktopCommandExecutionError } from '../../../errors/mcpToolError.js';
 import { DesktopMcpServer } from '../../../server.desktop.js';
 import { DesktopTool } from '../tool.js';
@@ -32,7 +33,7 @@ import { proposalSchema } from './proposalSchema.js';
 // manifest.template == filename, and listTemplateManifests() is [...loadManifests().values()]).
 
 const paramsSchema = {
-  session: z.string().describe('Session ID from list-instances.'),
+  session: z.string().optional().describe('Session ID; optional if pinned or unique.'),
   ask: z.string().describe('Natural-language chart request.'),
   // WATCH-CLASS (required): bind-template makes `proposal` OPTIONAL (Call-1 classify vs
   // Call-2 validate). validate-proposal has one job — validate a filled proposal — so the
@@ -101,7 +102,12 @@ export const getValidateProposalTool = (
         extra,
         args: { session, ask, proposal, minConfidence },
         callback: async () => {
-          const executor = await extra.getExecutor(session);
+          const sessionResult = resolveSession(session);
+          if (sessionResult.isErr()) {
+            return sessionResult.error.toErr();
+          }
+          const resolvedSession = sessionResult.value;
+          const executor = await extra.getExecutor(resolvedSession);
           const xmlResult = await getWorkbookXml({ executor, signal: extra.signal });
           if (xmlResult.isErr()) {
             return new DesktopCommandExecutionError(xmlResult.error).toErr();

--- a/src/tools/desktop/commands/executeTableauCommand.ts
+++ b/src/tools/desktop/commands/executeTableauCommand.ts
@@ -2,12 +2,13 @@ import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { Ok } from 'ts-results-es';
 import { z } from 'zod';
 
+import { resolveSession } from '../../../desktop/sessionResolution.js';
 import { ArgsValidationError, DesktopCommandExecutionError } from '../../../errors/mcpToolError.js';
 import { DesktopMcpServer } from '../../../server.desktop.js';
 import { DesktopTool } from '../tool.js';
 
 const paramsSchema = {
-  session: z.string().describe('Session ID from list-instances.'),
+  session: z.string().optional().describe('Session ID; optional if pinned or unique.'),
   command: z
     .string()
     .describe(
@@ -40,6 +41,12 @@ export const getExecuteTableauCommandTool = (
         extra,
         args: { session, command, args },
         callback: async () => {
+          const sessionResult = resolveSession(session);
+          if (sessionResult.isErr()) {
+            return sessionResult.error.toErr();
+          }
+          const resolvedSession = sessionResult.value;
+
           const parts = command.split(':');
           if (parts.length !== 2) {
             return new ArgsValidationError(
@@ -54,7 +61,7 @@ export const getExecuteTableauCommandTool = (
             ).toErr();
           }
 
-          const executor = await extra.getExecutor(session);
+          const executor = await extra.getExecutor(resolvedSession);
           const result = await executor.executeCommand({
             namespace,
             command: cmd,

--- a/src/tools/desktop/coordination/batchCreateAndCacheSheets.ts
+++ b/src/tools/desktop/coordination/batchCreateAndCacheSheets.ts
@@ -9,6 +9,7 @@ import { getWorkbookXml } from '../../../desktop/commands/workbook/getWorkbookXm
 import { getWorksheetXml } from '../../../desktop/commands/workbook/getWorksheetXml.js';
 import { loadWorkbookXml } from '../../../desktop/commands/workbook/loadWorkbookXml.js';
 import { addDashboard, addSheet } from '../../../desktop/metadata/index.js';
+import { resolveSession } from '../../../desktop/sessionResolution.js';
 import {
   DesktopCommandExecutionError,
   WorkbookXmlLoadFailedError,
@@ -17,7 +18,7 @@ import { DesktopMcpServer } from '../../../server.desktop.js';
 import { DesktopTool } from '../tool.js';
 
 const paramsSchema = {
-  session: z.string().describe('Session ID from list-instances.'),
+  session: z.string().optional().describe('Session ID; optional if pinned or unique.'),
   worksheetNames: z.array(z.string()).describe('Names of worksheets to create.'),
   dashboardName: z.string().describe('Name of dashboard to create.'),
 };
@@ -51,9 +52,14 @@ export const getBatchCreateAndCacheSheetsTool = (
         extra,
         args: { session, worksheetNames, dashboardName },
         callback: async () => {
-          const executor = await extra.getExecutor(session);
+          const sessionResult = resolveSession(session);
+          if (sessionResult.isErr()) {
+            return sessionResult.error.toErr();
+          }
+          const resolvedSession = sessionResult.value;
+          const executor = await extra.getExecutor(resolvedSession);
           const signal = extra.signal;
-          const cache = new DesktopCache(session);
+          const cache = new DesktopCache(resolvedSession);
 
           // Fetch current workbook
           const workbookResult = await getWorkbookXml({ executor, signal });

--- a/src/tools/desktop/coordination/buildAndApplyWorksheet.ts
+++ b/src/tools/desktop/coordination/buildAndApplyWorksheet.ts
@@ -6,6 +6,7 @@ import { z } from 'zod';
 
 import { loadWorksheetXml } from '../../../desktop/commands/workbook/loadWorksheetXml.js';
 import { listAvailableFields } from '../../../desktop/metadata/index.js';
+import { resolveSession } from '../../../desktop/sessionResolution.js';
 import { spliceBoundFacet } from '../../../desktop/templates/facetSplice.js';
 import { ensureUserNamespace } from '../../../desktop/templates/injectTemplateCore.js';
 import { rewriteFieldReferences } from '../../../desktop/templates/fieldReferenceRewriter.js';
@@ -30,7 +31,7 @@ function escapeXml(text: string): string {
 }
 
 const paramsSchema = {
-  session: z.string().describe('Session ID from list-instances.'),
+  session: z.string().optional().describe('Session ID; optional if pinned or unique.'),
   taskSpec: z
     .object({
       worksheetName: z.string(),
@@ -172,13 +173,19 @@ export const getBuildAndApplyWorksheetTool = (
             );
           }
 
+          const sessionResult = resolveSession(session);
+          if (sessionResult.isErr()) {
+            return sessionResult.error.toErr();
+          }
+          const resolvedSession = sessionResult.value;
+
           // Inject title and replace field references. Per-apply calc namespacing is
           // wired at this tool boundary: the shared core defaults namespacing OFF and
           // never mints its own nonce, so derive one from session + apply timestamp
           // (randomUUID guards same-millisecond applies). Distinct nonces => distinct
           // calc-name suffixes => repeated applies into one workbook don't collide.
           templateXml = templateXml.replace(/\{\{TITLE\}\}/g, escapeXml(worksheetName));
-          const applyNonce = `${session}:${Date.now()}:${randomUUID()}`;
+          const applyNonce = `${resolvedSession}:${Date.now()}:${randomUUID()}`;
           // W28-C: splice a BOUND facet pill onto the trellis shelf BEFORE the frozen
           // core rewrite (identity no-op when no facet is bound). The core then maps
           // [Facet] → the bound field so the facet actually renders.
@@ -202,7 +209,7 @@ export const getBuildAndApplyWorksheetTool = (
           const worksheetXml = worksheetMatch[0];
 
           // Apply to Tableau
-          const executor = await extra.getExecutor(session);
+          const executor = await extra.getExecutor(resolvedSession);
           const signal = extra.signal;
           const applyResult = await loadWorksheetXml({
             worksheetName,

--- a/src/tools/desktop/coordination/planDashboardCreation.ts
+++ b/src/tools/desktop/coordination/planDashboardCreation.ts
@@ -5,13 +5,14 @@ import { z } from 'zod';
 import { DesktopCache } from '../../../desktop/cache.js';
 import { getWorkbookXml } from '../../../desktop/commands/workbook/getWorkbookXml.js';
 import { resolveField } from '../../../desktop/metadata/index.js';
+import { resolveSession } from '../../../desktop/sessionResolution.js';
 import { listTemplateNames } from '../../../desktop/templates/templatePath.js';
 import { ArgsValidationError, DesktopCommandExecutionError } from '../../../errors/mcpToolError.js';
 import { DesktopMcpServer } from '../../../server.desktop.js';
 import { DesktopTool } from '../tool.js';
 
 const paramsSchema = {
-  session: z.string().describe('Session ID from list-instances.'),
+  session: z.string().optional().describe('Session ID; optional if pinned or unique.'),
   dashboardName: z.string().describe('Name of the dashboard to create.'),
   title: z.string().optional().describe('Optional dashboard title.'),
   layout: z
@@ -77,7 +78,12 @@ export const getPlanDashboardCreationTool = (
         extra,
         args: { session, dashboardName, title, layout, worksheets },
         callback: async () => {
-          const executor = await extra.getExecutor(session);
+          const sessionResult = resolveSession(session);
+          if (sessionResult.isErr()) {
+            return sessionResult.error.toErr();
+          }
+          const resolvedSession = sessionResult.value;
+          const executor = await extra.getExecutor(resolvedSession);
           const signal = extra.signal;
           const workbookResult = await getWorkbookXml({ executor, signal });
 
@@ -89,7 +95,7 @@ export const getPlanDashboardCreationTool = (
           const templateFiles = listTemplateNames();
 
           // Resolve all requested fields
-          const cache = new DesktopCache(session);
+          const cache = new DesktopCache(resolvedSession);
           const fieldMap: Record<string, string | null> = {};
           const aggregationWarnings: string[] = [];
           const ambiguousFields: Array<{ field: string; candidates: string[] }> = [];

--- a/src/tools/desktop/dashboard/applyDashboard.ts
+++ b/src/tools/desktop/dashboard/applyDashboard.ts
@@ -9,6 +9,7 @@ import {
   isOverInlineXmlCap,
   xmlByteLength,
 } from '../../../desktop/inlineXmlCap.js';
+import { resolveSession } from '../../../desktop/sessionResolution.js';
 import {
   ArgsValidationError,
   DashboardXmlLoadFailedError,
@@ -20,7 +21,7 @@ import { DesktopMcpServer } from '../../../server.desktop.js';
 import { DesktopTool } from '../tool.js';
 
 const paramsSchema = {
-  session: z.string().describe('Session ID from list-instances.'),
+  session: z.string().optional().describe('Session ID; optional if pinned or unique.'),
   dashboardName: z.string().describe('Name of the dashboard to update (must already exist).'),
   mode: z
     .enum(['file', 'inline'])
@@ -97,7 +98,12 @@ export const getApplyDashboardTool = (
             }
           }
 
-          const executor = await extra.getExecutor(session);
+          const sessionResult = resolveSession(session);
+          if (sessionResult.isErr()) {
+            return sessionResult.error.toErr();
+          }
+          const resolvedSession = sessionResult.value;
+          const executor = await extra.getExecutor(resolvedSession);
           const result = await loadDashboardXml({
             dashboardName,
             xml: dashboardXml,

--- a/src/tools/desktop/dashboard/applyDashboardWithViewpoints.ts
+++ b/src/tools/desktop/dashboard/applyDashboardWithViewpoints.ts
@@ -7,6 +7,7 @@ import { getWorkbookXml } from '../../../desktop/commands/workbook/getWorkbookXm
 import { injectViewpoints } from '../../../desktop/commands/workbook/injectViewpoints.js';
 import { loadDashboardXml } from '../../../desktop/commands/workbook/loadDashboardXml.js';
 import { loadWorkbookXml } from '../../../desktop/commands/workbook/loadWorkbookXml.js';
+import { resolveSession } from '../../../desktop/sessionResolution.js';
 import {
   ArgsValidationError,
   DashboardXmlLoadFailedError,
@@ -19,7 +20,7 @@ import { DesktopMcpServer } from '../../../server.desktop.js';
 import { DesktopTool } from '../tool.js';
 
 const paramsSchema = {
-  session: z.string().describe('Session ID from list-instances.'),
+  session: z.string().optional().describe('Session ID; optional if pinned or unique.'),
   dashboardName: z.string().describe('Name of the dashboard.'),
   dashboardFile: z.string().describe('Cached dashboard XML file to apply.'),
   worksheetNames: z.array(z.string()).describe('Worksheet viewpoints to register.'),
@@ -70,7 +71,12 @@ export const getApplyDashboardWithViewpointsTool = (
             return new ArgsValidationError(`Dashboard file is empty: ${dashboardFile}`).toErr();
           }
 
-          const executor = await extra.getExecutor(session);
+          const sessionResult = resolveSession(session);
+          if (sessionResult.isErr()) {
+            return sessionResult.error.toErr();
+          }
+          const resolvedSession = sessionResult.value;
+          const executor = await extra.getExecutor(resolvedSession);
 
           // Fetch current workbook, inject viewpoints, apply workbook
           const workbookResult = await getWorkbookXml({ executor, signal: extra.signal });

--- a/src/tools/desktop/dashboard/buildAndApplyDashboard.ts
+++ b/src/tools/desktop/dashboard/buildAndApplyDashboard.ts
@@ -7,6 +7,7 @@ import { getWorkbookXml } from '../../../desktop/commands/workbook/getWorkbookXm
 import { injectViewpoints } from '../../../desktop/commands/workbook/injectViewpoints.js';
 import { loadDashboardXml } from '../../../desktop/commands/workbook/loadDashboardXml.js';
 import { loadWorkbookXml } from '../../../desktop/commands/workbook/loadWorkbookXml.js';
+import { resolveSession } from '../../../desktop/sessionResolution.js';
 import {
   DashboardXmlLoadFailedError,
   DesktopCommandExecutionError,
@@ -18,7 +19,7 @@ import { DesktopTool } from '../tool.js';
 import { buildDashboardXml, computeZones, layoutSpecSchema } from './dashboardZones.js';
 
 const paramsSchema = {
-  session: z.string().describe('Session ID from list-instances.'),
+  session: z.string().optional().describe('Session ID; optional if pinned or unique.'),
   dashboardName: z.string().describe('Name of the dashboard to build and apply.'),
   dashboardFile: z.string().describe('Cached dashboard XML file.'),
   workbookFile: z.string().describe('Cached workbook XML file.'),
@@ -79,7 +80,12 @@ export const getBuildAndApplyDashboardTool = (
           // both this tool and dashboard-auto-apply share one builder. Zero behavior change.
           const zones = computeZones(titleText, layoutSpec);
           const dashboardXml = buildDashboardXml(dashboardName, zones);
-          const executor = await extra.getExecutor(session);
+          const sessionResult = resolveSession(session);
+          if (sessionResult.isErr()) {
+            return sessionResult.error.toErr();
+          }
+          const resolvedSession = sessionResult.value;
+          const executor = await extra.getExecutor(resolvedSession);
 
           // Fetch workbook, inject viewpoints, apply workbook
           const workbookResult = await getWorkbookXml({ executor, signal: extra.signal });

--- a/src/tools/desktop/dashboard/dashboardAutoApply.ts
+++ b/src/tools/desktop/dashboard/dashboardAutoApply.ts
@@ -25,6 +25,7 @@ import {
 } from '../../../desktop/commands/workbook/loadWorkbookXml.js';
 import { bundledIntelligenceProvider } from '../../../desktop/intelligence/provider.js';
 import { deleteDashboard, listWorkbookDashboards } from '../../../desktop/metadata/dashboards.js';
+import { resolveSession } from '../../../desktop/sessionResolution.js';
 import { injectTemplate } from '../../../desktop/templates/injectTemplate.js';
 import {
   buildInjectedWorkbookXml,
@@ -35,7 +36,6 @@ import { ExecuteCommandError } from '../../../desktop/toolExecutor/toolExecutor.
 import { DesktopCommandExecutionError } from '../../../errors/mcpToolError.js';
 import { DesktopMcpServer } from '../../../server.desktop.js';
 import { getExceptionMessage } from '../../../utils/getExceptionMessage.js';
-import { resolveSession } from '../binder/bindTemplate.js';
 import { DesktopTool } from '../tool.js';
 import { buildDashboardXml, computeZones } from './dashboardZones.js';
 

--- a/src/tools/desktop/dashboard/getDashboardXml.ts
+++ b/src/tools/desktop/dashboard/getDashboardXml.ts
@@ -12,6 +12,7 @@ import {
   logInlineXmlCapHit,
   xmlByteLength,
 } from '../../../desktop/inlineXmlCap.js';
+import { resolveSession } from '../../../desktop/sessionResolution.js';
 import {
   DesktopCommandExecutionError,
   GetDashboardXmlFailedError,
@@ -22,7 +23,7 @@ import { DesktopMcpServer } from '../../../server.desktop.js';
 import { DesktopTool } from '../tool.js';
 
 const paramsSchema = {
-  session: z.string().describe('Session ID from list-instances.'),
+  session: z.string().optional().describe('Session ID; optional if pinned or unique.'),
   dashboardName: z.string().describe('Existing dashboard name.'),
   mode: z
     .enum(['file', 'inline'])
@@ -60,7 +61,12 @@ export const getGetDashboardXmlTool = (
         extra,
         args: { session, dashboardName, mode },
         callback: async () => {
-          const executor = await extra.getExecutor(session);
+          const sessionResult = resolveSession(session);
+          if (sessionResult.isErr()) {
+            return sessionResult.error.toErr();
+          }
+          const resolvedSession = sessionResult.value;
+          const executor = await extra.getExecutor(resolvedSession);
           const result = await getDashboardXml({ dashboardName, executor, signal: extra.signal });
 
           if (result.isErr()) {

--- a/src/tools/desktop/health/dashboardHealthCheck.test.ts
+++ b/src/tools/desktop/health/dashboardHealthCheck.test.ts
@@ -237,6 +237,7 @@ describe('dashboardHealthCheck read-only proof (import audit)', () => {
       '../../../desktop/binder/memo.js',
       '../../../desktop/binder/schema-summary.js',
       '../../../desktop/commands/workbook/getWorkbookXml.js',
+      '../../../desktop/sessionResolution.js',
       '../../../errors/mcpToolError.js',
       '../../../server.desktop.js',
       '../tool.js',

--- a/src/tools/desktop/health/dashboardHealthCheck.ts
+++ b/src/tools/desktop/health/dashboardHealthCheck.ts
@@ -35,6 +35,7 @@ import {
   summarizeSchema,
 } from '../../../desktop/binder/schema-summary.js';
 import { getWorkbookXml } from '../../../desktop/commands/workbook/getWorkbookXml.js';
+import { resolveSession } from '../../../desktop/sessionResolution.js';
 import { DesktopCommandExecutionError } from '../../../errors/mcpToolError.js';
 import { DesktopMcpServer } from '../../../server.desktop.js';
 import { DesktopTool } from '../tool.js';
@@ -380,7 +381,7 @@ export function runDashboardHealthCheck({
 // ── Tool registration ────────────────────────────────────────────────────────
 
 const paramsSchema = {
-  session: z.string().describe('Session ID from list-instances.'),
+  session: z.string().optional().describe('Session ID; optional if pinned or unique.'),
   manifest: bindingRecordSchema.describe('Binding manifest from a prior bind.'),
 };
 
@@ -410,7 +411,12 @@ export const getDashboardHealthCheckTool = (
         extra,
         args: { session, manifest },
         callback: async () => {
-          const executor = await extra.getExecutor(session);
+          const sessionResult = resolveSession(session);
+          if (sessionResult.isErr()) {
+            return sessionResult.error.toErr();
+          }
+          const resolvedSession = sessionResult.value;
+          const executor = await extra.getExecutor(resolvedSession);
           const xmlResult = await getWorkbookXml({ executor, signal: extra.signal });
           if (xmlResult.isErr()) {
             return new DesktopCommandExecutionError(xmlResult.error).toErr();

--- a/src/tools/desktop/session/checkForUserChanges.ts
+++ b/src/tools/desktop/session/checkForUserChanges.ts
@@ -2,15 +2,14 @@ import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { Ok } from 'ts-results-es';
 import { z } from 'zod';
 
+import { resolveSession } from '../../../desktop/sessionResolution.js';
 import { GetEventsFailedError } from '../../../errors/mcpToolError.js';
 import { log } from '../../../logging/logger.js';
 import { DesktopMcpServer } from '../../../server.desktop.js';
 import { DesktopTool } from '../tool.js';
 
 const paramsSchema = {
-  session: z
-    .string()
-    .describe('Session ID from tool that lists running Tableau Desktop instances.'),
+  session: z.string().optional().describe('Session ID; optional if pinned or unique.'),
   sinceSequence: z
     .number()
     .optional()
@@ -50,7 +49,11 @@ export const getCheckForUserChangesTool = (
         extra,
         args: { session, sinceSequence },
         callback: async () => {
-          const executor = await extra.getExecutor(session);
+          const sessionResult = resolveSession(session);
+          if (sessionResult.isErr()) {
+            return sessionResult.error.toErr();
+          }
+          const executor = await extra.getExecutor(sessionResult.value);
           const result = await executor.getEvents({
             signal: extra.signal,
             sinceSequence,

--- a/src/tools/desktop/workbook/applyWorkbook.ts
+++ b/src/tools/desktop/workbook/applyWorkbook.ts
@@ -9,6 +9,7 @@ import {
   isOverInlineXmlCap,
   xmlByteLength,
 } from '../../../desktop/inlineXmlCap.js';
+import { resolveSession } from '../../../desktop/sessionResolution.js';
 import {
   ArgsValidationError,
   DesktopCommandExecutionError,
@@ -20,7 +21,7 @@ import { DesktopMcpServer } from '../../../server.desktop.js';
 import { DesktopTool } from '../tool.js';
 
 const paramsSchema = {
-  session: z.string().describe('Session ID from list-instances.'),
+  session: z.string().optional().describe('Session ID; optional if pinned or unique.'),
   mode: z
     .enum(['file', 'inline'])
     .optional()
@@ -95,7 +96,12 @@ export const getApplyWorkbookTool = (
             }
           }
 
-          const executor = await extra.getExecutor(session);
+          const sessionResult = resolveSession(session);
+          if (sessionResult.isErr()) {
+            return sessionResult.error.toErr();
+          }
+          const resolvedSession = sessionResult.value;
+          const executor = await extra.getExecutor(resolvedSession);
           const result = await loadWorkbookXml({
             xml: workbookXml,
             executor,

--- a/src/tools/desktop/workbook/getWorkbookXml.ts
+++ b/src/tools/desktop/workbook/getWorkbookXml.ts
@@ -89,9 +89,7 @@ export const getGetWorkbookXmlTool = (
           }
 
           // Save to cache file (requested file mode, or forced by the cap).
-          const cacheFile = new DesktopCache(resolvedSession).getCacheFilePath({
-            prefix: 'workbook',
-          });
+          const cacheFile = new DesktopCache().getCacheFilePath({ prefix: 'workbook' });
           writeFileSync(cacheFile, workbookXml, 'utf-8');
 
           if (capFired) {

--- a/src/tools/desktop/workbook/getWorkbookXml.ts
+++ b/src/tools/desktop/workbook/getWorkbookXml.ts
@@ -12,13 +12,14 @@ import {
   logInlineXmlCapHit,
   xmlByteLength,
 } from '../../../desktop/inlineXmlCap.js';
+import { resolveSession } from '../../../desktop/sessionResolution.js';
 import { DesktopCommandExecutionError } from '../../../errors/mcpToolError.js';
 import { log } from '../../../logging/logger.js';
 import { DesktopMcpServer } from '../../../server.desktop.js';
 import { DesktopTool } from '../tool.js';
 
 const paramsSchema = {
-  session: z.string().describe('Session ID from list-instances.'),
+  session: z.string().optional().describe('Session ID; optional if pinned or unique.'),
   mode: z
     .enum(['file', 'inline'])
     .optional()
@@ -61,7 +62,12 @@ export const getGetWorkbookXmlTool = (
         extra,
         args: { session, mode },
         callback: async () => {
-          const executor = await extra.getExecutor(session);
+          const sessionResult = resolveSession(session);
+          if (sessionResult.isErr()) {
+            return sessionResult.error.toErr();
+          }
+          const resolvedSession = sessionResult.value;
+          const executor = await extra.getExecutor(resolvedSession);
           const result = await getWorkbookXml({ executor, signal: extra.signal });
 
           if (result.isErr()) {
@@ -83,7 +89,9 @@ export const getGetWorkbookXmlTool = (
           }
 
           // Save to cache file (requested file mode, or forced by the cap).
-          const cacheFile = new DesktopCache().getCacheFilePath({ prefix: 'workbook' });
+          const cacheFile = new DesktopCache(resolvedSession).getCacheFilePath({
+            prefix: 'workbook',
+          });
           writeFileSync(cacheFile, workbookXml, 'utf-8');
 
           if (capFired) {

--- a/src/tools/desktop/workbook/listDashboards.ts
+++ b/src/tools/desktop/workbook/listDashboards.ts
@@ -2,12 +2,13 @@ import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
 
 import { listDashboards } from '../../../desktop/commands/workbook/listDashboards.js';
+import { resolveSession } from '../../../desktop/sessionResolution.js';
 import { DesktopCommandExecutionError } from '../../../errors/mcpToolError.js';
 import { DesktopMcpServer } from '../../../server.desktop.js';
 import { DesktopTool } from '../tool.js';
 
 const paramsSchema = {
-  session: z.string().describe('Tableau instance Session ID from list-instances.'),
+  session: z.string().optional().describe('Session ID; optional if pinned or unique.'),
 };
 
 const title = 'List All Dashboards in Workbook';
@@ -33,7 +34,12 @@ export const getListDashboardsTool = (
         extra,
         args: { session },
         callback: async () => {
-          const executor = await extra.getExecutor(session);
+          const sessionResult = resolveSession(session);
+          if (sessionResult.isErr()) {
+            return sessionResult.error.toErr();
+          }
+          const resolvedSession = sessionResult.value;
+          const executor = await extra.getExecutor(resolvedSession);
           const result = await listDashboards({ executor, signal: extra.signal });
 
           if (result.isErr()) {

--- a/src/tools/desktop/workbook/listWorksheets.ts
+++ b/src/tools/desktop/workbook/listWorksheets.ts
@@ -2,12 +2,13 @@ import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
 
 import { listWorksheets } from '../../../desktop/commands/workbook/listWorksheets.js';
+import { resolveSession } from '../../../desktop/sessionResolution.js';
 import { DesktopCommandExecutionError } from '../../../errors/mcpToolError.js';
 import { DesktopMcpServer } from '../../../server.desktop.js';
 import { DesktopTool } from '../tool.js';
 
 const paramsSchema = {
-  session: z.string().describe('Tableau instance Session ID from list-instances.'),
+  session: z.string().optional().describe('Session ID; optional if pinned or unique.'),
 };
 
 const title = 'List All Worksheets in Workbook';
@@ -33,7 +34,12 @@ export const getListWorksheetsTool = (
         extra,
         args: { session },
         callback: async () => {
-          const executor = await extra.getExecutor(session);
+          const sessionResult = resolveSession(session);
+          if (sessionResult.isErr()) {
+            return sessionResult.error.toErr();
+          }
+          const resolvedSession = sessionResult.value;
+          const executor = await extra.getExecutor(resolvedSession);
           const result = await listWorksheets({ executor, signal: extra.signal });
 
           if (result.isErr()) {

--- a/src/tools/desktop/worksheet/applyWorksheet.ts
+++ b/src/tools/desktop/worksheet/applyWorksheet.ts
@@ -9,6 +9,7 @@ import {
   isOverInlineXmlCap,
   xmlByteLength,
 } from '../../../desktop/inlineXmlCap.js';
+import { resolveSession } from '../../../desktop/sessionResolution.js';
 import {
   ArgsValidationError,
   DesktopCommandExecutionError,
@@ -20,7 +21,7 @@ import { DesktopMcpServer } from '../../../server.desktop.js';
 import { DesktopTool } from '../tool.js';
 
 const paramsSchema = {
-  session: z.string().describe('Session ID from list-instances.'),
+  session: z.string().optional().describe('Session ID; optional if pinned or unique.'),
   worksheetName: z.string().describe('Name of the worksheet to update (must already exist).'),
   mode: z
     .enum(['file', 'inline'])
@@ -96,7 +97,12 @@ export const getApplyWorksheetTool = (
             }
           }
 
-          const executor = await extra.getExecutor(session);
+          const sessionResult = resolveSession(session);
+          if (sessionResult.isErr()) {
+            return sessionResult.error.toErr();
+          }
+          const resolvedSession = sessionResult.value;
+          const executor = await extra.getExecutor(resolvedSession);
           const result = await loadWorksheetXml({
             worksheetName,
             xml: worksheetXml,

--- a/src/tools/desktop/worksheet/deleteWorksheet.ts
+++ b/src/tools/desktop/worksheet/deleteWorksheet.ts
@@ -23,6 +23,7 @@ import type {
   ParsedWorkbook,
   ParsedWorksheet,
 } from '../../../desktop/metadata/types.js';
+import { resolveSession } from '../../../desktop/sessionResolution.js';
 import {
   DesktopCommandExecutionError,
   WorkbookXmlLoadFailedError,
@@ -155,7 +156,7 @@ function refusal(
 }
 
 const paramsSchema = {
-  session: z.string().describe('Session ID from list-instances.'),
+  session: z.string().optional().describe('Session ID; optional if pinned or unique.'),
   worksheetName: z.string().min(1).describe('Existing worksheet name to delete.'),
 };
 
@@ -185,7 +186,12 @@ export const getDeleteWorksheetTool = (
         extra,
         args: { session, worksheetName },
         callback: async () => {
-          const executor = await extra.getExecutor(session);
+          const sessionResult = resolveSession(session);
+          if (sessionResult.isErr()) {
+            return sessionResult.error.toErr();
+          }
+          const resolvedSession = sessionResult.value;
+          const executor = await extra.getExecutor(resolvedSession);
 
           // ── Events anchor (pre-read) — the standard gate (bindTemplate.ts /
           // dashboardAutoApply.ts): capture BEFORE the read so the (read, apply]

--- a/src/tools/desktop/worksheet/getWorksheetXml.ts
+++ b/src/tools/desktop/worksheet/getWorksheetXml.ts
@@ -12,6 +12,7 @@ import {
   logInlineXmlCapHit,
   xmlByteLength,
 } from '../../../desktop/inlineXmlCap.js';
+import { resolveSession } from '../../../desktop/sessionResolution.js';
 import {
   DesktopCommandExecutionError,
   GetWorksheetXmlFailedError,
@@ -22,7 +23,7 @@ import { DesktopMcpServer } from '../../../server.desktop.js';
 import { DesktopTool } from '../tool.js';
 
 const paramsSchema = {
-  session: z.string().describe('Session ID from list-instances.'),
+  session: z.string().optional().describe('Session ID; optional if pinned or unique.'),
   worksheetName: z.string().describe('Existing worksheet name.'),
   mode: z
     .enum(['file', 'inline'])
@@ -67,7 +68,12 @@ export const getGetWorksheetXmlTool = (
         extra,
         args: { session, worksheetName, mode },
         callback: async () => {
-          const executor = await extra.getExecutor(session);
+          const sessionResult = resolveSession(session);
+          if (sessionResult.isErr()) {
+            return sessionResult.error.toErr();
+          }
+          const resolvedSession = sessionResult.value;
+          const executor = await extra.getExecutor(resolvedSession);
           const result = await getWorksheetXml({ worksheetName, executor, signal: extra.signal });
 
           if (result.isErr()) {


### PR DESCRIPTION
## What

Pin the desktop MCP to the Tableau Desktop that launched the agent, so the agent connects to the right instance deterministically and never has to call `list-instances`.

## Why

The desktop pid is the join key across all three processes: Desktop writes `<pid>.json` discovery files, and the MCP's session id **is** that pid. The agent launcher runs inside the Desktop process, so it already knows the pid. It now forwards it as `TABLEAU_DESKTOP_SESSION_ID` (via tab-agent-south), and this PR makes the MCP honor it.

```mermaid
flowchart LR
  D[Tableau Desktop] -->|TABLEAU_DESKTOP_SESSION_ID = its pid| TA[tab-agent-south]
  TA -->|env on stdio MCP| MCP[tableau-mcp]
  MCP -->|pins every tool to that pid| D
```

## Changes

- `config.desktop.ts`: read `TABLEAU_DESKTOP_SESSION_ID` into `desktopSessionId` (numeric-pid validated; blank/non-numeric ignored).
- New `desktop/sessionResolution.ts`: shared `resolveSession()` with precedence **explicit arg > pinned config > single-instance auto-resolve > fail closed**. Transport-aware (External Client API vs Agent API). Relocated the old `bindTemplate` resolver here so there is one implementation.
- All 18 session-scoped tools: `session` param is now `.optional()` and resolved centrally, so the agent can omit it.
- When pinned: `list-instances` is **not registered** and the `session-resolution` routing prose is dropped from `DESKTOP_INSTRUCTIONS`.
- Unpinned / multi-Desktop behavior is unchanged.

## Test

- vitest: full suite green (3129 passing). Added tests for the resolver, config, pinned tool-registration, and pinned instructions.
- tsc + eslint clean. Tool-surface byte budget still respected.

Pairs with tab-agent-south MR !25 which sets `TABLEAU_DESKTOP_SESSION_ID` on the MCP subprocess.