### PR TITLE
desktop: byte-port a2td classifier (75% bind-rate work) + template parity sync

### DIFF
--- a/lockstep.hashes.json
+++ b/lockstep.hashes.json
@@ -1,6 +1,6 @@
 {
   "src/desktop/binder/calc-derivation.ts": "5105d466e3c31019affa91320edf3047259301ca5cd27aeb5883ba1faa251098",
-  "src/desktop/binder/classify.ts": "445a8bd854675108c7bc057970823ad6ed65663681cf135ee393fd15b4d05ef5",
+  "src/desktop/binder/classify.ts": "4a49e134a6c4e683ce9d728728bc67c3e8e4098a2656e35973d31811e918a657",
   "src/desktop/binder/escape.ts": "3c79bcf77c33fad64975e95ea57df5fb3e416008633e15dc7a585018fbc92d3f",
   "src/desktop/binder/manifest-types.ts": "9ce310c1e294d3784084b854edf52ef4f7c4cf7a8e13ebba7071dc3957c6114d",
   "src/desktop/binder/manifest-validation.ts": "e29ecfa9e10e57593a4f72e498f35ca8b1b28a1227fc0cb4aed057870566df60",

--- a/src/desktop/binder/classify.ts
+++ b/src/desktop/binder/classify.ts
@@ -433,6 +433,20 @@ const CHART_NOUN_KEYWORDS: ReadonlySet<string> = new Set([
   // specificity ranking (multi-token 'sales-over-time' &c.) governs instead, so
   // admitting it cannot create a cross-template flip later.
   'over-time',
+  // 'timeline' rides the same lone-winner contract as 'over-time': it is a
+  // deterministic time-axis chart noun carried by EXACTLY ONE fast-path-eligible
+  // template — trend-line-chart — so "timeline of X" names a line chart. Without
+  // it a noun-less timeline ask ("Timeline of Sales using Order Date") demotes to
+  // propose now that time-series is a TWO-member eligible family (trend-line-chart +
+  // gantt-task-rollup-chart) and strict-majority nativity has collapsed. Admitting
+  // it is safe because NO eligible template collides on it: gantt-task-rollup-chart's
+  // eligible intent_keywords are gantt-task-rollup / task-rollup / gantt-rollup /
+  // one-bar-per-task / gantt / task-schedule — no 'timeline'; the timeline-ish gantt
+  // templates (gantt-timeline-chart, gantt-chart) are NOT fast_path_eligible and
+  // classifyNoLlm ignores them. Lone-winner is the only path this admits; if a second
+  // eligible time-series template ever carries 'timeline', the TIE path's chart-noun
+  // specificity ranking governs, so admitting it cannot create a cross-template flip.
+  'timeline',
   // Second growth event same night: the 13th-15th stamps made deviation
   // (quota joins ww-ou-arrow) and distribution (box-plot joins bar-code)
   // two-member families, collapsing nativity for the incumbent members'
@@ -517,6 +531,54 @@ function familyNativeKeywords(
 }
 
 /**
+ * Every field name / caption / bare column name in the schema, lowercased. Feeds
+ * fieldNameMatchInAsk's EXACT-FIRST tie-break: a field's plural alias is suppressed
+ * at any token another field claims by its exact name (so with both "Region" and
+ * "Regions" present, ask "Regions" resolves to the exact "Regions" and "Region"'s
+ * alias yields nothing there). Built from the SAME name-variant set that
+ * matchFieldsInAsk / askNamesField test against, so suppression is exhaustive.
+ */
+function fieldExactNames(fields: SchemaField[]): Set<string> {
+  const out = new Set<string>();
+  for (const f of fields) {
+    for (const n of [bareName(f.columnName), f.caption, f.name]) {
+      if (n && n.length > 0) out.add(n.toLowerCase());
+    }
+  }
+  return out;
+}
+
+/**
+ * FIELD-NAME <-> ASK MATCH with a ONE-WAY, EXACT-FIRST trailing-`s` alias. Returns
+ * the index of the first whole-token occurrence of field name `name` in `ask`, else
+ * -1. This is the FIELD-ONLY matcher used by maskFieldNames / matchFieldsInAsk /
+ * askNamesField; it is deliberately DISTINCT from phraseIndexInAsk (the keyword
+ * matcher), which is UNCHANGED so keyword scoring is unaffected.
+ *
+ *   - EXACT FIRST: an exact whole-token occurrence always wins and is returned as-is.
+ *   - ONE-WAY PLURAL ALIAS: if `name` does NOT already end in `s`, its naive plural
+ *     `name + "s"` also matches — field "Region" matches ask token "Regions". A name
+ *     that already ends in `s` gains NO singular alias, so "Sales" never matches
+ *     "Sale", and "Species" / "Address" / "Tickets" / "Resolution Hours" stay
+ *     exact-only.
+ *   - NAIVE TRAILING-`s` ONLY: no ies / es / stemmer, so "Category" does NOT match
+ *     "Categories" (deliberately out of scope for this MR).
+ *   - EXACT-FIRST TIE-BREAK ACROSS FIELDS: the plural alias is suppressed whenever the
+ *     pluralized token is another field's EXACT name (`exactNames`), so "Region"'s
+ *     alias never claims a "Regions" span that a field literally named "Regions" owns
+ *     by exact match.
+ */
+function fieldNameMatchInAsk(ask: string, name: string, exactNames: ReadonlySet<string>): number {
+  const exact = phraseIndexInAsk(ask, name);
+  if (exact >= 0) return exact;
+  const n = name.toLowerCase().trim();
+  if (!n || n.endsWith('s')) return -1; // one-way: an `s`-final name gains no alias
+  const plural = `${n}s`;
+  if (exactNames.has(plural)) return -1; // exact-first: another field owns this token
+  return phraseIndexInAsk(ask, plural);
+}
+
+/**
  * Blank out whole-token occurrences of every field name/caption/bare column name
  * in the ask (replaced by spaces so token boundaries are preserved). Used for
  * TEMPLATE SELECTION and aggregation-word detection so a field NAME can never
@@ -527,6 +589,7 @@ function familyNativeKeywords(
  */
 function maskFieldNames(ask: string, s: SchemaSummary): string {
   let masked = ask;
+  const exactNames = fieldExactNames(s.fields);
   // LONGEST FIELD NAME FIRST. Schema-order masking fragments a compound field:
   // masking "Region" before "Country/Region" turns it into "Country/      " so the
   // compound's own regex no longer matches, and the surviving "Country" token trips
@@ -539,7 +602,14 @@ function maskFieldNames(ask: string, s: SchemaSummary): string {
       (n): n is string => !!n && n.length > 0,
     );
     for (const n of names) {
-      const re = new RegExp(`(^|[^a-z0-9])(${escapeRegex(n.toLowerCase())})([^a-z0-9]|$)`, 'gi');
+      const lower = n.toLowerCase();
+      // ONE-WAY plural alias, in lockstep with fieldNameMatchInAsk: a name not already
+      // ending in `s` also masks its naive plural token, so "Regions" is blanked WHOLE
+      // for a field "Region" — no partial "region"+leftover-"s" residue that could then
+      // keyword-match. Suppressed when the plural is another field's exact name (that
+      // field masks the token itself), preserving exact-first tie-breaking.
+      const pluralSuffix = !lower.endsWith('s') && !exactNames.has(`${lower}s`) ? 's?' : '';
+      const re = new RegExp(`(^|[^a-z0-9])(${escapeRegex(lower)}${pluralSuffix})([^a-z0-9]|$)`, 'gi');
       masked = masked.replace(
         re,
         (_whole, pre: string, mid: string, post: string) => pre + ' '.repeat(mid.length) + post,
@@ -551,6 +621,7 @@ function maskFieldNames(ask: string, s: SchemaSummary): string {
 
 /** Fields whose name/caption/bare column name appear in the ask, earliest-first. */
 function matchFieldsInAsk(ask: string, s: SchemaSummary): SchemaField[] {
+  const exactNames = fieldExactNames(s.fields);
   const hits: Array<{ field: SchemaField; index: number }> = [];
   for (const f of s.fields) {
     const names = [bareName(f.columnName), f.caption, f.name].filter(
@@ -558,7 +629,7 @@ function matchFieldsInAsk(ask: string, s: SchemaSummary): SchemaField[] {
     );
     let best = -1;
     for (const n of names) {
-      const idx = phraseIndexInAsk(ask, n);
+      const idx = fieldNameMatchInAsk(ask, n, exactNames);
       if (idx >= 0 && (best < 0 || idx < best)) best = idx;
     }
     if (best >= 0) hits.push({ field: f, index: best });
@@ -568,11 +639,11 @@ function matchFieldsInAsk(ask: string, s: SchemaSummary): SchemaField[] {
 }
 
 /** Whole-phrase test: does the ask NAME this field (by name, caption, or bare column)? */
-function askNamesField(ask: string, f: SchemaField): boolean {
+function askNamesField(ask: string, f: SchemaField, exactNames: ReadonlySet<string>): boolean {
   const names = [bareName(f.columnName), f.caption, f.name].filter(
     (n): n is string => !!n && n.length > 0,
   );
-  return names.some((n) => phraseIndexInAsk(ask, n) >= 0);
+  return names.some((n) => fieldNameMatchInAsk(ask, n, exactNames) >= 0);
 }
 
 /** Normalized content tokens of a field's name/caption/bare column name (for ask overlap). */
@@ -638,8 +709,9 @@ function narrowFields(
   if (fields.length <= maxFields) return { fields, withheld: 0 };
 
   const askTokens = contentTokens(ask);
+  const exactNames = fieldExactNames(fields);
   const ranked = fields.map((f, index) => {
-    const named = askNamesField(ask, f);
+    const named = askNamesField(ask, f, exactNames);
     let overlap = 0;
     if (askTokens.size > 0) {
       for (const t of fieldContentTokens(f)) if (askTokens.has(t)) overlap++;
@@ -816,6 +888,68 @@ function resolveGeoSlots(
 }
 
 /**
+ * EXPLICIT TIME-AXIS INTENT (unique-date temporal completion). Conservative
+ * allowlist of phrases that UNAMBIGUOUSLY ask for a time axis, so a required
+ * temporal slot the ask did not name may be auto-completed with the schema's lone
+ * date field. Matched as WHOLE tokens against the MASKED ask (field names blanked),
+ * so a field literally named "Trend"/"Calendar"/"Period" can never arm completion.
+ * Hyphenated cues also match their natural spaced form via phraseIndexInAsk's
+ * `-`→[\s-]+ transform ("over-time" hits "over time"; "by-month" hits "by month").
+ * DELIBERATELY excludes bare 'line' (a mark type, not a time axis) and vague filter
+ * phrases like "right now" — they do not name a time axis, so must not trigger a
+ * date auto-completion. Mirrors FACET_CUES: a tight, explicit-cue-only allowlist.
+ */
+const TIME_INTENT_CUES: readonly string[] = [
+  'trend',
+  'timeline',
+  'time-series',
+  'over-time',
+  'by-month',
+  'by-week',
+  'by-quarter',
+  'by-year',
+  'calendar',
+  'period',
+  'change-over-time',
+  'month-over-month',
+  'year-over-year',
+  'yoy',
+];
+
+/** True when the (masked) ask carries an explicit time-axis cue from the allowlist. */
+function askHasExplicitTimeIntent(maskedAsk: string): boolean {
+  return TIME_INTENT_CUES.some((cue) => phraseIndexInAsk(maskedAsk, cue) >= 0);
+}
+
+/**
+ * UNIQUE-DATE TEMPORAL COMPLETION (mirrors the W60 geo-slot completion). When a
+ * chosen template's lone required temporal slot was NOT filled by an ask-named
+ * field, complete it with the schema's SINGLE date/datetime field — but only under
+ * strict, fail-closed preconditions so it can never introduce ambiguity:
+ *   - the masked ask carries EXPLICIT time-axis intent (`TIME_INTENT_CUES`) — a bare
+ *     mark word like 'line' is not enough;
+ *   - the ask names EXACTLY ONE compatible measure (0 ⇒ nothing to plot; 2+ ⇒ not a
+ *     plain single-measure trend, e.g. a dual-axis combo, so fail closed);
+ *   - the schema has EXACTLY ONE temporal field total passing `isTemporal` (0 ⇒
+ *     nothing to complete; 2+ ⇒ ambiguous which date, so fail closed — the strict
+ *     one-candidate floor, exactly like geo's unique-max rule).
+ * Any miss ⇒ null. The caller runs this ONLY in the FINAL bind pass (never in
+ * selectWithinFamily's slot-fit probes), so completion can never make an extra
+ * candidate look bindable during tie-breaking.
+ */
+function completeTemporalSlot(
+  maskedAsk: string,
+  matched: SchemaField[],
+  schemaFields: SchemaField[],
+): SchemaField | null {
+  if (!askHasExplicitTimeIntent(maskedAsk)) return null;
+  if (matched.filter(isMeasure).length !== 1) return null;
+  const temporals = schemaFields.filter(isTemporal);
+  if (temporals.length !== 1) return null;
+  return temporals[0];
+}
+
+/**
  * Role-greedy field assignment (design §3.5 step 2): fill each required, bindable
  * slot with the first still-unused matched field of the compatible role/kind —
  * measures → quantitative, dimensions → categorical/temporal. GEO slots are the
@@ -828,12 +962,19 @@ function resolveGeoSlots(
  * Shared machinery: classifyNoLlm emits with it, and the intra-family tiebreak's
  * slot-fit test calls it to answer "do the ask's fields satisfy this candidate?"
  * with the exact assignment that would be emitted — no separate approximation.
+ *
+ * `temporalCompletion` is supplied ONLY by classifyNoLlm's FINAL bind pass (the
+ * masked ask + full schema fields for unique-date completion). selectWithinFamily's
+ * slot-fit probes omit it, so a required temporal slot the ask did not name can be
+ * auto-completed from the schema's lone date field ONLY in the final bind — never
+ * during tie-breaking, where it could make an extra candidate look bindable.
  */
 function roleGreedyBind(
   m: TemplateManifest,
   matched: SchemaField[],
   aggOverride: Derivation | null,
   schemaDims: SchemaField[],
+  temporalCompletion?: { maskedAsk: string; schemaFields: SchemaField[] } | null,
 ): {
   bindings: Array<{ slot_id: string; field: string; derivation?: Derivation }>;
   provenance: string[];
@@ -861,6 +1002,10 @@ function roleGreedyBind(
   let geoPicks: Map<string, SchemaField> | null = null;
   let geoAutoCompleted = new Map<string, SchemaField>();
   let geoResolved = false;
+  // Active required temporal slots. Unique-date completion arms ONLY when there is
+  // exactly ONE (a multi-temporal template never auto-fills a date, fail closed).
+  const temporalSlots = m.slots.filter((s) => isActive(s) && s.kind === 'temporal');
+  const temporalAutoCompleted = new Map<string, SchemaField>();
 
   for (const slot of m.slots) {
     if (!isActive(slot)) continue;
@@ -874,6 +1019,24 @@ function roleGreedyBind(
         break;
       case 'temporal':
         chosen = take(isTemporal);
+        // UNIQUE-DATE TEMPORAL COMPLETION (final bind pass only; mirrors W60 geo): a
+        // lone required temporal slot the ask did not name is completed with the
+        // schema's single date field, under the strict preconditions in
+        // completeTemporalSlot. `temporalCompletion` is passed ONLY by classifyNoLlm's
+        // final bind — selectWithinFamily's slot-fit probes omit it, so completion can
+        // never make an extra candidate look bindable during tie-breaking.
+        if (!chosen && temporalCompletion && temporalSlots.length === 1) {
+          const completed = completeTemporalSlot(
+            temporalCompletion.maskedAsk,
+            matched,
+            temporalCompletion.schemaFields,
+          );
+          if (completed) {
+            used.add(completed);
+            temporalAutoCompleted.set(slot.slot_id, completed);
+            chosen = completed;
+          }
+        }
         break;
       case 'geo': {
         // Resolve ALL geo slots together on first encounter, over the dimensions not
@@ -914,6 +1077,14 @@ function roleGreedyBind(
     provenance.push(
       `Using '${f.name}' for the required geo slot '${slotId}' — auto-completed from the ` +
         'datasource because the ask named no matching field.',
+    );
+  }
+  // Surface a temporal slot AUTO-COMPLETED from the schema's lone date field (unique-
+  // date completion, W60 geo sibling) so the caller can tell the agent which field it
+  // chose for a required time axis the ask did not name.
+  for (const [slotId, f] of temporalAutoCompleted) {
+    provenance.push(
+      `Using '${f.name}' for required temporal slot '${slotId}' because it is the only date field in the datasource.`,
     );
   }
 
@@ -1124,7 +1295,14 @@ export function classifyNoLlm(
   // the hazard notes + avoid_when and judges the actual schema.
   if (hasDeterministicPathBlockingHazard(chosen)) return null;
 
-  const rgb = roleGreedyBind(chosen, matched, aggOverride, schemaDims);
+  // FINAL bind pass — the ONLY place unique-date temporal completion is armed (pass
+  // the masked ask + full schema so a lone required date slot the ask did not name
+  // can complete with the schema's single date field). selectWithinFamily's earlier
+  // slot-fit probes deliberately omit this context (no completion during tie-break).
+  const rgb = roleGreedyBind(chosen, matched, aggOverride, schemaDims, {
+    maskedAsk,
+    schemaFields: summary.fields,
+  });
   if (!rgb) return null; // required slot unfilled → fail closed
   const bindings = rgb.bindings;
   // OPTIONAL small-multiples facet (W23-SM1): additively bind a simple-trellis facet

--- a/src/desktop/binder/manifest-validation.test.ts
+++ b/src/desktop/binder/manifest-validation.test.ts
@@ -55,7 +55,7 @@ describe('binder/manifest-validation — pure module surface', () => {
 describe('binder/manifest-validation — superset is backward-compatible with the bundled manifests', () => {
   const bundled = readBundledManifestFiles();
 
-  it('there are 42 bundled manifests to check', () => {
+  it('there are 44 bundled manifests to check', () => {
     // W26-B re-snapshot: the shipped supply was resynced to the factory's full 39-template
     // set (17 → 39; +22 new manifests copied verbatim, trust fields unchanged).
     // W28-D true byte-for-byte mirror: the remaining stale factory manifests were resynced
@@ -67,9 +67,11 @@ describe('binder/manifest-validation — superset is backward-compatible with th
     // parity-port: the factory's spatial-symbol-map-latlon (render_verified 'none',
     // fast_path_eligible false) was the last missing template manifest; its XML + manifest
     // were ported verbatim, taking the count 41 → 42.
+    // classifier-lockstep-port: the a2td parity sync added deviation-arrow + magnitude-simple-bar
+    // (both render_verified 'none' → fast_path_eligible false) verbatim, taking 42 → 44.
     // Pinned in lockstep with the on-disk count so a silent add/drop of a bundled manifest
     // fails here.
-    expect(bundled.length).toBe(42);
+    expect(bundled.length).toBe(44);
   });
 
   it('every bundled manifest validates through the new types’ validator (no errors)', () => {

--- a/src/desktop/data/content-manifest.json
+++ b/src/desktop/data/content-manifest.json
@@ -2,9 +2,9 @@
   "_generated": true,
   "_generator": "src/scripts/buildTemplateManifests.ts",
   "_warning": "GENERATED FILE — do not hand-edit. Re-run `npx tsx src/scripts/buildTemplateManifests.ts`.",
-  "content_version": "2.11.0+content.2026-07-10",
+  "content_version": "2.11.0+content.2026-07-11",
   "schema_version": "1",
-  "generated": "2026-07-10",
+  "generated": "2026-07-11",
   "engine_compat": {
     "server_min": "2.11.0",
     "node": ">=22.7.5"
@@ -66,6 +66,11 @@
       "bytes": 3250
     },
     {
+      "path": "data-visualization-templates-xml/deviation-arrow.xml",
+      "sha256": "338b99d6780fe108781e51a202fb1dc2cb0562106a8300b9c92e72bf5ccc8cfa",
+      "bytes": 4318
+    },
+    {
       "path": "data-visualization-templates-xml/deviation-diverging-bar.xml",
       "sha256": "dfd31d10c3c1cd0de8dd039334a33fcb536962d46afc58ab74db24e86fe6b356",
       "bytes": 3728
@@ -124,6 +129,11 @@
       "path": "data-visualization-templates-xml/magnitude-paired-column-chart.xml",
       "sha256": "54e13afb3c004b2b511fd25d84bfce712cc28e5f289f12e03e8cbedbedb569fa",
       "bytes": 2459
+    },
+    {
+      "path": "data-visualization-templates-xml/magnitude-simple-bar.xml",
+      "sha256": "86822337c84088ead4638cbdcb7259a90225acfd9ff8ee6578ee3f4209a773c9",
+      "bytes": 2474
     },
     {
       "path": "data-visualization-templates-xml/pareto-chart.xml",
@@ -242,13 +252,13 @@
     },
     {
       "path": "template-manifests.index.json",
-      "sha256": "cb9726caa03efca21f396c74ece9af7942135e09a16513bf2e94b15c1f4bfa46",
-      "bytes": 246333
+      "sha256": "1069eee776c2e976368c8180d1031ba59e9555fcd0a47147ff8464a3ccde8cb0",
+      "bytes": 258585
     },
     {
       "path": "template-manifests/box-plot-chart.manifest.json",
-      "sha256": "a9c331defeb1acfb11a48bed01692a8cdcbfa3fa9b9e8b51c632a58d4830fea5",
-      "bytes": 7607
+      "sha256": "a1c5f0a48aaf7f30963e20b569b7179167bf0e3fafcb11dc99acbc3aad050fde",
+      "bytes": 7623
     },
     {
       "path": "template-manifests/bullet-variance-chart.manifest.json",
@@ -299,6 +309,11 @@
       "path": "template-manifests/correlation-scatter-plot-chart.manifest.json",
       "sha256": "516262563717665ed80cb52d3f87331cbb78a18561c7acfa17c8c46a3a767fb9",
       "bytes": 4773
+    },
+    {
+      "path": "template-manifests/deviation-arrow.manifest.json",
+      "sha256": "0cc9fea66b80778aa4e1d6df0900b5d7e00f0c8bde0f22f4f8e95bcd287d1c47",
+      "bytes": 8164
     },
     {
       "path": "template-manifests/deviation-diverging-bar.manifest.json",
@@ -361,6 +376,11 @@
       "bytes": 4120
     },
     {
+      "path": "template-manifests/magnitude-simple-bar.manifest.json",
+      "sha256": "7288c37cd87d1b9817590ba11b01f35a635d4a7641a99803a63db62ecbbec6ed",
+      "bytes": 2946
+    },
+    {
       "path": "template-manifests/pareto-chart.manifest.json",
       "sha256": "0c81718e05d2e10bde0909f26b7c1ab92383625ab8af0f8f98b7aa83548a8651",
       "bytes": 4714
@@ -407,13 +427,13 @@
     },
     {
       "path": "template-manifests/ranking-ordered-bar.manifest.json",
-      "sha256": "bf80efd2313e097d268758a6dcb0d4c3e82502c812ecbd3b4d538de133ac19d8",
-      "bytes": 3300
+      "sha256": "1ef1517c621eacd37c289328a95852d41afa5ccad41ec2b8d5b3bd65780b648e",
+      "bytes": 3308
     },
     {
       "path": "template-manifests/ranking-ordered-column.manifest.json",
-      "sha256": "94c3b50eb80c294ea8d0c1046e3d09cb95570c34891cfd9b0459c8aef928ee27",
-      "bytes": 1914
+      "sha256": "90e4e6d009fe9cf7ca006241bf610db69348b8e133d13da67380ea156adabd7a",
+      "bytes": 1926
     },
     {
       "path": "template-manifests/slope-chart.manifest.json",
@@ -427,18 +447,18 @@
     },
     {
       "path": "template-manifests/spatial-symbol-map-latlon.manifest.json",
-      "sha256": "ea10b86fa91acd95f2d2decef3b1da46684028c3ebe203a82dd7360a7c1b2fb6",
-      "bytes": 3513
+      "sha256": "8bc4cb6b55dccc4176489fdc14feb11c3bd0e679684c00f4eb1b0e506b8b2850",
+      "bytes": 3567
     },
     {
       "path": "template-manifests/spatial-symbol-map.manifest.json",
-      "sha256": "21276c67b45d5a515a91ea061fe3654b6153e3f10f5bae809c7274e6fd3e0ee9",
-      "bytes": 2763
+      "sha256": "990940cedc79e801a2285ae382dd2531261f8cd4530fd4bacd1ccae35c5b5c01",
+      "bytes": 2821
     },
     {
       "path": "template-manifests/trend-line-chart.manifest.json",
-      "sha256": "5fc22f9bcb36191730a41da9eff272de748c59a014d07c80459bf68aa765451b",
-      "bytes": 5182
+      "sha256": "cd915dd51cc7dea5e2e1fea757522019f0c147f1d0d3399d0cd771f7fdd51e4f",
+      "bytes": 5222
     },
     {
       "path": "template-manifests/ww-floating-bars.manifest.json",

--- a/src/desktop/data/data-visualization-templates-xml/deviation-arrow.xml
+++ b/src/desktop/data/data-visualization-templates-xml/deviation-arrow.xml
@@ -1,0 +1,97 @@
+<workbook xmlns:user='http://www.tableausoftware.com/xml/user'>
+  <worksheets>
+    <worksheet name='{{TITLE}}'>
+  <layout-options>
+    <title>
+      <formatted-text>
+        <run>&lt;Sheet Name&gt;
+</run>
+        <run fontname='Tableau Light' fontsize='9'>One row per member: the shaft spans the reference line value to the actual value on a shared measure axis, and the arrowhead at the actual end is colored by whether the actual finished OVER the line (one hue) or UNDER it (another) via SIGN(actual - line).</run>
+      </formatted-text>
+    </title>
+  </layout-options>
+  <table>
+    <view>
+      <datasources>
+        <datasource name='{{DATASOURCE}}' />
+      </datasources>
+      <datasource-dependencies datasource='{{DATASOURCE}}'>
+        <column caption='Over/Under Sign' datatype='integer' name='[Over-Under Sign]' role='measure' type='quantitative'>
+          <calculation class='tableau' formula='SIGN(SUM([Actual])-SUM([Line]))' />
+        </column>
+        <column datatype='string' name='[Member]' role='dimension' type='nominal' />
+        <column datatype='real' name='[Actual]' role='measure' type='quantitative' />
+        <column datatype='real' name='[Line]' role='measure' type='quantitative' />
+        <column-instance column='[Member]' derivation='None' name='[none:Member:nk]' pivot='key' type='nominal' />
+        <column-instance column='[Actual]' derivation='Sum' name='[sum:Actual:qk]' pivot='key' type='quantitative' />
+        <column-instance column='[Line]' derivation='Sum' name='[sum:Line:qk]' pivot='key' type='quantitative' />
+        <column-instance column='[Over-Under Sign]' derivation='User' name='[usr:Over-Under Sign:qk]' pivot='key' type='quantitative' />
+      </datasource-dependencies>
+      <filter class='categorical' column='[{{DATASOURCE}}].[:Measure Names]'>
+        <groupfilter function='union' user:op='manual'>
+          <groupfilter function='member' level='[:Measure Names]' member='&quot;[{{DATASOURCE}}].[sum:Line:qk]&quot;' />
+          <groupfilter function='member' level='[:Measure Names]' member='&quot;[{{DATASOURCE}}].[sum:Actual:qk]&quot;' />
+        </groupfilter>
+      </filter>
+      <slices>
+        <column>[{{DATASOURCE}}].[:Measure Names]</column>
+      </slices>
+      <aggregation value='true' />
+    </view>
+    <style>
+      <style-rule element='worksheet'>
+        <format attr='display-field-labels' scope='rows' value='false' />
+      </style-rule>
+      <style-rule element='zeroline'>
+        <format attr='line-visibility' value='off' />
+      </style-rule>
+    </style>
+    <panes>
+      <pane selection-relaxation-option='selection-relaxation-allow' x-axis-name='[{{DATASOURCE}}].[Multiple Values]'>
+        <view>
+          <breakdown value='auto' />
+        </view>
+        <mark class='Line' />
+        <mark-sizing mark-sizing-setting='marks-scaling-off' />
+        <encodings>
+          <color column='[{{DATASOURCE}}].[usr:Over-Under Sign:qk]' />
+          <path column='[{{DATASOURCE}}].[:Measure Names]' />
+        </encodings>
+        <style>
+          <style-rule element='mark'>
+            <format attr='mark-labels-show' value='false' />
+          </style-rule>
+        </style>
+      </pane>
+      <pane selection-relaxation-option='selection-relaxation-allow' x-axis-name='[{{DATASOURCE}}].[sum:Actual:qk]'>
+        <view>
+          <breakdown value='auto' />
+        </view>
+        <mark class='Shape' />
+        <mark-sizing mark-sizing-setting='marks-scaling-off' />
+        <encodings>
+          <color column='[{{DATASOURCE}}].[usr:Over-Under Sign:qk]' />
+          <shape column='[{{DATASOURCE}}].[usr:Over-Under Sign:qk]' />
+        </encodings>
+        <style>
+          <style-rule element='mark'>
+            <format attr='mark-labels-show' value='false' />
+          </style-rule>
+        </style>
+      </pane>
+    </panes>
+    <rows>[{{DATASOURCE}}].[none:Member:nk]</rows>
+    <cols>([{{DATASOURCE}}].[Multiple Values] + [{{DATASOURCE}}].[sum:Actual:qk])</cols>
+  </table>
+  <simple-id uuid='00000000-0000-0000-0000-000000000001' />
+</worksheet>
+  </worksheets>
+  <windows>
+    <window class='worksheet' maximized='true' name='{{TITLE}}'>
+  <viewpoint>
+    <zoom type='entire-view' />
+  </viewpoint>
+  <simple-id uuid='00000000-0000-0000-0000-000000000002' />
+</window>
+  </windows>
+</workbook>

--- a/src/desktop/data/data-visualization-templates-xml/magnitude-simple-bar.xml
+++ b/src/desktop/data/data-visualization-templates-xml/magnitude-simple-bar.xml
@@ -1,0 +1,66 @@
+<workbook>
+  <worksheets>
+    <worksheet name='{{TITLE}}'>
+  <layout-options>
+    <title>
+      <formatted-text>
+        <run>&lt;Sheet Name&gt;
+</run>
+        <run fontname='Tableau Light' fontsize='9'>Bar length shows each category's absolute magnitude on the measure; bars are sorted by size to make the comparison easy to read.</run>
+      </formatted-text>
+    </title>
+  </layout-options>
+  <table>
+    <view>
+      <datasources>
+        <datasource caption='{{DATASOURCE}}' name='{{DATASOURCE}}' />
+      </datasources>
+      <datasource-dependencies datasource='{{DATASOURCE}}'>
+        <column datatype='string' name='[Category]' role='dimension' type='nominal' />
+        <column datatype='real' name='[Sales]' role='measure' type='quantitative' />
+        <column-instance column='[Category]' derivation='None' name='[none:Category:nk]' pivot='key' type='nominal' />
+        <column-instance column='[Sales]' derivation='Sum' name='[sum:Sales:qk]' pivot='key' type='quantitative' />
+      </datasource-dependencies>
+      <computed-sort column='[{{DATASOURCE}}].[none:Category:nk]' direction='DESC' using='[{{DATASOURCE}}].[sum:Sales:qk]' />
+      <aggregation value='true' />
+    </view>
+    <style>
+      <style-rule element='axis'>
+        <format attr='line-visibility' value='off' />
+        <format attr='title' class='0' field='[{{DATASOURCE}}].[sum:Sales:qk]' scope='cols' value='' />
+      </style-rule>
+      <style-rule element='worksheet'>
+        <format attr='display-field-labels' scope='rows' value='false' />
+      </style-rule>
+      <style-rule element='zeroline'>
+        <format attr='line-visibility' value='off' />
+      </style-rule>
+    </style>
+    <panes>
+      <pane selection-relaxation-option='selection-relaxation-allow'>
+        <view>
+          <breakdown value='auto' />
+        </view>
+        <mark class='Bar' />
+        <style>
+          <style-rule element='mark'>
+            <format attr='mark-color' value='#666666' />
+          </style-rule>
+        </style>
+      </pane>
+    </panes>
+    <rows>[{{DATASOURCE}}].[none:Category:nk]</rows>
+    <cols>[{{DATASOURCE}}].[sum:Sales:qk]</cols>
+  </table>
+  <simple-id uuid='00000000-0000-0000-0000-000000000001' />
+</worksheet>
+  </worksheets>
+  <windows>
+    <window class='worksheet' maximized='true' name='{{TITLE}}'>
+  <viewpoint>
+    <zoom type='entire-view' />
+  </viewpoint>
+  <simple-id uuid='00000000-0000-0000-0000-000000000002' />
+</window>
+  </windows>
+</workbook>

--- a/src/desktop/data/template-manifests.index.json
+++ b/src/desktop/data/template-manifests.index.json
@@ -3,7 +3,7 @@
   "_generator": "src/scripts/buildTemplateManifests.ts",
   "_warning": "GENERATED FILE — do not hand-edit. Edit data/template-manifests/*.manifest.json and re-run `npx tsx src/scripts/buildTemplateManifests.ts`.",
   "_source": "data/template-manifests/*.manifest.json",
-  "count": 42,
+  "count": 44,
   "fast_path_templates": [
     "box-plot-chart",
     "correlation-scatter-plot-chart",
@@ -64,7 +64,8 @@
         "box-and-whisker",
         "whisker",
         "quartile",
-        "distribution"
+        "distribution",
+        "spread-out"
       ],
       "description": "A box-and-whisker plot showing the DISTRIBUTION of a measure: Circle marks at one point per grain member (the level dimension on the level-of-detail shelf), a continuous measure axis on rows ([sum:Measure:qk]), and a per-cell box-plot reference line (boxplot-whisker-type='standard') that draws the median / IQR box + whiskers over those points; an OPTIONAL facet dimension on cols splits the distribution into side-by-side boxes. Serves UC7 (distribution analysis) and the UC4 ranged/uncertainty view. Generalized from the repo distribution-bar-code-chart (a live-stamped strip plot: detail-grain dim on lod + aggregated measure axis) plus the distribution-box-whisker catalog exemplar's box-plot reference-line + Circle marks. Live render-verified 2026-07-06 by the golden-parity gate (composite 98; see portability_evidence.render_evidence): structural 0.97297 (5/5 critical), pixel 1.0, binding-sanity sane via reconciled 800=800=EXPECTED_COUNT Copy>Data mark counts (grain live-corrected from the disproven Segment-FD assumption) and caption-leak pass.",
       "avoid_when": [
@@ -1165,6 +1166,134 @@
           "code": "hidden-aggregate-role-from",
           "detail": "[Region] aggregate-role-from='[State/Province]' is not rewritten; target field inherits the template's secondary-role hint (verification-report correction).",
           "xml": "correlation-scatter-plot-chart.xml:15"
+        }
+      ]
+    },
+    {
+      "template": "deviation-arrow",
+      "family": "deviation",
+      "readiness": "GREEN",
+      "fast_path_eligible": false,
+      "fast_path_blockers": [],
+      "portability_evidence": {
+        "fixture_bind": true,
+        "render_verified": "none"
+      },
+      "datasource_placeholder": true,
+      "placeholders": [
+        "TITLE",
+        "DATASOURCE"
+      ],
+      "intent_keywords": [
+        "deviation-arrow",
+        "over-under"
+      ],
+      "description": "A GENERIC over/under deviation arrow: one row per member, with a Line-mark shaft spanning the reference LINE value to the ACTUAL value on a shared measure axis (both measures folded via Measure Values, connected by a path on Measure Names) and a Shape-mark arrowhead at the actual end, colored by SIGN(SUM([Actual]) - SUM([Line])) so an over/actual-beats-line reads as one hue and an under as another. Three plain slots {member, actual, line} bound as ordinary categorical + two quantitative measures; the ONLY calc is the aggregate sign, which references the two bindable measure slots with plain arithmetic (SUM + subtraction + SIGN) and is rewritten on bind. Cloned from ww-ou-arrow's dual-mark (Line shaft + Shape arrowhead) arrow grammar but with EVERY compound-string-parse calc removed: no SPLIT/TRIM of a '<prefix> <winner>-<loser>' score string, no '<name> (<year>)' member-label parse, no season/id/roman-numeral text columns, and no inline O/U-diff spine. Intent keywords are deliberately DISTINCT from ww-ou-arrow's 'arrow-chart'/'over-under-arrow' chart-nouns (this template uses 'over-under' + the unique slug 'deviation-arrow'): those two nouns live in classify.ts CHART_NOUN_KEYWORDS, and a SECOND fast_path_eligible carrier of a chart-noun trips the lone-winner uniqueness contract (manifest.test.ts 'every classify.ts CHART_NOUN_KEYWORD is carried by <=1 fast_path_eligible manifest'), so carrying them would make this template un-stampable. Stamp-ready but deliberately UNSTAMPED (render_verified 'none' -> fast_path_eligible false) until the orchestrator live-verifies it.",
+      "avoid_when": [
+        "The actual and/or reference values arrive as COMPOUND score/label strings that must be SPLIT-parsed (e.g. a 'KC 25-22' combined-score string, or a '<name> (<year>)' member label) - use ww-ou-arrow, whose calcs parse exactly those Super-Bowl-style shapes; this generic template takes two PLAIN numeric measures and does no string parsing, so a compound-string field binds the wrong value.",
+        "The framing is quota / attainment / actual-vs-goal (a rep or region measured against a quota or target as 'how much of goal attained'), where a bar with a per-cell reference line reads better - use quota-attainment-bullet; this arrow shows the directional over/under gap between two peer measures, not quota attainment.",
+        "A distinct over/under hue (e.g. teal over, red under) and left/right arrowhead GLYPHS are required on first render - that value->hue and value->glyph mapping is datasource-level style NOT carried by this worksheet-only template (see hazard datasource-style-dropped); the encodings' driving field is carried, but the marks fall back to the default palette + default shape until the style is re-injected at stamp time."
+      ],
+      "slots": [
+        {
+          "slot_id": "member",
+          "template_field": "Member",
+          "derivation": "none",
+          "role": [
+            "rows"
+          ],
+          "kind": "categorical",
+          "bindable": true,
+          "required": true,
+          "notes": "One arrow row per member on rows ([none:Member:nk]). The categorical the deviation is compared across (region / segment / rep)."
+        },
+        {
+          "slot_id": "actual",
+          "template_field": "Actual",
+          "derivation": "sum",
+          "role": [
+            "cols",
+            "measure-values",
+            "calc-input"
+          ],
+          "kind": "quantitative",
+          "bindable": true,
+          "required": true,
+          "notes": "The ACTUAL measure, SUM([Actual]) -> [sum:Actual:qk]. The far (arrowhead) endpoint of the shaft: it is the Shape pane's cols axis AND one of the two measures folded onto the shared Measure Values axis, AND the minuend of the sign calc. replaceFieldReferences rewrites [Actual] in the calc formula on bind."
+        },
+        {
+          "slot_id": "line",
+          "template_field": "Line",
+          "derivation": "sum",
+          "role": [
+            "measure-values",
+            "calc-input"
+          ],
+          "kind": "quantitative",
+          "bindable": true,
+          "required": true,
+          "notes": "The reference/target LINE measure, SUM([Line]) -> [sum:Line:qk]. The near endpoint of the shaft (the second measure folded onto the shared Measure Values axis via the Measure Names filter) and the subtrahend of the sign calc. replaceFieldReferences rewrites [Line] in the calc formula on bind. Superstore has no natural target column, so at stamp time bind a second real measure as the reference (e.g. Profit) or a genuine plan/target measure."
+        }
+      ],
+      "calcs": [
+        {
+          "slot_id": "over_under_sign_calc",
+          "template_field": "Over-Under Sign",
+          "derivation": "usr",
+          "role": [
+            "color",
+            "shape"
+          ],
+          "kind": "calc",
+          "bindable": false,
+          "required": true,
+          "formula": "SIGN(SUM([Actual])-SUM([Line]))",
+          "formula_refs": [
+            "Actual",
+            "Line"
+          ],
+          "depends_on_slots": [
+            "actual",
+            "line"
+          ],
+          "result_role": "measure",
+          "inputs": [
+            {
+              "ref": "Actual",
+              "slot_id": "actual",
+              "slot_kind": "quantitative",
+              "required": true,
+              "template_internal": false
+            },
+            {
+              "ref": "Line",
+              "slot_id": "line",
+              "slot_kind": "quantitative",
+              "required": true,
+              "template_internal": false
+            }
+          ],
+          "prereqs": [
+            "raw-formula-refs"
+          ],
+          "notes": "SIGN(SUM([Actual])-SUM([Line])) -> +1 over / 0 tie / -1 under. Drives BOTH the arrow color and the arrowhead shape encoding. A generic, PLAIN-arithmetic aggregate calc (SUM + subtraction + SIGN) referencing only the two bindable measure slots - NO SPLIT/TRIM/parse; the compound-string-parse hazard of ww-ou-arrow is intentionally absent. Both bare refs rewrite on bind (raw-formula-refs). The discrete over/under hue + left/right glyph MAP is datasource-level style (see hazard datasource-style-dropped); this calc only supplies the driving field."
+        }
+      ],
+      "hazards": [
+        {
+          "code": "signed-deviation-measure",
+          "detail": "Deviation family: the encoding reads as an OVER/UNDER direction, so bind a genuine actual measure and a genuine reference/target measure whose difference is meaningfully signed. If the reference is not a comparable peer measure (same unit, same grain), the over/under hue and the shaft length are not interpretable. Superstore has no built-in target column, so pick a real second measure (e.g. Profit as the reference) or a plan/target measure at stamp time.",
+          "xml": "deviation-arrow.xml:19"
+        },
+        {
+          "code": "datasource-style-dropped",
+          "detail": "The distinct over/under COLOR palette (e.g. teal over / red under) and the left/right arrowhead SHAPE glyph map are datasource-level <style> in the ww-ou-arrow golden, NOT expressible in a worksheet-only template. This template carries the color + shape ENCODINGS (which field drives them: the sign calc) but not the value->hue / value->glyph MAP, so on first apply the marks fall back to the default palette + default shape. Advisory only (surfaced via avoid_when), NOT a deterministic-path-blocking hazard; faithful hue/glyph is re-injected at stamp time.",
+          "xml": "deviation-arrow.xml:56"
+        },
+        {
+          "code": "raw-formula-refs",
+          "detail": "The sign calc references the bare bindable [Actual]/[Line]; templates.ts rewriteFormulaFieldRefs repairs them on bind because each is a bindable bare-key slot (same pattern as deviation-diverging-bar / correlation-scatter-plot-chart). Gate #6 asserts both are bound. There are NO template-internal calc-to-calc refs and NO parse coercions (contrast ww-ou-arrow, whose INT(SPLIT(...)) chain is the compound-string-parse blocker this template removes).",
+          "xml": "deviation-arrow.xml:20"
         }
       ]
     },
@@ -2528,6 +2657,65 @@
       ]
     },
     {
+      "template": "magnitude-simple-bar",
+      "family": "magnitude",
+      "readiness": "GREEN",
+      "fast_path_eligible": false,
+      "fast_path_blockers": [],
+      "portability_evidence": {
+        "fixture_bind": true,
+        "render_verified": "none"
+      },
+      "datasource_placeholder": true,
+      "placeholders": [
+        "TITLE",
+        "DATASOURCE"
+      ],
+      "intent_keywords": [
+        "magnitude",
+        "absolute"
+      ],
+      "description": "Horizontal bars, one per category; bar length = the measure's ABSOLUTE magnitude (a size comparison across categories). Bars are sorted descending by the measure purely as a READING AID — the sort is not a ranking contract (no top-N, best/worst, or positional semantics). The magnitude family's generic {category, measure} bar: cloned from ranking-ordered-bar's two-slot categorical+quantitative bar shape, but with ranking-specific keywords, subtitle, and sort-role labels removed, and NO period/temporal slot or hardcoded incomplete-period filter (the HARDCODED_FILTER_MEMBERS blocker that keeps magnitude-paired-bar / magnitude-paired-column-chart off the fast path). Stamp-ready but not yet live-verified: render_verified 'none' -> fast_path_eligible false until the orchestrator live-stamps it.",
+      "avoid_when": [
+        "The user explicitly wants a ranked or top-N / bottom-N ordering as the point of the chart (best/worst, leaders/laggards) - reach for ranking-ordered-bar or ranking-ordered-column, where the sort order IS the contract; here the descending sort is only a reading aid.",
+        "The comparison is period-over-period (this year vs last year, before vs after) - use the magnitude paired-bar or paired-column family, which pairs a measure over two or more time periods per group."
+      ],
+      "slots": [
+        {
+          "slot_id": "category",
+          "template_field": "Category",
+          "derivation": "none",
+          "role": [
+            "rows"
+          ],
+          "kind": "categorical",
+          "bindable": true,
+          "required": true,
+          "notes": "One horizontal bar per member on rows. Also the dimension instance the computed-sort orders (DESC by the measure) - a reading aid, not a ranking contract."
+        },
+        {
+          "slot_id": "measure",
+          "template_field": "Sales",
+          "derivation": "sum",
+          "role": [
+            "cols"
+          ],
+          "kind": "quantitative",
+          "bindable": true,
+          "required": true,
+          "notes": "Bar length on cols = the measure's magnitude, aggregated as SUM. Template_field 'Sales' is just the placeholder column the field-swap injector renames to the bound measure; the computed-sort's using= references this instance."
+        }
+      ],
+      "calcs": [],
+      "hazards": [
+        {
+          "code": "computed-sort-pill-coupling",
+          "detail": "The computed-sort binds the category dimension instance ([none:Category:nk]) to the measure instance ([sum:Sales:qk]); both slots must bind or the sort dangles. Both are required, so this is satisfied by coverage. (This is the ONLY carry-over from the ranking donor's sort mechanic; unlike ranking, the sort here is presentational, not a top-N contract.)",
+          "xml": "magnitude-simple-bar.xml:24"
+        }
+      ]
+    },
+    {
       "template": "pareto-chart",
       "family": "specialized",
       "readiness": "YELLOW",
@@ -3417,6 +3605,7 @@
       ],
       "intent_keywords": [
         "ranking",
+        "rank",
         "sorted-bar",
         "bar",
         "top",
@@ -3501,6 +3690,7 @@
       ],
       "intent_keywords": [
         "ranking",
+        "rank",
         "sorted-column",
         "column",
         "vertical-bar",
@@ -3742,7 +3932,10 @@
       "intent_keywords": [
         "latlon-symbol-map",
         "latitude-longitude-map",
+        "lat-long-map",
+        "lat-lon-map",
         "coordinate-map",
+        "gps-map",
         "point-map",
         "symbol-map",
         "bubble-map",
@@ -3833,8 +4026,11 @@
       "intent_keywords": [
         "symbol-map",
         "proportional-symbol-map",
+        "graduated-symbol-map",
         "bubble-map",
         "point-map",
+        "dot-map",
+        "pin-map",
         "spatial",
         "map"
       ],
@@ -3947,7 +4143,9 @@
         "month-over-month",
         "period-over-period",
         "forecast",
-        "change-over-time"
+        "change-over-time",
+        "calendar-year",
+        "across-the-calendar"
       ],
       "description": "A line of an aggregated measure over a truncated date on the x-axis; shows trend across time.",
       "avoid_when": [

--- a/src/desktop/data/template-manifests/box-plot-chart.manifest.json
+++ b/src/desktop/data/template-manifests/box-plot-chart.manifest.json
@@ -40,7 +40,8 @@
   "box-and-whisker",
   "whisker",
   "quartile",
-  "distribution"
+  "distribution",
+  "spread-out"
  ],
  "description": "A box-and-whisker plot showing the DISTRIBUTION of a measure: Circle marks at one point per grain member (the level dimension on the level-of-detail shelf), a continuous measure axis on rows ([sum:Measure:qk]), and a per-cell box-plot reference line (boxplot-whisker-type='standard') that draws the median / IQR box + whiskers over those points; an OPTIONAL facet dimension on cols splits the distribution into side-by-side boxes. Serves UC7 (distribution analysis) and the UC4 ranged/uncertainty view. Generalized from the repo distribution-bar-code-chart (a live-stamped strip plot: detail-grain dim on lod + aggregated measure axis) plus the distribution-box-whisker catalog exemplar's box-plot reference-line + Circle marks. Live render-verified 2026-07-06 by the golden-parity gate (composite 98; see portability_evidence.render_evidence): structural 0.97297 (5/5 critical), pixel 1.0, binding-sanity sane via reconciled 800=800=EXPECTED_COUNT Copy>Data mark counts (grain live-corrected from the disproven Segment-FD assumption) and caption-leak pass.",
  "avoid_when": [

--- a/src/desktop/data/template-manifests/deviation-arrow.manifest.json
+++ b/src/desktop/data/template-manifests/deviation-arrow.manifest.json
@@ -1,0 +1,128 @@
+{
+  "template": "deviation-arrow",
+  "family": "deviation",
+  "readiness": "GREEN",
+  "fast_path_eligible": false,
+  "fast_path_blockers": [],
+  "portability_evidence": {
+    "fixture_bind": true,
+    "render_verified": "none"
+  },
+  "datasource_placeholder": true,
+  "placeholders": [
+    "TITLE",
+    "DATASOURCE"
+  ],
+  "intent_keywords": [
+    "deviation-arrow",
+    "over-under"
+  ],
+  "description": "A GENERIC over/under deviation arrow: one row per member, with a Line-mark shaft spanning the reference LINE value to the ACTUAL value on a shared measure axis (both measures folded via Measure Values, connected by a path on Measure Names) and a Shape-mark arrowhead at the actual end, colored by SIGN(SUM([Actual]) - SUM([Line])) so an over/actual-beats-line reads as one hue and an under as another. Three plain slots {member, actual, line} bound as ordinary categorical + two quantitative measures; the ONLY calc is the aggregate sign, which references the two bindable measure slots with plain arithmetic (SUM + subtraction + SIGN) and is rewritten on bind. Cloned from ww-ou-arrow's dual-mark (Line shaft + Shape arrowhead) arrow grammar but with EVERY compound-string-parse calc removed: no SPLIT/TRIM of a '<prefix> <winner>-<loser>' score string, no '<name> (<year>)' member-label parse, no season/id/roman-numeral text columns, and no inline O/U-diff spine. Intent keywords are deliberately DISTINCT from ww-ou-arrow's 'arrow-chart'/'over-under-arrow' chart-nouns (this template uses 'over-under' + the unique slug 'deviation-arrow'): those two nouns live in classify.ts CHART_NOUN_KEYWORDS, and a SECOND fast_path_eligible carrier of a chart-noun trips the lone-winner uniqueness contract (manifest.test.ts 'every classify.ts CHART_NOUN_KEYWORD is carried by <=1 fast_path_eligible manifest'), so carrying them would make this template un-stampable. Stamp-ready but deliberately UNSTAMPED (render_verified 'none' -> fast_path_eligible false) until the orchestrator live-verifies it.",
+  "avoid_when": [
+    "The actual and/or reference values arrive as COMPOUND score/label strings that must be SPLIT-parsed (e.g. a 'KC 25-22' combined-score string, or a '<name> (<year>)' member label) - use ww-ou-arrow, whose calcs parse exactly those Super-Bowl-style shapes; this generic template takes two PLAIN numeric measures and does no string parsing, so a compound-string field binds the wrong value.",
+    "The framing is quota / attainment / actual-vs-goal (a rep or region measured against a quota or target as 'how much of goal attained'), where a bar with a per-cell reference line reads better - use quota-attainment-bullet; this arrow shows the directional over/under gap between two peer measures, not quota attainment.",
+    "A distinct over/under hue (e.g. teal over, red under) and left/right arrowhead GLYPHS are required on first render - that value->hue and value->glyph mapping is datasource-level style NOT carried by this worksheet-only template (see hazard datasource-style-dropped); the encodings' driving field is carried, but the marks fall back to the default palette + default shape until the style is re-injected at stamp time."
+  ],
+  "slots": [
+    {
+      "slot_id": "member",
+      "template_field": "Member",
+      "derivation": "none",
+      "role": [
+        "rows"
+      ],
+      "kind": "categorical",
+      "bindable": true,
+      "required": true,
+      "notes": "One arrow row per member on rows ([none:Member:nk]). The categorical the deviation is compared across (region / segment / rep)."
+    },
+    {
+      "slot_id": "actual",
+      "template_field": "Actual",
+      "derivation": "sum",
+      "role": [
+        "cols",
+        "measure-values",
+        "calc-input"
+      ],
+      "kind": "quantitative",
+      "bindable": true,
+      "required": true,
+      "notes": "The ACTUAL measure, SUM([Actual]) -> [sum:Actual:qk]. The far (arrowhead) endpoint of the shaft: it is the Shape pane's cols axis AND one of the two measures folded onto the shared Measure Values axis, AND the minuend of the sign calc. replaceFieldReferences rewrites [Actual] in the calc formula on bind."
+    },
+    {
+      "slot_id": "line",
+      "template_field": "Line",
+      "derivation": "sum",
+      "role": [
+        "measure-values",
+        "calc-input"
+      ],
+      "kind": "quantitative",
+      "bindable": true,
+      "required": true,
+      "notes": "The reference/target LINE measure, SUM([Line]) -> [sum:Line:qk]. The near endpoint of the shaft (the second measure folded onto the shared Measure Values axis via the Measure Names filter) and the subtrahend of the sign calc. replaceFieldReferences rewrites [Line] in the calc formula on bind. Superstore has no natural target column, so at stamp time bind a second real measure as the reference (e.g. Profit) or a genuine plan/target measure."
+    }
+  ],
+  "calcs": [
+    {
+      "slot_id": "over_under_sign_calc",
+      "template_field": "Over-Under Sign",
+      "derivation": "usr",
+      "role": [
+        "color",
+        "shape"
+      ],
+      "kind": "calc",
+      "bindable": false,
+      "required": true,
+      "formula": "SIGN(SUM([Actual])-SUM([Line]))",
+      "formula_refs": [
+        "Actual",
+        "Line"
+      ],
+      "depends_on_slots": [
+        "actual",
+        "line"
+      ],
+      "result_role": "measure",
+      "inputs": [
+        {
+          "ref": "Actual",
+          "slot_id": "actual",
+          "slot_kind": "quantitative",
+          "required": true,
+          "template_internal": false
+        },
+        {
+          "ref": "Line",
+          "slot_id": "line",
+          "slot_kind": "quantitative",
+          "required": true,
+          "template_internal": false
+        }
+      ],
+      "prereqs": [
+        "raw-formula-refs"
+      ],
+      "notes": "SIGN(SUM([Actual])-SUM([Line])) -> +1 over / 0 tie / -1 under. Drives BOTH the arrow color and the arrowhead shape encoding. A generic, PLAIN-arithmetic aggregate calc (SUM + subtraction + SIGN) referencing only the two bindable measure slots - NO SPLIT/TRIM/parse; the compound-string-parse hazard of ww-ou-arrow is intentionally absent. Both bare refs rewrite on bind (raw-formula-refs). The discrete over/under hue + left/right glyph MAP is datasource-level style (see hazard datasource-style-dropped); this calc only supplies the driving field."
+    }
+  ],
+  "hazards": [
+    {
+      "code": "signed-deviation-measure",
+      "detail": "Deviation family: the encoding reads as an OVER/UNDER direction, so bind a genuine actual measure and a genuine reference/target measure whose difference is meaningfully signed. If the reference is not a comparable peer measure (same unit, same grain), the over/under hue and the shaft length are not interpretable. Superstore has no built-in target column, so pick a real second measure (e.g. Profit as the reference) or a plan/target measure at stamp time.",
+      "xml": "deviation-arrow.xml:19"
+    },
+    {
+      "code": "datasource-style-dropped",
+      "detail": "The distinct over/under COLOR palette (e.g. teal over / red under) and the left/right arrowhead SHAPE glyph map are datasource-level <style> in the ww-ou-arrow golden, NOT expressible in a worksheet-only template. This template carries the color + shape ENCODINGS (which field drives them: the sign calc) but not the value->hue / value->glyph MAP, so on first apply the marks fall back to the default palette + default shape. Advisory only (surfaced via avoid_when), NOT a deterministic-path-blocking hazard; faithful hue/glyph is re-injected at stamp time.",
+      "xml": "deviation-arrow.xml:56"
+    },
+    {
+      "code": "raw-formula-refs",
+      "detail": "The sign calc references the bare bindable [Actual]/[Line]; templates.ts rewriteFormulaFieldRefs repairs them on bind because each is a bindable bare-key slot (same pattern as deviation-diverging-bar / correlation-scatter-plot-chart). Gate #6 asserts both are bound. There are NO template-internal calc-to-calc refs and NO parse coercions (contrast ww-ou-arrow, whose INT(SPLIT(...)) chain is the compound-string-parse blocker this template removes).",
+      "xml": "deviation-arrow.xml:20"
+    }
+  ]
+}

--- a/src/desktop/data/template-manifests/magnitude-simple-bar.manifest.json
+++ b/src/desktop/data/template-manifests/magnitude-simple-bar.manifest.json
@@ -1,0 +1,33 @@
+{
+  "template": "magnitude-simple-bar",
+  "family": "magnitude",
+  "readiness": "GREEN",
+  "fast_path_eligible": false,
+  "fast_path_blockers": [],
+  "portability_evidence": {
+    "fixture_bind": true,
+    "render_verified": "none"
+  },
+  "datasource_placeholder": true,
+  "placeholders": ["TITLE", "DATASOURCE"],
+  "intent_keywords": ["magnitude", "absolute"],
+  "description": "Horizontal bars, one per category; bar length = the measure's ABSOLUTE magnitude (a size comparison across categories). Bars are sorted descending by the measure purely as a READING AID — the sort is not a ranking contract (no top-N, best/worst, or positional semantics). The magnitude family's generic {category, measure} bar: cloned from ranking-ordered-bar's two-slot categorical+quantitative bar shape, but with ranking-specific keywords, subtitle, and sort-role labels removed, and NO period/temporal slot or hardcoded incomplete-period filter (the HARDCODED_FILTER_MEMBERS blocker that keeps magnitude-paired-bar / magnitude-paired-column-chart off the fast path). Stamp-ready but not yet live-verified: render_verified 'none' -> fast_path_eligible false until the orchestrator live-stamps it.",
+  "avoid_when": [
+    "The user explicitly wants a ranked or top-N / bottom-N ordering as the point of the chart (best/worst, leaders/laggards) - reach for ranking-ordered-bar or ranking-ordered-column, where the sort order IS the contract; here the descending sort is only a reading aid.",
+    "The comparison is period-over-period (this year vs last year, before vs after) - use the magnitude paired-bar or paired-column family, which pairs a measure over two or more time periods per group."
+  ],
+  "slots": [
+    { "slot_id": "category", "template_field": "Category", "derivation": "none",
+      "role": ["rows"], "kind": "categorical", "bindable": true, "required": true,
+      "notes": "One horizontal bar per member on rows. Also the dimension instance the computed-sort orders (DESC by the measure) - a reading aid, not a ranking contract." },
+    { "slot_id": "measure", "template_field": "Sales", "derivation": "sum",
+      "role": ["cols"], "kind": "quantitative", "bindable": true, "required": true,
+      "notes": "Bar length on cols = the measure's magnitude, aggregated as SUM. Template_field 'Sales' is just the placeholder column the field-swap injector renames to the bound measure; the computed-sort's using= references this instance." }
+  ],
+  "calcs": [],
+  "hazards": [
+    { "code": "computed-sort-pill-coupling",
+      "detail": "The computed-sort binds the category dimension instance ([none:Category:nk]) to the measure instance ([sum:Sales:qk]); both slots must bind or the sort dangles. Both are required, so this is satisfied by coverage. (This is the ONLY carry-over from the ranking donor's sort mechanic; unlike ranking, the sort here is presentational, not a top-N contract.)",
+      "xml": "magnitude-simple-bar.xml:24" }
+  ]
+}

--- a/src/desktop/data/template-manifests/ranking-ordered-bar.manifest.json
+++ b/src/desktop/data/template-manifests/ranking-ordered-bar.manifest.json
@@ -20,7 +20,7 @@
   },
   "datasource_placeholder": true,
   "placeholders": ["TITLE", "DATASOURCE"],
-  "intent_keywords": ["ranking", "sorted-bar", "bar", "top", "highest", "lowest"],
+  "intent_keywords": ["ranking", "rank", "sorted-bar", "bar", "top", "highest", "lowest"],
   "description": "Horizontal bars, one per category; bar length = measure; sorted descending by the measure.",
   "avoid_when": [
     "The 'top' here is positional layering — marks drawn on top of a reference line or another chart layer — not a top-N ranking; a positional or annotation placement is not a sorted bar chart."

--- a/src/desktop/data/template-manifests/ranking-ordered-column.manifest.json
+++ b/src/desktop/data/template-manifests/ranking-ordered-column.manifest.json
@@ -25,6 +25,7 @@
   ],
   "intent_keywords": [
     "ranking",
+    "rank",
     "sorted-column",
     "column",
     "vertical-bar",

--- a/src/desktop/data/template-manifests/spatial-symbol-map-latlon.manifest.json
+++ b/src/desktop/data/template-manifests/spatial-symbol-map-latlon.manifest.json
@@ -16,7 +16,10 @@
   "intent_keywords": [
     "latlon-symbol-map",
     "latitude-longitude-map",
+    "lat-long-map",
+    "lat-lon-map",
     "coordinate-map",
+    "gps-map",
     "point-map",
     "symbol-map",
     "bubble-map",

--- a/src/desktop/data/template-manifests/spatial-symbol-map.manifest.json
+++ b/src/desktop/data/template-manifests/spatial-symbol-map.manifest.json
@@ -16,8 +16,11 @@
   "intent_keywords": [
     "symbol-map",
     "proportional-symbol-map",
+    "graduated-symbol-map",
     "bubble-map",
     "point-map",
+    "dot-map",
+    "pin-map",
     "spatial",
     "map"
   ],

--- a/src/desktop/data/template-manifests/trend-line-chart.manifest.json
+++ b/src/desktop/data/template-manifests/trend-line-chart.manifest.json
@@ -20,7 +20,7 @@
   },
   "datasource_placeholder": true,
   "placeholders": ["TITLE", "DATASOURCE"],
-  "intent_keywords": ["trend", "over-time", "line", "time-series", "timeline", "by-month", "sales-over-time", "year-over-year", "yoy", "prior-year", "current-year", "rolling", "moving-average", "moving-sum", "running-total", "month-over-month", "period-over-period", "forecast", "change-over-time"],
+  "intent_keywords": ["trend", "over-time", "line", "time-series", "timeline", "by-month", "sales-over-time", "year-over-year", "yoy", "prior-year", "current-year", "rolling", "moving-average", "moving-sum", "running-total", "month-over-month", "period-over-period", "forecast", "change-over-time", "calendar-year", "across-the-calendar"],
   "description": "A line of an aggregated measure over a truncated date on the x-axis; shows trend across time.",
   "avoid_when": [
     "The x-axis is a set of DISCRETE, non-temporal CATEGORIES (categorical members such as products or segments) instead of a continuous time axis. A line CONNECTS adjacent points and so IMPLIES CONTINUITY between them, drawing a misleading slope across unrelated categorical members; a cross-category breakdown with no time axis belongs on a bar chart. Keep this line template for a continuous time x-axis only \u2014 do not bind a discrete category to the x."

--- a/src/desktop/data/templates/deviation-arrow.xml
+++ b/src/desktop/data/templates/deviation-arrow.xml
@@ -1,0 +1,97 @@
+<workbook xmlns:user='http://www.tableausoftware.com/xml/user'>
+  <worksheets>
+    <worksheet name='{{TITLE}}'>
+  <layout-options>
+    <title>
+      <formatted-text>
+        <run>&lt;Sheet Name&gt;
+</run>
+        <run fontname='Tableau Light' fontsize='9'>One row per member: the shaft spans the reference line value to the actual value on a shared measure axis, and the arrowhead at the actual end is colored by whether the actual finished OVER the line (one hue) or UNDER it (another) via SIGN(actual - line).</run>
+      </formatted-text>
+    </title>
+  </layout-options>
+  <table>
+    <view>
+      <datasources>
+        <datasource name='{{DATASOURCE}}' />
+      </datasources>
+      <datasource-dependencies datasource='{{DATASOURCE}}'>
+        <column caption='Over/Under Sign' datatype='integer' name='[Over-Under Sign]' role='measure' type='quantitative'>
+          <calculation class='tableau' formula='SIGN(SUM([Actual])-SUM([Line]))' />
+        </column>
+        <column datatype='string' name='[Member]' role='dimension' type='nominal' />
+        <column datatype='real' name='[Actual]' role='measure' type='quantitative' />
+        <column datatype='real' name='[Line]' role='measure' type='quantitative' />
+        <column-instance column='[Member]' derivation='None' name='[none:Member:nk]' pivot='key' type='nominal' />
+        <column-instance column='[Actual]' derivation='Sum' name='[sum:Actual:qk]' pivot='key' type='quantitative' />
+        <column-instance column='[Line]' derivation='Sum' name='[sum:Line:qk]' pivot='key' type='quantitative' />
+        <column-instance column='[Over-Under Sign]' derivation='User' name='[usr:Over-Under Sign:qk]' pivot='key' type='quantitative' />
+      </datasource-dependencies>
+      <filter class='categorical' column='[{{DATASOURCE}}].[:Measure Names]'>
+        <groupfilter function='union' user:op='manual'>
+          <groupfilter function='member' level='[:Measure Names]' member='&quot;[{{DATASOURCE}}].[sum:Line:qk]&quot;' />
+          <groupfilter function='member' level='[:Measure Names]' member='&quot;[{{DATASOURCE}}].[sum:Actual:qk]&quot;' />
+        </groupfilter>
+      </filter>
+      <slices>
+        <column>[{{DATASOURCE}}].[:Measure Names]</column>
+      </slices>
+      <aggregation value='true' />
+    </view>
+    <style>
+      <style-rule element='worksheet'>
+        <format attr='display-field-labels' scope='rows' value='false' />
+      </style-rule>
+      <style-rule element='zeroline'>
+        <format attr='line-visibility' value='off' />
+      </style-rule>
+    </style>
+    <panes>
+      <pane selection-relaxation-option='selection-relaxation-allow' x-axis-name='[{{DATASOURCE}}].[Multiple Values]'>
+        <view>
+          <breakdown value='auto' />
+        </view>
+        <mark class='Line' />
+        <mark-sizing mark-sizing-setting='marks-scaling-off' />
+        <encodings>
+          <color column='[{{DATASOURCE}}].[usr:Over-Under Sign:qk]' />
+          <path column='[{{DATASOURCE}}].[:Measure Names]' />
+        </encodings>
+        <style>
+          <style-rule element='mark'>
+            <format attr='mark-labels-show' value='false' />
+          </style-rule>
+        </style>
+      </pane>
+      <pane selection-relaxation-option='selection-relaxation-allow' x-axis-name='[{{DATASOURCE}}].[sum:Actual:qk]'>
+        <view>
+          <breakdown value='auto' />
+        </view>
+        <mark class='Shape' />
+        <mark-sizing mark-sizing-setting='marks-scaling-off' />
+        <encodings>
+          <color column='[{{DATASOURCE}}].[usr:Over-Under Sign:qk]' />
+          <shape column='[{{DATASOURCE}}].[usr:Over-Under Sign:qk]' />
+        </encodings>
+        <style>
+          <style-rule element='mark'>
+            <format attr='mark-labels-show' value='false' />
+          </style-rule>
+        </style>
+      </pane>
+    </panes>
+    <rows>[{{DATASOURCE}}].[none:Member:nk]</rows>
+    <cols>([{{DATASOURCE}}].[Multiple Values] + [{{DATASOURCE}}].[sum:Actual:qk])</cols>
+  </table>
+  <simple-id uuid='00000000-0000-0000-0000-000000000001' />
+</worksheet>
+  </worksheets>
+  <windows>
+    <window class='worksheet' maximized='true' name='{{TITLE}}'>
+  <viewpoint>
+    <zoom type='entire-view' />
+  </viewpoint>
+  <simple-id uuid='00000000-0000-0000-0000-000000000002' />
+</window>
+  </windows>
+</workbook>

--- a/src/desktop/data/templates/magnitude-simple-bar.xml
+++ b/src/desktop/data/templates/magnitude-simple-bar.xml
@@ -1,0 +1,66 @@
+<workbook>
+  <worksheets>
+    <worksheet name='{{TITLE}}'>
+  <layout-options>
+    <title>
+      <formatted-text>
+        <run>&lt;Sheet Name&gt;
+</run>
+        <run fontname='Tableau Light' fontsize='9'>Bar length shows each category's absolute magnitude on the measure; bars are sorted by size to make the comparison easy to read.</run>
+      </formatted-text>
+    </title>
+  </layout-options>
+  <table>
+    <view>
+      <datasources>
+        <datasource caption='{{DATASOURCE}}' name='{{DATASOURCE}}' />
+      </datasources>
+      <datasource-dependencies datasource='{{DATASOURCE}}'>
+        <column datatype='string' name='[Category]' role='dimension' type='nominal' />
+        <column datatype='real' name='[Sales]' role='measure' type='quantitative' />
+        <column-instance column='[Category]' derivation='None' name='[none:Category:nk]' pivot='key' type='nominal' />
+        <column-instance column='[Sales]' derivation='Sum' name='[sum:Sales:qk]' pivot='key' type='quantitative' />
+      </datasource-dependencies>
+      <computed-sort column='[{{DATASOURCE}}].[none:Category:nk]' direction='DESC' using='[{{DATASOURCE}}].[sum:Sales:qk]' />
+      <aggregation value='true' />
+    </view>
+    <style>
+      <style-rule element='axis'>
+        <format attr='line-visibility' value='off' />
+        <format attr='title' class='0' field='[{{DATASOURCE}}].[sum:Sales:qk]' scope='cols' value='' />
+      </style-rule>
+      <style-rule element='worksheet'>
+        <format attr='display-field-labels' scope='rows' value='false' />
+      </style-rule>
+      <style-rule element='zeroline'>
+        <format attr='line-visibility' value='off' />
+      </style-rule>
+    </style>
+    <panes>
+      <pane selection-relaxation-option='selection-relaxation-allow'>
+        <view>
+          <breakdown value='auto' />
+        </view>
+        <mark class='Bar' />
+        <style>
+          <style-rule element='mark'>
+            <format attr='mark-color' value='#666666' />
+          </style-rule>
+        </style>
+      </pane>
+    </panes>
+    <rows>[{{DATASOURCE}}].[none:Category:nk]</rows>
+    <cols>[{{DATASOURCE}}].[sum:Sales:qk]</cols>
+  </table>
+  <simple-id uuid='00000000-0000-0000-0000-000000000001' />
+</worksheet>
+  </worksheets>
+  <windows>
+    <window class='worksheet' maximized='true' name='{{TITLE}}'>
+  <viewpoint>
+    <zoom type='entire-view' />
+  </viewpoint>
+  <simple-id uuid='00000000-0000-0000-0000-000000000002' />
+</window>
+  </windows>
+</workbook>

--- a/src/desktop/validation/templates-no-self-reject.invariant.test.ts
+++ b/src/desktop/validation/templates-no-self-reject.invariant.test.ts
@@ -33,7 +33,7 @@ const xmlFiles = fs
   .sort();
 
 describe('validation/templates — no bundled template self-rejects on invalid-derivation-string', () => {
-  it('discovers the shipped template XML corpus (45: 44 day-1 sync + spatial-symbol-map-latlon)', () => {
+  it('discovers the shipped template XML corpus (47: 44 day-1 sync + spatial-symbol-map-latlon + deviation-arrow + magnitude-simple-bar)', () => {
     expect(
       xmlFiles.length,
       'expected the shipped template XML corpus to be non-empty',
@@ -42,7 +42,9 @@ describe('validation/templates — no bundled template self-rejects on invalid-d
     // this invariant is caught (adjust deliberately when the corpus grows).
     // parity-port: +1 for spatial-symbol-map-latlon.xml (the per-file it.each below still
     // proves it does not self-reject on invalid-derivation-string).
-    expect(xmlFiles.length).toBe(45);
+    // classifier-lockstep-port: +2 for deviation-arrow.xml + magnitude-simple-bar.xml
+    // (a2td template parity sync; both render_verified 'none' → fast_path_eligible false).
+    expect(xmlFiles.length).toBe(47);
   });
 
   it.each(xmlFiles)(


### PR DESCRIPTION
Byte-identical port of a2td's classifier from a2td main d148768 — sha256 `4a49e134a6c4e683…` matches on both sides; lockstep pin refreshed via `check-lockstep --update` (gate green 6/6). Zero call-site edits: the new 5th `roleGreedyBind` param and `askNamesField` change are file-private.

Carries the three changes that took a2td's in-envelope deterministic bind rate **62.5% → 75%**: `timeline` chart-noun, fail-closed unique-date temporal completion, and the plural-aware exact-name field alias.

Parity sync rides along (PR #481 pattern): `deviation-arrow` + `magnitude-simple-bar` templates/manifests (both `fast_path_eligible:false` — no carrier-uniqueness impact), six #183 `intent_keywords` additions, index + content-manifest regenerated (42 → 44 manifests), count-pins advanced.

**Known:** `classify.ts:612` carries one prettier long-line error — same lockstep-drift class as `fieldReferenceRewriter.ts`; unfixable without breaking byte-identity.

**Validation:** full suite 3,232 passed, tsc clean, lockstep gate green.

Independent of the shelf-consolidation PR; note `claude/refine-route-port`'s CHART_NOUN mirror parity test will demand `timeline` when the two stacks meet (by design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)