### PR TITLE
fix(desktop): derive honest calc caption when formula inputs are rebound (Ben test1)

### DIFF
--- a/lockstep.hashes.json
+++ b/lockstep.hashes.json
@@ -4,5 +4,5 @@
   "src/desktop/binder/escape.ts": "3c79bcf77c33fad64975e95ea57df5fb3e416008633e15dc7a585018fbc92d3f",
   "src/desktop/binder/manifest-types.ts": "9ce310c1e294d3784084b854edf52ef4f7c4cf7a8e13ebba7071dc3957c6114d",
   "src/desktop/binder/manifest-validation.ts": "e29ecfa9e10e57593a4f72e498f35ca8b1b28a1227fc0cb4aed057870566df60",
-  "src/desktop/templates/fieldReferenceRewriter.ts": "16bf6cd00eea6d8dfcde797449ecd9fa8bfa8ff21ad81f87fa06e3f0b2f375a9"
+  "src/desktop/templates/fieldReferenceRewriter.ts": "62c0ed0840d7a5a0cba49a972ce887e9e7f67f2137927b6a92e5507297a92005"
 }

--- a/src/desktop/templates/fieldReferenceRewriter.test.ts
+++ b/src/desktop/templates/fieldReferenceRewriter.test.ts
@@ -239,6 +239,64 @@ describe('rewriteFieldReferences — calc caption rewrite (synthetic; no shipped
   });
 });
 
+describe('rewriteFieldReferences — calc caption derivation when formula inputs are remapped (Ben regression)', () => {
+  // Live defect (Ben, 2026-07-09 test1.twbx): correlation-scatter calc kept its
+  // human caption "Profit Ratio" after its formula was rebound to SUM([Profit])/
+  // SUM([Discount]), creating a second, wrong "Profit Ratio" beside the real one.
+  // Fix: derive an honest caption when the formula field refs change.
+  const xml =
+    '<workbook><worksheets><worksheet><table><view>' +
+    "<datasource-dependencies datasource='{{DATASOURCE}}'>" +
+    "<column caption='Profit Ratio' datatype='real' name='[CalcRatio]' role='measure' type='quantitative'>" +
+    "<calculation class='tableau' formula='SUM([Profit])/SUM([Sales])' />" +
+    '</column>' +
+    "<column datatype='real' name='[Profit]' role='measure' type='quantitative' />" +
+    "<column datatype='real' name='[Sales]' role='measure' type='quantitative' />" +
+    "<column datatype='real' name='[Discount]' role='measure' type='quantitative' />" +
+    '</datasource-dependencies></view></table></worksheet></worksheets></workbook>';
+
+  it('derives an honest caption when the formula inputs are remapped (humanized formula)', () => {
+    // Bind Profit→Profit (identity), Sales→Discount (different) — caption should update.
+    const r = rewriteFieldReferences(
+      xml,
+      { Profit: '[DS].[sum:Profit:qk]', Sales: '[DS].[sum:Discount:qk]' },
+      'DS',
+    );
+    expect(r).toContain('formula="SUM([Profit])/SUM([Discount])"');
+    expect(r).toContain('caption="Profit / Discount"'); // humanized formula (strategy 2)
+    expect(r).not.toContain('caption="Profit Ratio"'); // stale caption is gone
+  });
+
+  it('keeps the original caption when the formula is NOT remapped (identity bind)', () => {
+    const r = rewriteFieldReferences(
+      xml,
+      { Profit: '[DS].[sum:Profit:qk]', Sales: '[DS].[sum:Sales:qk]' },
+      'DS',
+    );
+    expect(r).toContain('caption="Profit Ratio"'); // unchanged
+  });
+
+  it('leaves bracket-bearing captions alone (already handled by step 3b-ii)', () => {
+    const xmlBracket =
+      '<workbook><worksheets><worksheet><table><view>' +
+      "<datasource-dependencies datasource='{{DATASOURCE}}'>" +
+      "<column caption='[Profit]/[Sales]' datatype='real' name='[CalcRatio]' role='measure' type='quantitative'>" +
+      "<calculation class='tableau' formula='SUM([Profit])/SUM([Sales])' />" +
+      '</column>' +
+      "<column datatype='real' name='[Profit]' role='measure' type='quantitative' />" +
+      "<column datatype='real' name='[Sales]' role='measure' type='quantitative' />" +
+      '</datasource-dependencies></view></table></worksheet></worksheets></workbook>';
+    const r = rewriteFieldReferences(
+      xmlBracket,
+      { Profit: '[DS].[sum:Gains:qk]', Sales: '[DS].[sum:Revenue:qk]' },
+      'DS',
+    );
+    // Step 3b-ii handles bracket captions; step 3b (human caption) is skipped.
+    expect(r).toContain('caption="[Gains]/[Revenue]"');
+    expect(r).not.toContain('[Profit]');
+  });
+});
+
 describe('rewriteFieldReferences — per-apply calc namespacing (opt-in, deterministic)', () => {
   // Deviation from A: namespacing defaults OFF and never mints its own nonce; the
   // caller must pass `applyNonce`. This keeps the core pure/deterministic.

--- a/src/desktop/templates/fieldReferenceRewriter.ts
+++ b/src/desktop/templates/fieldReferenceRewriter.ts
@@ -309,13 +309,26 @@ export function rewriteFieldReferences(
     }
   }
 
-  // 3b. Rewrite bare [FieldName] refs inside calc formula bodies.
+  // 3b. Rewrite bare [FieldName] refs inside calc formula bodies. When the
+  //   remap changed the formula and the owning column carries a purely human
+  //   caption (no `[..]` token), the template's caption now misnames the calc
+  //   (and can duplicate an existing datasource caption) — derive an honest one.
   const calcElements = selectElements('//calculation[@formula]', doc);
   for (const calc of calcElements) {
     const formula = calc.getAttribute('formula');
     if (formula) {
       const rewritten = rewriteFormulaFieldRefs(formula, baseTarget);
-      if (rewritten !== formula) calc.setAttribute('formula', rewritten);
+      if (rewritten !== formula) {
+        calc.setAttribute('formula', rewritten);
+        const col = calc.parentNode as Element | null;
+        if (col && col.nodeType === 1 && (col as Element).tagName === 'column') {
+          const caption = (col as Element).getAttribute('caption');
+          if (caption && !caption.includes('[')) {
+            const derived = deriveRemappedCalcCaption(caption, formula, rewritten, baseTarget);
+            if (derived && derived !== caption) (col as Element).setAttribute('caption', derived);
+          }
+        }
+      }
     }
   }
 
@@ -512,6 +525,50 @@ function rewriteFormulaFieldRefs(formula: string, baseTarget: Record<string, str
     const target = baseTarget[innerName];
     return target ? `[${target}]` : whole;
   });
+}
+
+/**
+ * Derive an honest caption for a calc column whose FORMULA field refs were
+ * remapped to different base fields while its human caption still names the
+ * template's original fields. Live defect (Ben, 2026-07-09 test1.twbx): the
+ * correlation-scatter calc kept caption "Profit Ratio" after its formula was
+ * rebound to SUM([Profit])/SUM([Discount]) — a second, wrong "Profit Ratio"
+ * beside the datasource's real one. Strategy, first hit wins:
+ *   1. whole-word-replace remapped old field names inside the caption;
+ *   2. humanize the rewritten formula (AGG([X]) → X) when the result is a
+ *      short, plain field expression;
+ *   3. append the distinct new field names to the original caption.
+ * Returns null when nothing was remapped (identity binds keep their caption).
+ */
+function deriveRemappedCalcCaption(
+  caption: string,
+  originalFormula: string,
+  rewrittenFormula: string,
+  baseTarget: Record<string, string>,
+): string | null {
+  const changedPairs = new Map<string, string>();
+  for (const m of originalFormula.matchAll(/\[([^\]]+)\]/g)) {
+    const target = baseTarget[m[1]];
+    if (target && target !== m[1]) changedPairs.set(m[1], target);
+  }
+  if (changedPairs.size === 0) return null;
+
+  let replaced = caption;
+  for (const [oldName, newName] of changedPairs) {
+    const escaped = oldName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    replaced = replaced.replace(new RegExp(`\\b${escaped}\\b`, 'g'), newName);
+  }
+  if (replaced !== caption) return replaced;
+
+  const humanized = rewrittenFormula
+    .replace(/\b(?:SUM|AVG|MIN|MAX|MEDIAN|ATTR|COUNTD|COUNT|STDEVP|STDEV|VARP|VAR)\s*\(\s*\[([^\]]+)\]\s*\)/gi, '$1')
+    .replace(/\[([^\]]+)\]/g, '$1')
+    .replace(/\s*([+\-*/])\s*/g, ' $1 ')
+    .replace(/\s+/g, ' ')
+    .trim();
+  if (!/[[\]()]/.test(humanized) && humanized.length <= 60) return humanized;
+
+  return `${caption} (${Array.from(new Set(changedPairs.values())).join(', ')})`;
 }
 
 /**


### PR DESCRIPTION
## Summary

Port of a2td fix (Ben test1 regression, 2026-07-09): when a template calc's formula field-refs are remapped during apply and the owning column has a purely human caption (no brackets), the template's caption now misnames the calc and can duplicate an existing datasource caption.

**Live defect:** correlation-scatter calc kept "Profit Ratio" after rebinding its formula from `SUM([Profit])/SUM([Sales])` to `SUM([Profit])/SUM([Discount])`, creating a second, wrong "Profit Ratio" beside the real one.

**Fix:** adds `deriveRemappedCalcCaption` function (strategies: whole-word replace, humanize formula, or append new field names) and calls it from step 3b when a calc formula is rewritten.

This is the shipping copy (tableau-mcp `feature/authoring` branch) of the already-validated a2td fix (commit 9fb0585 on `claude/wave32`).

## Changes

- **`src/desktop/templates/fieldReferenceRewriter.ts`**: Add `deriveRemappedCalcCaption` function and call it from step 3b when a calc formula is rewritten
- **`src/desktop/templates/fieldReferenceRewriter.test.ts`**: Add Ben regression test suite (3 test cases)
- **`lockstep.hashes.json`**: Update hash for `fieldReferenceRewriter.ts`

## Test plan

- ✅ Build passes (`npm run build`)
- ✅ Lockstep check passes (`node scripts/check-lockstep.mjs`)
- ✅ All 27 rewriter tests pass (including 3 new Ben regression tests)
- ✅ New test covers: honest caption derivation when formula inputs change, identity bind keeps original caption, bracket captions left alone

## Validation summary

**What I validated:**
- TypeScript build compiles cleanly
- Lockstep hash mechanism correctly updated
- All existing tests continue to pass
- New regression test validates the fix (humanized formula caption: `Profit / Discount`)

**Residual risk:**
- Calc caption derivation strategies are heuristic (whole-word replace → humanize → append); edge cases with unusual field names or formulas may produce suboptimal captions (but never stale/wrong ones)

🤖 Generated with [Claude Code](https://claude.com/claude-code)