### PR TITLE
desktop: a2td parity resync — Ben Hart knowledge, symbol-map-latlon, 22 manifest stamps

### DIFF
--- a/resources/desktop/knowledge/_index.md
+++ b/resources/desktop/knowledge/_index.md
@@ -83,6 +83,7 @@ Entries show the tactics slug and, where one exists, its strategy companion.
 - Reviewing a dashboard before publishing (checklist) → `strategy/dashboard-design/dashboard-peer-review-checklist`
 
 ### "I'm choosing an approach / scoping the request"
+- Verify assumptions with a throwaway diagnostic view before committing to a design → `strategy/workflow/diagnostic-view-loop`
 - Native vs Exchange vs build a custom viz → `personalization/choosing-a-custom-viz-solution`
 - Discovery / alignment before building → `personalization/discovery-first-authoring`
 - Validate data availability & quality before building → `personalization/validate-data-before-building`

--- a/resources/desktop/knowledge/personalization/discovery-first-authoring.md
+++ b/resources/desktop/knowledge/personalization/discovery-first-authoring.md
@@ -59,7 +59,7 @@ Offer this instead:
 
 The discovery-first preamble for a non-trivial build-a-viz request:
 
-1. **Bootstrap:** `tableau-list-instances` -> capture `_session`.
+1. **Bootstrap:** if `tableau-list-instances` is absent from the tool list, the session is pinned to the launching Desktop; skip discovery because session-scoped tools already target it. Otherwise, call `tableau-list-instances` -> capture `_session`.
 2. **Inventory cheap-first (budget 2-4 calls):** `tableau-list-available-fields` -> `tableau-list-worksheets` -> `tableau-list-dashboards`. Use `tableau-get-workbook` (mode=file) or `tableau-save-metadata-xml` only if you need exact XML/encodings.
 3. **Align:** restate the goal in one line; name the available fields/sheets; flag any mismatch (missing field, high cardinality, wrong grain); choose the authoring surface.
 4. **Clarify (bounded):** ask at most 1-2 `tableau-ask-user` questions, and only when a mismatch blocks safe building; otherwise proceed and state your assumptions.

--- a/resources/desktop/knowledge/strategy/workflow/diagnostic-view-loop.md
+++ b/resources/desktop/knowledge/strategy/workflow/diagnostic-view-loop.md
@@ -1,0 +1,91 @@
+# Diagnostic View Loop: Test Data Assumptions Before Committing to a Viz
+
+SE knowledge entry for field-observed authoring behavior that should guide BI agents when a user challenges a recommendation or the agent realizes it is relying on an untested data assumption.
+
+## Scope Check
+
+- Primary audience: Tableau user / SE assisting a Tableau user
+- Authoring outcome improved: validate, create, improve
+- In-scope reason: Helps an agent turn a challenged recommendation or implicit assumption into a small, evidence-backed diagnostic view before committing to a final visualization design.
+- Out-of-scope risk: none
+- Tags: diagnostic view, assumption testing, hypothesis check, data validation, exploratory analysis, evidence-backed recommendation, throwaway sheet, iterative authoring, replace weak viz, user challenge
+- Expected agent behavior: When the user questions the agent's recommendation or the agent notices it has made an implicit assumption, the agent should acknowledge the assumption, build the smallest diagnostic view that can test it against the real data, state the result, and use that evidence to improve or replace the proposed visualization.
+- Relevant user prompts/search terms: "why did you choose that chart", "are you assuming this field behaves that way", "prove that recommendation", "check the data before building", "test your assumption", "that chart does not seem right", "can you verify this pattern", "build a diagnostic view first", "replace this weak viz with a better one"
+- Safe refusal condition: Do not present the diagnostic finding as proof if the available data cannot test the hypothesis, the sample is too small, or the relevant fields are missing; explain the limitation and ask whether to proceed with a caveated design or pause for better data.
+
+## When to Use
+
+Use this guidance when a user challenges the agent's recommendation, asks why the agent chose a chart or analytic approach, or points out that the recommendation may be based on an assumption about the data.
+
+Also use it when the agent catches itself relying on an unverified assumption, such as "the categories are balanced enough for this comparison," "this measure varies by segment," "the relationship is roughly linear," "the top performers are stable over time," or "this existing view is the best way to show the pattern."
+
+This is not a replacement for normal discovery-first authoring. It is a short loop inside an authoring session: acknowledge the uncertainty, create a small diagnostic view, read the data signal, then either proceed, revise, or replace the weaker visualization.
+
+## Best Practices
+
+- Acknowledge the assumption plainly. If the user questions the recommendation, do not defend the original answer reflexively. Say what assumption the recommendation depended on and that you will test it against the actual data.
+- Build the smallest diagnostic view that can answer the question. Prefer a throwaway worksheet, table, histogram, scatterplot, box plot, small multiple, or simple ranked bar over a polished dashboard.
+- Name the diagnostic view clearly while working, using labels such as `DIAGNOSTIC - Segment Distribution` or `DIAGNOSTIC - Trend by Region`, so it is not mistaken for final deliverable content.
+- Test one hypothesis at a time. The view should answer a specific question: "Is the distribution skewed?", "Does the relationship hold within each segment?", "Are the top categories stable?", or "Is this aggregate hiding subgroup differences?"
+- Read the result back before building. State what the diagnostic view proved, disproved, or failed to determine. Then connect that result to the design decision.
+- Use the diagnostic finding to improve the workbook, not just to justify the original recommendation. If the evidence shows the original view is weaker, replace it with the better view.
+- Remove, hide, or clearly separate diagnostic sheets before final delivery unless the user wants to keep them as an audit trail or exploratory appendix.
+- Keep the loop short. A diagnostic view is a decision aid, not a second dashboard project.
+
+### When to Say No
+
+Say no to treating a diagnostic view as conclusive when the data cannot support the test.
+
+Recommended wording:
+
+> I can test that assumption with a quick diagnostic view, but the current data does not contain the field or grain needed to prove it. I can either build a caveated version using the closest available evidence, or we can pause until the right data is available.
+
+Offer this instead:
+
+- A caveated recommendation that states the untested assumption.
+- A narrower diagnostic test using fields that do exist.
+- A request for the missing field, grain, or time period needed to verify the hypothesis.
+
+## Common Mistakes
+
+- Defending the first recommendation instead of testing it. A user challenge is often a signal that the agent made an implicit assumption the user can see.
+- Building a polished replacement before diagnosing the issue. Without the diagnostic step, the agent may simply swap one unsupported design for another.
+- Making the diagnostic view too broad. A throwaway sheet should answer one question quickly, not explore every possible slice.
+- Forgetting to use the result. The loop is only valuable if the diagnostic finding changes or confirms the final design decision.
+- Leaving diagnostic sheets in the final workbook without explanation. They can confuse users if they look like unfinished deliverables.
+- Treating exploratory findings as final proof. A diagnostic view can validate whether a design is appropriate for the current workbook, but it does not automatically establish causality or long-term stability.
+
+## Implementation
+
+1. **Notice the challenge or assumption.** Trigger the loop when the user questions a recommendation, when the agent says or implies "this probably," or when the proposed design depends on a data shape that has not been checked.
+2. **State the hypothesis.** Convert the assumption into a testable sentence: "I assumed sales concentration is high enough that a Top-N view will be useful."
+3. **Create a small diagnostic view.** Use the simplest worksheet or exploratory view that can test the hypothesis against the actual data.
+4. **Read the result.** Summarize what the view shows in plain language, including uncertainty or limitations.
+5. **Decide.** Keep the original design if the hypothesis holds, revise it if the evidence points elsewhere, or pause if the hypothesis cannot be tested.
+6. **Replace weak output when needed.** If an existing visualization is less informative than the evidence-backed alternative, replace it rather than leaving both as competing answers.
+7. **Clean up.** Remove, hide, or label the diagnostic sheet according to whether the user wants an audit trail.
+
+### Worked Example
+
+**Hypothesis:** The agent recommends a ranked bar chart of product categories because it assumes a few categories dominate revenue. The user asks, "Are you sure this should be a Top-N chart? What if revenue is evenly spread?"
+
+**Diagnostic sheet:** The agent creates `DIAGNOSTIC - Revenue Concentration`, a simple sorted bar chart of revenue by product category with percent of total in the label or tooltip. It checks whether the top categories account for a large share of total revenue and whether there is a meaningful drop-off.
+
+**Decision:** The diagnostic view shows revenue is not concentrated: the top category is only slightly above the next several categories, and the long tail still contributes materially. The agent states that the Top-N assumption was weak, then replaces the original Top-N chart with a distribution-focused view, such as a full sorted bar chart grouped by category family or a treemap only if the user needs part-to-whole scanning. The final explanation says the design changed because the real data showed broad contribution rather than a dominant few categories.
+
+## Related Knowledge
+
+- Extends [Discovery-First Authoring: Inventory and Align Before You Build](data/knowledge/personalization/discovery-first-authoring.md): this entry covers the in-session loop to test a specific assumption after discovery or after a user challenge.
+- Related to [Validate Data Availability and Quality Before Building a Dashboard](data/knowledge/personalization/validate-data-before-building.md): both entries prevent unsupported builds; this one focuses on fast, throwaway diagnostic views used to verify design assumptions.
+- Related to [Chart Type Selection](data/knowledge/strategy/viz-design/chart-selection.md): diagnostic views help stress-test whether the selected chart type matches the actual data shape.
+
+## Source and Confidence
+
+- Source/evidence type: live SE session
+- Source: Ben Hart, live session, 2026-07-09
+- Customer-identifying details removed: yes
+- Confidence: field-observed
+- Last reviewed: 2026-07-09
+```
+```markdown
+- Verify assumptions with a throwaway diagnostic view before committing to a design → `strategy/workflow/diagnostic-view-loop`

--- a/resources/desktop/knowledge/tactics/data/calc-caption-follows-formula-rebind.md
+++ b/resources/desktop/knowledge/tactics/data/calc-caption-follows-formula-rebind.md
@@ -1,0 +1,77 @@
+# Calc Caption Must Follow a Formula Rebind → a Human Caption Left Untouched Becomes a Lie
+
+When a template calc's FORMULA field-refs are remapped during apply (template field → the user's actual bound field), the calc's **human-readable `caption` must be updated too** — otherwise the caption keeps naming the OLD fields while the formula now computes over the NEW ones. The apply "completes," the math is correct, but the label lies. Two calcs can even end up with the **same caption and different formulas**.
+
+## Scope Check
+
+- Primary audience: Tableau agent / SE authoring XML
+- Authoring outcome improved: create, troubleshoot
+- In-scope reason: A calc column carries both a `<calculation formula>` and a human `caption`. When field-reference rewriting remaps the formula's inputs to different bound fields, a caption with no bracket token is left verbatim by the auto-name path, so the visible name no longer matches the math. Root-caused live from a Ben Hart dogfood repro (2026-07-10).
+- Out-of-scope risk: none
+- Tags: calculated-field, calc-caption, caption-stale, formula-rebind, field-ref-rewrite, misleading-label, duplicate-caption, profit-ratio, template-apply, correlation-scatter, heatmap, per-apply-namespacing, honest-caption
+- Relevant user prompts/search terms: "two fields with the same name but different formulas", "the heatmap color and text are different calculations both called the same thing", "calc caption says Profit Ratio but the formula divides by Discount", "template calc label is wrong after binding to my data", "why do I have two Profit Ratio fields", "the calculated field name doesn't match its formula after apply", "caption not updated when formula rebound"
+
+## When to Use
+
+Reach for this when a template applies onto the user's data and the calc **renders with correct math but a misleading name** — most visibly, two calcs sharing one caption with divergent formulas (the Ben Hart *Profit Ratio* repro: one calc `SUM([Profit])/SUM([Sales])`, another `SUM([Profit])/SUM([Discount])`, both captioned `Profit Ratio`, one on the heatmap color and one on its text).
+
+Distinguish from the two shadow variants:
+
+- **Formula is DROPPED, stale one kept** (calc-name == existing calc) → renders, wrong math → `calc-formula-shadowed-by-stale-datasource-calc.md`.
+- **Calc IGNORED entirely** (calc-name == real data column) → blank viz → `calc-name-collides-with-field.md`.
+- **This entry** → formula is CORRECT (field-refs were rebound as intended) but the **caption** was left naming the pre-rebind fields → misleading label, not wrong numbers.
+
+The tell that separates this from the shadow variants: the math is right; only the human name is wrong.
+
+## Best Practices
+
+1. **When a formula's field-refs are remapped, re-derive the caption in lockstep** — but ONLY for captions that are safe to rewrite. Skip captions that already carry a `[` bracket token (those are handled by the auto-name caption path); act on bracket-free human captions like `Profit Ratio`.
+2. **Derive honestly, in priority order:** (a) whole-word-replace the old field names with the new inside the existing caption (`Profit / Sales` → `Profit / Discount`); else (b) humanize the rewritten formula if it's short and plain (strip `AGG([X])`→`X`, drop brackets, space operators) — `SUM([Profit])/SUM([Discount])` → `Profit / Discount`; else (c) append the distinct new field names in parens to the original caption (`Profit Ratio (Discount)`) rather than fabricate a name.
+3. **Identity binds keep their caption.** If nothing was remapped (the template field bound to the same-named field), leave the caption verbatim — do not churn it.
+4. **This REFINES the "keep captions human-readable" rule** from `calc-formula-shadowed-by-stale-datasource-calc.md`. Per-apply NAME namespacing (the `_tpl_<hash>` suffix) still must not touch the caption. But that rule assumed the formula's meaning was unchanged. A formula *rebind* changes the meaning, so the caption is no longer a safe human constant — it must track the rebind.
+
+## Common Mistakes
+
+1. **Leaving a bracket-free caption verbatim after a rebind.** `caption='Profit Ratio'` on a template calc whose formula was `SUM([Profit])/SUM([Sales])` and got rebound to `SUM([Profit])/SUM([Discount])`. The apply completes; the field now measures profit-over-discount but still reads "Profit Ratio". On a chart that uses the template's original calc AND the rebound one (heatmap color vs. text), you get two "Profit Ratio" fields with different math — "not something I'd call correct, but within the normal range of wrong" (Ben Hart, 2026-07-10).
+2. **Over-rewriting the caption on an identity bind.** If Sales bound to Sales, do not touch `Profit Ratio` — deriving a caption when nothing changed just churns labels.
+3. **Rewriting a caption that already contains `[` brackets here.** Those are auto-named captions that mirror formula syntax; they're owned by the separate bracket-caption path. Touching them from the rebind path double-rewrites.
+
+## Implementation in Tableau Desktop
+
+WRONG — formula rebound, caption left stale (produces the duplicate-name defect):
+
+```xml
+<!-- template calc, before apply: -->
+<column caption='Profit Ratio' name='[Calculation_l]' role='measure' type='quantitative'>
+  <calculation class='tableau' formula='SUM([Profit])/SUM([Sales])' />
+</column>
+<!-- user binds Sales -> Discount. Formula field-refs are remapped correctly,
+     but the caption is left verbatim: -->
+<column caption='Profit Ratio' name='[Calculation_l]' role='measure' type='quantitative'>
+  <calculation class='tableau' formula='SUM([Profit])/SUM([Discount])' />
+</column>
+<!-- → correct math, misleading label. Alongside the template's original
+     Profit Ratio, the data pane / heatmap now shows two 'Profit Ratio' calcs. -->
+```
+
+RIGHT — caption tracks the rebind:
+
+```xml
+<column caption='Profit / Discount' name='[Calculation_l]' role='measure' type='quantitative'>
+  <calculation class='tableau' formula='SUM([Profit])/SUM([Discount])' />
+</column>
+<!-- caption derived: humanized rewritten formula 'Profit / Discount' (short, plain).
+     Had the original caption been e.g. 'Profit / Sales', whole-word replace would
+     yield 'Profit / Discount' directly. On an identity bind, caption stays verbatim. -->
+```
+
+The substitution layer does this automatically: in `replaceFieldReferences` (`src/lockstep-core/fieldReferenceRewriter.ts`, step "3b"), after `rewriteFormulaFieldRefs` changes a `<calculation formula>`, `deriveRemappedCalcCaption` recomputes the owning column's `caption` when it has no `[` token, via the three-tier derivation above; it returns `null` (no change) when nothing was remapped. This runs before the pre-existing bracket-caption path ("3b-ii"), which only touches `[..]`-bearing captions — the two are non-overlapping. Confirmed against the `correlation-scatter-plot-chart.xml` template (regression: `src/server/tools/templates.test.ts`, "calc caption follows formula rebind (Ben test1 regression)").
+
+**What does NOT work / residual gap:** an identity bind onto a datasource that ALREADY carries an equivalent calc still produces a harmless duplicate caption — correct math, confusing label — because per-apply namespacing always mints a fresh `_tpl_` calc instead of detecting and reusing an existing equivalent one. That's a deliberate post-MVP deferral (it conflicts with the anti-shadow rename's purpose and needs formula-equivalence detection), not covered by this fix.
+
+## Related Knowledge
+
+- `tactics/data/calc-formula-shadowed-by-stale-datasource-calc.md` — the per-apply NAME-namespacing sibling; its "keep captions human-readable" best practice is refined by THIS entry for the rebind case.
+- `tactics/data/calc-name-collides-with-field.md` — calc name == data column → blank viz.
+- `tactics/data/calc-fields.md` — calc / parameter XML structure; formulas reference internal names, the UI displays captions.
+- `tactics/workflow/templates.md` — template injection workflow.

--- a/resources/desktop/knowledge/tactics/data/calc-formula-shadowed-by-stale-datasource-calc.md
+++ b/resources/desktop/knowledge/tactics/data/calc-formula-shadowed-by-stale-datasource-calc.md
@@ -25,7 +25,7 @@ Both are silent: the apply returns "completed"; only the render (or a diagnostic
 ## Best Practices
 
 1. **Namespace template-internal calc names per apply.** When injecting a template, rename the template's OWN calc columns to per-apply-unique names (e.g. `Calculation_GanttSize` → `Calculation_GanttSize_tpl_<shorthash>`) consistently across the column definition, its column-instances, encodings, and any formula that references it. A stale same-named datasource calc then cannot capture the reference. This is default-on in the injector (see Implementation).
-2. **Keep captions human-readable.** Namespace only the internal `name` token; leave `caption` (what the user sees) untouched so pills stay legible.
+2. **Keep captions human-readable — but track a formula REBIND.** Per-apply NAME namespacing (the `_tpl_` suffix) touches only the internal `name` token; leave `caption` alone so pills stay legible. **Exception:** if the same apply also *rebinds* the formula's field-refs to different bound fields, a bracket-free caption then misnames the calc and must be re-derived — see `calc-caption-follows-formula-rebind.md`.
 3. **Never rename dataset-bound fields.** Only the template's derived calc columns get suffixed; mapped data fields keep their names.
 4. **Verify the render, not the status.** A "completed" apply with wrong numbers is the signature — inspect a text table of the calc, or capture the viz, before trusting a fast-path apply onto a reused datasource.
 
@@ -68,6 +68,7 @@ The substitution layer does this automatically: `replaceFieldReferences` (`src/s
 ## Related Knowledge
 
 - `tactics/data/calc-name-collides-with-field.md` — the sibling **field-collision** variant (calc name == a real data column → the calc is IGNORED → blank viz). This entry is the **calc-vs-calc** variant (stale formula kept → wrong result).
+- `tactics/data/calc-caption-follows-formula-rebind.md` — the **caption** counterpart: when a formula rebind is correct but the human caption is left stale (misleading label, right math). Refines this entry's "keep captions human-readable" rule.
 - `tactics/data/calc-fields.md` — calculated-field / parameter XML structure.
 - `tactics/data/round-trip-normalization.md` — what Tableau rewrites/drops on load.
 - `tactics/workflow/templates.md` — template injection workflow.

--- a/resources/desktop/knowledge/tactics/workflow/recovery.md
+++ b/resources/desktop/knowledge/tactics/workflow/recovery.md
@@ -89,8 +89,9 @@ Switching to any worksheet triggers a full view-context evaluation that complete
 If Tableau Desktop is stuck (commands time out, dialogs can't be dismissed, or the workbook is corrupted):
 1. Save the most recent working snapshot to a `.twb` file in a known location
 2. Use `execute_tableau_command` with `tabui:open-workbook` on the backup file, OR ask the user to open it manually
-3. After the new instance is running, call `tableau-list-instances` to discover its session ID
-4. Switch to the new session and continue work
+3. If `tableau-list-instances` is absent from the tool list, the session is pinned to the launching Desktop; open the backup in that Desktop, or restart the MCP session against the fresh Desktop
+4. Otherwise, after the new instance is running, call `tableau-list-instances` to discover its session ID
+5. Switch to the new session and continue work
 
 ## Common Mistakes
 

--- a/src/desktop/binder/manifest-validation.test.ts
+++ b/src/desktop/binder/manifest-validation.test.ts
@@ -55,7 +55,7 @@ describe('binder/manifest-validation — pure module surface', () => {
 describe('binder/manifest-validation — superset is backward-compatible with the bundled manifests', () => {
   const bundled = readBundledManifestFiles();
 
-  it('there are 41 bundled manifests to check', () => {
+  it('there are 42 bundled manifests to check', () => {
     // W26-B re-snapshot: the shipped supply was resynced to the factory's full 39-template
     // set (17 → 39; +22 new manifests copied verbatim, trust fields unchanged).
     // W28-D true byte-for-byte mirror: the remaining stale factory manifests were resynced
@@ -64,9 +64,12 @@ describe('binder/manifest-validation — superset is backward-compatible with th
     // W59 template-sync: the seven missing fast-path XMLs ported from the factory with
     // manifests copied verbatim (six overwrote stale copies; ww-ou-arrow's manifest was
     // net-new), taking the count 40 → 41.
+    // parity-port: the factory's spatial-symbol-map-latlon (render_verified 'none',
+    // fast_path_eligible false) was the last missing template manifest; its XML + manifest
+    // were ported verbatim, taking the count 41 → 42.
     // Pinned in lockstep with the on-disk count so a silent add/drop of a bundled manifest
     // fails here.
-    expect(bundled.length).toBe(41);
+    expect(bundled.length).toBe(42);
   });
 
   it('every bundled manifest validates through the new types’ validator (no errors)', () => {

--- a/src/desktop/data/content-manifest.json
+++ b/src/desktop/data/content-manifest.json
@@ -206,6 +206,11 @@
       "bytes": 3355
     },
     {
+      "path": "data-visualization-templates-xml/spatial-symbol-map-latlon.xml",
+      "sha256": "954fdf3343d0231c1dd8837a938b2193e123627c01aacbac01b7f26c7427db52",
+      "bytes": 2828
+    },
+    {
       "path": "data-visualization-templates-xml/spatial-symbol-map.xml",
       "sha256": "0e10814f07d32b7c4c1a9113f0b6d2db9e62119316d39630db43a3415fd424d0",
       "bytes": 2852
@@ -237,23 +242,23 @@
     },
     {
       "path": "template-manifests.index.json",
-      "sha256": "88d48e47f756af9f15906c4cffddaab18febe97fe6836defe75e86822c403593",
-      "bytes": 230883
+      "sha256": "cb9726caa03efca21f396c74ece9af7942135e09a16513bf2e94b15c1f4bfa46",
+      "bytes": 246333
     },
     {
       "path": "template-manifests/box-plot-chart.manifest.json",
-      "sha256": "e3cb287a383b13b2e413c4a2dd61dcde703a7abbf6d86627a772f17e6b3a4928",
-      "bytes": 7523
+      "sha256": "a9c331defeb1acfb11a48bed01692a8cdcbfa3fa9b9e8b51c632a58d4830fea5",
+      "bytes": 7607
     },
     {
       "path": "template-manifests/bullet-variance-chart.manifest.json",
-      "sha256": "64098d8739656b5751cbc63591967ec19a07f16ad2272f8a818502e14038ae53",
-      "bytes": 5412
+      "sha256": "d2b14571e8948be28a75dd71bbd05fe58be39b283da0f8c55a3a2a9fd728314d",
+      "bytes": 6064
     },
     {
       "path": "template-manifests/change-over-time-area-chart.manifest.json",
-      "sha256": "c9556b196500c5e0fecbffffdca5a152034682398bd7a790e10fa6655c4431f2",
-      "bytes": 1856
+      "sha256": "a755116c3b56367f97f976591c987230799408ead7bf5458f59e99eb8201fae5",
+      "bytes": 2576
     },
     {
       "path": "template-manifests/change-over-time-calendar-heatmap.manifest.json",
@@ -262,8 +267,8 @@
     },
     {
       "path": "template-manifests/change-over-time-stacked-area-chart.manifest.json",
-      "sha256": "4edcd16aac3ab8c3fe39284c7456a188e74d90506e29e4148f1312a24d19d3ce",
-      "bytes": 1775
+      "sha256": "b9cb54ca189b63993cfeeec311a40321728877d7539c81d54b04e158084af11d",
+      "bytes": 2516
     },
     {
       "path": "template-manifests/connected-scatterplot.manifest.json",
@@ -287,18 +292,18 @@
     },
     {
       "path": "template-manifests/correlation-highlight-table.manifest.json",
-      "sha256": "fb0afcc6fecb727f92044e7a1ed4f3afac9d7e34a50c7bb4792ee30ed464f996",
-      "bytes": 5811
+      "sha256": "a02b8a92f328569ac59102d06d004f6bf9072fd27ad3a617a22fc0e81a966510",
+      "bytes": 6669
     },
     {
       "path": "template-manifests/correlation-scatter-plot-chart.manifest.json",
-      "sha256": "5d679334b17903a5a1099cfcd0f31de232dff5ef72fe754bdedab532bb07a533",
-      "bytes": 4687
+      "sha256": "516262563717665ed80cb52d3f87331cbb78a18561c7acfa17c8c46a3a767fb9",
+      "bytes": 4773
     },
     {
       "path": "template-manifests/deviation-diverging-bar.manifest.json",
-      "sha256": "2e369ac51bcca9d1a96d6efd014578f561f77edaa47e5198b050ba075434cac8",
-      "bytes": 4749
+      "sha256": "66116aa3eb4bcb096fd93215bcd092d065ea2dd2bba9d0d88189b7e61169654f",
+      "bytes": 5490
     },
     {
       "path": "template-manifests/deviation-gain-loss-chart.manifest.json",
@@ -312,18 +317,18 @@
     },
     {
       "path": "template-manifests/distribution-bar-code-chart.manifest.json",
-      "sha256": "74b8123718ed76649f6991363eb96a9358b11591d046fe33ba76a0f518df8df3",
-      "bytes": 2948
+      "sha256": "d561f42bee77294615a1611edebff6890a9729b62135545f597c576b6f4001b0",
+      "bytes": 3034
     },
     {
       "path": "template-manifests/distribution-histogram.manifest.json",
-      "sha256": "c5e177d839219b67d03f013352fb18b765301b29553079398bf33bb2d24be4d6",
-      "bytes": 5445
+      "sha256": "04992d8f0fe60659fef4e5a3a8e6238c327394d28945f24eaf6a1370c99b2b97",
+      "bytes": 8457
     },
     {
       "path": "template-manifests/funnel-chart.manifest.json",
-      "sha256": "91b1bdfd520bab734cee8bb2892eda2002a9fd0028cf7f478e3580e83179723d",
-      "bytes": 7168
+      "sha256": "faaf1caf7205609768c04706f80ffecbbd623608e41a8a96f0585f479b5cb75e",
+      "bytes": 7252
     },
     {
       "path": "template-manifests/gantt-chart.manifest.json",
@@ -332,8 +337,8 @@
     },
     {
       "path": "template-manifests/gantt-task-rollup-chart.manifest.json",
-      "sha256": "b61291596e313728c0862b681505c9fba5ea6d5bb9736643bccd53ae050aea9f",
-      "bytes": 9109
+      "sha256": "83bb5437f0a7e0e5439b43ee73b7468dad8a1ce096b0f70e9af3157b6081811e",
+      "bytes": 9193
     },
     {
       "path": "template-manifests/gantt-timeline-chart.manifest.json",
@@ -342,18 +347,18 @@
     },
     {
       "path": "template-manifests/kpi-text.manifest.json",
-      "sha256": "977064a88359563476fe43afcaa15466687b89daa280cfc20587636f985a053c",
-      "bytes": 1980
+      "sha256": "f2ffe3f48162928c8070fd730d30aacedda002942a6d5503b8cb751af845d1a7",
+      "bytes": 2066
     },
     {
       "path": "template-manifests/magnitude-paired-bar.manifest.json",
-      "sha256": "922ca8545ceacbaf28f1fd0efc22bece3f5e52401bdf903d85471ac2fa0c23e3",
-      "bytes": 3424
+      "sha256": "01e2a407c64a3dabc74aea591de9d7237f8f87de3d7449b18d1e2219e5a5af1b",
+      "bytes": 4329
     },
     {
       "path": "template-manifests/magnitude-paired-column-chart.manifest.json",
-      "sha256": "5d40aff2e959c014e71f303c2f4d09d1a71eea19b7b85b8bc7f7eca66de45c4e",
-      "bytes": 3206
+      "sha256": "d9c21398452b228bc31f7aa75c5dc0a18bac0366756be71c0eb12f554b9999b0",
+      "bytes": 4120
     },
     {
       "path": "template-manifests/pareto-chart.manifest.json",
@@ -362,8 +367,8 @@
     },
     {
       "path": "template-manifests/part-to-whole-pie-chart.manifest.json",
-      "sha256": "e611193d1eec140c576879eab88ac9529c52a866f9fda394ec46d7f113ecdb6e",
-      "bytes": 1950
+      "sha256": "6d527ce9ea6d642d59d7589f9a7a9ac0d82efc71ed00615ead6d345d7b94214e",
+      "bytes": 2028
     },
     {
       "path": "template-manifests/part-to-whole-proportional-stacked-bar.manifest.json",
@@ -372,13 +377,13 @@
     },
     {
       "path": "template-manifests/part-to-whole-stacked-bar-chart.manifest.json",
-      "sha256": "c36cf53dc9f8f1cdbb2bf56565c9abce9cfa1dac154942e5a187771409b96b47",
-      "bytes": 2838
+      "sha256": "2e1468976ce56baf6c77417ca3c54a2d725847004e5dfda7fe6e6b4328732227",
+      "bytes": 2924
     },
     {
       "path": "template-manifests/part-to-whole-treemap-chart.manifest.json",
-      "sha256": "c954e6c491fc64cf3fb081db700a12df037ed80bc45c0a39ebcbafad252d0987",
-      "bytes": 2273
+      "sha256": "7a34cfc40ff51d5f16d5b784bb004fb3084934605fd37f0c989a42eac08041a0",
+      "bytes": 2359
     },
     {
       "path": "template-manifests/part-to-whole-waterfall.manifest.json",
@@ -387,8 +392,8 @@
     },
     {
       "path": "template-manifests/quota-attainment-bullet.manifest.json",
-      "sha256": "d440645c62d86ab3f990923f28228d13ebee73d65a78dd4a0ea00d6f105f299c",
-      "bytes": 7700
+      "sha256": "fd790c8d6fdf2b3747e3da9d07be119f60369ce33d4e813204e72c6f258be18b",
+      "bytes": 7784
     },
     {
       "path": "template-manifests/ranking-bump-chart.manifest.json",
@@ -402,13 +407,13 @@
     },
     {
       "path": "template-manifests/ranking-ordered-bar.manifest.json",
-      "sha256": "ba1931651c6fa8f9871eba46af855d14a656e40671266c2f499aef05b2be7bb8",
-      "bytes": 3214
+      "sha256": "bf80efd2313e097d268758a6dcb0d4c3e82502c812ecbd3b4d538de133ac19d8",
+      "bytes": 3300
     },
     {
       "path": "template-manifests/ranking-ordered-column.manifest.json",
-      "sha256": "fd2ba0fa6ccf940b2e9878280c251723a8ae0c879889b355bed1b9d915b195ba",
-      "bytes": 1828
+      "sha256": "94c3b50eb80c294ea8d0c1046e3d09cb95570c34891cfd9b0459c8aef928ee27",
+      "bytes": 1914
     },
     {
       "path": "template-manifests/slope-chart.manifest.json",
@@ -421,14 +426,19 @@
       "bytes": 5913
     },
     {
+      "path": "template-manifests/spatial-symbol-map-latlon.manifest.json",
+      "sha256": "ea10b86fa91acd95f2d2decef3b1da46684028c3ebe203a82dd7360a7c1b2fb6",
+      "bytes": 3513
+    },
+    {
       "path": "template-manifests/spatial-symbol-map.manifest.json",
       "sha256": "21276c67b45d5a515a91ea061fe3654b6153e3f10f5bae809c7274e6fd3e0ee9",
       "bytes": 2763
     },
     {
       "path": "template-manifests/trend-line-chart.manifest.json",
-      "sha256": "a3f76e50ba83cc1a85656149de632bf29ec17b14b0eed601f70effabf050f6eb",
-      "bytes": 3908
+      "sha256": "5fc22f9bcb36191730a41da9eff272de748c59a014d07c80459bf68aa765451b",
+      "bytes": 5182
     },
     {
       "path": "template-manifests/ww-floating-bars.manifest.json",
@@ -437,8 +447,8 @@
     },
     {
       "path": "template-manifests/ww-ou-arrow.manifest.json",
-      "sha256": "4f391a1799e81713daf8d3e9c3c7ce28ef775ffaf33c0e8120ce3c171c29457a",
-      "bytes": 16614
+      "sha256": "4e5aac6aec5595b8aa85dfe84f820c26a0b308fd9a27339fb99a780b5e5ffff4",
+      "bytes": 16700
     },
     {
       "path": "template-manifests/ww-ou-diff.manifest.json",

--- a/src/desktop/data/data-visualization-templates-xml/spatial-symbol-map-latlon.xml
+++ b/src/desktop/data/data-visualization-templates-xml/spatial-symbol-map-latlon.xml
@@ -1,0 +1,69 @@
+<workbook>
+  <worksheets>
+    <worksheet name='{{TITLE}}'>
+  <table>
+    <view>
+      <datasources>
+        <datasource name='{{DATASOURCE}}' />
+      </datasources>
+      <mapsources>
+        <mapsource name='Tableau' />
+      </mapsources>
+      <datasource-dependencies datasource='{{DATASOURCE}}'>
+        <column datatype='real' name='[Latitude]' role='measure' type='quantitative' />
+        <column datatype='real' name='[Longitude]' role='measure' type='quantitative' />
+        <column datatype='string' name='[Detail]' role='dimension' type='nominal' />
+        <column datatype='real' name='[Measure]' role='measure' type='quantitative' />
+        <column-instance column='[Latitude]' derivation='Avg' name='[avg:Latitude:qk]' pivot='key' type='quantitative' />
+        <column-instance column='[Longitude]' derivation='Avg' name='[avg:Longitude:qk]' pivot='key' type='quantitative' />
+        <column-instance column='[Detail]' derivation='None' name='[none:Detail:nk]' pivot='key' type='nominal' />
+        <column-instance column='[Measure]' derivation='Sum' name='[sum:Measure:qk]' pivot='key' type='quantitative' />
+      </datasource-dependencies>
+      <aggregation value='true' />
+    </view>
+    <style>
+      <style-rule element='map'>
+        <format attr='washout' value='0.0' />
+        <format attr='map-snap-zoom' value='true' />
+      </style-rule>
+      <style-rule element='mark'>
+        <encoding attr='color' field='[{{DATASOURCE}}].[sum:Measure:qk]' symmetric='false' type='interpolated' />
+      </style-rule>
+    </style>
+    <panes>
+      <pane selection-relaxation-option='selection-relaxation-disallow'>
+        <view>
+          <breakdown value='auto' />
+        </view>
+        <mark class='Circle' />
+        <mark-sizing mark-sizing-setting='marks-scaling-off' />
+        <encodings>
+          <size column='[{{DATASOURCE}}].[sum:Measure:qk]' />
+          <color column='[{{DATASOURCE}}].[sum:Measure:qk]' />
+          <lod column='[{{DATASOURCE}}].[none:Detail:nk]' />
+        </encodings>
+        <style>
+          <style-rule element='mark'>
+            <format attr='mark-transparency' value='170' />
+            <format attr='has-stroke' value='true' />
+            <format attr='stroke-color' value='#b4b4b4' />
+            <format attr='size' value='1.5932043790817261' />
+          </style-rule>
+        </style>
+      </pane>
+    </panes>
+    <rows>[{{DATASOURCE}}].[avg:Latitude:qk]</rows>
+    <cols>[{{DATASOURCE}}].[avg:Longitude:qk]</cols>
+  </table>
+  <simple-id uuid='00000000-0000-0000-0000-000000000001' />
+</worksheet>
+  </worksheets>
+  <windows>
+    <window class='worksheet' maximized='true' name='{{TITLE}}'>
+  <viewpoint>
+    <zoom type='entire-view' />
+  </viewpoint>
+  <simple-id uuid='00000000-0000-0000-0000-000000000002' />
+</window>
+  </windows>
+</workbook>

--- a/src/desktop/data/template-manifests.index.json
+++ b/src/desktop/data/template-manifests.index.json
@@ -3,7 +3,7 @@
   "_generator": "src/scripts/buildTemplateManifests.ts",
   "_warning": "GENERATED FILE — do not hand-edit. Edit data/template-manifests/*.manifest.json and re-run `npx tsx src/scripts/buildTemplateManifests.ts`.",
   "_source": "data/template-manifests/*.manifest.json",
-  "count": 41,
+  "count": 42,
   "fast_path_templates": [
     "box-plot-chart",
     "correlation-scatter-plot-chart",
@@ -31,6 +31,7 @@
       "portability_evidence": {
         "fixture_bind": true,
         "render_verified": "live-2026-07-06",
+        "xml_sha256": "88884a946deae4555f31ab65c4063f1105e2a100a534cf494b3f55f10b1ad797",
         "render_evidence": {
           "method": "gate-composite",
           "date": "2026-07-06",
@@ -219,6 +220,11 @@
           "xml": "bullet-variance-chart.xml:31"
         },
         {
+          "code": "multi-currency-raw-sum",
+          "detail": "Product evidence (product team, 2026-07) - has bitten someone: when the actual and/or target rows carry a MIXED currency_code (USD + EUR + GBP ...), neither measure may be summed raw. SUM([Actual]) on cols and the per-cell SUM([Target]) reference line add different currency units as one number, so the attainment gap is silently WRONG (a data-correctness bug, not a formatting one). The template has no currency awareness. Convert to a single reporting currency, or filter to one currency_code, before binding a revenue/quota measure.",
+          "xml": "bullet-variance-chart.xml:33"
+        },
+        {
           "code": "not-live-render-verified",
           "detail": "Compiled HERMETICALLY via the factory route (no live Tableau Desktop). portability_evidence.render_verified='none' and fast_path_eligible=false: the template binds the committed fixture (fixture_bind computed true — a dim + two distinct measures) but has NO live render-readback proof. A live-YYYY-MM-DD stamp is EARNED later by the golden-parity gate / a hand-stamp with render_evidence, never granted at compile time.",
           "xml": "bullet-variance-chart.xml:1"
@@ -290,8 +296,13 @@
       "hazards": [
         {
           "code": "hidden-aggregate-role-from",
-          "detail": "[Region] aggregate-role-from='[State/Province]' is not rewritten by replaceFieldReferences; the target field inherits the template's secondary-role hint. Verification report corrects this template from GREEN to YELLOW. Safe under binding (cosmetic), so fast_path_eligible stays true.",
+          "detail": "[Region] aggregate-role-from='[State/Province]' is not rewritten by replaceFieldReferences; the target field inherits the template's secondary-role hint. Verification report corrects this template from GREEN to YELLOW. Safe under binding (cosmetic), so this hazard does not block the fast path; fast_path_eligible is false here pending live render-verification.",
           "xml": "change-over-time-area-chart.xml:11"
+        },
+        {
+          "code": "line-implies-continuity-needs-time-axis",
+          "detail": "Product evidence (product team, 2026-07) — has bitten someone: the filled area connects adjacent points along the x, so it IMPLIES CONTINUITY over a continuous date axis. The order_date slot must bind a real continuous/truncated date ([tqr:Order Date:qk] on cols); binding a DISCRETE category to the x draws bands between unrelated members that read as change-over-time where none exists. A cross-category comparison with no time axis belongs on a bar chart — keep this template for a continuous time x only.",
+          "xml": "change-over-time-area-chart.xml:32"
         }
       ]
     },
@@ -438,8 +449,13 @@
       "hazards": [
         {
           "code": "hidden-aggregate-role-from",
-          "detail": "[Region] aggregate-role-from='[State/Province]' is not rewritten; target inherits the secondary-role hint. Verification report corrects this template from GREEN to YELLOW. Safe under binding, so fast_path_eligible stays true.",
+          "detail": "[Region] aggregate-role-from='[State/Province]' is not rewritten; target inherits the secondary-role hint. Verification report corrects this template from GREEN to YELLOW. Safe under binding, so this hazard does not block the fast path; fast_path_eligible is false here pending live render-verification.",
           "xml": "change-over-time-stacked-area-chart.xml:11"
+        },
+        {
+          "code": "line-implies-continuity-needs-time-axis",
+          "detail": "Product evidence (product team, 2026-07) — has bitten someone: the stacked filled areas connect adjacent points along the x, so they IMPLY CONTINUITY over a continuous date axis. The order_date slot must bind a real continuous/truncated date ([tqr:Order Date:qk] on cols); binding a DISCRETE category to the x draws bands between unrelated members that read as composition-over-time where none exists. A cross-category comparison with no time axis belongs on a bar chart — keep this template for a continuous time x only.",
+          "xml": "change-over-time-stacked-area-chart.xml:32"
         }
       ]
     },
@@ -992,6 +1008,11 @@
           "xml": "correlation-highlight-table.xml:24-34"
         },
         {
+          "code": "hardcoded-member-inclusion",
+          "detail": "STRUCTURED hazard class read by the bind-time period guard (src/binder/period-guard.ts, W36-D-v1). The load-bearing filter here is a categorical MEMBER INCLUSION (a Sub-Category union of 7 members), NOT a date-part period exclusion — even though this template DOES bind a date (Order Date at Month + Year), the hardcoded filter is on Sub-Category, so the incomplete-period concern does not apply. The incomplete-period guard therefore DECLINES to veto on period grounds; the template stays ineligible via its HARDCODED_FILTER_MEMBERS blocker, and its v2 path is member parameterization (collapse to level-members), not a period trim. Classified explicitly so the period guard's non-fire is auditable rather than incidental.",
+          "xml": "correlation-highlight-table.xml:24-34"
+        },
+        {
           "code": "raw-formula-refs",
           "detail": "The Profit-Ratio calc references the bare bindable [Profit]/[Sales]; templates.ts rewriteFormulaFieldRefs repairs them on bind ONLY because both are bindable bare-key slots (same pattern as correlation-scatter-plot-chart). Gate #6 asserts both are bound.",
           "xml": "correlation-highlight-table.xml:10-11"
@@ -1007,6 +1028,7 @@
       "portability_evidence": {
         "fixture_bind": true,
         "render_verified": "live-2026-07-06",
+        "xml_sha256": "f50364bb90648c7ead3f6b7b247c4d6fa2082b7460e06a34b916ca4287ec3958",
         "render_evidence": {
           "method": "gate-composite",
           "date": "2026-07-06",
@@ -1264,6 +1286,11 @@
         {
           "code": "hardcoded-filter-blocking",
           "detail": "The source workbook pins Region to a single INCLUSION member (function='member' Region='\"Central\"') kept on the Filters shelf (<slices>). This lane does NOT run the compile-time filter neutralizer (no XML edits), so the member rides along VERBATIM and is flagged HARDCODED_FILTER_MEMBERS: a bound dataset without a 'Central' region member renders empty. A follow-up can PARAMETERIZE it to unblock.",
+          "xml": "deviation-diverging-bar.xml:30-32"
+        },
+        {
+          "code": "hardcoded-member-inclusion",
+          "detail": "STRUCTURED hazard class read by the bind-time period guard (src/binder/period-guard.ts, W36-D-v1). The load-bearing filter here is a categorical MEMBER INCLUSION (Region='Central'), NOT a date-part period exclusion — so the incomplete-period guard deliberately DECLINES to veto this template on period grounds (it would be wrong to call a Region pin an 'incomplete period'). It stays ineligible via its HARDCODED_FILTER_MEMBERS blocker; its v2 path is member parameterization (collapse to level-members), not a period trim. Classified explicitly so the period guard's non-fire is auditable rather than incidental.",
           "xml": "deviation-diverging-bar.xml:30-32"
         },
         {
@@ -1543,6 +1570,7 @@
       "portability_evidence": {
         "fixture_bind": true,
         "render_verified": "live-2026-07-05",
+        "xml_sha256": "cb23201e338af6c48b1bd63d35b136e96cbe77ccd2d89efcd9ae2de228cbb752",
         "render_evidence": {
           "basis": "hand-stamp: live tier1-smoke render + non-blank pixel-floor probe + human review (coverage-envelope extension from 4 to up to 7 families); no numeric structural-parity score was measured",
           "lane": "tier1-smoke live-verify 2026-07-05 (Tableau Desktop pid 36540, open 'Super Bowl by the Numbers' datasource; no-LLM binder: O/U Line(avg)->cols, Super Bowl->rows, Teams/Conference->detail)",
@@ -1636,7 +1664,27 @@
       ],
       "portability_evidence": {
         "fixture_bind": true,
-        "render_verified": "none"
+        "render_verified": "live-2026-07-06",
+        "render_evidence": {
+          "method": "gate-composite",
+          "date": "2026-07-06",
+          "structural": 0.97297,
+          "critical_pass": "5/5",
+          "pixel": 0.91667,
+          "pixel_regions": 6,
+          "sanity": "sane",
+          "sanity_signals": [
+            "mark-count=pass reconciled=true (21=21 (live-measured twice, unpinned→21), Worksheet>Copy>Data on source and applied sheets)",
+            "caption-leak=pass"
+          ],
+          "run": "per-leg source-anchor replay (W38-LIVE-2) after the canonical Bar mark fidelity fix; width-500 bin rewrites; the invalid-column-instance-pivot bin exemption (W31-A/E) cleared the prior product-wide apply rejection live",
+          "artifacts": "local-only under ~/TableauGoldens/lab/ (distribution* renders, worksheet XMLs, w38l2 stamp JSON)",
+          "basis": "golden-parity gate run 2026-07-06 (source-anchor replay, W38-LIVE-2): structural 0.97297 (5/5 critical; sole miss = salience-1 resolved-title, sheet names differ by design), pixel 0.91667 (6 ROIs, same-geometry captures), composite 95, binding-sanity sane via reconciled Copy>Data mark counts 21=21 (live-measured twice, unpinned→21). STAMP EARNED, ELIGIBILITY WITHHELD: the DATASET_SPECIFIC_FORMULA blocker (bin width is data-dependent; the leg adapted 283→500 via rewrite) remains until a bind-time bin-width adapter computes it per-dataset — the render proof does not clear the blocker.",
+          "lane": "fable-direct stamp run 2026-07-06 (orchestrator gate run over W38-LIVE-2 per-leg evidence; grade scratchpad imports parity-grade.mjs verbatim)",
+          "gate_composite": 95,
+          "high_pass": "0/0",
+          "pixel_oracle": "source render (same-geometry back-to-back captures on the live instance; 6 ROIs). Source and applied are two INDEPENDENT renders of the same data on the same instance."
+        }
       },
       "datasource_placeholder": true,
       "placeholders": [
@@ -1651,7 +1699,7 @@
         "bins",
         "spread"
       ],
-      "description": "A histogram: one CONTINUOUS measure is binned into equal-width buckets on the X axis (cols) and the COUNT of records per bucket sets the bar heights on the Y axis (rows). The bin is a template-owned calc column ([Profit (bin)], class='bin') derived from the same measure that is counted. Factory-compiled hermetically from the repo distribution-histogram exemplar (Superstore Profit); structurally compiled, NOT render-verified.",
+      "description": "A histogram: one CONTINUOUS measure is binned into equal-width buckets on the X axis (cols) and the COUNT of records per bucket sets the bar heights on the Y axis (rows). The bin is a template-owned calc column ([Profit (bin)], class='bin') derived from the same measure that is counted. Factory-compiled hermetically from the repo distribution-histogram exemplar (Superstore Profit); live render-verified 2026-07-06 by the golden-parity gate (composite 95; see portability_evidence.render_evidence) BUT ELIGIBILITY WITHHELD (fast_path_eligible=false): the DATASET_SPECIFIC_FORMULA blocker (the bin width is dataset-derived — the leg adapted 283→500 by hand-rewrite) stands until a bind-time bin-width adapter computes it per dataset, and a render proof does not clear that blocker.",
       "avoid_when": [
         "The field is categorical / discrete — a histogram bins a CONTINUOUS measure; for counts per named category use a bar chart, not a histogram.",
         "The ask is to compare a metric across named categories or over time — a histogram shows the distribution SHAPE of one measure, not cross-category magnitude or a trend.",
@@ -1705,7 +1753,12 @@
       "hazards": [
         {
           "code": "bin-size-dataset-specific",
-          "detail": "The bin column carries size='283' / peg='0' baked from the source measure's (Profit's) value range. On bind the bin's formula ref [Profit] is rewritten to the bound measure, but the bin WIDTH attribute is NOT recomputed — a measure with a much smaller range collapses to one bar, a much larger range explodes into thousands of slivers. The bin width is the histogram's defining parameter, so this is a load-bearing, dataset-specific formula parameter (fast_path_blocker DATASET_SPECIFIC_FORMULA) that a human/data-aware step must retune after binding, not a cosmetic note. PRODUCT EVIDENCE (UC7 distribution analysis): bin width is STORY-CHANGING, not merely cosmetic — too few bins hide the shape, too many shatter it into noise, and the right count is dataset-dependent, so the retune is an analytical decision the author must own. Separately, OUTLIERS can SWAMP the chart: a long tail forces a wide domain so the bulk of the distribution crushes into the first bin or two; exclude/cap extremes or use a log axis when a few extreme values dominate the range.",
+          "detail": "The bin column carries size='283' / peg='0' baked from the source measure's (Profit's) value range. On bind the bin's formula ref [Profit] is rewritten to the bound measure, but the bin WIDTH attribute is NOT recomputed — a measure with a much smaller range collapses to one bar, a much larger range explodes into thousands of slivers. The bin width is the histogram's defining parameter, so this is a load-bearing, dataset-specific formula parameter (fast_path_blocker DATASET_SPECIFIC_FORMULA) that a human/data-aware step must retune after binding, not a cosmetic note. PRODUCT EVIDENCE (UC7 distribution analysis): bin width is STORY-CHANGING, not merely cosmetic — too few bins hide the shape, too many shatter it into noise, and the right count is dataset-dependent, so the retune is an analytical decision the author must own. Separately, OUTLIERS can SWAMP the chart: a long tail forces a wide domain so the bulk of the distribution crushes into the first bin or two; exclude/cap extremes or use a log axis when a few extreme values dominate the range. The baked size=283 is authored-dataset-specific — derived from the source measure's (Superstore Profit's) value range this template was compiled from — so it is a starting point to retune per dataset, never a portable constant (product team, 2026-07).",
+          "xml": "distribution-histogram.xml:11"
+        },
+        {
+          "code": "small-n-histogram-is-noise",
+          "detail": "Product evidence (product team, 2026-07) — has bitten someone: under ~30 rows a histogram's shape is statistical NOISE, not a distribution. A handful of records scattered across equal-width bins reads as a random staircase and invites over-interpretation of bumps that would vanish on the next data pull. Below roughly 30 observations prefer a BAR CHART of the individual values (or a dot/strip plot); a histogram earns its shape only once each bin holds enough observations to be stable.",
           "xml": "distribution-histogram.xml:11"
         },
         {
@@ -1715,7 +1768,7 @@
         },
         {
           "code": "not-live-render-verified",
-          "detail": "render_verified='none': this template was compiled HERMETICALLY via the factory route (no live Tableau Desktop, no stamp). fixture_bind=true proves the required measure slot binds against the committed schema fixture, but that is necessary-not-sufficient. The render_verified stamp is EARNED later by a live golden-parity render-readback leg, never granted at compile time.",
+          "detail": "render_verified='live-2026-07-06': this template was compiled HERMETICALLY via the factory route and then live render-verified by the golden-parity gate (composite 95: structural 0.97297, pixel 0.91667, binding-sanity sane via reconciled 21=21 Copy>Data mark counts + caption-leak pass). ELIGIBILITY IS WITHHELD NONETHELESS (fast_path_eligible=false): the DATASET_SPECIFIC_FORMULA blocker (the bin width is dataset-derived — the leg adapted 283→500 via rewrite) is NOT cleared by a render proof; it stands until a bind-time bin-width adapter computes the width per dataset. See portability_evidence.render_evidence for the auditable basis.",
           "xml": "distribution-histogram.xml"
         }
       ]
@@ -1729,6 +1782,7 @@
       "portability_evidence": {
         "fixture_bind": true,
         "render_verified": "live-2026-07-06",
+        "xml_sha256": "09dd141149ed8ddc2c6161776f71efcb28a427582483a140fdc47cf74e0433d7",
         "render_evidence": {
           "method": "gate-composite",
           "date": "2026-07-06",
@@ -2035,6 +2089,7 @@
       "portability_evidence": {
         "fixture_bind": true,
         "render_verified": "live-2026-07-06",
+        "xml_sha256": "88a67da2a8703811cc32990bb04247cdd879bb5f0b3f10f6ae124f747c938dba",
         "render_evidence": {
           "method": "gate-composite",
           "date": "2026-07-06",
@@ -2254,6 +2309,7 @@
       "portability_evidence": {
         "fixture_bind": true,
         "render_verified": "live-2026-07-04",
+        "xml_sha256": "c949d0041cb100b30ab2845e53f3c4326c12bc018700869a9b10f4ddca881516",
         "render_evidence": {
           "basis": "hand-stamp: live render + structural parity + human review (original generic-template stamp; no numeric structural-parity score was retained for this legacy stamp)",
           "lane": "generic-template live-verify 2026-07-04 (original four: kpi / part-to-whole / ranking / time-series)",
@@ -2377,6 +2433,11 @@
           "xml": "magnitude-paired-bar.xml:17"
         },
         {
+          "code": "incomplete-period-exclusion",
+          "detail": "STRUCTURED hazard class read by the bind-time period guard (src/binder/period-guard.ts, W36-D-v1). The Year-of-Order-Date EXCLUSION above is a load-bearing incomplete-latest-period guard at the YEAR grain. At bind time only field metadata is visible (no row data), so the guard CANNOT prove the bound data's latest year is complete, nor that the hardcoded excluded members {2024, 2025} name the actual incomplete period. When a date is bound it therefore VETOES the fast path (escalate 'incomplete-period-unattested') unless the caller attests period-completeness (periodCompletenessAttested). The HARDCODED_FILTER_MEMBERS blocker and the hardcoded-filter-blocking prose hazard REMAIN — v1 documents the path and does not flip fast_path_eligible; v2 will compute a data-driven trim.",
+          "xml": "magnitude-paired-bar.xml:17"
+        },
+        {
           "code": "hidden-aggregate-role-from",
           "detail": "[Region] carries aggregate-role-from='[State/Province]', a cosmetic secondary-role hint that is not rewritten onto the bound field (same behavior as slope-chart / correlation-scatter-plot-chart). No binding impact.",
           "xml": "magnitude-paired-bar.xml:11"
@@ -2452,6 +2513,11 @@
         {
           "code": "hardcoded-filter-blocking",
           "detail": "The source workbook filters Year of Order Date with an EXCLUSION (function='except') that removes {2024, 2025} — a partial/incomplete-recent-year guard (short partial-year columns would distort the paired-column magnitude read). The factory filter policy fails CLOSED on exclusions: dropping or neutralizing an exclusion WIDENS the data (re-includes the removed years) in a potentially result-corrupting direction, and the excluded years are source-calendar literals. Kept VERBATIM and flagged HARDCODED_FILTER_MEMBERS — not fast-path eligible until a follow-up re-expresses the exclusion as a declared 'exclude incomplete periods' slot.",
+          "xml": "magnitude-paired-column-chart.xml:17"
+        },
+        {
+          "code": "incomplete-period-exclusion",
+          "detail": "STRUCTURED hazard class read by the bind-time period guard (src/binder/period-guard.ts, W36-D-v1). The Year-of-Order-Date EXCLUSION above is a load-bearing incomplete-latest-period guard at the YEAR grain. At bind time only field metadata is visible (no row data), so the guard CANNOT prove the bound data's latest year is complete, nor that the hardcoded excluded members {2024, 2025} name the actual incomplete period. When a date is bound it therefore VETOES the fast path (escalate 'incomplete-period-unattested') unless the caller attests period-completeness (periodCompletenessAttested). The HARDCODED_FILTER_MEMBERS blocker and the hardcoded-filter-blocking prose hazard REMAIN — v1 documents the path and does not flip fast_path_eligible; v2 will compute a data-driven trim.",
           "xml": "magnitude-paired-column-chart.xml:17"
         },
         {
@@ -2612,7 +2678,7 @@
       "hazards": [
         {
           "code": "hidden-aggregate-role-from",
-          "detail": "[Region] aggregate-role-from='[State/Province]' is not rewritten; target inherits the secondary-role hint. Verification report corrects this template from GREEN to YELLOW. Safe under binding, so fast_path_eligible stays true.",
+          "detail": "[Region] aggregate-role-from='[State/Province]' is not rewritten; target inherits the secondary-role hint. Verification report corrects this template from GREEN to YELLOW. Safe under binding, so this hazard does not block the fast path; fast_path_eligible is false here pending live render-verification.",
           "xml": "part-to-whole-pie-chart.xml:10"
         }
       ]
@@ -2755,6 +2821,7 @@
       "portability_evidence": {
         "fixture_bind": true,
         "render_verified": "live-2026-07-05",
+        "xml_sha256": "e137d910087d740f25fad4b6d6b485139e72b256e5c6e5fab26a488a7bed0f77",
         "render_evidence": {
           "basis": "hand-stamp: live render + structural parity + human review",
           "lane": "W2-R008 live-verify 2026-07-05",
@@ -2845,6 +2912,7 @@
       "portability_evidence": {
         "fixture_bind": true,
         "render_verified": "live-2026-07-04",
+        "xml_sha256": "1dbfa890b4e36aff212910b8c2f0a22d6c7746856c8db0d26c39e5eae8b5bb73",
         "render_evidence": {
           "basis": "hand-stamp: live render + structural parity + human review (original generic-template stamp; no numeric structural-parity score was retained for this legacy stamp)",
           "lane": "generic-template live-verify 2026-07-04 (original four: kpi / part-to-whole / ranking / time-series)",
@@ -3058,6 +3126,7 @@
       "portability_evidence": {
         "fixture_bind": true,
         "render_verified": "live-2026-07-06",
+        "xml_sha256": "6a0dfe73ca8d106a296fff0d22a06870c893124adf2a7079f33663e2ac92a614",
         "render_evidence": {
           "method": "gate-composite",
           "date": "2026-07-06",
@@ -3330,6 +3399,7 @@
       "portability_evidence": {
         "fixture_bind": true,
         "render_verified": "live-2026-07-04",
+        "xml_sha256": "63040f0d4b4ee0f84f995a82ea0a7845453e078708e1cd55aa13f878ffc00d0e",
         "render_evidence": {
           "basis": "hand-stamp: live render + structural parity + human review (original generic-template stamp; no numeric structural-parity score was retained for this legacy stamp)",
           "lane": "generic-template live-verify 2026-07-04 (original four: kpi / part-to-whole / ranking / time-series)",
@@ -3413,6 +3483,7 @@
       "portability_evidence": {
         "fixture_bind": true,
         "render_verified": "live-2026-07-05",
+        "xml_sha256": "05c11de9177a6a48db4180669cbaec11d19a6c0a08c7379e418edbe0b1c61cf9",
         "render_evidence": {
           "basis": "hand-stamp: live render + structural parity + human review",
           "lane": "W2-R008 live-verify 2026-07-05",
@@ -3654,6 +3725,97 @@
       ]
     },
     {
+      "template": "spatial-symbol-map-latlon",
+      "family": "spatial",
+      "readiness": "YELLOW",
+      "fast_path_eligible": false,
+      "fast_path_blockers": [],
+      "portability_evidence": {
+        "fixture_bind": true,
+        "render_verified": "none"
+      },
+      "datasource_placeholder": true,
+      "placeholders": [
+        "TITLE",
+        "DATASOURCE"
+      ],
+      "intent_keywords": [
+        "latlon-symbol-map",
+        "latitude-longitude-map",
+        "coordinate-map",
+        "point-map",
+        "symbol-map",
+        "bubble-map",
+        "spatial",
+        "map"
+      ],
+      "description": "A real latitude/longitude point symbol map: Longitude and Latitude measure columns are placed on Cols/Rows as AVG continuous axes, one Circle mark per detail dimension member, sized and colored by a measure. Use for datasets that already carry real coordinate columns rather than Tableau-generated geocoding fields.",
+      "slots": [
+        {
+          "slot_id": "longitude",
+          "template_field": "Longitude",
+          "derivation": "avg",
+          "role": [
+            "cols"
+          ],
+          "kind": "quantitative",
+          "bindable": true,
+          "required": true,
+          "notes": "Real longitude measure column, aggregated as AVG and placed on Columns as [avg:Longitude:qk]."
+        },
+        {
+          "slot_id": "latitude",
+          "template_field": "Latitude",
+          "derivation": "avg",
+          "role": [
+            "rows"
+          ],
+          "kind": "quantitative",
+          "bindable": true,
+          "required": true,
+          "notes": "Real latitude measure column, aggregated as AVG and placed on Rows as [avg:Latitude:qk]."
+        },
+        {
+          "slot_id": "detail",
+          "template_field": "Detail",
+          "derivation": "none",
+          "role": [
+            "detail"
+          ],
+          "kind": "categorical",
+          "bindable": true,
+          "required": true,
+          "notes": "Detail/grain dimension: one mark per member (e.g. City, Site, Team, or point name). Placed on the level-of-detail shelf as [none:Detail:nk]. Renamed from the draft's [Country] to a generic [Detail] because the XML declares no geographic semantic-role — calling it Country would imply geo behavior the template does not carry."
+        },
+        {
+          "slot_id": "size_color_measure",
+          "template_field": "Measure",
+          "derivation": "sum",
+          "role": [
+            "size",
+            "color"
+          ],
+          "kind": "quantitative",
+          "bindable": true,
+          "required": true,
+          "notes": "Measure used for BOTH symbol size and continuous color as [sum:Measure:qk]. REQUIRED (not optional): the XML hard-references [sum:Measure:qk] in the size encoding, the color encoding, and the datasource-level color style-rule; validateBinding SKIPS unbound optional slots, so leaving this optional would strand a dangling [Measure] template field on apply unless the target datasource happens to carry [Measure]. The current optional-slot apply glue is proven only for facets."
+        }
+      ],
+      "calcs": [],
+      "hazards": [
+        {
+          "code": "coordinate-slot-affinity-unproven",
+          "detail": "UNKNOWN: current no-LLM quantitative binding is role-greedy, not latitude/longitude-name-affine; coordinate slots can swap unless a route/proposal test proves otherwise.",
+          "xml": "spatial-symbol-map-latlon.xml:rows-cols"
+        },
+        {
+          "code": "real-coordinate-map-unverified",
+          "detail": "UNKNOWN: shipped map templates use generated Latitude/Longitude with mapsources; no committed real-measure lat/lon map precedent proves map layer behavior before live render/readback.",
+          "xml": "spatial-symbol-map-latlon.xml:mapsources,rows,cols"
+        }
+      ]
+    },
+    {
       "template": "spatial-symbol-map",
       "family": "spatial",
       "readiness": "YELLOW",
@@ -3750,6 +3912,7 @@
       "portability_evidence": {
         "fixture_bind": true,
         "render_verified": "live-2026-07-04",
+        "xml_sha256": "fe35111190516e789d2db3666a7f4f86899e149839b203079a4e42f297c80f44",
         "render_evidence": {
           "basis": "hand-stamp: live render + structural parity + human review (original generic-template stamp; no numeric structural-parity score was retained for this legacy stamp)",
           "lane": "generic-template live-verify 2026-07-04 (original four: kpi / part-to-whole / ranking / time-series)",
@@ -3787,6 +3950,9 @@
         "change-over-time"
       ],
       "description": "A line of an aggregated measure over a truncated date on the x-axis; shows trend across time.",
+      "avoid_when": [
+        "The x-axis is a set of DISCRETE, non-temporal CATEGORIES (categorical members such as products or segments) instead of a continuous time axis. A line CONNECTS adjacent points and so IMPLIES CONTINUITY between them, drawing a misleading slope across unrelated categorical members; a cross-category breakdown with no time axis belongs on a bar chart. Keep this line template for a continuous time x-axis only — do not bind a discrete category to the x."
+      ],
       "slots": [
         {
           "slot_id": "order_date",
@@ -3829,6 +3995,11 @@
         {
           "code": "month-trunc-short-form-ruling",
           "detail": "RULING (H3.2 tmn/tmo reconciliation): 'tmn' is the REAL Month-Trunc short-form live Tableau writes — confirmed in this template XML (derivation='Month-Trunc' name='[tmn:Order Date:qk]'), in real Tableau Public workbooks (data/twb-example-index.json: [sqlserver…].[tmn:Order Date:qk], [dataengine…].[tmn:DateTime (Days):ok]), in src/metadata/fields.ts:434, and in tactics/tree/column-instance-prefixes.md. The binder/manifests standardize on canonical 'tmn'; templates.ts derivationMap accepts BOTH 'tmn' and legacy 'tmo' as aliases → 'Month-Trunc'. XML is ground truth; no derivation normalization is applied.",
+          "xml": "trend-line-chart.xml:13"
+        },
+        {
+          "code": "line-implies-continuity-needs-time-axis",
+          "detail": "Product evidence (product team, 2026-07) — has bitten someone: a line mark connects adjacent points, so it IMPLIES CONTINUITY along the x-axis. The order_date slot must bind a real continuous time field; binding a DISCRETE category to the x draws a slope between unrelated members that reads as a trend where none exists (a 'compare X across categories' ask must route to a bar chart, not here). Tracked-hazard companion to the discrete-categories avoid_when: the classifier demotes an otherwise-clean line bind when the ask names a discrete categorical breakdown with no time axis.",
           "xml": "trend-line-chart.xml:13"
         }
       ]
@@ -4055,7 +4226,8 @@
       "fast_path_blockers": [],
       "portability_evidence": {
         "fixture_bind": true,
-        "render_verified": "live-2026-07-05"
+        "render_verified": "live-2026-07-10",
+        "xml_sha256": "5db1a3b2cfec461045137ab393da8ae58fc972eddb54f4d1722d8082e260ec8f"
       },
       "datasource_placeholder": true,
       "placeholders": [

--- a/src/desktop/data/template-manifests/box-plot-chart.manifest.json
+++ b/src/desktop/data/template-manifests/box-plot-chart.manifest.json
@@ -7,6 +7,7 @@
  "portability_evidence": {
   "fixture_bind": true,
   "render_verified": "live-2026-07-06",
+  "xml_sha256": "88884a946deae4555f31ab65c4063f1105e2a100a534cf494b3f55f10b1ad797",
   "render_evidence": {
    "method": "gate-composite",
    "date": "2026-07-06",

--- a/src/desktop/data/template-manifests/bullet-variance-chart.manifest.json
+++ b/src/desktop/data/template-manifests/bullet-variance-chart.manifest.json
@@ -84,6 +84,11 @@
       "xml": "bullet-variance-chart.xml:31"
     },
     {
+      "code": "multi-currency-raw-sum",
+      "detail": "Product evidence (product team, 2026-07) - has bitten someone: when the actual and/or target rows carry a MIXED currency_code (USD + EUR + GBP ...), neither measure may be summed raw. SUM([Actual]) on cols and the per-cell SUM([Target]) reference line add different currency units as one number, so the attainment gap is silently WRONG (a data-correctness bug, not a formatting one). The template has no currency awareness. Convert to a single reporting currency, or filter to one currency_code, before binding a revenue/quota measure.",
+      "xml": "bullet-variance-chart.xml:33"
+    },
+    {
       "code": "not-live-render-verified",
       "detail": "Compiled HERMETICALLY via the factory route (no live Tableau Desktop). portability_evidence.render_verified='none' and fast_path_eligible=false: the template binds the committed fixture (fixture_bind computed true \u2014 a dim + two distinct measures) but has NO live render-readback proof. A live-YYYY-MM-DD stamp is EARNED later by the golden-parity gate / a hand-stamp with render_evidence, never granted at compile time.",
       "xml": "bullet-variance-chart.xml:1"

--- a/src/desktop/data/template-manifests/change-over-time-area-chart.manifest.json
+++ b/src/desktop/data/template-manifests/change-over-time-area-chart.manifest.json
@@ -22,7 +22,10 @@
   "calcs": [],
   "hazards": [
     { "code": "hidden-aggregate-role-from",
-      "detail": "[Region] aggregate-role-from='[State/Province]' is not rewritten by replaceFieldReferences; the target field inherits the template's secondary-role hint. Verification report corrects this template from GREEN to YELLOW. Safe under binding (cosmetic), so fast_path_eligible stays true.",
-      "xml": "change-over-time-area-chart.xml:11" }
+      "detail": "[Region] aggregate-role-from='[State/Province]' is not rewritten by replaceFieldReferences; the target field inherits the template's secondary-role hint. Verification report corrects this template from GREEN to YELLOW. Safe under binding (cosmetic), so this hazard does not block the fast path; fast_path_eligible is false here pending live render-verification.",
+      "xml": "change-over-time-area-chart.xml:11" },
+    { "code": "line-implies-continuity-needs-time-axis",
+      "detail": "Product evidence (product team, 2026-07) — has bitten someone: the filled area connects adjacent points along the x, so it IMPLIES CONTINUITY over a continuous date axis. The order_date slot must bind a real continuous/truncated date ([tqr:Order Date:qk] on cols); binding a DISCRETE category to the x draws bands between unrelated members that read as change-over-time where none exists. A cross-category comparison with no time axis belongs on a bar chart — keep this template for a continuous time x only.",
+      "xml": "change-over-time-area-chart.xml:32" }
   ]
 }

--- a/src/desktop/data/template-manifests/change-over-time-stacked-area-chart.manifest.json
+++ b/src/desktop/data/template-manifests/change-over-time-stacked-area-chart.manifest.json
@@ -22,7 +22,10 @@
   "calcs": [],
   "hazards": [
     { "code": "hidden-aggregate-role-from",
-      "detail": "[Region] aggregate-role-from='[State/Province]' is not rewritten; target inherits the secondary-role hint. Verification report corrects this template from GREEN to YELLOW. Safe under binding, so fast_path_eligible stays true.",
-      "xml": "change-over-time-stacked-area-chart.xml:11" }
+      "detail": "[Region] aggregate-role-from='[State/Province]' is not rewritten; target inherits the secondary-role hint. Verification report corrects this template from GREEN to YELLOW. Safe under binding, so this hazard does not block the fast path; fast_path_eligible is false here pending live render-verification.",
+      "xml": "change-over-time-stacked-area-chart.xml:11" },
+    { "code": "line-implies-continuity-needs-time-axis",
+      "detail": "Product evidence (product team, 2026-07) — has bitten someone: the stacked filled areas connect adjacent points along the x, so they IMPLY CONTINUITY over a continuous date axis. The order_date slot must bind a real continuous/truncated date ([tqr:Order Date:qk] on cols); binding a DISCRETE category to the x draws bands between unrelated members that read as composition-over-time where none exists. A cross-category comparison with no time axis belongs on a bar chart — keep this template for a continuous time x only.",
+      "xml": "change-over-time-stacked-area-chart.xml:32" }
   ]
 }

--- a/src/desktop/data/template-manifests/correlation-highlight-table.manifest.json
+++ b/src/desktop/data/template-manifests/correlation-highlight-table.manifest.json
@@ -143,6 +143,11 @@
       "xml": "correlation-highlight-table.xml:24-34"
     },
     {
+      "code": "hardcoded-member-inclusion",
+      "detail": "STRUCTURED hazard class read by the bind-time period guard (src/binder/period-guard.ts, W36-D-v1). The load-bearing filter here is a categorical MEMBER INCLUSION (a Sub-Category union of 7 members), NOT a date-part period exclusion \u2014 even though this template DOES bind a date (Order Date at Month + Year), the hardcoded filter is on Sub-Category, so the incomplete-period concern does not apply. The incomplete-period guard therefore DECLINES to veto on period grounds; the template stays ineligible via its HARDCODED_FILTER_MEMBERS blocker, and its v2 path is member parameterization (collapse to level-members), not a period trim. Classified explicitly so the period guard's non-fire is auditable rather than incidental.",
+      "xml": "correlation-highlight-table.xml:24-34"
+    },
+    {
       "code": "raw-formula-refs",
       "detail": "The Profit-Ratio calc references the bare bindable [Profit]/[Sales]; templates.ts rewriteFormulaFieldRefs repairs them on bind ONLY because both are bindable bare-key slots (same pattern as correlation-scatter-plot-chart). Gate #6 asserts both are bound.",
       "xml": "correlation-highlight-table.xml:10-11"

--- a/src/desktop/data/template-manifests/correlation-scatter-plot-chart.manifest.json
+++ b/src/desktop/data/template-manifests/correlation-scatter-plot-chart.manifest.json
@@ -7,6 +7,7 @@
   "portability_evidence": {
     "fixture_bind": true,
     "render_verified": "live-2026-07-06",
+    "xml_sha256": "f50364bb90648c7ead3f6b7b247c4d6fa2082b7460e06a34b916ca4287ec3958",
     "render_evidence": {
       "method": "gate-composite",
       "date": "2026-07-06",

--- a/src/desktop/data/template-manifests/deviation-diverging-bar.manifest.json
+++ b/src/desktop/data/template-manifests/deviation-diverging-bar.manifest.json
@@ -119,6 +119,11 @@
       "xml": "deviation-diverging-bar.xml:30-32"
     },
     {
+      "code": "hardcoded-member-inclusion",
+      "detail": "STRUCTURED hazard class read by the bind-time period guard (src/binder/period-guard.ts, W36-D-v1). The load-bearing filter here is a categorical MEMBER INCLUSION (Region='Central'), NOT a date-part period exclusion — so the incomplete-period guard deliberately DECLINES to veto this template on period grounds (it would be wrong to call a Region pin an 'incomplete period'). It stays ineligible via its HARDCODED_FILTER_MEMBERS blocker; its v2 path is member parameterization (collapse to level-members), not a period trim. Classified explicitly so the period guard's non-fire is auditable rather than incidental.",
+      "xml": "deviation-diverging-bar.xml:30-32"
+    },
+    {
       "code": "raw-formula-refs",
       "detail": "The Profit-Ratio calc references the bare bindable [Profit]/[Sales]; templates.ts rewriteFormulaFieldRefs repairs them on bind ONLY because both are bindable bare-key slots (same pattern as correlation-scatter-plot-chart). Gate #6 asserts both are bound.",
       "xml": "deviation-diverging-bar.xml:19-20"

--- a/src/desktop/data/template-manifests/distribution-bar-code-chart.manifest.json
+++ b/src/desktop/data/template-manifests/distribution-bar-code-chart.manifest.json
@@ -7,6 +7,7 @@
   "portability_evidence": {
     "fixture_bind": true,
     "render_verified": "live-2026-07-05",
+    "xml_sha256": "cb23201e338af6c48b1bd63d35b136e96cbe77ccd2d89efcd9ae2de228cbb752",
     "render_evidence": {
       "basis": "hand-stamp: live tier1-smoke render + non-blank pixel-floor probe + human review (coverage-envelope extension from 4 to up to 7 families); no numeric structural-parity score was measured",
       "lane": "tier1-smoke live-verify 2026-07-05 (Tableau Desktop pid 36540, open 'Super Bowl by the Numbers' datasource; no-LLM binder: O/U Line(avg)->cols, Super Bowl->rows, Teams/Conference->detail)",

--- a/src/desktop/data/template-manifests/distribution-histogram.manifest.json
+++ b/src/desktop/data/template-manifests/distribution-histogram.manifest.json
@@ -1,94 +1,119 @@
 {
-  "template": "distribution-histogram",
-  "family": "distribution",
-  "readiness": "YELLOW",
-  "fast_path_eligible": false,
-  "fast_path_blockers": [
-    "DATASET_SPECIFIC_FORMULA"
-  ],
-  "portability_evidence": {
-    "fixture_bind": true,
-    "render_verified": "none"
+ "template": "distribution-histogram",
+ "family": "distribution",
+ "readiness": "YELLOW",
+ "fast_path_eligible": false,
+ "fast_path_blockers": [
+  "DATASET_SPECIFIC_FORMULA"
+ ],
+ "portability_evidence": {
+  "fixture_bind": true,
+  "render_verified": "live-2026-07-06",
+  "render_evidence": {
+   "method": "gate-composite",
+   "date": "2026-07-06",
+   "structural": 0.97297,
+   "critical_pass": "5/5",
+   "pixel": 0.91667,
+   "pixel_regions": 6,
+   "sanity": "sane",
+   "sanity_signals": [
+    "mark-count=pass reconciled=true (21=21 (live-measured twice, unpinned→21), Worksheet>Copy>Data on source and applied sheets)",
+    "caption-leak=pass"
+   ],
+   "run": "per-leg source-anchor replay (W38-LIVE-2) after the canonical Bar mark fidelity fix; width-500 bin rewrites; the invalid-column-instance-pivot bin exemption (W31-A/E) cleared the prior product-wide apply rejection live",
+   "artifacts": "local-only under ~/TableauGoldens/lab/ (distribution* renders, worksheet XMLs, w38l2 stamp JSON)",
+   "basis": "golden-parity gate run 2026-07-06 (source-anchor replay, W38-LIVE-2): structural 0.97297 (5/5 critical; sole miss = salience-1 resolved-title, sheet names differ by design), pixel 0.91667 (6 ROIs, same-geometry captures), composite 95, binding-sanity sane via reconciled Copy>Data mark counts 21=21 (live-measured twice, unpinned→21). STAMP EARNED, ELIGIBILITY WITHHELD: the DATASET_SPECIFIC_FORMULA blocker (bin width is data-dependent; the leg adapted 283→500 via rewrite) remains until a bind-time bin-width adapter computes it per-dataset — the render proof does not clear the blocker.",
+   "lane": "fable-direct stamp run 2026-07-06 (orchestrator gate run over W38-LIVE-2 per-leg evidence; grade scratchpad imports parity-grade.mjs verbatim)",
+   "gate_composite": 95,
+   "high_pass": "0/0",
+   "pixel_oracle": "source render (same-geometry back-to-back captures on the live instance; 6 ROIs). Source and applied are two INDEPENDENT renders of the same data on the same instance."
+  }
+ },
+ "datasource_placeholder": true,
+ "placeholders": [
+  "TITLE",
+  "DATASOURCE"
+ ],
+ "intent_keywords": [
+  "histogram",
+  "distribution",
+  "frequency",
+  "binned",
+  "bins",
+  "spread"
+ ],
+ "description": "A histogram: one CONTINUOUS measure is binned into equal-width buckets on the X axis (cols) and the COUNT of records per bucket sets the bar heights on the Y axis (rows). The bin is a template-owned calc column ([Profit (bin)], class='bin') derived from the same measure that is counted. Factory-compiled hermetically from the repo distribution-histogram exemplar (Superstore Profit); live render-verified 2026-07-06 by the golden-parity gate (composite 95; see portability_evidence.render_evidence) BUT ELIGIBILITY WITHHELD (fast_path_eligible=false): the DATASET_SPECIFIC_FORMULA blocker (the bin width is dataset-derived — the leg adapted 283→500 by hand-rewrite) stands until a bind-time bin-width adapter computes it per dataset, and a render proof does not clear that blocker.",
+ "avoid_when": [
+  "The field is categorical / discrete — a histogram bins a CONTINUOUS measure; for counts per named category use a bar chart, not a histogram.",
+  "The ask is to compare a metric across named categories or over time — a histogram shows the distribution SHAPE of one measure, not cross-category magnitude or a trend.",
+  "The bound measure's range differs greatly from the source measure's — the template's hardcoded bin width (size=283) does not auto-recompute on bind and must be reviewed, or the viz over/under-bins (one giant bar or thousands of slivers)."
+ ],
+ "slots": [
+  {
+   "slot_id": "measure",
+   "template_field": "Profit",
+   "derivation": "cnt",
+   "role": [
+    "rows"
+   ],
+   "kind": "quantitative",
+   "bindable": true,
+   "required": true,
+   "notes": "The single bindable measure. It is COUNTed on rows (Y axis) as [cnt:Profit:qk] AND is the input the bin calc [Profit (bin)] buckets on cols — the classic Tableau histogram default (one field, binned + counted). Binds to any measure; base column [Profit], shelf instance [cnt:Profit:qk]."
+  }
+ ],
+ "calcs": [
+  {
+   "slot_id": "measure_bin",
+   "template_field": "Profit (bin)",
+   "derivation": "none",
+   "role": [
+    "cols"
+   ],
+   "kind": "calc",
+   "bindable": false,
+   "required": true,
+   "formula": "[Profit]",
+   "formula_refs": [
+    "Profit"
+   ],
+   "depends_on_slots": [
+    "measure"
+   ],
+   "result_role": "dimension",
+   "inputs": [
+    {
+     "ref": "Profit",
+     "slot_id": "measure",
+     "slot_kind": "quantitative",
+     "required": true,
+     "template_internal": false
+    }
+   ],
+   "notes": "The DEFINING distribution slot: a template-owned bin column (<calculation class='bin' size='283' peg='0' decimals='2' formula='[Profit]'/>) placed on cols as [none:Profit (bin):qk] (with a show-full-range). It is treated as a first-class calc — its formula ref [Profit] is rewritten to the bound measure on apply (forcing the 'measure' slot to bind) — but its bin WIDTH (size) is a dataset-derived parameter that does NOT recompute on bind (see the bin-size-dataset-specific hazard / DATASET_SPECIFIC_FORMULA blocker)."
+  }
+ ],
+ "hazards": [
+  {
+   "code": "bin-size-dataset-specific",
+   "detail": "The bin column carries size='283' / peg='0' baked from the source measure's (Profit's) value range. On bind the bin's formula ref [Profit] is rewritten to the bound measure, but the bin WIDTH attribute is NOT recomputed — a measure with a much smaller range collapses to one bar, a much larger range explodes into thousands of slivers. The bin width is the histogram's defining parameter, so this is a load-bearing, dataset-specific formula parameter (fast_path_blocker DATASET_SPECIFIC_FORMULA) that a human/data-aware step must retune after binding, not a cosmetic note. PRODUCT EVIDENCE (UC7 distribution analysis): bin width is STORY-CHANGING, not merely cosmetic — too few bins hide the shape, too many shatter it into noise, and the right count is dataset-dependent, so the retune is an analytical decision the author must own. Separately, OUTLIERS can SWAMP the chart: a long tail forces a wide domain so the bulk of the distribution crushes into the first bin or two; exclude/cap extremes or use a log axis when a few extreme values dominate the range. The baked size=283 is authored-dataset-specific — derived from the source measure's (Superstore Profit's) value range this template was compiled from — so it is a starting point to retune per dataset, never a portable constant (product team, 2026-07).",
+   "xml": "distribution-histogram.xml:11"
   },
-  "datasource_placeholder": true,
-  "placeholders": [
-    "TITLE",
-    "DATASOURCE"
-  ],
-  "intent_keywords": [
-    "histogram",
-    "distribution",
-    "frequency",
-    "binned",
-    "bins",
-    "spread"
-  ],
-  "description": "A histogram: one CONTINUOUS measure is binned into equal-width buckets on the X axis (cols) and the COUNT of records per bucket sets the bar heights on the Y axis (rows). The bin is a template-owned calc column ([Profit (bin)], class='bin') derived from the same measure that is counted. Factory-compiled hermetically from the repo distribution-histogram exemplar (Superstore Profit); structurally compiled, NOT render-verified.",
-  "avoid_when": [
-    "The field is categorical / discrete — a histogram bins a CONTINUOUS measure; for counts per named category use a bar chart, not a histogram.",
-    "The ask is to compare a metric across named categories or over time — a histogram shows the distribution SHAPE of one measure, not cross-category magnitude or a trend.",
-    "The bound measure's range differs greatly from the source measure's — the template's hardcoded bin width (size=283) does not auto-recompute on bind and must be reviewed, or the viz over/under-bins (one giant bar or thousands of slivers)."
-  ],
-  "slots": [
-    {
-      "slot_id": "measure",
-      "template_field": "Profit",
-      "derivation": "cnt",
-      "role": [
-        "rows"
-      ],
-      "kind": "quantitative",
-      "bindable": true,
-      "required": true,
-      "notes": "The single bindable measure. It is COUNTed on rows (Y axis) as [cnt:Profit:qk] AND is the input the bin calc [Profit (bin)] buckets on cols — the classic Tableau histogram default (one field, binned + counted). Binds to any measure; base column [Profit], shelf instance [cnt:Profit:qk]."
-    }
-  ],
-  "calcs": [
-    {
-      "slot_id": "measure_bin",
-      "template_field": "Profit (bin)",
-      "derivation": "none",
-      "role": [
-        "cols"
-      ],
-      "kind": "calc",
-      "bindable": false,
-      "required": true,
-      "formula": "[Profit]",
-      "formula_refs": [
-        "Profit"
-      ],
-      "depends_on_slots": [
-        "measure"
-      ],
-      "result_role": "dimension",
-      "inputs": [
-        {
-          "ref": "Profit",
-          "slot_id": "measure",
-          "slot_kind": "quantitative",
-          "required": true,
-          "template_internal": false
-        }
-      ],
-      "notes": "The DEFINING distribution slot: a template-owned bin column (<calculation class='bin' size='283' peg='0' decimals='2' formula='[Profit]'/>) placed on cols as [none:Profit (bin):qk] (with a show-full-range). It is treated as a first-class calc — its formula ref [Profit] is rewritten to the bound measure on apply (forcing the 'measure' slot to bind) — but its bin WIDTH (size) is a dataset-derived parameter that does NOT recompute on bind (see the bin-size-dataset-specific hazard / DATASET_SPECIFIC_FORMULA blocker)."
-    }
-  ],
-  "hazards": [
-    {
-      "code": "bin-size-dataset-specific",
-      "detail": "The bin column carries size='283' / peg='0' baked from the source measure's (Profit's) value range. On bind the bin's formula ref [Profit] is rewritten to the bound measure, but the bin WIDTH attribute is NOT recomputed — a measure with a much smaller range collapses to one bar, a much larger range explodes into thousands of slivers. The bin width is the histogram's defining parameter, so this is a load-bearing, dataset-specific formula parameter (fast_path_blocker DATASET_SPECIFIC_FORMULA) that a human/data-aware step must retune after binding, not a cosmetic note. PRODUCT EVIDENCE (UC7 distribution analysis): bin width is STORY-CHANGING, not merely cosmetic — too few bins hide the shape, too many shatter it into noise, and the right count is dataset-dependent, so the retune is an analytical decision the author must own. Separately, OUTLIERS can SWAMP the chart: a long tail forces a wide domain so the bulk of the distribution crushes into the first bin or two; exclude/cap extremes or use a log axis when a few extreme values dominate the range.",
-      "xml": "distribution-histogram.xml:11"
-    },
-    {
-      "code": "bin-caption-not-rewritten",
-      "detail": "The bin column ([Profit (bin)], kind=calc, bindable=false) and its instance [none:Profit (bin):qk] are template-owned and are NOT rewritten on bind — only the bin's formula ref [Profit] is. So after binding to e.g. Sales the X-axis caption still reads 'Profit (bin)'. Cosmetic (the viz renders correctly); relabel the bin field/axis on the bound sheet if the source-measure name must not leak.",
-      "xml": "distribution-histogram.xml:10"
-    },
-    {
-      "code": "not-live-render-verified",
-      "detail": "render_verified='none': this template was compiled HERMETICALLY via the factory route (no live Tableau Desktop, no stamp). fixture_bind=true proves the required measure slot binds against the committed schema fixture, but that is necessary-not-sufficient. The render_verified stamp is EARNED later by a live golden-parity render-readback leg, never granted at compile time.",
-      "xml": "distribution-histogram.xml"
-    }
-  ]
+  {
+   "code": "small-n-histogram-is-noise",
+   "detail": "Product evidence (product team, 2026-07) — has bitten someone: under ~30 rows a histogram's shape is statistical NOISE, not a distribution. A handful of records scattered across equal-width bins reads as a random staircase and invites over-interpretation of bumps that would vanish on the next data pull. Below roughly 30 observations prefer a BAR CHART of the individual values (or a dot/strip plot); a histogram earns its shape only once each bin holds enough observations to be stable.",
+   "xml": "distribution-histogram.xml:11"
+  },
+  {
+   "code": "bin-caption-not-rewritten",
+   "detail": "The bin column ([Profit (bin)], kind=calc, bindable=false) and its instance [none:Profit (bin):qk] are template-owned and are NOT rewritten on bind — only the bin's formula ref [Profit] is. So after binding to e.g. Sales the X-axis caption still reads 'Profit (bin)'. Cosmetic (the viz renders correctly); relabel the bin field/axis on the bound sheet if the source-measure name must not leak.",
+   "xml": "distribution-histogram.xml:10"
+  },
+  {
+   "code": "not-live-render-verified",
+   "detail": "render_verified='live-2026-07-06': this template was compiled HERMETICALLY via the factory route and then live render-verified by the golden-parity gate (composite 95: structural 0.97297, pixel 0.91667, binding-sanity sane via reconciled 21=21 Copy>Data mark counts + caption-leak pass). ELIGIBILITY IS WITHHELD NONETHELESS (fast_path_eligible=false): the DATASET_SPECIFIC_FORMULA blocker (the bin width is dataset-derived — the leg adapted 283→500 via rewrite) is NOT cleared by a render proof; it stands until a bind-time bin-width adapter computes the width per dataset. See portability_evidence.render_evidence for the auditable basis.",
+   "xml": "distribution-histogram.xml"
+  }
+ ]
 }

--- a/src/desktop/data/template-manifests/funnel-chart.manifest.json
+++ b/src/desktop/data/template-manifests/funnel-chart.manifest.json
@@ -7,6 +7,7 @@
  "portability_evidence": {
   "fixture_bind": true,
   "render_verified": "live-2026-07-06",
+  "xml_sha256": "09dd141149ed8ddc2c6161776f71efcb28a427582483a140fdc47cf74e0433d7",
   "render_evidence": {
    "method": "gate-composite",
    "date": "2026-07-06",

--- a/src/desktop/data/template-manifests/gantt-task-rollup-chart.manifest.json
+++ b/src/desktop/data/template-manifests/gantt-task-rollup-chart.manifest.json
@@ -7,6 +7,7 @@
  "portability_evidence": {
   "fixture_bind": true,
   "render_verified": "live-2026-07-06",
+  "xml_sha256": "88a67da2a8703811cc32990bb04247cdd879bb5f0b3f10f6ae124f747c938dba",
   "render_evidence": {
    "method": "gate-composite",
    "date": "2026-07-06",

--- a/src/desktop/data/template-manifests/kpi-text.manifest.json
+++ b/src/desktop/data/template-manifests/kpi-text.manifest.json
@@ -7,6 +7,7 @@
   "portability_evidence": {
     "fixture_bind": true,
     "render_verified": "live-2026-07-04",
+    "xml_sha256": "c949d0041cb100b30ab2845e53f3c4326c12bc018700869a9b10f4ddca881516",
     "render_evidence": {
       "basis": "hand-stamp: live render + structural parity + human review (original generic-template stamp; no numeric structural-parity score was retained for this legacy stamp)",
       "lane": "generic-template live-verify 2026-07-04 (original four: kpi / part-to-whole / ranking / time-series)",

--- a/src/desktop/data/template-manifests/magnitude-paired-bar.manifest.json
+++ b/src/desktop/data/template-manifests/magnitude-paired-bar.manifest.json
@@ -70,6 +70,11 @@
       "xml": "magnitude-paired-bar.xml:17"
     },
     {
+      "code": "incomplete-period-exclusion",
+      "detail": "STRUCTURED hazard class read by the bind-time period guard (src/binder/period-guard.ts, W36-D-v1). The Year-of-Order-Date EXCLUSION above is a load-bearing incomplete-latest-period guard at the YEAR grain. At bind time only field metadata is visible (no row data), so the guard CANNOT prove the bound data's latest year is complete, nor that the hardcoded excluded members {2024, 2025} name the actual incomplete period. When a date is bound it therefore VETOES the fast path (escalate 'incomplete-period-unattested') unless the caller attests period-completeness (periodCompletenessAttested). The HARDCODED_FILTER_MEMBERS blocker and the hardcoded-filter-blocking prose hazard REMAIN — v1 documents the path and does not flip fast_path_eligible; v2 will compute a data-driven trim.",
+      "xml": "magnitude-paired-bar.xml:17"
+    },
+    {
       "code": "hidden-aggregate-role-from",
       "detail": "[Region] carries aggregate-role-from='[State/Province]', a cosmetic secondary-role hint that is not rewritten onto the bound field (same behavior as slope-chart / correlation-scatter-plot-chart). No binding impact.",
       "xml": "magnitude-paired-bar.xml:11"

--- a/src/desktop/data/template-manifests/magnitude-paired-column-chart.manifest.json
+++ b/src/desktop/data/template-manifests/magnitude-paired-column-chart.manifest.json
@@ -70,6 +70,11 @@
       "xml": "magnitude-paired-column-chart.xml:17"
     },
     {
+      "code": "incomplete-period-exclusion",
+      "detail": "STRUCTURED hazard class read by the bind-time period guard (src/binder/period-guard.ts, W36-D-v1). The Year-of-Order-Date EXCLUSION above is a load-bearing incomplete-latest-period guard at the YEAR grain. At bind time only field metadata is visible (no row data), so the guard CANNOT prove the bound data's latest year is complete, nor that the hardcoded excluded members {2024, 2025} name the actual incomplete period. When a date is bound it therefore VETOES the fast path (escalate 'incomplete-period-unattested') unless the caller attests period-completeness (periodCompletenessAttested). The HARDCODED_FILTER_MEMBERS blocker and the hardcoded-filter-blocking prose hazard REMAIN — v1 documents the path and does not flip fast_path_eligible; v2 will compute a data-driven trim.",
+      "xml": "magnitude-paired-column-chart.xml:17"
+    },
+    {
       "code": "hidden-aggregate-role-from",
       "detail": "[Region] carries aggregate-role-from='[State/Province]', a cosmetic secondary-role hint that is not rewritten onto the bound field (same behavior as magnitude-paired-bar / slope-chart). No binding impact.",
       "xml": "magnitude-paired-column-chart.xml:11"

--- a/src/desktop/data/template-manifests/part-to-whole-pie-chart.manifest.json
+++ b/src/desktop/data/template-manifests/part-to-whole-pie-chart.manifest.json
@@ -26,7 +26,7 @@
   "calcs": [],
   "hazards": [
     { "code": "hidden-aggregate-role-from",
-      "detail": "[Region] aggregate-role-from='[State/Province]' is not rewritten; target inherits the secondary-role hint. Verification report corrects this template from GREEN to YELLOW. Safe under binding, so fast_path_eligible stays true.",
+      "detail": "[Region] aggregate-role-from='[State/Province]' is not rewritten; target inherits the secondary-role hint. Verification report corrects this template from GREEN to YELLOW. Safe under binding, so this hazard does not block the fast path; fast_path_eligible is false here pending live render-verification.",
       "xml": "part-to-whole-pie-chart.xml:10" }
   ]
 }

--- a/src/desktop/data/template-manifests/part-to-whole-stacked-bar-chart.manifest.json
+++ b/src/desktop/data/template-manifests/part-to-whole-stacked-bar-chart.manifest.json
@@ -7,6 +7,7 @@
   "portability_evidence": {
     "fixture_bind": true,
     "render_verified": "live-2026-07-05",
+    "xml_sha256": "e137d910087d740f25fad4b6d6b485139e72b256e5c6e5fab26a488a7bed0f77",
     "render_evidence": {
       "basis": "hand-stamp: live render + structural parity + human review",
       "lane": "W2-R008 live-verify 2026-07-05",

--- a/src/desktop/data/template-manifests/part-to-whole-treemap-chart.manifest.json
+++ b/src/desktop/data/template-manifests/part-to-whole-treemap-chart.manifest.json
@@ -7,6 +7,7 @@
   "portability_evidence": {
     "fixture_bind": true,
     "render_verified": "live-2026-07-04",
+    "xml_sha256": "1dbfa890b4e36aff212910b8c2f0a22d6c7746856c8db0d26c39e5eae8b5bb73",
     "render_evidence": {
       "basis": "hand-stamp: live render + structural parity + human review (original generic-template stamp; no numeric structural-parity score was retained for this legacy stamp)",
       "lane": "generic-template live-verify 2026-07-04 (original four: kpi / part-to-whole / ranking / time-series)",

--- a/src/desktop/data/template-manifests/quota-attainment-bullet.manifest.json
+++ b/src/desktop/data/template-manifests/quota-attainment-bullet.manifest.json
@@ -7,6 +7,7 @@
  "portability_evidence": {
   "fixture_bind": true,
   "render_verified": "live-2026-07-06",
+  "xml_sha256": "6a0dfe73ca8d106a296fff0d22a06870c893124adf2a7079f33663e2ac92a614",
   "render_evidence": {
    "method": "gate-composite",
    "date": "2026-07-06",

--- a/src/desktop/data/template-manifests/ranking-ordered-bar.manifest.json
+++ b/src/desktop/data/template-manifests/ranking-ordered-bar.manifest.json
@@ -7,6 +7,7 @@
   "portability_evidence": {
     "fixture_bind": true,
     "render_verified": "live-2026-07-04",
+    "xml_sha256": "63040f0d4b4ee0f84f995a82ea0a7845453e078708e1cd55aa13f878ffc00d0e",
     "render_evidence": {
       "basis": "hand-stamp: live render + structural parity + human review (original generic-template stamp; no numeric structural-parity score was retained for this legacy stamp)",
       "lane": "generic-template live-verify 2026-07-04 (original four: kpi / part-to-whole / ranking / time-series)",

--- a/src/desktop/data/template-manifests/ranking-ordered-column.manifest.json
+++ b/src/desktop/data/template-manifests/ranking-ordered-column.manifest.json
@@ -7,6 +7,7 @@
   "portability_evidence": {
     "fixture_bind": true,
     "render_verified": "live-2026-07-05",
+    "xml_sha256": "05c11de9177a6a48db4180669cbaec11d19a6c0a08c7379e418edbe0b1c61cf9",
     "render_evidence": {
       "basis": "hand-stamp: live render + structural parity + human review",
       "lane": "W2-R008 live-verify 2026-07-05",

--- a/src/desktop/data/template-manifests/spatial-symbol-map-latlon.manifest.json
+++ b/src/desktop/data/template-manifests/spatial-symbol-map-latlon.manifest.json
@@ -1,0 +1,91 @@
+{
+  "template": "spatial-symbol-map-latlon",
+  "family": "spatial",
+  "readiness": "YELLOW",
+  "fast_path_eligible": false,
+  "fast_path_blockers": [],
+  "portability_evidence": {
+    "fixture_bind": true,
+    "render_verified": "none"
+  },
+  "datasource_placeholder": true,
+  "placeholders": [
+    "TITLE",
+    "DATASOURCE"
+  ],
+  "intent_keywords": [
+    "latlon-symbol-map",
+    "latitude-longitude-map",
+    "coordinate-map",
+    "point-map",
+    "symbol-map",
+    "bubble-map",
+    "spatial",
+    "map"
+  ],
+  "description": "A real latitude/longitude point symbol map: Longitude and Latitude measure columns are placed on Cols/Rows as AVG continuous axes, one Circle mark per detail dimension member, sized and colored by a measure. Use for datasets that already carry real coordinate columns rather than Tableau-generated geocoding fields.",
+  "slots": [
+    {
+      "slot_id": "longitude",
+      "template_field": "Longitude",
+      "derivation": "avg",
+      "role": [
+        "cols"
+      ],
+      "kind": "quantitative",
+      "bindable": true,
+      "required": true,
+      "notes": "Real longitude measure column, aggregated as AVG and placed on Columns as [avg:Longitude:qk]."
+    },
+    {
+      "slot_id": "latitude",
+      "template_field": "Latitude",
+      "derivation": "avg",
+      "role": [
+        "rows"
+      ],
+      "kind": "quantitative",
+      "bindable": true,
+      "required": true,
+      "notes": "Real latitude measure column, aggregated as AVG and placed on Rows as [avg:Latitude:qk]."
+    },
+    {
+      "slot_id": "detail",
+      "template_field": "Detail",
+      "derivation": "none",
+      "role": [
+        "detail"
+      ],
+      "kind": "categorical",
+      "bindable": true,
+      "required": true,
+      "notes": "Detail/grain dimension: one mark per member (e.g. City, Site, Team, or point name). Placed on the level-of-detail shelf as [none:Detail:nk]. Renamed from the draft's [Country] to a generic [Detail] because the XML declares no geographic semantic-role — calling it Country would imply geo behavior the template does not carry."
+    },
+    {
+      "slot_id": "size_color_measure",
+      "template_field": "Measure",
+      "derivation": "sum",
+      "role": [
+        "size",
+        "color"
+      ],
+      "kind": "quantitative",
+      "bindable": true,
+      "required": true,
+      "notes": "Measure used for BOTH symbol size and continuous color as [sum:Measure:qk]. REQUIRED (not optional): the XML hard-references [sum:Measure:qk] in the size encoding, the color encoding, and the datasource-level color style-rule; validateBinding SKIPS unbound optional slots, so leaving this optional would strand a dangling [Measure] template field on apply unless the target datasource happens to carry [Measure]. The current optional-slot apply glue is proven only for facets."
+    }
+  ],
+  "calcs": [],
+  "hazards": [
+    {
+      "code": "coordinate-slot-affinity-unproven",
+      "detail": "UNKNOWN: current no-LLM quantitative binding is role-greedy, not latitude/longitude-name-affine; coordinate slots can swap unless a route/proposal test proves otherwise.",
+      "xml": "spatial-symbol-map-latlon.xml:rows-cols"
+    },
+    {
+      "code": "real-coordinate-map-unverified",
+      "detail": "UNKNOWN: shipped map templates use generated Latitude/Longitude with mapsources; no committed real-measure lat/lon map precedent proves map layer behavior before live render/readback.",
+      "xml": "spatial-symbol-map-latlon.xml:mapsources,rows,cols"
+    }
+  ]
+}

--- a/src/desktop/data/template-manifests/trend-line-chart.manifest.json
+++ b/src/desktop/data/template-manifests/trend-line-chart.manifest.json
@@ -7,6 +7,7 @@
   "portability_evidence": {
     "fixture_bind": true,
     "render_verified": "live-2026-07-04",
+    "xml_sha256": "fe35111190516e789d2db3666a7f4f86899e149839b203079a4e42f297c80f44",
     "render_evidence": {
       "basis": "hand-stamp: live render + structural parity + human review (original generic-template stamp; no numeric structural-parity score was retained for this legacy stamp)",
       "lane": "generic-template live-verify 2026-07-04 (original four: kpi / part-to-whole / ranking / time-series)",
@@ -21,6 +22,9 @@
   "placeholders": ["TITLE", "DATASOURCE"],
   "intent_keywords": ["trend", "over-time", "line", "time-series", "timeline", "by-month", "sales-over-time", "year-over-year", "yoy", "prior-year", "current-year", "rolling", "moving-average", "moving-sum", "running-total", "month-over-month", "period-over-period", "forecast", "change-over-time"],
   "description": "A line of an aggregated measure over a truncated date on the x-axis; shows trend across time.",
+  "avoid_when": [
+    "The x-axis is a set of DISCRETE, non-temporal CATEGORIES (categorical members such as products or segments) instead of a continuous time axis. A line CONNECTS adjacent points and so IMPLIES CONTINUITY between them, drawing a misleading slope across unrelated categorical members; a cross-category breakdown with no time axis belongs on a bar chart. Keep this line template for a continuous time x-axis only \u2014 do not bind a discrete category to the x."
+  ],
   "slots": [
     { "slot_id": "order_date", "template_field": "Order Date", "derivation": "tmn",
       "role": ["cols"], "kind": "temporal", "bindable": true, "required": true,
@@ -35,6 +39,9 @@
   "hazards": [
     { "code": "month-trunc-short-form-ruling",
       "detail": "RULING (H3.2 tmn/tmo reconciliation): 'tmn' is the REAL Month-Trunc short-form live Tableau writes — confirmed in this template XML (derivation='Month-Trunc' name='[tmn:Order Date:qk]'), in real Tableau Public workbooks (data/twb-example-index.json: [sqlserver…].[tmn:Order Date:qk], [dataengine…].[tmn:DateTime (Days):ok]), in src/metadata/fields.ts:434, and in tactics/tree/column-instance-prefixes.md. The binder/manifests standardize on canonical 'tmn'; templates.ts derivationMap accepts BOTH 'tmn' and legacy 'tmo' as aliases → 'Month-Trunc'. XML is ground truth; no derivation normalization is applied.",
+      "xml": "trend-line-chart.xml:13" },
+    { "code": "line-implies-continuity-needs-time-axis",
+      "detail": "Product evidence (product team, 2026-07) — has bitten someone: a line mark connects adjacent points, so it IMPLIES CONTINUITY along the x-axis. The order_date slot must bind a real continuous time field; binding a DISCRETE category to the x draws a slope between unrelated members that reads as a trend where none exists (a 'compare X across categories' ask must route to a bar chart, not here). Tracked-hazard companion to the discrete-categories avoid_when: the classifier demotes an otherwise-clean line bind when the ask names a discrete categorical breakdown with no time axis.",
       "xml": "trend-line-chart.xml:13" }
   ]
 }

--- a/src/desktop/data/template-manifests/ww-ou-arrow.manifest.json
+++ b/src/desktop/data/template-manifests/ww-ou-arrow.manifest.json
@@ -6,7 +6,8 @@
   "fast_path_blockers": [],
   "portability_evidence": {
     "fixture_bind": true,
-    "render_verified": "live-2026-07-05"
+    "render_verified": "live-2026-07-10",
+    "xml_sha256": "5db1a3b2cfec461045137ab393da8ae58fc972eddb54f4d1722d8082e260ec8f"
   },
   "datasource_placeholder": true,
   "placeholders": [

--- a/src/desktop/data/templates/spatial-symbol-map-latlon.xml
+++ b/src/desktop/data/templates/spatial-symbol-map-latlon.xml
@@ -1,0 +1,69 @@
+<workbook>
+  <worksheets>
+    <worksheet name='{{TITLE}}'>
+  <table>
+    <view>
+      <datasources>
+        <datasource name='{{DATASOURCE}}' />
+      </datasources>
+      <mapsources>
+        <mapsource name='Tableau' />
+      </mapsources>
+      <datasource-dependencies datasource='{{DATASOURCE}}'>
+        <column datatype='real' name='[Latitude]' role='measure' type='quantitative' />
+        <column datatype='real' name='[Longitude]' role='measure' type='quantitative' />
+        <column datatype='string' name='[Detail]' role='dimension' type='nominal' />
+        <column datatype='real' name='[Measure]' role='measure' type='quantitative' />
+        <column-instance column='[Latitude]' derivation='Avg' name='[avg:Latitude:qk]' pivot='key' type='quantitative' />
+        <column-instance column='[Longitude]' derivation='Avg' name='[avg:Longitude:qk]' pivot='key' type='quantitative' />
+        <column-instance column='[Detail]' derivation='None' name='[none:Detail:nk]' pivot='key' type='nominal' />
+        <column-instance column='[Measure]' derivation='Sum' name='[sum:Measure:qk]' pivot='key' type='quantitative' />
+      </datasource-dependencies>
+      <aggregation value='true' />
+    </view>
+    <style>
+      <style-rule element='map'>
+        <format attr='washout' value='0.0' />
+        <format attr='map-snap-zoom' value='true' />
+      </style-rule>
+      <style-rule element='mark'>
+        <encoding attr='color' field='[{{DATASOURCE}}].[sum:Measure:qk]' symmetric='false' type='interpolated' />
+      </style-rule>
+    </style>
+    <panes>
+      <pane selection-relaxation-option='selection-relaxation-disallow'>
+        <view>
+          <breakdown value='auto' />
+        </view>
+        <mark class='Circle' />
+        <mark-sizing mark-sizing-setting='marks-scaling-off' />
+        <encodings>
+          <size column='[{{DATASOURCE}}].[sum:Measure:qk]' />
+          <color column='[{{DATASOURCE}}].[sum:Measure:qk]' />
+          <lod column='[{{DATASOURCE}}].[none:Detail:nk]' />
+        </encodings>
+        <style>
+          <style-rule element='mark'>
+            <format attr='mark-transparency' value='170' />
+            <format attr='has-stroke' value='true' />
+            <format attr='stroke-color' value='#b4b4b4' />
+            <format attr='size' value='1.5932043790817261' />
+          </style-rule>
+        </style>
+      </pane>
+    </panes>
+    <rows>[{{DATASOURCE}}].[avg:Latitude:qk]</rows>
+    <cols>[{{DATASOURCE}}].[avg:Longitude:qk]</cols>
+  </table>
+  <simple-id uuid='00000000-0000-0000-0000-000000000001' />
+</worksheet>
+  </worksheets>
+  <windows>
+    <window class='worksheet' maximized='true' name='{{TITLE}}'>
+  <viewpoint>
+    <zoom type='entire-view' />
+  </viewpoint>
+  <simple-id uuid='00000000-0000-0000-0000-000000000002' />
+</window>
+  </windows>
+</workbook>

--- a/src/desktop/validation/templates-no-self-reject.invariant.test.ts
+++ b/src/desktop/validation/templates-no-self-reject.invariant.test.ts
@@ -33,14 +33,16 @@ const xmlFiles = fs
   .sort();
 
 describe('validation/templates — no bundled template self-rejects on invalid-derivation-string', () => {
-  it('discovers the shipped template XML corpus (44 post day-1 vendor sync)', () => {
+  it('discovers the shipped template XML corpus (45: 44 day-1 sync + spatial-symbol-map-latlon)', () => {
     expect(
       xmlFiles.length,
       'expected the shipped template XML corpus to be non-empty',
     ).toBeGreaterThan(0);
     // Pin the count verified by hand tonight so a template added/removed without re-running
     // this invariant is caught (adjust deliberately when the corpus grows).
-    expect(xmlFiles.length).toBe(44);
+    // parity-port: +1 for spatial-symbol-map-latlon.xml (the per-file it.each below still
+    // proves it does not self-reject on invalid-derivation-string).
+    expect(xmlFiles.length).toBe(45);
   });
 
   it.each(xmlFiles)(


### PR DESCRIPTION
## What

Mechanical vendor sync from a2td (post-#181 merge), continuing the day-1 sync lane (#478) and the caption-rebind port (#480):

- **Knowledge**: Ben Hart's `diagnostic-view-loop` + `calc-caption-follows-formula-rebind` (day-1 session learnings), pin-aware refreshes (`_index`, `discovery-first-authoring`, `recovery`), and one byte-coupled cross-ref update. All 92 knowledge files now byte-match a2td.
- **Templates**: adds `spatial-symbol-map-latlon` (both XML dirs + manifest; unstamped ⇒ not fast-path eligible, so zero routing change until it earns a live stamp) and resyncs all 42 manifests — 22 were stale, including `ww-ou-arrow`'s fresh `live-2026-07-10` restamp and the `portability_evidence.xml_sha256` hashes across the stamped set. Index + content-manifest regenerated with this repo's own generator, not hand-copied.
- Two deliberate count-pin tests advanced (41→42, 44→45) for the latlon addition, with rationale comments.

Deliberately **not** ported (decision-gated, flagged in the parity audit): a2td's larger validation registry (27 rules vs 7 here) and the refine-op route stack (RouteSpec/route-gate/ask-router/refine-worksheet) — both are L-sized, security-relevant surfaces that deserve a spec'd port, not a mechanical copy.

## Validation

Full vitest **3226 passed** (226 files), `tsc --noEmit` clean, `check-lockstep` OK (6/6), `stampHash.invariant` 62 passed / 1 pre-existing skip. Note: `npm run lint` is red on 9 files **untouched by this PR** at base `4e3cde16` (one is lockstep-locked) — pre-existing drift needing separate cleanup; both files this PR edits lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)