### PR TITLE
desktop: port the a2td refine fast-lane + route layer (Slices A+B, Phase-3 reviewed)

### DIFF
--- a/src/desktop/binder/ask-router.test.ts
+++ b/src/desktop/binder/ask-router.test.ts
@@ -1,0 +1,112 @@
+// src/desktop/binder/ask-router.test.ts
+//
+// The route layer's SELECTOR. Pins that selectEligible reuses the binder's model-free matcher
+// (unique decisive keyword-argmax over the fast_path_eligible pool) and NEVER selects unproven
+// supply, plus the CHART_NOUN_KEYWORDS lockstep parity with classify.ts (the hand-maintained
+// mirror MUST equal the hash-gated classifier's table exactly, and this file must import
+// NOTHING from classify.ts).
+
+import fs from 'fs';
+import path from 'path';
+import { beforeAll, describe, expect, it } from 'vitest';
+
+import { selectEligible } from './ask-router.js';
+import { loadManifests } from './manifest.js';
+import type { TemplateManifest } from './manifest-types.js';
+
+const repoRoot = path.resolve(__dirname, '..', '..', '..');
+
+let manifests: TemplateManifest[];
+beforeAll(() => {
+  manifests = [...loadManifests().values()];
+});
+
+/** A minimal, structurally-sufficient manifest for matcher/eligibility pinning. */
+function mkManifest(over: Partial<TemplateManifest> & { template: string }): TemplateManifest {
+  return {
+    family: 'specialized',
+    readiness: 'GREEN',
+    fast_path_eligible: true,
+    fast_path_blockers: [],
+    intent_keywords: [],
+    description: 'synthetic test manifest',
+    placeholders: ['TITLE', 'DATASOURCE'],
+    slots: [],
+    calcs: [],
+    ...over,
+  } as unknown as TemplateManifest;
+}
+
+describe('selectEligible — reuses the binder matcher, fail-closed on unproven/ambiguous supply', () => {
+  it('selects the decisive eligible template for a plain bar ask (real manifests)', () => {
+    const m = selectEligible('bar chart of sales by region', manifests);
+    expect(m).not.toBeNull();
+    expect(m!.template).toBe('ranking-ordered-bar');
+  });
+
+  it('returns null for gibberish (nothing scores)', () => {
+    expect(selectEligible('asdf qwerty zxcv plok', manifests)).toBeNull();
+  });
+
+  it('selects a stamped template but NEVER an unstamped one for the same ask', () => {
+    const ask = 'frobnicate chart of things';
+    const stamped = mkManifest({ template: 'frob', intent_keywords: ['frobnicate'] });
+    const unstamped = mkManifest({
+      template: 'frob',
+      intent_keywords: ['frobnicate'],
+      fast_path_eligible: false,
+    });
+    expect(selectEligible(ask, [stamped])?.template).toBe('frob');
+    expect(selectEligible(ask, [unstamped])).toBeNull();
+  });
+
+  it('fail-closed on a keyword-score tie (two templates argmax) — returns null', () => {
+    const a = mkManifest({ template: 'a-chart', family: 'ranking', intent_keywords: ['widget'] });
+    const b = mkManifest({
+      template: 'b-chart',
+      family: 'distribution',
+      intent_keywords: ['widget'],
+    });
+    expect(selectEligible('a widget please', [a, b])).toBeNull();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CHART_NOUN_KEYWORDS LOCKSTEP PARITY — the ask-router mirror MUST equal the
+// classify.ts table EXACTLY, and this file must keep importing NOTHING from classify.ts
+// (the hash-gated classifier stays byte-untouched).
+describe('ask-router — CHART_NOUN_KEYWORDS lockstep parity with classify.ts', () => {
+  const ASK_ROUTER_SRC = path.join(repoRoot, 'src', 'desktop', 'binder', 'ask-router.ts');
+  const CLASSIFY_SRC = path.join(repoRoot, 'src', 'desktop', 'binder', 'classify.ts');
+
+  // Regex-extract the CHART_NOUN_KEYWORDS Set literal's string members from a source file.
+  // ANCHORED on `const CHART_NOUN_KEYWORDS` so the PLURALIZABLE_CHART_NOUNS set (whose doc
+  // comment mentions CHART_NOUN_KEYWORDS) can never match by accident; STRIPS `//` line
+  // comments first so growth-provenance prose that quotes example phrases is ignored and only
+  // the real entries remain.
+  function extractChartNouns(file: string): Set<string> {
+    const src = fs.readFileSync(file, 'utf8');
+    const m = src.match(/const\s+CHART_NOUN_KEYWORDS[^=]*=\s*new Set\(\[([\s\S]*?)\]\)/);
+    expect(m, `CHART_NOUN_KEYWORDS Set literal not found in ${file}`).not.toBeNull();
+    const body = m![1].replace(/\/\/[^\n]*/g, '');
+    const nouns = [...body.matchAll(/['"]([^'"]+)['"]/g)].map((x) => x[1].toLowerCase());
+    expect(nouns.length, `${file}: expected a non-empty CHART_NOUN_KEYWORDS table`).toBeGreaterThan(
+      0,
+    );
+    return new Set(nouns);
+  }
+
+  it('both source files declare the SAME CHART_NOUN_KEYWORDS set (set equality)', () => {
+    const ask = extractChartNouns(ASK_ROUTER_SRC);
+    const classify = extractChartNouns(CLASSIFY_SRC);
+    expect([...ask].sort()).toEqual([...classify].sort());
+  });
+
+  it('ask-router.ts imports NOTHING from classify.ts (the classifier stays untouched)', () => {
+    const src = fs.readFileSync(ASK_ROUTER_SRC, 'utf8');
+    // Match only real module specifiers (quoted); the file's prose comment naming classify.ts
+    // is unquoted and must not trip this.
+    expect(src).not.toMatch(/from\s+['"][^'"]*\/classify[^'"]*['"]/);
+    expect(src).not.toMatch(/import\(\s*['"][^'"]*\/classify[^'"]*['"]\s*\)/);
+  });
+});

--- a/src/desktop/binder/ask-router.ts
+++ b/src/desktop/binder/ask-router.ts
@@ -112,6 +112,7 @@ const CHART_NOUN_KEYWORDS: ReadonlySet<string> = new Set([
   'boxplot',
   'box-and-whisker',
   'over-time',
+  'timeline',
   'arrow-chart',
   'over-under-arrow',
   'bar-code',

--- a/src/desktop/binder/ask-router.ts
+++ b/src/desktop/binder/ask-router.ts
@@ -1,0 +1,159 @@
+// src/desktop/binder/ask-router.ts
+//
+// The route layer's SELECTOR (Slice B, ported from a2td src/binder/ask-router.ts).
+// SELECTOR-ONLY by design: it turns a masked ask into the single eligible template the
+// binder's own model-free matcher would pick, and NOTHING more. It never executes, never
+// binds fields, never touches a live schema — the a2td tier-ladder / validateBinding
+// disposer (routeAsk) is deliberately NOT ported (that is the binder's job, not the route
+// layer's). `route-spec.ts` reuses this exact seam for schema-free ask-SHAPE detection so
+// the route layer never re-derives classification.
+//
+// LOCKSTEP MIRROR: this file imports NOTHING from `./classify.ts` (the hash-gated
+// lockstep-core classifier stays byte-untouched). The matcher primitives below
+// (phraseIndexInAsk / keywordScore / familyNativeKeywords / selectEligible) and the
+// CHART_NOUN_KEYWORDS table are hand-maintained copies of classify.ts's. ask-router.test.ts
+// regex-extracts BOTH CHART_NOUN_KEYWORDS tables and asserts SET EQUALITY, so any growth in
+// classify.ts must be mirrored here or the parity test goes RED.
+
+import type { TemplateManifest } from './manifest-types.js';
+
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * PLURALIZABLE CHART-NOUN TOKENS (parity with classify.ts): a keyword phrase earns a
+ * trailing-`s` tolerance in phraseIndexInAsk ONLY when its final token is a chart-type
+ * noun ("bars"↔"bar", "maps"↔"map"), never for a non-noun keyword ("trend"↛"trends").
+ */
+const PLURALIZABLE_CHART_NOUNS: ReadonlySet<string> = new Set([
+  'bar',
+  'column',
+  'map',
+  'treemap',
+  'pie',
+  'donut',
+]);
+
+/**
+ * Index of the first whole-token occurrence of `phrase` in `ask`, else -1. Hyphen in a
+ * keyword matches hyphen OR whitespace in the ask ("over-time" ↔ "over time"); a
+ * chart-noun final token gets an optional trailing `s`. Reimplemented from classify.ts.
+ */
+function phraseIndexInAsk(ask: string, phrase: string): number {
+  const p = phrase.toLowerCase().trim();
+  if (!p) return -1;
+  const body = escapeRegex(p).replace(/-/g, '[\\s-]+');
+  const tokens = p.split(/[^a-z0-9]+/).filter(Boolean);
+  const finalToken = tokens[tokens.length - 1];
+  const pluralSuffix = finalToken && PLURALIZABLE_CHART_NOUNS.has(finalToken) ? 's?' : '';
+  const re = new RegExp(`(^|[^a-z0-9])${body}${pluralSuffix}([^a-z0-9]|$)`);
+  const match = re.exec(ask.toLowerCase());
+  return match ? match.index : -1;
+}
+
+function keywordScore(ask: string, keywords: string[]): number {
+  let n = 0;
+  for (const kw of keywords) if (phraseIndexInAsk(ask, kw) >= 0) n++;
+  return n;
+}
+
+function matchedKeywords(ask: string, keywords: string[]): string[] {
+  return keywords.filter((kw) => phraseIndexInAsk(ask, kw) >= 0);
+}
+
+/**
+ * FAMILY-NATIVE vocabulary over the ELIGIBLE pool (parity with classify.ts): a keyword is
+ * native to a family when carried by a STRICT MAJORITY of that family's fast_path_eligible
+ * templates (a single-member family ⇒ all its keywords). Separates a family's defining
+ * vocabulary from a keyword a lone member merely borrowed.
+ */
+function familyNativeKeywords(family: string, manifests: TemplateManifest[]): Set<string> {
+  const sets: Set<string>[] = [];
+  for (const m of manifests) {
+    if (!m.fast_path_eligible || m.family !== family) continue;
+    sets.push(new Set(m.intent_keywords.map((k) => k.toLowerCase())));
+  }
+  const counts = new Map<string, number>();
+  for (const s of sets) for (const k of s) counts.set(k, (counts.get(k) ?? 0) + 1);
+  const threshold = sets.length / 2;
+  const native = new Set<string>();
+  for (const [k, c] of counts) if (c > threshold) native.add(k);
+  return native;
+}
+
+/**
+ * Distinctive chart-shape nouns (lowercased intent_keyword tokens) — a match is a
+ * deterministic chart-TYPE selector, exempting a lone winner from the family-native guard.
+ * VERBATIM MIRROR of classify.ts's CHART_NOUN_KEYWORDS, kept in lockstep BY HAND because
+ * this file imports NOTHING from classify.ts. ask-router.test.ts regex-extracts BOTH tables
+ * and asserts SET EQUALITY, so every classify.ts growth must be mirrored here.
+ */
+const CHART_NOUN_KEYWORDS: ReadonlySet<string> = new Set([
+  'bar',
+  'sorted-bar',
+  'column',
+  'sorted-column',
+  'vertical-bar',
+  'stacked-bar',
+  'treemap',
+  'pie',
+  'donut',
+  'line',
+  'trend',
+  'gantt',
+  'histogram',
+  'bullet',
+  'funnel',
+  'slope',
+  'slope-chart',
+  'slope-graph',
+  'box-plot',
+  'boxplot',
+  'box-and-whisker',
+  'over-time',
+  'arrow-chart',
+  'over-under-arrow',
+  'bar-code',
+  'strip-plot',
+  'dot-strip',
+  'waterfall',
+  'choropleth',
+  'filled-map',
+  'region-map',
+]);
+
+function wonChartNoun(maskedAsk: string, keywords: string[]): boolean {
+  return matchedKeywords(maskedAsk, keywords).some((kw) =>
+    CHART_NOUN_KEYWORDS.has(kw.toLowerCase()),
+  );
+}
+
+/**
+ * BIND-path template selection over the ELIGIBLE pool. Fail-closed: bind only on a UNIQUE
+ * keyword-argmax winner that is DECISIVE (won a family-native keyword OR a distinctive chart
+ * noun). Any keyword-score tie ⇒ null. `selectEligible` enforces the `fast_path_eligible`
+ * stamp, so a route can never point at unproven supply.
+ *
+ * The route layer's ONLY consult of the binder's matcher: `route-spec.ts` calls this for
+ * schema-free ask-SHAPE detection and must never re-derive classification.
+ */
+export function selectEligible(
+  maskedAsk: string,
+  manifests: TemplateManifest[],
+): TemplateManifest | null {
+  const scored = manifests
+    .filter((m) => m.fast_path_eligible)
+    .map((m) => ({ m, score: keywordScore(maskedAsk, m.intent_keywords) }))
+    .filter((x) => x.score > 0);
+  if (scored.length === 0) return null;
+  const maxScore = scored.reduce((mx, s) => Math.max(mx, s.score), 0);
+  const top = scored.filter((s) => s.score === maxScore);
+  if (top.length !== 1) return null; // fail-closed on any tie
+  const m = top[0].m;
+  const native = familyNativeKeywords(m.family, manifests);
+  const won = matchedKeywords(maskedAsk, m.intent_keywords);
+  const decisive =
+    won.some((kw) => native.has(kw.toLowerCase())) || wonChartNoun(maskedAsk, m.intent_keywords);
+  return decisive ? m : null;
+}

--- a/src/desktop/binder/route-spec.test.ts
+++ b/src/desktop/binder/route-spec.test.ts
@@ -1,0 +1,194 @@
+// src/desktop/binder/route-spec.test.ts
+//
+// The route layer's typed registry. Pins the ask-shape → route table and that bind-first
+// classification defers to the binder's OWN model-free matcher (selectEligible) + the
+// eligibility stamp — never a re-derived classifier. Refine-asks classify into the taxonomy;
+// only supported refine shapes (top-N / sort) route refine-op.
+
+import { beforeAll, describe, expect, it } from 'vitest';
+
+import { selectEligible } from './ask-router.js';
+import { loadManifests } from './manifest.js';
+import type { TemplateManifest } from './manifest-types.js';
+import {
+  classifyAskRoute,
+  normalizeAskForMatch,
+  REFINE_SHAPES,
+  SHAPE_ROUTE,
+} from './route-spec.js';
+
+let manifests: TemplateManifest[];
+beforeAll(() => {
+  manifests = [...loadManifests().values()];
+});
+
+function mkManifest(over: Partial<TemplateManifest> & { template: string }): TemplateManifest {
+  return {
+    family: 'specialized',
+    readiness: 'GREEN',
+    fast_path_eligible: true,
+    fast_path_blockers: [],
+    intent_keywords: [],
+    description: 'synthetic test manifest',
+    placeholders: ['TITLE', 'DATASOURCE'],
+    slots: [],
+    calcs: [],
+    ...over,
+  } as unknown as TemplateManifest;
+}
+
+describe('SHAPE_ROUTE — the typed ask-shape → route table', () => {
+  it('maps every shape to a valid route class', () => {
+    for (const r of new Set(Object.values(SHAPE_ROUTE))) {
+      expect(['bind-first', 'scratch-pipeline', 'refine-op', 'free']).toContain(r);
+    }
+  });
+
+  it('routes hazards to scratch-pipeline, selected refines to refine-op, deferred refines to free', () => {
+    expect(SHAPE_ROUTE['hazard-set']).toBe('scratch-pipeline');
+    expect(SHAPE_ROUTE['hazard-drilldown']).toBe('scratch-pipeline');
+    expect(SHAPE_ROUTE['refine-top-n']).toBe('refine-op');
+    expect(SHAPE_ROUTE['refine-sort']).toBe('refine-op');
+    expect(SHAPE_ROUTE['refine-filter']).toBe('free');
+    expect(SHAPE_ROUTE['refine-period']).toBe('free');
+    expect(SHAPE_ROUTE['refine-encoding']).toBe('free');
+    expect(SHAPE_ROUTE['bind-first-template']).toBe('bind-first');
+  });
+});
+
+describe('classifyAskRoute — bind-first (plain chart with eligible supply)', () => {
+  it('routes a plain bar ask to bind-first, naming the eligible template', () => {
+    const d = classifyAskRoute('bar chart of Sales by Region', manifests);
+    expect(d.route).toBe('bind-first');
+    expect(d.shape).toBe('bind-first-template');
+    expect(d.template).toBe('ranking-ordered-bar');
+  });
+
+  it('bind-first ONLY when the matched template supply is stamped/eligible', () => {
+    const ask = 'frobnicate chart of things';
+    const eligible = mkManifest({ template: 'frob-chart', intent_keywords: ['frobnicate'] });
+    const notEligible = mkManifest({
+      template: 'frob-chart',
+      intent_keywords: ['frobnicate'],
+      fast_path_eligible: false,
+    });
+    expect(classifyAskRoute(ask, [eligible]).route).toBe('bind-first');
+    expect(classifyAskRoute(ask, [notEligible]).route).toBe('free');
+  });
+
+  it('classification uses the binder matcher: a shape the matcher rejects can never be bind-first', () => {
+    const gibberish = 'asdf qwerty zxcv plok';
+    expect(selectEligible(gibberish, manifests)).toBeNull();
+    expect(classifyAskRoute(gibberish, manifests).route).toBe('free');
+  });
+});
+
+describe('classifyAskRoute — hazard shapes → scratch-pipeline', () => {
+  it("routes a 'create a set' ask to scratch-pipeline", () => {
+    const d = classifyAskRoute('create a set of my top customers', manifests);
+    expect(d.route).toBe('scratch-pipeline');
+    expect(d.shape).toBe('hazard-set');
+  });
+
+  it('routes a drilldown ask to scratch-pipeline', () => {
+    const d = classifyAskRoute('drill down into Sub-Category by Sales', manifests);
+    expect(d.route).toBe('scratch-pipeline');
+    expect(d.shape).toBe('hazard-drilldown');
+  });
+});
+
+describe('classifyAskRoute — refine-asks classify into taxonomy with selected routes', () => {
+  it("'top five X' → refine-top-n taxonomy, route refine-op", () => {
+    const d = classifyAskRoute('top five customers by sales', manifests);
+    expect(d.shape).toBe('refine-top-n');
+    expect(d.route).toBe('refine-op');
+    expect(REFINE_SHAPES.has(d.shape)).toBe(true);
+  });
+
+  it("'just Q4' → refine-period taxonomy, route free", () => {
+    const d = classifyAskRoute('just Q4 numbers', manifests);
+    expect(d.shape).toBe('refine-period');
+    expect(d.route).toBe('free');
+  });
+
+  it("'sort by' → refine-sort taxonomy, route refine-op", () => {
+    const d = classifyAskRoute('sort by profit descending', manifests);
+    expect(d.shape).toBe('refine-sort');
+    expect(d.route).toBe('refine-op');
+  });
+
+  it("'filter/only' → refine-filter taxonomy, route free", () => {
+    const d = classifyAskRoute('filter to only the West region', manifests);
+    expect(d.shape).toBe('refine-filter');
+    expect(d.route).toBe('free');
+  });
+});
+
+describe('classifyAskRoute — refine detection is EDIT-CONTEXT gated', () => {
+  it('a NEW bar chart that only MENTIONS top/bottom classifies bind-first (NOT refine)', () => {
+    // A new-viz ask that merely mentions top/bottom must fall through to the matcher.
+    const ask =
+      'Create a horizontal bar chart of total Profit by Sub-Category, calling out the ' +
+      "few highest-profit Sub-Categories (the 'top performers') and the few lowest-profit ones " +
+      "(the 'bottom performers'); do not replace or delete existing worksheets.";
+    const d = classifyAskRoute(ask, manifests);
+    expect(d.route, 'a new bar chart that only mentions top/bottom must route bind-first').toBe(
+      'bind-first',
+    );
+    expect(d.shape).toBe('bind-first-template');
+    expect(d.template).toBe('ranking-ordered-bar');
+  });
+
+  it('a reworded, keyword-bearing near-paraphrase still classifies bind-first', () => {
+    const paraphrase =
+      'Please build a sorted horizontal bar chart of Profit per Sub-Category, ranked from ' +
+      'highest to lowest, with the top and bottom performers standing out as their own groups.';
+    const d = classifyAskRoute(paraphrase, manifests);
+    expect(d.route).toBe('bind-first');
+    expect(d.template).toBe('ranking-ordered-bar');
+  });
+
+  it('messy punctuation / casing / spacing still classifies bind-first', () => {
+    const messy = '  RANKED   BAR-CHART!!!  (highest → lowest)  of PROFIT — by sub-category…  ';
+    expect(normalizeAskForMatch(messy)).toBe(
+      'ranked bar-chart highest lowest of profit by sub-category',
+    );
+    expect(classifyAskRoute(messy, manifests).route).toBe('bind-first');
+  });
+
+  it("'just the top five sub-categories' (bare refine, no chart noun) classifies refine-top-n", () => {
+    const d = classifyAskRoute('just the top five sub-categories', manifests);
+    expect(d.shape).toBe('refine-top-n');
+    expect(d.route).toBe('refine-op');
+  });
+
+  it("'show that as a line' (anaphoric re-encode) classifies refine-ish, never bind-first", () => {
+    const d = classifyAskRoute('show that as a line', manifests);
+    expect(REFINE_SHAPES.has(d.shape), `${d.shape} should be a refine shape`).toBe(true);
+    expect(d.route).toBe('free');
+    expect(d.route).not.toBe('bind-first');
+  });
+
+  it("a genuinely NEW 'top 10 reps by quota attainment bar chart' ask is NOT refine", () => {
+    const d = classifyAskRoute('top 10 reps by quota attainment bar chart', manifests);
+    expect(
+      REFINE_SHAPES.has(d.shape),
+      'a new-viz ask with bare top-N vocab must not be refine',
+    ).toBe(false);
+    expect(d.shape).not.toBe('refine-top-n');
+  });
+});
+
+describe('classifyAskRoute — fail-open free', () => {
+  it('an absent/blank ask routes free', () => {
+    expect(classifyAskRoute(undefined, manifests).route).toBe('free');
+    expect(classifyAskRoute(undefined, manifests).shape).toBe('empty');
+    expect(classifyAskRoute('   ', manifests).route).toBe('free');
+  });
+
+  it('gibberish routes free (no template supply)', () => {
+    const d = classifyAskRoute('asdf qwerty zxcv plok', manifests);
+    expect(d.route).toBe('free');
+    expect(d.shape).toBe('unmatched');
+  });
+});

--- a/src/desktop/binder/route-spec.ts
+++ b/src/desktop/binder/route-spec.ts
@@ -1,0 +1,238 @@
+// src/desktop/binder/route-spec.ts
+//
+// The route layer's typed REGISTRY (Slice B, ported from a2td src/binder/route-spec.ts). A
+// typed table mapping an ask-SHAPE to a route class, plus a schema-free shape classifier that
+// REUSES the binder's own model-free matcher (`selectEligible` in ask-router.ts) for
+// bind-first detection — it NEVER re-derives classification.
+//
+// The classifier is deterministic + model-free: the route is computed once from the ask/task
+// text, before any live workbook schema is known. It reuses `selectEligible` (keyword /
+// family-native / chart-noun selection over the masked ask), the same selection rules the
+// binder runs; the full field-binding classifier additionally needs a live schema and so
+// cannot run here.
+//
+//   bind-first       — a plain chart shape whose template supply is STAMPED/eligible. Gated on
+//                      `selectEligible`, which filters `fast_path_eligible`, so a route can
+//                      never point at unproven supply.
+//   scratch-pipeline — a hazard shape the binder has no fast-path supply for (sets,
+//                      drilldown): the general from-scratch authoring path owns it.
+//   refine-op        — supported refine-asks (top-N / sort). Unsupported/deferred refine asks
+//                      remain `free` until their typed worksheet adapters exist.
+//   free             — the fail-open default (organic asks, no matched eligible supply).
+
+import { selectEligible } from './ask-router.js';
+import type { TemplateManifest } from './manifest-types.js';
+
+/** The four route classes an ask-shape maps to. */
+export type RouteClass = 'bind-first' | 'scratch-pipeline' | 'refine-op' | 'free';
+
+/**
+ * The recognized ask shapes. `refine-*` shapes are the refine taxonomy; only the worksheet
+ * adapters that exist route to `refine-op` (the tmcp refine-worksheet fast lane covers
+ * refine-top-n / refine-sort — Slice A).
+ */
+export type AskShape =
+  | 'empty'
+  | 'hazard-set'
+  | 'hazard-drilldown'
+  | 'refine-top-n'
+  | 'refine-filter'
+  | 'refine-sort'
+  | 'refine-period'
+  | 'refine-encoding'
+  | 'bind-first-template'
+  | 'unmatched';
+
+/**
+ * THE TYPED TABLE. ask-shape → route class. Only supported refine shapes map to `refine-op`;
+ * the rest stay `free`, which is exactly why the taxonomy is separated from the route.
+ */
+export const SHAPE_ROUTE: Record<AskShape, RouteClass> = {
+  empty: 'free',
+  'hazard-set': 'scratch-pipeline',
+  'hazard-drilldown': 'scratch-pipeline',
+  'refine-top-n': 'refine-op',
+  'refine-filter': 'free',
+  'refine-sort': 'refine-op',
+  'refine-period': 'free',
+  'refine-encoding': 'free',
+  'bind-first-template': 'bind-first',
+  unmatched: 'free',
+};
+
+/** The refine-taxonomy shapes; only a subset currently routes to `refine-op`. */
+export const REFINE_SHAPES: ReadonlySet<AskShape> = new Set<AskShape>([
+  'refine-top-n',
+  'refine-filter',
+  'refine-sort',
+  'refine-period',
+  'refine-encoding',
+]);
+
+export interface RouteDecision {
+  /** The route class the ask-shape maps to (via SHAPE_ROUTE). */
+  route: RouteClass;
+  /** The classified ask shape. */
+  shape: AskShape;
+  /** The eligible template the matcher selected, when the shape is bind-first-template. */
+  template: string | null;
+  /** One-line, deterministic rationale (for audit). */
+  reason: string;
+}
+
+// ───────────────────────── shape detectors (deterministic, no model) ─────────────────────────
+
+/**
+ * HAZARD shapes the binder has no fast-path supply for: Tableau SETS and DRILLDOWN
+ * (hierarchy navigation). These never bind a stamped template; routing them `free` lets an
+ * agent fall to whole-workbook XML surgery, so the registry routes them to the general
+ * scratch pipeline explicitly.
+ */
+function detectHazard(text: string): AskShape | null {
+  // Any drill* form: "drill down", "drilldown", "drill-down", "drill into", "drilling".
+  if (/\bdrill/i.test(text)) return 'hazard-drilldown';
+  // A Tableau "set" — require a construction/containment cue so "dataset"/"subset"/
+  // "settings" can't false-fire.
+  if (
+    /\b(?:create|make|define|build|combine|combined|new|add|group)\s+(?:an?\s+)?sets?\b/i.test(
+      text,
+    ) ||
+    /\bsets?\s+of\b/i.test(text) ||
+    /\b(?:into|as)\s+(?:an?\s+)?sets?\b/i.test(text)
+  ) {
+    return 'hazard-set';
+  }
+  return null;
+}
+
+const NUMBER_WORD =
+  '(?:\\d+|one|two|three|four|five|six|seven|eight|nine|ten|eleven|twelve|fifteen|twenty|fifty|hundred)';
+const TOP_N_RE = new RegExp(
+  `\\b(?:top|bottom|highest|lowest|first|last)\\s+${NUMBER_WORD}\\b`,
+  'i',
+);
+
+/**
+ * NEW-VIZ signal: a chart-type noun or a generic viz word. Its presence marks the ask as a
+ * request to BUILD a chart, so bare top-N / period / sort VOCABULARY in it is new-viz wording,
+ * not a refinement of an on-screen viz.
+ */
+const NEW_VIZ_RE =
+  /\b(?:bars?|columns?|line|lines|pie|donut|treemap|maps?|scatter|histogram|bullet|gantt|funnel|waterfall|heat-?map|box-?plot|area|bubble|slope|charts?|graphs?|plots?|viz|visuali[sz]ations?|dashboards?)\b/i;
+
+/**
+ * EDIT signals — the evidence that an ask REFINES an already-built viz. Either an anaphora
+ * referring to an existing viz, or an explicit instruction to modify one. The anaphora form is
+ * scoped to VIZ nouns so a NEW-viz constraint (e.g. "using its existing datasource … do not
+ * delete existing worksheets") is not misread as a refinement.
+ */
+const EDIT_ANAPHORA_RE =
+  /\b(?:this|that|the|current|existing)\s+(?:(?:bar|line|column|pie|scatter|area|stacked)\s+)?(?:chart|graph|plot|viz|visuali[sz]ation|view|dashboard)\b/i;
+const EDIT_INSTRUCTION_RE =
+  /\b(?:change|modify|update|convert|swap|re-?colou?r|re-?sort|adjust|tweak|instead)\b|\b(?:make|show|render|turn|set)\s+(?:it|that|this|them|these|those)\b/i;
+
+/** True when the ask carries an EDIT signal (anaphora to an existing viz OR a modify instruction). */
+function hasEditContext(text: string): boolean {
+  return EDIT_ANAPHORA_RE.test(text) || EDIT_INSTRUCTION_RE.test(text);
+}
+
+/**
+ * REFINE shapes: top-N, period slice, sort, filter, or a bare re-encode. GATED on edit
+ * context: a refine is claimed ONLY when the ask refers to / modifies an existing viz.
+ *   • op VOCABULARY present inside a NEW-VIZ ask WITHOUT an edit signal → NOT refine (fall
+ *     through to selectEligible);
+ *   • otherwise → the matching refine shape;
+ *   • no op vocab, but an anaphoric edit ("show that as a line") → refine-encoding.
+ * Order is most-specific first (top-N and period before the broad sort/filter cues).
+ */
+function detectRefine(text: string): AskShape | null {
+  let op: AskShape | null = null;
+  if (TOP_N_RE.test(text) || /\btop-?n\b/i.test(text)) op = 'refine-top-n';
+  else if (/\bq[1-4]\b/i.test(text) || /\b(?:ytd|mtd|qtd)\b/i.test(text)) op = 'refine-period';
+  else if (/\bsort(?:ed)?\s+by\b|\border\s+by\b|\brank(?:ed)?\s+by\b/i.test(text))
+    op = 'refine-sort';
+  else if (/\bjust\b|\bonly\b|\bfilter\b|\bexclude\b|\brestrict(?:ed)?\s+to\b/i.test(text))
+    op = 'refine-filter';
+
+  const editContext = hasEditContext(text);
+
+  if (op) {
+    // Bare op vocabulary inside a NEW-VIZ ask with NO edit signal is new-viz wording — let it
+    // fall through to the bind-first / selectEligible check.
+    if (NEW_VIZ_RE.test(text) && !editContext) return null;
+    return op;
+  }
+
+  // No explicit op vocab: a bare anaphoric EDIT of an existing viz ("show that as a line") is
+  // still a refinement, never a bind-first new build.
+  if (editContext) return 'refine-encoding';
+  return null;
+}
+
+function decide(shape: AskShape, template: string | null, reason: string): RouteDecision {
+  return { shape, route: SHAPE_ROUTE[shape], template, reason };
+}
+
+/**
+ * Light normalization applied to the TEXT PASSED TO `selectEligible` — never a fork of its
+ * logic, only a wrap of its input. `selectEligible` already lowercases and treats every
+ * non-alphanumeric char as a token boundary; this pass collapses runs of whitespace /
+ * punctuation to a single space and drops non-ASCII punctuation (em dashes, smart quotes,
+ * parentheses) so a reworded-but-keyword-bearing ask matches the same templates regardless of
+ * cosmetic spacing / quoting variance. Hyphens are PRESERVED (a hyphenated keyword like
+ * "sorted-bar" matches hyphen-or-space either way in `phraseIndexInAsk`).
+ */
+export function normalizeAskForMatch(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/**
+ * Classify an ask/task text into a {shape, route}. Deterministic + model-free.
+ *
+ * Precedence (each earlier rule is more specific / higher-hazard than the next):
+ *   1. empty       — no ask text ⇒ free (fail-open, a spec invariant).
+ *   2. hazard      — sets / drilldown ⇒ scratch-pipeline (no fast-path supply).
+ *   3. refine      — top-N / period / sort / filter / re-encode WITH edit context ⇒ taxonomy
+ *                    label, route per SHAPE_ROUTE. Bare refine vocabulary inside a NEW-VIZ ask
+ *                    (no edit signal) does NOT match here — it falls through to bind-first.
+ *   4. bind-first  — `selectEligible` selects a DECISIVE, STAMPED template ⇒ bind-first.
+ *   5. unmatched   — nothing selected ⇒ free.
+ */
+export function classifyAskRoute(
+  ask: string | null | undefined,
+  manifests: TemplateManifest[],
+): RouteDecision {
+  const text = (ask ?? '').trim();
+  if (!text) return decide('empty', null, 'no ask text — fail-open to free');
+
+  const hazard = detectHazard(text);
+  if (hazard) {
+    return decide(
+      hazard,
+      null,
+      'hazard shape (set/drilldown) — no fast-path supply; route via the scratch pipeline',
+    );
+  }
+
+  const refine = detectRefine(text);
+  if (refine) {
+    return decide(refine, null, 'refine shape (edit-context gated) — route per refine-op taxonomy');
+  }
+
+  // Wrap (never fork) selectEligible's input with a light normalization pass so a reworded,
+  // keyword-bearing near-paraphrase classifies the same as the canonical ask.
+  const eligible = selectEligible(normalizeAskForMatch(text), manifests);
+  if (eligible) {
+    return decide(
+      'bind-first-template',
+      eligible.template,
+      `binder matcher selected eligible template '${eligible.template}'`,
+    );
+  }
+
+  return decide('unmatched', null, 'no eligible template shape matched — free');
+}

--- a/src/desktop/refine/refineWorksheet.test.ts
+++ b/src/desktop/refine/refineWorksheet.test.ts
@@ -1,0 +1,330 @@
+import {
+  confirmSortDirectionApplied,
+  confirmTopNApplied,
+  planSortDirection,
+  planTopN,
+} from './refineWorksheet.js';
+
+// A single-worksheet fragment shaped exactly like `tabui:save-worksheet` returns:
+// one nominal dimension CI (Region) + one measure CI (SUM Sales), a safe self-closing
+// <computed-sort>, and <aggregation> — the ranking-ordered-bar envelope.
+const BASE = `<worksheet name='Sales by Region' xmlns:user='http://www.tableausoftware.com/xml/user'>
+  <table>
+    <view>
+      <datasources>
+        <datasource caption='Superstore' name='Superstore' />
+      </datasources>
+      <datasource-dependencies datasource='Superstore'>
+        <column datatype='string' name='[Region]' role='dimension' type='nominal' />
+        <column datatype='real' name='[Sales]' role='measure' type='quantitative' />
+        <column-instance column='[Region]' derivation='None' name='[none:Region:nk]' pivot='key' type='nominal' />
+        <column-instance column='[Sales]' derivation='Sum' name='[sum:Sales:qk]' pivot='key' type='quantitative' />
+      </datasource-dependencies>
+      <computed-sort column='[Superstore].[none:Region:nk]' direction='DESC' using='[Superstore].[sum:Sales:qk]' />
+      <aggregation value='true' />
+    </view>
+    <style />
+    <panes>
+      <pane>
+        <view><breakdown value='auto' /></view>
+        <mark class='Bar' />
+      </pane>
+    </panes>
+    <rows>[Superstore].[none:Region:nk]</rows>
+    <cols>[Superstore].[sum:Sales:qk]</cols>
+  </table>
+  <simple-id uuid='00000000-0000-0000-0000-000000000001' />
+</worksheet>`;
+
+/** Replace the datasource-dependencies block body with custom columns/CIs. */
+function withDeps(depBody: string): string {
+  return BASE.replace(
+    /<datasource-dependencies datasource='Superstore'>[\s\S]*?<\/datasource-dependencies>/,
+    `<datasource-dependencies datasource='Superstore'>${depBody}</datasource-dependencies>`,
+  );
+}
+
+const REGION_COL = "<column datatype='string' name='[Region]' role='dimension' type='nominal' />";
+const SALES_COL = "<column datatype='real' name='[Sales]' role='measure' type='quantitative' />";
+const REGION_CI =
+  "<column-instance column='[Region]' derivation='None' name='[none:Region:nk]' pivot='key' type='nominal' />";
+const SALES_CI =
+  "<column-instance column='[Sales]' derivation='Sum' name='[sum:Sales:qk]' pivot='key' type='quantitative' />";
+
+describe('planTopN — happy path', () => {
+  it('inserts a function=end top filter and a slices entry before aggregation', () => {
+    const r = planTopN(BASE, { n: 5 });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.filterColumn).toBe('[Superstore].[none:Region:nk]');
+
+    // The Top-N filter, with the confirmed native attributes.
+    expect(r.xml).toContain("<filter class='categorical' column='[Superstore].[none:Region:nk]'>");
+    expect(r.xml).toMatch(/function='end'\s+end='top'\s+count='5'/);
+    expect(r.xml).toContain("function='order' direction='DESC' expression='SUM([Sales])'");
+    expect(r.xml).toContain(
+      "function='level-members' level='[none:Region:nk]' user:ui-enumeration='all'",
+    );
+
+    // A slices node listing the filtered CI was created.
+    expect(r.xml).toContain('<slices><column>[Superstore].[none:Region:nk]</column></slices>');
+
+    // Ordering invariant: filter + slices both precede <aggregation>.
+    const filterIdx = r.xml.indexOf('<filter');
+    const slicesIdx = r.xml.indexOf('<slices>');
+    const aggIdx = r.xml.indexOf('<aggregation');
+    expect(filterIdx).toBeGreaterThan(-1);
+    expect(filterIdx).toBeLessThan(slicesIdx);
+    expect(slicesIdx).toBeLessThan(aggIdx);
+    // Filter is placed after the datasource-dependencies anchor.
+    expect(filterIdx).toBeGreaterThan(r.xml.indexOf('</datasource-dependencies>'));
+  });
+
+  it('emits end=bottom direction=ASC for a bottom-N ask', () => {
+    const r = planTopN(BASE, { n: 3, end: 'bottom' });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.xml).toMatch(/function='end'\s+end='bottom'\s+count='3'/);
+    expect(r.xml).toContain("function='order' direction='ASC'");
+  });
+});
+
+describe('planTopN — kill criteria (refuse with message)', () => {
+  it('refuses n below 1', () => {
+    const r = planTopN(BASE, { n: 0 });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.reason).toMatch(/between 1 and 50/);
+  });
+
+  it('refuses n above 50', () => {
+    const r = planTopN(BASE, { n: 51 });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.reason).toMatch(/between 1 and 50/);
+  });
+
+  it('refuses a non-integer n', () => {
+    const r = planTopN(BASE, { n: 2.5 });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.reason).toMatch(/between 1 and 50/);
+  });
+
+  it('refuses a missing n', () => {
+    const r = planTopN(BASE, { n: undefined as unknown as number });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.reason).toMatch(/between 1 and 50/);
+  });
+
+  it('refuses when more than one categorical dimension is present', () => {
+    const xml = withDeps(
+      REGION_COL +
+        "<column datatype='string' name='[Category]' role='dimension' type='nominal' />" +
+        SALES_COL +
+        REGION_CI +
+        "<column-instance column='[Category]' derivation='None' name='[none:Category:nk]' pivot='key' type='nominal' />" +
+        SALES_CI,
+    );
+    const r = planTopN(xml, { n: 5 });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.reason).toMatch(/more than one categorical dimension/i);
+  });
+
+  it('refuses when more than one measure is present', () => {
+    const xml = withDeps(
+      REGION_COL +
+        SALES_COL +
+        "<column datatype='real' name='[Profit]' role='measure' type='quantitative' />" +
+        REGION_CI +
+        SALES_CI +
+        "<column-instance column='[Profit]' derivation='Sum' name='[sum:Profit:qk]' pivot='key' type='quantitative' />",
+    );
+    const r = planTopN(xml, { n: 5 });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.reason).toMatch(/more than one measure/i);
+  });
+
+  it('refuses when no categorical dimension can be identified', () => {
+    const xml = withDeps(SALES_COL + SALES_CI);
+    const r = planTopN(xml, { n: 5 });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.reason).toMatch(/single categorical dimension/i);
+  });
+
+  it('refuses when no measure can be identified', () => {
+    const xml = withDeps(REGION_COL + REGION_CI);
+    const r = planTopN(xml, { n: 5 });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.reason).toMatch(/single measure/i);
+  });
+
+  it('refuses when the worksheet uses a calculated field', () => {
+    const xml = withDeps(
+      REGION_COL +
+        SALES_COL +
+        REGION_CI +
+        SALES_CI +
+        "<column-instance column='[Calculation_1]' derivation='User' name='[usr:Calculation_1:qk]' pivot='key' type='quantitative' />",
+    );
+    const r = planTopN(xml, { n: 5 });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.reason).toMatch(/calculated field/i);
+  });
+
+  it('refuses when the worksheet uses a set/group', () => {
+    const xml = BASE.replace(
+      '</datasource-dependencies>',
+      "</datasource-dependencies>\n      <group name='[Top Regions]' name-style='unqualified'><groupfilter function='member' level='[none:Region:nk]' member='East' /></group>",
+    );
+    const r = planTopN(xml, { n: 5 });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.reason).toMatch(/set\/group/i);
+  });
+
+  it('refuses when the worksheet references a parameter', () => {
+    const xml = withDeps(
+      REGION_COL +
+        SALES_COL +
+        "<column datatype='integer' name='[Top N]' param-domain-type='range' role='measure' type='quantitative' value='5' />" +
+        REGION_CI +
+        SALES_CI,
+    );
+    const r = planTopN(xml, { n: 5 });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.reason).toMatch(/parameter/i);
+  });
+
+  it('refuses when a Top-N (function=end) filter already exists', () => {
+    const existing =
+      "</datasource-dependencies>\n      <filter class='categorical' column='[Superstore].[none:Region:nk]'>" +
+      "<groupfilter function='end' end='top' count='10'><groupfilter function='order' direction='DESC' expression='SUM([Sales])'>" +
+      "<groupfilter function='level-members' level='[none:Region:nk]' user:ui-enumeration='all' /></groupfilter></groupfilter></filter>";
+    const xml = BASE.replace('</datasource-dependencies>', existing);
+    const r = planTopN(xml, { n: 5 });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.reason).toMatch(/already exists/i);
+  });
+
+  it('refuses when there is no datasource-dependencies anchor', () => {
+    // CIs present (so dim/measure are unambiguous) but the block is self-closing, so
+    // there is no </datasource-dependencies> to anchor the filter insertion against.
+    const xml = BASE.replace(
+      /<datasource-dependencies datasource='Superstore'>[\s\S]*?<\/datasource-dependencies>/,
+      `<datasource-dependencies datasource='Superstore' />\n      ${REGION_CI}\n      ${SALES_CI}`,
+    );
+    const r = planTopN(xml, { n: 5 });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.reason).toMatch(/anchor/i);
+  });
+});
+
+describe('planTopN — security (hostile derived values are escaped, not injected)', () => {
+  it('escapes a datasource name containing XML metacharacters at insertion', () => {
+    // A hostile datasource name carrying `& < >` — chars that WOULD break out of the
+    // column='...' attribute (or open a bogus element) if the derived filterColumn were
+    // string-built verbatim. Only the dependencies' datasource is changed; the CIs stay
+    // unambiguous so the plan still succeeds.
+    const xml = BASE.replace(
+      "datasource-dependencies datasource='Superstore'",
+      "datasource-dependencies datasource='Ev&il<x>'",
+    );
+    const r = planTopN(xml, { n: 5 });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    // The raw filterColumn is returned unescaped (used for the readback xpath) ...
+    expect(r.filterColumn).toBe('[Ev&il<x>].[none:Region:nk]');
+    // ... but the spliced attribute value is fully entity-escaped — no raw `& < >`.
+    expect(r.xml).toContain("column='[Ev&amp;il&lt;x&gt;].[none:Region:nk]'");
+    expect(r.xml).not.toContain("column='[Ev&il<x>]");
+  });
+});
+
+describe('confirmTopNApplied', () => {
+  it('is true for a patch that landed and false for the un-patched source', () => {
+    const r = planTopN(BASE, { n: 5 });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(confirmTopNApplied(r.xml, r.filterColumn)).toBe(true);
+    expect(confirmTopNApplied(BASE, r.filterColumn)).toBe(false);
+  });
+});
+
+describe('planSortDirection', () => {
+  it('flips DESC to ASC on the single self-closing computed-sort', () => {
+    const r = planSortDirection(BASE, { direction: 'ASC' });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.column).toBe('[Superstore].[none:Region:nk]');
+    expect(r.xml).toContain(
+      "<computed-sort column='[Superstore].[none:Region:nk]' direction='ASC' using='[Superstore].[sum:Sales:qk]' />",
+    );
+    expect(r.xml).not.toContain("direction='DESC'");
+  });
+
+  it('flips ASC to DESC', () => {
+    const asc = BASE.replace("direction='DESC'", "direction='ASC'");
+    const r = planSortDirection(asc, { direction: 'DESC' });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.xml).toContain("direction='DESC'");
+    expect(r.xml).not.toContain("direction='ASC'");
+  });
+
+  it('refuses an invalid direction', () => {
+    const r = planSortDirection(BASE, { direction: 'SIDEWAYS' as unknown as 'ASC' });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.reason).toMatch(/ASC.*DESC/);
+  });
+
+  it('refuses when no computed-sort is present', () => {
+    const xml = BASE.replace(/<computed-sort[^>]*\/>/, '');
+    const r = planSortDirection(xml, { direction: 'ASC' });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.reason).toMatch(/no <computed-sort>/i);
+  });
+
+  it('refuses when more than one computed-sort is present', () => {
+    const xml = BASE.replace(
+      "<aggregation value='true' />",
+      "<computed-sort column='[Superstore].[none:Region:nk]' direction='ASC' using='[Superstore].[sum:Sales:qk]' />\n      <aggregation value='true' />",
+    );
+    const r = planSortDirection(xml, { direction: 'ASC' });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.reason).toMatch(/more than one <computed-sort>/i);
+  });
+
+  it('refuses the nested <sort class=computed-sort> crash form', () => {
+    const nested = BASE.replace(
+      /<computed-sort[^>]*\/>/,
+      "<sort class='computed-sort' column='[Superstore].[none:Region:nk]' direction='DESC'><sort-computation direction='DESC' field='[Superstore].[sum:Sales:qk]' /></sort>",
+    );
+    const r = planSortDirection(nested, { direction: 'ASC' });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.reason).toMatch(/nested/i);
+  });
+});
+
+describe('confirmSortDirectionApplied', () => {
+  it('confirms the flipped direction on readback and rejects the stale one', () => {
+    const r = planSortDirection(BASE, { direction: 'ASC' });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(confirmSortDirectionApplied(r.xml, r.column, 'ASC')).toBe(true);
+    expect(confirmSortDirectionApplied(BASE, r.column, 'ASC')).toBe(false);
+  });
+});

--- a/src/desktop/refine/refineWorksheet.test.ts
+++ b/src/desktop/refine/refineWorksheet.test.ts
@@ -258,6 +258,20 @@ describe('confirmTopNApplied', () => {
     expect(confirmTopNApplied(r.xml, r.filterColumn)).toBe(true);
     expect(confirmTopNApplied(BASE, r.filterColumn)).toBe(false);
   });
+
+  it("neither throws nor false-positives on a column ref containing a quote ([none:O'Brien:nk])", () => {
+    const quoted = "[none:O'Brien:nk]";
+    const withFilter = `<worksheet name='q' xmlns:user='http://www.tableausoftware.com/xml/user'>
+      <table><view>
+        <filter class='categorical' column="${quoted}"><groupfilter function='end' /></filter>
+      </view></table>
+    </worksheet>`;
+    expect(confirmTopNApplied(withFilter, quoted)).toBe(true);
+    expect(confirmTopNApplied(withFilter, '[none:Other:nk]')).toBe(false);
+    // The injection shape: a value engineered to alter an interpolated XPath
+    // predicate must simply not match (it is compared as a plain string).
+    expect(confirmTopNApplied(withFilter, "x' or @column!='")).toBe(false);
+  });
 });
 
 describe('planSortDirection', () => {
@@ -326,5 +340,17 @@ describe('confirmSortDirectionApplied', () => {
     if (!r.ok) return;
     expect(confirmSortDirectionApplied(r.xml, r.column, 'ASC')).toBe(true);
     expect(confirmSortDirectionApplied(BASE, r.column, 'ASC')).toBe(false);
+  });
+
+  it('neither throws nor false-positives on a column ref containing a quote', () => {
+    const quoted = "[sum:O'Brien Sales:qk]";
+    const withSort = `<worksheet name='q' xmlns:user='http://www.tableausoftware.com/xml/user'>
+      <table><view>
+        <computed-sort column="${quoted}" direction='ASC' />
+      </view></table>
+    </worksheet>`;
+    expect(confirmSortDirectionApplied(withSort, quoted, 'ASC')).toBe(true);
+    expect(confirmSortDirectionApplied(withSort, quoted, 'DESC')).toBe(false);
+    expect(confirmSortDirectionApplied(withSort, "x' or @column!='", 'ASC')).toBe(false);
   });
 });

--- a/src/desktop/refine/refineWorksheet.ts
+++ b/src/desktop/refine/refineWorksheet.ts
@@ -347,8 +347,11 @@ export function planSortDirection(
 export function confirmTopNApplied(readbackXml: string, filterColumn: string): boolean {
   const doc = parseXml(readbackXml);
   if (!doc) return false;
-  const expr = filterColumn ? `//filter[@column='${filterColumn}']` : '//filter';
-  const filters = xpath.select(expr, doc as unknown as Node) as Element[];
+  // Column refs legally contain quotes (e.g. [none:O'Brien:nk]) — never
+  // interpolate them into an XPath literal; compare attributes in JS.
+  const filters = (xpath.select('//filter', doc as unknown as Node) as Element[]).filter(
+    (f) => !filterColumn || f.getAttribute('column') === filterColumn,
+  );
   return filters.some(
     (f) =>
       (xpath.select("count(.//groupfilter[@function='end'])", f as unknown as Node) as number) > 0,
@@ -366,7 +369,9 @@ export function confirmSortDirectionApplied(
 ): boolean {
   const doc = parseXml(readbackXml);
   if (!doc) return false;
-  const expr = column ? `//computed-sort[@column='${column}']` : '//computed-sort';
-  const sorts = xpath.select(expr, doc as unknown as Node) as Element[];
+  // Same quote-safety rule as confirmTopNApplied: attribute match in JS.
+  const sorts = (xpath.select('//computed-sort', doc as unknown as Node) as Element[]).filter(
+    (s) => !column || s.getAttribute('column') === column,
+  );
   return sorts.some((s) => (s.getAttribute('direction') ?? '') === direction);
 }

--- a/src/desktop/refine/refineWorksheet.ts
+++ b/src/desktop/refine/refineWorksheet.ts
@@ -1,0 +1,372 @@
+/**
+ * Pure worksheet-XML planners for the `refine-worksheet` desktop tool (refine fast lane).
+ *
+ * These functions are the ONLY place the tool decides WHAT to change. They take a single
+ * fetched worksheet fragment (as `tabui:save-worksheet` / the External Client API sheet
+ * slice returns it), plan a MINIMAL patch, and either return the patched XML or a precise
+ * refusal. They do NO I/O — the tool wraps them with fetch -> preflight -> apply-once ->
+ * readback.
+ *
+ * Two operations only:
+ *   - top_n: insert a native `function="end"` top/bottom filter on the sheet's single
+ *     unambiguous categorical dimension CI, keyed by its single measure CI, then
+ *     create/extend <slices>.
+ *   - sort_direction: flip `direction` on an existing single self-closing <computed-sort>.
+ *     The nested <sort class="computed-sort"> form crashes Desktop and is refused.
+ *
+ * Refusal, not repair: anything outside this tiny envelope (ambiguous dims/measures, n
+ * outside 1..50, sets/params/rollups/calcs, an existing Top-N, a nested/absent/multiple
+ * computed-sort) returns `{ ok: false, reason }` so the caller can hand back to the
+ * standard authoring path instead of entering whole-workbook XML surgery.
+ *
+ * Repo-agnostic by construction: this module imports only third-party XML libraries
+ * (@xmldom/xmldom, xpath) — no tableau-mcp modules — so it is a byte-adoption candidate
+ * for cross-repo lockstep. Derived values (field/CI names read out of the live, untrusted
+ * worksheet XML) are XML-escaped before insertion; only closed enums and an integer count
+ * ever reach an attribute unescaped.
+ */
+import { DOMParser } from '@xmldom/xmldom';
+import * as xpath from 'xpath';
+
+export type TopNEnd = 'top' | 'bottom';
+export type SortDirection = 'ASC' | 'DESC';
+
+export interface TopNPlan {
+  ok: true;
+  xml: string;
+  /** DS-qualified CI of the filtered dimension — the readback confirmation target. */
+  filterColumn: string;
+}
+export interface SortPlan {
+  ok: true;
+  xml: string;
+  /** The computed-sort `column` (may be "") — the readback confirmation target. */
+  column: string;
+  direction: SortDirection;
+}
+export interface RefineRefusal {
+  ok: false;
+  reason: string;
+}
+
+/** Canonical measure-aggregation derivation -> the aggregation function used in the Top-N `expression`. */
+const AGG_DERIVATIONS: Record<string, string> = {
+  Sum: 'SUM',
+  Avg: 'AVG',
+  Count: 'COUNT',
+  CountD: 'COUNTD',
+  Median: 'MEDIAN',
+  Min: 'MIN',
+  Max: 'MAX',
+  Stdev: 'STDEV',
+  StdevP: 'STDEVP',
+  Var: 'VAR',
+  VarP: 'VARP',
+  Attribute: 'ATTR',
+};
+
+interface ColumnInstance {
+  name: string;
+  column: string;
+  derivation: string;
+  type: string;
+}
+
+const refuse = (reason: string): RefineRefusal => ({ ok: false, reason });
+
+/**
+ * Error-suppressing DOM parse. Malformed XML is surfaced by the apply path's preflight
+ * validation, so here a parse failure simply yields `null` and the readback confirmation
+ * fails safe (returns false -> refusal). The function-form `errorHandler` matches
+ * @xmldom/xmldom >=0.9, which rejects the legacy object form.
+ */
+function parseXml(xml: string): Document | null {
+  try {
+    const parser = new DOMParser({ errorHandler: () => {} });
+    const doc = parser.parseFromString(String(xml ?? '').trim(), 'text/xml') as unknown as Document;
+    return doc ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Escape a value derived from the (untrusted) worksheet XML before it is spliced back into
+ * an attribute value or element text. For a normal Tableau qualified name (bracketed
+ * identifier, no `& < > ' "`) this is the identity function, so patched XML is byte-stable;
+ * a hostile name cannot break out of its attribute/text context.
+ */
+function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/'/g, '&apos;')
+    .replace(/"/g, '&quot;');
+}
+
+/** Read a single/double-quoted attribute value out of an element's attribute slice. */
+function attrVal(attrs: string, key: string): string {
+  const m = attrs.match(new RegExp(`\\b${key}=(?:'([^']*)'|"([^"]*)")`));
+  return m ? (m[1] ?? m[2] ?? '') : '';
+}
+
+/** All `<column-instance>` declarations (open tag only — table-calc CIs may have children). */
+function parseColumnInstances(xml: string): ColumnInstance[] {
+  const out: ColumnInstance[] = [];
+  const re = /<column-instance\b([^>]*?)\/?>/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(xml)) !== null) {
+    const attrs = m[1];
+    const name = attrVal(attrs, 'name');
+    if (!name) continue;
+    out.push({
+      name,
+      column: attrVal(attrs, 'column'),
+      derivation: attrVal(attrs, 'derivation'),
+      type: attrVal(attrs, 'type'),
+    });
+  }
+  return out;
+}
+
+/** The datasource name — from the dependencies block, else the first <datasource>. */
+function datasourceName(xml: string): string {
+  const dep = xml.match(/<datasource-dependencies\b[^>]*\bdatasource=(?:'([^']*)'|"([^"]*)")/);
+  if (dep) return dep[1] ?? dep[2] ?? '';
+  const ds = xml.match(/<datasource\b[^>]*\bname=(?:'([^']*)'|"([^"]*)")/);
+  return ds ? (ds[1] ?? ds[2] ?? '') : '';
+}
+
+/** A plain categorical dimension CI: nominal + None derivation (e.g. [none:Region:nk]). */
+function isDimensionCi(ci: ColumnInstance): boolean {
+  return ci.type === 'nominal' && ci.derivation === 'None';
+}
+
+/** A measure CI: quantitative with a canonical aggregation derivation (e.g. [sum:Sales:qk]). */
+function isMeasureCi(ci: ColumnInstance): boolean {
+  return (
+    ci.type === 'quantitative' &&
+    Object.prototype.hasOwnProperty.call(AGG_DERIVATIONS, ci.derivation)
+  );
+}
+
+/**
+ * Detect a construct that puts the sheet OUTSIDE the envelope. Returns a short kind
+ * ("calc"|"set"|"param") or null. Order matters only for the message; all three refuse.
+ */
+function unsupportedConstruct(xml: string, cis: ColumnInstance[]): 'calc' | 'set' | 'param' | null {
+  if (cis.some((c) => c.derivation === 'User') || /<calculation\b/.test(xml)) return 'calc';
+  // `<group ` / `<group>` is a set/group; `<groupfilter` (no boundary) is NOT matched.
+  if (/<group(\s|>)/.test(xml)) return 'set';
+  if (/\[Parameters\]/.test(xml) || /\bparam-domain-type=/.test(xml)) return 'param';
+  return null;
+}
+
+/** A Top-N filter is already present iff any groupfilter carries `function="end"`. */
+function hasExistingTopN(xml: string): boolean {
+  return /function=(?:'end'|"end")/.test(xml);
+}
+
+function buildTopNFilter(p: {
+  filterColumn: string;
+  count: number;
+  end: TopNEnd;
+  direction: SortDirection;
+  expression: string;
+  level: string;
+}): string {
+  return (
+    `<filter class='categorical' column='${p.filterColumn}'>` +
+    `<groupfilter function='end' end='${p.end}' count='${p.count}' user:ui-top-by-field='true' units='records' user:ui-marker='end'>` +
+    `<groupfilter function='order' direction='${p.direction}' expression='${p.expression}' user:ui-marker='order'>` +
+    `<groupfilter function='level-members' level='${p.level}' user:ui-enumeration='all' user:ui-marker='enumerate' />` +
+    '</groupfilter>' +
+    '</groupfilter>' +
+    '</filter>'
+  );
+}
+
+/**
+ * Insert the filter after </datasource-dependencies> and create/extend <slices> so the
+ * filtered CI is listed. Order stays: dependencies -> filter -> (sort) -> slices -> aggregation.
+ */
+function insertFilterAndSlices(xml: string, filterXml: string, sliceColumn: string): string {
+  let out = xml.replace(/<\/datasource-dependencies>/, (m) => `${m}\n      ${filterXml}`);
+  const sliceEntry = `<column>${sliceColumn}</column>`;
+
+  if (/<slices\b[^>]*\/>/.test(out)) {
+    // Empty self-closing <slices/> -> expand with the one entry.
+    out = out.replace(/<slices\b[^>]*\/>/, `<slices>${sliceEntry}</slices>`);
+  } else if (/<slices>[\s\S]*?<\/slices>/.test(out)) {
+    // Existing <slices>...</slices> -> append the entry unless the CI is already listed.
+    if (!out.includes(sliceColumn)) {
+      out = out.replace(/<\/slices>/, `${sliceEntry}</slices>`);
+    }
+  } else if (/<aggregation\b/.test(out)) {
+    // No slices node -> create one immediately before <aggregation>, matching its indent.
+    out = out.replace(/(\s*)(<aggregation\b)/, `$1<slices>${sliceEntry}</slices>$1$2`);
+  } else {
+    // No aggregation anchor either -> place slices right after the filter.
+    out = out.replace(filterXml, `${filterXml}\n      <slices>${sliceEntry}</slices>`);
+  }
+  return out;
+}
+
+/**
+ * Plan a Top-N filter on the worksheet's single categorical dimension by its single
+ * measure. Refuses per the kill criteria. Pure: returns patched XML or a refusal.
+ */
+export function planTopN(
+  xml: string,
+  opts: { n: number; end?: TopNEnd },
+): TopNPlan | RefineRefusal {
+  const n = opts.n;
+  if (typeof n !== 'number' || !Number.isInteger(n) || n < 1 || n > 50) {
+    return refuse(`top_n.n must be an integer between 1 and 50 (got ${JSON.stringify(opts.n)}).`);
+  }
+  const end: TopNEnd = opts.end ?? 'top';
+  if (end !== 'top' && end !== 'bottom') {
+    return refuse(`top_n.end must be "top" or "bottom" (got ${JSON.stringify(opts.end)}).`);
+  }
+
+  const cis = parseColumnInstances(xml);
+  const unsupported = unsupportedConstruct(xml, cis);
+  if (unsupported === 'calc') {
+    return refuse(
+      'the worksheet uses a calculated field (derivation="User"); Top-N over calcs is out of scope for this refinement.',
+    );
+  }
+  if (unsupported === 'set') {
+    return refuse(
+      'the worksheet uses a set/group; set-based Top-N is out of scope for this refinement.',
+    );
+  }
+  if (unsupported === 'param') {
+    return refuse(
+      'the worksheet references a parameter; parameterized Top-N is out of scope for this refinement.',
+    );
+  }
+
+  const dims = cis.filter(isDimensionCi);
+  if (dims.length === 0)
+    return refuse('could not identify a single categorical dimension to rank.');
+  if (dims.length > 1) {
+    return refuse('more than one categorical dimension is present; the Top-N target is ambiguous.');
+  }
+
+  const measures = cis.filter(isMeasureCi);
+  if (measures.length === 0) return refuse('could not identify a single measure to rank by.');
+  if (measures.length > 1) {
+    return refuse('more than one measure is present; the ranking measure is ambiguous.');
+  }
+
+  if (hasExistingTopN(xml)) {
+    return refuse(
+      'a Top-N (function="end") filter already exists; refusing to patch an existing filter without risking <slices>/<aggregation> ordering.',
+    );
+  }
+  if (!/<\/datasource-dependencies>/.test(xml)) {
+    return refuse(
+      'the worksheet <view> has no <datasource-dependencies> anchor; cannot place the filter safely before <slices>/<aggregation>.',
+    );
+  }
+
+  const ds = datasourceName(xml);
+  if (!ds) return refuse('could not determine the worksheet datasource name.');
+
+  const dim = dims[0];
+  const measure = measures[0];
+  const func = AGG_DERIVATIONS[measure.derivation];
+  const expression = `${func}(${measure.column})`;
+  const direction: SortDirection = end === 'top' ? 'DESC' : 'ASC';
+  // Returned raw (used for the readback xpath + tool label); escaped only at insertion.
+  const filterColumn = `[${ds}].${dim.name}`;
+
+  const filterXml = buildTopNFilter({
+    filterColumn: escapeXml(filterColumn),
+    count: n,
+    end,
+    direction,
+    expression: escapeXml(expression),
+    level: escapeXml(dim.name),
+  });
+  const out = insertFilterAndSlices(xml, filterXml, escapeXml(filterColumn));
+  return { ok: true, xml: out, filterColumn };
+}
+
+/**
+ * Plan a direction flip on the worksheet's single self-closing <computed-sort>. Refuses if
+ * absent, if more than one is present, if the direction is invalid, or if the sort uses the
+ * nested <sort class="computed-sort"> crash form. Pure.
+ */
+export function planSortDirection(
+  xml: string,
+  opts: { direction: SortDirection },
+): SortPlan | RefineRefusal {
+  const direction = opts.direction;
+  if (direction !== 'ASC' && direction !== 'DESC') {
+    return refuse(
+      `sort_direction.direction must be "ASC" or "DESC" (got ${JSON.stringify(opts.direction)}).`,
+    );
+  }
+
+  // The crashing/undefined nested form: a <sort class="computed-sort"> element, or a
+  // non-self-closing <computed-sort> open tag (a child follows). Both are refused — only
+  // the safe self-closing <computed-sort .../> can be flipped.
+  const hasNestedSortEl = /<sort\b[^>]*\bclass=(?:'computed-sort'|"computed-sort")[^>]*>/.test(xml);
+  const nonSelfClosingComputedSort = /<computed-sort\b[^>]*[^/]>/.test(xml);
+  if (hasNestedSortEl || nonSelfClosingComputedSort) {
+    return refuse(
+      'the sort uses the nested <sort class="computed-sort"> form; only the safe self-closing <computed-sort/> can be flipped.',
+    );
+  }
+
+  const selfClosing = [...xml.matchAll(/<computed-sort\b[^>]*\/>/g)];
+  if (selfClosing.length === 0) return refuse('no <computed-sort> present to change direction on.');
+  if (selfClosing.length > 1) {
+    return refuse('more than one <computed-sort> present; the target sort is ambiguous.');
+  }
+
+  const tag = selfClosing[0][0];
+  const column = attrVal(tag, 'column');
+  let newTag: string;
+  if (/\bdirection=(?:'[^']*'|"[^"]*")/.test(tag)) {
+    newTag = tag.replace(/\bdirection=(?:'[^']*'|"[^"]*")/, `direction='${direction}'`);
+  } else {
+    newTag = tag.replace(/\s*\/>$/, ` direction='${direction}' />`);
+  }
+  const out = xml.replace(tag, newTag);
+  return { ok: true, xml: out, column, direction };
+}
+
+/**
+ * Confirm on readback that a Top-N filter for `filterColumn` (a groupfilter with
+ * `function="end"`) is present. Quote-agnostic (parses the DOM).
+ */
+export function confirmTopNApplied(readbackXml: string, filterColumn: string): boolean {
+  const doc = parseXml(readbackXml);
+  if (!doc) return false;
+  const expr = filterColumn ? `//filter[@column='${filterColumn}']` : '//filter';
+  const filters = xpath.select(expr, doc as unknown as Node) as Element[];
+  return filters.some(
+    (f) =>
+      (xpath.select("count(.//groupfilter[@function='end'])", f as unknown as Node) as number) > 0,
+  );
+}
+
+/**
+ * Confirm on readback that the computed-sort for `column` carries the requested
+ * `direction`. Quote-agnostic (parses the DOM).
+ */
+export function confirmSortDirectionApplied(
+  readbackXml: string,
+  column: string,
+  direction: SortDirection,
+): boolean {
+  const doc = parseXml(readbackXml);
+  if (!doc) return false;
+  const expr = column ? `//computed-sort[@column='${column}']` : '//computed-sort';
+  const sorts = xpath.select(expr, doc as unknown as Node) as Element[];
+  return sorts.some((s) => (s.getAttribute('direction') ?? '') === direction);
+}

--- a/src/desktop/route/route-gate.test.ts
+++ b/src/desktop/route/route-gate.test.ts
@@ -1,0 +1,314 @@
+// src/desktop/route/route-gate.test.ts
+//
+// The one-shot deflection gate. Fires ONLY when ROUTE_ENFORCEMENT is on, ONLY for an ask that
+// classifies to bind-first or a supported refine-op shape, ONLY once per (session, ask) — the
+// second call executes and records a route_override. Everything else is a no-op (fail-open).
+//
+// FLAG-OFF INERTNESS (constraint 3) is pinned explicitly: with the flag unset, checkRouteGate
+// is a total no-op — it returns null, classifies nothing that matters, and records nothing —
+// so tool behavior is byte-identical to the gate's absence. (tools/list byte-identity is pinned
+// separately by server.desktop.test.ts's serialized-surface test, which this slice leaves at
+// its exact prior total.)
+
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+
+import { loadManifests } from '../binder/manifest.js';
+import type { TemplateManifest } from '../binder/manifest-types.js';
+import {
+  BIND_TEMPLATE_TOOL,
+  checkRouteGate,
+  decideRouteGate,
+  deflectionText,
+  REFINE_WORKSHEET_TOOL,
+  refineDeflectionText,
+  routeEnforcementEnabled,
+} from './route-gate.js';
+import { sessionRouteState } from './route-state.js';
+
+const FLAG = 'ROUTE_ENFORCEMENT';
+const ORIGINAL = process.env[FLAG];
+
+function enable(): void {
+  process.env[FLAG] = 'on';
+}
+function disable(): void {
+  delete process.env[FLAG];
+}
+
+/** Parse the trailing structured marker content item (the next_route JSON blob). */
+function marker(result: { content: { type: 'text'; text: string }[] }): Record<string, unknown> {
+  const last = result.content[result.content.length - 1];
+  return JSON.parse(last.text) as Record<string, unknown>;
+}
+
+let manifests: TemplateManifest[];
+beforeAll(() => {
+  manifests = [...loadManifests().values()];
+});
+
+beforeEach(() => {
+  sessionRouteState.clear();
+  disable();
+});
+afterEach(() => {
+  if (ORIGINAL === undefined) delete process.env[FLAG];
+  else process.env[FLAG] = ORIGINAL;
+});
+
+describe('routeEnforcementEnabled (ROUTE_ENFORCEMENT, default OFF)', () => {
+  it('is off when the flag is unset', () => {
+    disable();
+    expect(routeEnforcementEnabled()).toBe(false);
+  });
+  it('is off when the flag is any value other than on', () => {
+    process.env[FLAG] = 'off';
+    expect(routeEnforcementEnabled()).toBe(false);
+    process.env[FLAG] = '0';
+    expect(routeEnforcementEnabled()).toBe(false);
+  });
+  it("is on only when the flag is 'on' (case-insensitive)", () => {
+    process.env[FLAG] = 'on';
+    expect(routeEnforcementEnabled()).toBe(true);
+    process.env[FLAG] = 'ON';
+    expect(routeEnforcementEnabled()).toBe(true);
+  });
+});
+
+describe('decideRouteGate (pure decision, flag-independent)', () => {
+  it('no-ops when the route is not bind-first or refine-op', () => {
+    expect(decideRouteGate({ route: 'free', shape: 'unmatched', alreadyDeflected: false })).toBe(
+      'noop',
+    );
+    expect(
+      decideRouteGate({ route: 'scratch-pipeline', shape: 'hazard-set', alreadyDeflected: false }),
+    ).toBe('noop');
+  });
+  it('no-ops for a refine-op route whose shape has no supported fast lane', () => {
+    expect(
+      decideRouteGate({ route: 'refine-op', shape: 'refine-encoding', alreadyDeflected: false }),
+    ).toBe('noop');
+  });
+  it('deflects a bind-first ask that has not been deflected yet', () => {
+    expect(
+      decideRouteGate({
+        route: 'bind-first',
+        shape: 'bind-first-template',
+        alreadyDeflected: false,
+      }),
+    ).toBe('deflect');
+  });
+  it('deflects a supported refine-op shape (top-N / sort) not yet deflected', () => {
+    expect(
+      decideRouteGate({ route: 'refine-op', shape: 'refine-top-n', alreadyDeflected: false }),
+    ).toBe('deflect');
+    expect(
+      decideRouteGate({ route: 'refine-op', shape: 'refine-sort', alreadyDeflected: false }),
+    ).toBe('deflect');
+  });
+  it('overrides (executes) once this (session, ask) was already deflected', () => {
+    expect(
+      decideRouteGate({
+        route: 'bind-first',
+        shape: 'bind-first-template',
+        alreadyDeflected: true,
+      }),
+    ).toBe('override');
+  });
+});
+
+describe('deflection text names the tmcp fast-lane tool on a single actionable line', () => {
+  it('bind-first wording names bind-template', () => {
+    expect(deflectionText('ranking-ordered-bar')).toBe(
+      "Route: bind-first. Template 'ranking-ordered-bar' matches this ask — call bind-template first; if it escalates or proposes, retry this call and it will proceed.",
+    );
+    expect(deflectionText('x').includes('\n')).toBe(false);
+    expect(BIND_TEMPLATE_TOOL).toBe('bind-template');
+  });
+  it('refine-op wording names refine-worksheet', () => {
+    expect(refineDeflectionText()).toBe(
+      'Route: refine-op. This is a supported worksheet refinement — call refine-worksheet first; if it refuses, retry this call and it will proceed.',
+    );
+    expect(refineDeflectionText().includes('\n')).toBe(false);
+    expect(REFINE_WORKSHEET_TOOL).toBe('refine-worksheet');
+  });
+});
+
+describe('checkRouteGate — flag OFF is a total no-op (inertness)', () => {
+  it('returns null and records nothing even for a deflectable ask', () => {
+    disable();
+    const r = checkRouteGate({
+      toolName: 'batch-create-and-cache-sheets',
+      sessionId: 'S1',
+      ask: 'bar chart of Sales by Region',
+      manifests,
+    });
+    expect(r).toBeNull();
+    expect(sessionRouteState.get('S1')).toBeUndefined();
+  });
+});
+
+describe('checkRouteGate — one-shot deflection then override (flag ON, real manifests)', () => {
+  beforeEach(enable);
+
+  it('first scratch-entry call for a bind-first ask is deflected (text + marker + recorded)', () => {
+    const r = checkRouteGate({
+      toolName: 'build-and-apply-worksheet',
+      sessionId: 'S1',
+      ask: 'bar chart of Sales by Region',
+      manifests,
+    });
+    expect(r).not.toBeNull();
+    expect(r!.isError).toBe(false);
+    expect(r!.content[0].text).toBe(deflectionText('ranking-ordered-bar'));
+    expect(marker(r!).next_route).toBe('bind-first');
+    expect(marker(r!).template).toBe('ranking-ordered-bar');
+
+    const s = sessionRouteState.get('S1')!;
+    expect(s.deflections).toHaveLength(1);
+    expect(s.deflections[0].tool).toBe('build-and-apply-worksheet');
+    expect(s.deflections[0].template).toBe('ranking-ordered-bar');
+    expect(s.deflections[0].next_route).toBe('bind-first');
+    expect(typeof s.deflections[0].ts).toBe('string');
+    expect(s.route_overrides).toEqual([]);
+  });
+
+  it('second call for the same (session, ask) executes (null) and records ONE route_override', () => {
+    const args = {
+      toolName: 'build-and-apply-worksheet',
+      sessionId: 'S1',
+      ask: 'bar chart of Sales by Region',
+      manifests,
+    };
+    checkRouteGate(args);
+    const second = checkRouteGate(args);
+    expect(second).toBeNull();
+    const s = sessionRouteState.get('S1')!;
+    expect(s.deflections).toHaveLength(1);
+    expect(s.route_overrides).toHaveLength(1);
+    expect(s.route_overrides[0].tool).toBe('build-and-apply-worksheet');
+    expect(s.route_overrides[0].template).toBe('ranking-ordered-bar');
+  });
+
+  it('never loops: 3 consecutive calls → 1 deflection, 2 executions, 1 override', () => {
+    const args = {
+      toolName: 'batch-create-and-cache-sheets',
+      sessionId: 'S1',
+      ask: 'bar chart of Sales by Region',
+      manifests,
+    };
+    const results = [1, 2, 3].map(() => checkRouteGate(args));
+    expect(results.filter((r) => r !== null)).toHaveLength(1);
+    expect(results.filter((r) => r === null)).toHaveLength(2);
+    const s = sessionRouteState.get('S1')!;
+    expect(s.deflections).toHaveLength(1);
+    expect(s.route_overrides).toHaveLength(1);
+  });
+
+  it('first refine-op ask is deflected with the refine tool marker and classified shape', () => {
+    const r = checkRouteGate({
+      toolName: 'build-and-apply-worksheet',
+      sessionId: 'S1',
+      ask: 'just the top five sub-categories',
+      manifests,
+    });
+    expect(r).not.toBeNull();
+    expect(r!.content[0].text).toBe(refineDeflectionText());
+    expect(marker(r!)).toEqual({
+      next_route: 'refine-op',
+      tool: 'refine-worksheet',
+      shape: 'refine-top-n',
+    });
+    const s = sessionRouteState.get('S1')!;
+    expect(s.deflections).toHaveLength(1);
+    expect(s.deflections[0]).toMatchObject({
+      tool: 'build-and-apply-worksheet',
+      next_route: 'refine-op',
+      shape: 'refine-top-n',
+      text: refineDeflectionText(),
+    });
+  });
+
+  it('second refine-op call executes and records a route_override', () => {
+    const args = {
+      toolName: 'build-and-apply-worksheet',
+      sessionId: 'S1',
+      ask: 'just the top five sub-categories',
+      manifests,
+    };
+    checkRouteGate(args);
+    const second = checkRouteGate(args);
+    expect(second).toBeNull();
+    const s = sessionRouteState.get('S1')!;
+    expect(s.deflections).toHaveLength(1);
+    expect(s.route_overrides).toHaveLength(1);
+    expect(s.route_overrides[0]).toMatchObject({
+      tool: 'build-and-apply-worksheet',
+      shape: 'refine-top-n',
+    });
+  });
+
+  it('one-shot is per (session, ask): a DIFFERENT ask in the same session deflects again', () => {
+    checkRouteGate({
+      toolName: 'build-and-apply-worksheet',
+      sessionId: 'S1',
+      ask: 'bar chart of Sales by Region',
+      manifests,
+    });
+    const other = checkRouteGate({
+      toolName: 'build-and-apply-worksheet',
+      sessionId: 'S1',
+      ask: 'just the top five sub-categories',
+      manifests,
+    });
+    expect(other).not.toBeNull();
+    expect(sessionRouteState.get('S1')!.deflections).toHaveLength(2);
+  });
+});
+
+describe('checkRouteGate — no-op cases (fail-open, flag ON)', () => {
+  beforeEach(enable);
+
+  it('a free / non-routed ask is never deflected', () => {
+    const r = checkRouteGate({
+      toolName: 'build-and-apply-worksheet',
+      sessionId: 'S1',
+      ask: 'asdf qwerty zxcv plok',
+      manifests,
+    });
+    expect(r).toBeNull();
+    expect(sessionRouteState.get('S1')).toBeUndefined();
+  });
+
+  it('a hazard (scratch-pipeline) ask is never deflected', () => {
+    const r = checkRouteGate({
+      toolName: 'build-and-apply-worksheet',
+      sessionId: 'S1',
+      ask: 'create a set of my top customers',
+      manifests,
+    });
+    expect(r).toBeNull();
+    expect(sessionRouteState.get('S1')).toBeUndefined();
+  });
+
+  it('a call with no session id is never deflected', () => {
+    expect(
+      checkRouteGate({
+        toolName: 'build-and-apply-worksheet',
+        sessionId: undefined,
+        ask: 'bar chart of Sales by Region',
+        manifests,
+      }),
+    ).toBeNull();
+  });
+
+  it('an empty ask is never deflected', () => {
+    const r = checkRouteGate({
+      toolName: 'build-and-apply-worksheet',
+      sessionId: 'S1',
+      ask: '   ',
+      manifests,
+    });
+    expect(r).toBeNull();
+    expect(sessionRouteState.get('S1')).toBeUndefined();
+  });
+});

--- a/src/desktop/route/route-gate.ts
+++ b/src/desktop/route/route-gate.ts
@@ -1,0 +1,215 @@
+// src/desktop/route/route-gate.ts
+//
+// The one-shot deflection GATE (Slice B, adapted from a2td src/server/route-gate.ts).
+// Flag-gated (ROUTE_ENFORCEMENT, default OFF), fail-open, additive: on a scratch-path ENTRY
+// tool it either lets the call proceed (returns null) or returns a typed deflection to be
+// RETURNED INSTEAD of executing — steering the agent to run the fast lane first when a stamped
+// template (or a supported refine) already covers the ask.
+//
+// SESSION-KEYED (constraint 1): tmcp has no episodes, so — unlike a2td, which pre-computed the
+// route at begin-episode and had the gate merely READ it — this gate CLASSIFIES the ask on
+// demand (via `classifyAskRoute`) and dedups per (session, ask) through the session route
+// state. Deflection text is generated at runtime; nothing is added to the tools/list surface.
+//
+// ONE-SHOT INVARIANT: at most one deflection per (session, ask). A SECOND scratch-entry call
+// for the same (session, ask) after a deflection executes and records a `route_override` —
+// never a loop.
+//
+// WIRING: this module is complete and self-contained but is NOT yet called from a live tool
+// handler. tmcp's slow-path tools (build-and-apply-worksheet, batch-create-and-cache-sheets,
+// plan-dashboard-creation) carry STRUCTURED specs, not a free-text ask, and there is no
+// begin-episode entry point at which an ask is captured against a session; adding an ask param
+// would grow the frozen tools/list surface. Wiring therefore requires a product decision on
+// where the ask enters (see the Slice B report). Flag-off inertness holds regardless.
+
+import { loadManifests } from '../binder/manifest.js';
+import type { TemplateManifest } from '../binder/manifest-types.js';
+import { type AskShape, classifyAskRoute, normalizeAskForMatch } from '../binder/route-spec.js';
+import { type RouteDeflection, type RouteOverride, sessionRouteState } from './route-state.js';
+
+/** The env flag that turns the gate on. Values on/off; DEFAULT OFF. */
+export const ROUTE_ENFORCEMENT_ENV = 'ROUTE_ENFORCEMENT';
+
+/** The tmcp fast-lane tools the gate steers toward (no `tableau-` prefix, per tmcp naming). */
+export const BIND_TEMPLATE_TOOL = 'bind-template';
+export const REFINE_WORKSHEET_TOOL = 'refine-worksheet';
+
+/**
+ * Whether route enforcement is on. Canonical value is "on", matched case-insensitively.
+ * Anything else — including unset — is OFF (the safe default: the product ships OFF; an eval
+ * harness sets it ON).
+ */
+export function routeEnforcementEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  return (env[ROUTE_ENFORCEMENT_ENV] ?? '').trim().toLowerCase() === 'on';
+}
+
+export type RouteGateDecision = 'noop' | 'deflect' | 'override';
+
+/** The refine shapes the tmcp refine-worksheet fast lane actually supports (Slice A). */
+const REFINE_GATE_SHAPES: ReadonlySet<AskShape> = new Set<AskShape>([
+  'refine-top-n',
+  'refine-sort',
+]);
+
+function isRefineGateShape(shape: AskShape): shape is 'refine-top-n' | 'refine-sort' {
+  return REFINE_GATE_SHAPES.has(shape);
+}
+
+/**
+ * The pure gate decision over a classified ask + whether this (session, ask) was already
+ * deflected (flag-independent):
+ *   • route is neither bind-first nor refine-op → noop (only routed operations are enforced)
+ *   • refine-op but not a supported refine shape → noop (no fast lane to steer toward)
+ *   • already deflected this (session, ask)      → override (execute; one-shot invariant)
+ *   • else                                        → deflect
+ */
+export function decideRouteGate(args: {
+  route: 'bind-first' | 'scratch-pipeline' | 'refine-op' | 'free';
+  shape: AskShape;
+  alreadyDeflected: boolean;
+}): RouteGateDecision {
+  const { route, shape, alreadyDeflected } = args;
+  if (route !== 'bind-first' && route !== 'refine-op') return 'noop';
+  if (route === 'refine-op' && !isRefineGateShape(shape)) return 'noop';
+  if (alreadyDeflected) return 'override';
+  return 'deflect';
+}
+
+/**
+ * The single agent-actionable deflection line for a bind-first ask. Names the matched
+ * template; contains no newline so it stays one line.
+ */
+export function deflectionText(template: string): string {
+  return (
+    `Route: bind-first. Template '${template}' matches this ask — call ${BIND_TEMPLATE_TOOL} ` +
+    'first; if it escalates or proposes, retry this call and it will proceed.'
+  );
+}
+
+export function refineDeflectionText(): string {
+  return (
+    `Route: refine-op. This is a supported worksheet refinement — call ${REFINE_WORKSHEET_TOOL} ` +
+    'first; if it refuses, retry this call and it will proceed.'
+  );
+}
+
+export interface RouteGateInput {
+  /** The scratch-entry tool being gated (recorded in the deflection/override receipt). */
+  toolName: string;
+  /** The resolved Desktop session id (undefined ⇒ no-op, fail-open). */
+  sessionId: string | undefined;
+  /** The user's ask/intent VERBATIM — classified on demand to pick the route. */
+  ask: string | null | undefined;
+  /** Manifest pool to classify against (defaults to the loaded template manifests). */
+  manifests?: TemplateManifest[];
+  /** Override the env source (tests). */
+  env?: NodeJS.ProcessEnv;
+}
+
+/**
+ * A tool-result envelope: the one agent-actionable line PLUS a trailing structured
+ * `next_route` marker as its own text content item (the server's structured-marker
+ * convention). `isError: false`: a deflection is an intentional redirect, not a failure.
+ *
+ * A `type` alias (not `interface`) on purpose: the MCP `CallToolResult` a handler returns has
+ * a `[x: string]: unknown` index signature, and only object-literal type aliases get the
+ * implicit index signature needed to be assignable to it.
+ */
+export type RouteGateResult = {
+  content: { type: 'text'; text: string }[];
+  isError: boolean;
+};
+
+/**
+ * The tool-facing gate. Returns a deflection result to RETURN INSTEAD of executing, or null to
+ * let the call proceed. Classifies the ask on demand and records the deflection / override in
+ * the SESSION route state.
+ *
+ * A no-op (returns null) when: the flag is off; there is no session id; the ask does not
+ * classify to an enforced route (bind-first, or a supported refine-op shape). On the
+ * second-and-later call for the same (session, ask) it returns null AND records a
+ * route_override (the one-shot invariant).
+ */
+export function checkRouteGate(input: RouteGateInput): RouteGateResult | null {
+  if (!routeEnforcementEnabled(input.env)) return null;
+  if (!input.sessionId) return null; // fail-open: no session to key state by
+
+  const manifests = input.manifests ?? [...loadManifests().values()];
+  const decision = classifyAskRoute(input.ask, manifests);
+  const askKey = normalizeAskForMatch((input.ask ?? '').trim());
+
+  const alreadyDeflected = sessionRouteState.hasDeflection(input.sessionId, askKey);
+  const gate = decideRouteGate({
+    route: decision.route,
+    shape: decision.shape,
+    alreadyDeflected,
+  });
+  if (gate === 'noop') return null;
+
+  const ts = new Date().toISOString();
+
+  if (gate === 'override') {
+    // One-shot on the override side too: record the override on the FIRST post-deflection
+    // execution only. Later calls still execute (return null) but add no further override.
+    if (!sessionRouteState.hasOverride(input.sessionId, askKey)) {
+      const override: RouteOverride =
+        decision.route === 'refine-op'
+          ? { tool: input.toolName, ts, ask: askKey, shape: decision.shape }
+          : {
+              tool: input.toolName,
+              ts,
+              ask: askKey,
+              template: decision.template ?? '(the matched template)',
+            };
+      sessionRouteState.recordOverride(input.sessionId, override);
+    }
+    return null;
+  }
+
+  // gate === 'deflect'
+  if (decision.route === 'refine-op') {
+    const text = refineDeflectionText();
+    const deflection: RouteDeflection = {
+      tool: input.toolName,
+      ts,
+      ask: askKey,
+      shape: decision.shape,
+      next_route: 'refine-op',
+      text,
+    };
+    sessionRouteState.recordDeflection(input.sessionId, deflection);
+    return {
+      content: [
+        { type: 'text', text },
+        {
+          type: 'text',
+          text: JSON.stringify({
+            next_route: 'refine-op',
+            tool: REFINE_WORKSHEET_TOOL,
+            shape: decision.shape,
+          }),
+        },
+      ],
+      isError: false,
+    };
+  }
+
+  const template = decision.template ?? '(the matched template)';
+  const text = deflectionText(template);
+  const deflection: RouteDeflection = {
+    tool: input.toolName,
+    ts,
+    ask: askKey,
+    template,
+    next_route: 'bind-first',
+    text,
+  };
+  sessionRouteState.recordDeflection(input.sessionId, deflection);
+  return {
+    content: [
+      { type: 'text', text },
+      { type: 'text', text: JSON.stringify({ next_route: 'bind-first', template }) },
+    ],
+    isError: false,
+  };
+}

--- a/src/desktop/route/route-state.test.ts
+++ b/src/desktop/route/route-state.test.ts
@@ -105,4 +105,20 @@ describe('SessionRouteStateStore', () => {
     expect(store.get('S-5')?.deflections).toHaveLength(1);
     expect(store.get(`S-${cap + 4}`)?.deflections).toHaveLength(1);
   });
+
+  it('per-session cap: each record array FIFO-evicts past MAX_ENTRIES_PER_SESSION', () => {
+    const store = new SessionRouteStateStore();
+    const cap = SessionRouteStateStore.MAX_ENTRIES_PER_SESSION;
+    for (let i = 0; i < cap + 3; i++) {
+      store.recordDeflection('S1', mkDeflection({ ask: `ask-${i}` }));
+      store.recordOverride('S1', { tool: 'x', ts: '', ask: `ask-${i}` });
+    }
+    const s = store.get('S1')!;
+    expect(s.deflections).toHaveLength(cap);
+    expect(s.route_overrides).toHaveLength(cap);
+    // Oldest evicted, newest retained — the one-shot invariant weakens to
+    // at-most-twice only for evicted asks.
+    expect(store.hasDeflection('S1', 'ask-0')).toBe(false);
+    expect(store.hasDeflection('S1', `ask-${cap + 2}`)).toBe(true);
+  });
 });

--- a/src/desktop/route/route-state.test.ts
+++ b/src/desktop/route/route-state.test.ts
@@ -1,0 +1,108 @@
+// src/desktop/route/route-state.test.ts
+//
+// Session-keyed route state. Deflections/overrides are recorded per resolved Desktop session
+// id and lazy-inited on first write (no begin-episode init exists). No-session paths no-op
+// (fail-open). The one-shot dedup key is (session, normalized-ask).
+
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { type RouteDeflection, sessionRouteState, SessionRouteStateStore } from './route-state.js';
+
+function mkDeflection(over: Partial<RouteDeflection> = {}): RouteDeflection {
+  return {
+    tool: 'build-and-apply-worksheet',
+    ts: new Date().toISOString(),
+    ask: 'bar chart of sales by region',
+    template: 'ranking-ordered-bar',
+    next_route: 'bind-first',
+    text: 'deflection body',
+    ...over,
+  };
+}
+
+describe('SessionRouteStateStore', () => {
+  beforeEach(() => sessionRouteState.clear());
+
+  it('recordDeflection lazy-inits the session state and appends the deflection', () => {
+    const store = new SessionRouteStateStore();
+    const s = store.recordDeflection('S1', mkDeflection())!;
+    expect(s.session_id).toBe('S1');
+    expect(s.deflections).toHaveLength(1);
+    expect(s.route_overrides).toEqual([]);
+    expect(store.get('S1')).toBe(s);
+  });
+
+  it('hasDeflection is keyed by (session, ask) — the one-shot dedup key', () => {
+    const store = new SessionRouteStateStore();
+    store.recordDeflection('S1', mkDeflection({ ask: 'bar chart of sales by region' }));
+    expect(store.hasDeflection('S1', 'bar chart of sales by region')).toBe(true);
+    // A different ask in the same session is a distinct one-shot.
+    expect(store.hasDeflection('S1', 'line chart over time')).toBe(false);
+    // A different session with the same ask is a distinct one-shot.
+    expect(store.hasDeflection('S2', 'bar chart of sales by region')).toBe(false);
+  });
+
+  it('recordOverride appends and hasOverride tracks it per (session, ask)', () => {
+    const store = new SessionRouteStateStore();
+    store.recordOverride('S1', {
+      tool: 'build-and-apply-worksheet',
+      ts: new Date().toISOString(),
+      ask: 'bar chart of sales by region',
+      template: 'ranking-ordered-bar',
+    });
+    expect(store.get('S1')!.route_overrides).toHaveLength(1);
+    expect(store.hasOverride('S1', 'bar chart of sales by region')).toBe(true);
+    expect(store.hasOverride('S1', 'other ask')).toBe(false);
+  });
+
+  it('get / hasDeflection no-op for an unknown or absent session id', () => {
+    const store = new SessionRouteStateStore();
+    expect(store.get('nope')).toBeUndefined();
+    expect(store.get(undefined)).toBeUndefined();
+    expect(store.hasDeflection(undefined, 'x')).toBe(false);
+    expect(store.hasDeflection('nope', 'x')).toBe(false);
+  });
+
+  it('recordDeflection / recordOverride no-op (undefined) without a session id (fail-open)', () => {
+    const store = new SessionRouteStateStore();
+    expect(store.recordDeflection(undefined, mkDeflection())).toBeUndefined();
+    expect(
+      store.recordOverride(undefined, {
+        tool: 'x',
+        ts: '',
+        ask: 'a',
+      }),
+    ).toBeUndefined();
+  });
+
+  it('evict removes a session state; reading it before evict still sees it', () => {
+    const store = new SessionRouteStateStore();
+    store.recordDeflection('S1', mkDeflection());
+    expect(store.get('S1')?.deflections).toHaveLength(1);
+    expect(store.evict('S1')).toBe(true);
+    expect(store.get('S1')).toBeUndefined();
+  });
+
+  it('evict is a no-op (false) for an unknown or absent session id (fail-open)', () => {
+    const store = new SessionRouteStateStore();
+    expect(store.evict('nope')).toBe(false);
+    expect(store.evict(undefined)).toBe(false);
+  });
+
+  it('exposes a shared module singleton that clear() resets', () => {
+    sessionRouteState.recordDeflection('S-a', mkDeflection());
+    expect(sessionRouteState.get('S-a')?.deflections).toHaveLength(1);
+    sessionRouteState.clear();
+    expect(sessionRouteState.get('S-a')).toBeUndefined();
+  });
+
+  it('safety cap: retains only the newest MAX_STATES; the oldest evict first', () => {
+    const store = new SessionRouteStateStore();
+    const cap = SessionRouteStateStore.MAX_STATES;
+    for (let i = 0; i < cap + 5; i++) store.recordDeflection(`S-${i}`, mkDeflection());
+    expect(store.get('S-0')).toBeUndefined();
+    expect(store.get('S-4')).toBeUndefined();
+    expect(store.get('S-5')?.deflections).toHaveLength(1);
+    expect(store.get(`S-${cap + 4}`)?.deflections).toHaveLength(1);
+  });
+});

--- a/src/desktop/route/route-state.ts
+++ b/src/desktop/route/route-state.ts
@@ -72,6 +72,14 @@ export class SessionRouteStateStore {
    */
   static readonly MAX_STATES = 500;
 
+  /**
+   * Per-session cap on each record array. A marathon session with enforcement on would
+   * otherwise grow one entry per unique ask, unbounded. FIFO eviction: past the cap, the
+   * one-shot invariant weakens to "at most twice" for the evicted (oldest) asks — benign
+   * next to unbounded memory.
+   */
+  static readonly MAX_ENTRIES_PER_SESSION = 200;
+
   private ensure(sessionId: string): SessionRouteState {
     let state = this.bySession.get(sessionId);
     if (!state) {
@@ -119,6 +127,9 @@ export class SessionRouteStateStore {
     if (!sessionId) return undefined;
     const state = this.ensure(sessionId);
     state.deflections.push(deflection);
+    while (state.deflections.length > SessionRouteStateStore.MAX_ENTRIES_PER_SESSION) {
+      state.deflections.shift();
+    }
     return state;
   }
 
@@ -133,6 +144,9 @@ export class SessionRouteStateStore {
     if (!sessionId) return undefined;
     const state = this.ensure(sessionId);
     state.route_overrides.push(override);
+    while (state.route_overrides.length > SessionRouteStateStore.MAX_ENTRIES_PER_SESSION) {
+      state.route_overrides.shift();
+    }
     return state;
   }
 

--- a/src/desktop/route/route-state.ts
+++ b/src/desktop/route/route-state.ts
@@ -1,0 +1,155 @@
+// src/desktop/route/route-state.ts
+//
+// SESSION-KEYED route state (Slice B, adapted from a2td src/server/route-state.ts). tmcp has
+// NO episode subsystem, so the a2td per-EPISODE record is ported onto the resolved Desktop
+// SESSION id instead. The `recordBindAttempt` / `recordRefineAttempt` episode integration is
+// deliberately DROPPED (there is no begin-episode/end-episode lifecycle to hang it on); the
+// one-shot deflection invariant is enforced per (session, ask) by the deflection/override
+// records here rather than by attempt counters.
+//
+// In-memory, per-server-process (a module singleton, same lifetime as SessionManager). The
+// gate (`route-gate.ts`) is the only writer; readers are tests and any future receipt surface.
+
+import type { AskShape, RouteClass } from '../binder/route-spec.js';
+
+export type { AskShape, RouteClass };
+
+/**
+ * A deflection issued by the gate. Carries the {tool, ts} receipt shape plus the issued
+ * next_route marker, the one-line agent-actionable text, and the normalized ask KEY it was
+ * issued for (the per-session one-shot dedup key — a2td used the episode id).
+ */
+export interface RouteDeflection {
+  /** The scratch-entry tool whose call was deflected. */
+  tool: string;
+  /** ISO timestamp the deflection was issued. */
+  ts: string;
+  /** The normalized ask key the deflection was issued for (one-shot dedup within a session). */
+  ask: string;
+  /** The eligible template the deflection names, for bind-first deflections. */
+  template?: string;
+  /** The classified refine shape the deflection names, for refine-op deflections. */
+  shape?: AskShape;
+  /** The route the deflection steers the agent toward. */
+  next_route: RouteClass;
+  /** One line of agent-actionable text (the deflection result body). */
+  text: string;
+}
+
+/**
+ * A recorded route override: a SECOND scratch-entry call for a (session, ask) already
+ * deflected, allowed to execute (the one-shot invariant — never deflect twice).
+ */
+export interface RouteOverride {
+  /** The scratch-entry tool whose call was allowed to execute post-deflection. */
+  tool: string;
+  /** ISO timestamp the override was recorded. */
+  ts: string;
+  /** The normalized ask key the prior deflection was issued for. */
+  ask: string;
+  /** The eligible template the prior deflection named, for bind-first overrides. */
+  template?: string;
+  /** The classified refine shape the prior deflection named, for refine-op overrides. */
+  shape?: AskShape;
+}
+
+export interface SessionRouteState {
+  /** The resolved Desktop session id this state is keyed by. */
+  session_id: string;
+  /** Deflections issued for this session by the gate. */
+  deflections: RouteDeflection[];
+  /** Route overrides recorded for this session (one per (session, ask) post-deflection). */
+  route_overrides: RouteOverride[];
+}
+
+export class SessionRouteStateStore {
+  private bySession = new Map<string, SessionRouteState>();
+
+  /**
+   * Safety cap on retained session states. A long-lived server that never sees an
+   * end-of-session signal would otherwise leak; keeping only the newest ~500 states bounds
+   * memory. A Map iterates in insertion order, so the oldest live key evicts first.
+   */
+  static readonly MAX_STATES = 500;
+
+  private ensure(sessionId: string): SessionRouteState {
+    let state = this.bySession.get(sessionId);
+    if (!state) {
+      state = { session_id: sessionId, deflections: [], route_overrides: [] };
+      this.bySession.set(sessionId, state);
+      while (this.bySession.size > SessionRouteStateStore.MAX_STATES) {
+        const oldest = this.bySession.keys().next().value;
+        if (oldest === undefined) break;
+        this.bySession.delete(oldest);
+      }
+    }
+    return state;
+  }
+
+  /** Route state for a session, if any. Undefined for an unknown/absent id (no-op). */
+  get(sessionId: string | undefined): SessionRouteState | undefined {
+    if (!sessionId) return undefined;
+    return this.bySession.get(sessionId);
+  }
+
+  /**
+   * Whether a deflection was already issued for this (session, ask). The one-shot invariant:
+   * once true, the gate overrides (executes) instead of deflecting again.
+   */
+  hasDeflection(sessionId: string | undefined, ask: string): boolean {
+    const state = this.get(sessionId);
+    return !!state && state.deflections.some((d) => d.ask === ask);
+  }
+
+  /** Whether an override was already recorded for this (session, ask). */
+  hasOverride(sessionId: string | undefined, ask: string): boolean {
+    const state = this.get(sessionId);
+    return !!state && state.route_overrides.some((o) => o.ask === ask);
+  }
+
+  /**
+   * Record a deflection issued by the gate. Lazy-inits the session state on first write. No
+   * episode/begin-episode init is needed (or exists) in the session-keyed world. No-op on a
+   * missing session id (fail-open).
+   */
+  recordDeflection(
+    sessionId: string | undefined,
+    deflection: RouteDeflection,
+  ): SessionRouteState | undefined {
+    if (!sessionId) return undefined;
+    const state = this.ensure(sessionId);
+    state.deflections.push(deflection);
+    return state;
+  }
+
+  /**
+   * Record a route override (a post-deflection execution). Same fail-open contract as
+   * recordDeflection; lazy-inits the session state if somehow absent.
+   */
+  recordOverride(
+    sessionId: string | undefined,
+    override: RouteOverride,
+  ): SessionRouteState | undefined {
+    if (!sessionId) return undefined;
+    const state = this.ensure(sessionId);
+    state.route_overrides.push(override);
+    return state;
+  }
+
+  /** Evict a session's route state. No-op (false) on a missing/unknown id (fail-open). */
+  evict(sessionId: string | undefined): boolean {
+    if (!sessionId) return false;
+    return this.bySession.delete(sessionId);
+  }
+
+  /** Test/reset helper. */
+  clear(): void {
+    this.bySession.clear();
+  }
+}
+
+/**
+ * Process-wide singleton (one MCP server == one process, same lifetime as SessionManager).
+ * A module singleton — not a server field — because the gate call sites import it directly.
+ */
+export const sessionRouteState = new SessionRouteStateStore();

--- a/src/server.desktop.test.ts
+++ b/src/server.desktop.test.ts
@@ -136,6 +136,10 @@ describe('desktop tools/list serialized surface', () => {
       total += (await serializeDesktopToolSurface(toolFactory(server))).length;
     }
 
+    // 46_000 is the ToolSearch auto-deferral cliff on MCP hosts, not a tunable constant — past it
+    // the whole desktop surface gets deferred behind ToolSearch. refine-worksheet (~1_798 bytes on
+    // a 45_810 base) intentionally leaves this RED on this branch: it is the merge blocker until
+    // the shelf-tool consolidation lands and frees the headroom. Never raise the cap to ship a tool.
     expect(total).toBeLessThanOrEqual(46_000);
   });
 });

--- a/src/server.desktop.test.ts
+++ b/src/server.desktop.test.ts
@@ -137,9 +137,10 @@ describe('desktop tools/list serialized surface', () => {
     }
 
     // 46_000 is the ToolSearch auto-deferral cliff on MCP hosts, not a tunable constant — past it
-    // the whole desktop surface gets deferred behind ToolSearch. refine-worksheet (~1_798 bytes on
-    // a 45_810 base) intentionally leaves this RED on this branch: it is the merge blocker until
-    // the shelf-tool consolidation lands and frees the headroom. Never raise the cap to ship a tool.
+    // the whole desktop surface gets deferred behind ToolSearch. The shelf-tool consolidation has
+    // landed, so this is GREEN: the serialized surface is 44_015 bytes, ~1_985 under the cliff.
+    // That headroom is the ENTIRE budget for future tools — trim tools to fit it; NEVER raise the
+    // cap to ship a tool (raising it just re-buries the whole surface behind ToolSearch).
     expect(total).toBeLessThanOrEqual(46_000);
   });
 });

--- a/src/tools/desktop/toolName.ts
+++ b/src/tools/desktop/toolName.ts
@@ -8,6 +8,7 @@ export const desktopToolNames = [
   'get-worksheet-xml',
   'apply-worksheet',
   'delete-worksheet',
+  'refine-worksheet',
   'get-dashboard-xml',
   'apply-dashboard',
   'apply-dashboard-with-viewpoints',

--- a/src/tools/desktop/tools.ts
+++ b/src/tools/desktop/tools.ts
@@ -39,6 +39,7 @@ import { getListWorksheetsTool } from './workbook/listWorksheets.js';
 import { getApplyWorksheetTool } from './worksheet/applyWorksheet.js';
 import { getDeleteWorksheetTool } from './worksheet/deleteWorksheet.js';
 import { getGetWorksheetXmlTool } from './worksheet/getWorksheetXml.js';
+import { getRefineWorksheetTool } from './worksheet/refineWorksheet.js';
 
 export const desktopToolFactories = [
   getListInstancesTool,
@@ -50,6 +51,7 @@ export const desktopToolFactories = [
   getGetWorksheetXmlTool,
   getApplyWorksheetTool,
   getDeleteWorksheetTool,
+  getRefineWorksheetTool,
   getGetDashboardXmlTool,
   getApplyDashboardTool,
   getApplyDashboardWithViewpointsTool,

--- a/src/tools/desktop/worksheet/refineWorksheet.test.ts
+++ b/src/tools/desktop/worksheet/refineWorksheet.test.ts
@@ -1,0 +1,309 @@
+import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { Err, Ok } from 'ts-results-es';
+import { z } from 'zod';
+
+import * as getWorksheetXmlModule from '../../../desktop/commands/workbook/getWorksheetXml.js';
+import * as loadWorksheetXmlModule from '../../../desktop/commands/workbook/loadWorksheetXml.js';
+import {
+  ArgsValidationError,
+  GetWorksheetXmlFailedError,
+  WorksheetXmlLoadFailedError,
+} from '../../../errors/mcpToolError.js';
+import { DesktopMcpServer } from '../../../server.desktop.js';
+import invariant from '../../../utils/invariant.js';
+import { Provider } from '../../../utils/provider.js';
+import { getMockRequestHandlerExtra } from '../toolContext.mock.js';
+import { getRefineWorksheetTool } from './refineWorksheet.js';
+
+vi.mock('../../../desktop/commands/workbook/getWorksheetXml.js');
+vi.mock('../../../desktop/commands/workbook/loadWorksheetXml.js');
+
+// A single-worksheet fragment shaped like the fetch returns: one nominal dimension CI
+// (Region) + one measure CI (SUM Sales), a safe self-closing <computed-sort>, and
+// <aggregation> — the ranking-ordered-bar envelope. Declares xmlns:user so the planner's
+// user:* filter attributes are in scope.
+const SOURCE = `<worksheet name='Sales by Region' xmlns:user='http://www.tableausoftware.com/xml/user'>
+  <table>
+    <view>
+      <datasources>
+        <datasource caption='Superstore' name='Superstore' />
+      </datasources>
+      <datasource-dependencies datasource='Superstore'>
+        <column datatype='string' name='[Region]' role='dimension' type='nominal' />
+        <column datatype='real' name='[Sales]' role='measure' type='quantitative' />
+        <column-instance column='[Region]' derivation='None' name='[none:Region:nk]' pivot='key' type='nominal' />
+        <column-instance column='[Sales]' derivation='Sum' name='[sum:Sales:qk]' pivot='key' type='quantitative' />
+      </datasource-dependencies>
+      <computed-sort column='[Superstore].[none:Region:nk]' direction='DESC' using='[Superstore].[sum:Sales:qk]' />
+      <aggregation value='true' />
+    </view>
+    <style />
+    <panes>
+      <pane>
+        <view><breakdown value='auto' /></view>
+        <mark class='Bar' />
+      </pane>
+    </panes>
+    <rows>[Superstore].[none:Region:nk]</rows>
+    <cols>[Superstore].[sum:Sales:qk]</cols>
+  </table>
+  <simple-id uuid='00000000-0000-0000-0000-000000000001' />
+</worksheet>`;
+
+// A source that PLANS fine (one dim, one measure, an anchor) but fails preflight: the extra
+// column-instance carries a non-canonical derivation ("Attr"), which the real
+// invalid-derivation-string rule rejects as an error. tmcp has no a2td-style
+// computed-sort-crash rule, so this exercises the tool's preflight seam against a rule that
+// actually exists here. The planner still refuses the nested computed-sort crash form
+// directly (covered in the planner test).
+const PREFLIGHT_FAIL_SOURCE = SOURCE.replace(
+  '</datasource-dependencies>',
+  "<column-instance column='[Sales]' derivation='Attr' name='[attr:Sales:xk]' pivot='key' type='ordinal' /></datasource-dependencies>",
+);
+
+type GetResult = Awaited<ReturnType<typeof getWorksheetXmlModule.getWorksheetXml>>;
+type LoadResult = Awaited<ReturnType<typeof loadWorksheetXmlModule.loadWorksheetXml>>;
+type ErrOf<R> = R extends Err<infer E> ? E : never;
+
+interface MockOpts {
+  source?: string;
+  fetchErr?: ErrOf<GetResult>;
+  applyErr?: ErrOf<LoadResult>;
+  /** Readback: 'echo' (the applied XML, default) or 'source' (Tableau silently dropped it). */
+  readback?: 'echo' | 'source';
+}
+
+const getMock = (): ReturnType<typeof vi.mocked<typeof getWorksheetXmlModule.getWorksheetXml>> =>
+  vi.mocked(getWorksheetXmlModule.getWorksheetXml);
+const loadMock = (): ReturnType<typeof vi.mocked<typeof loadWorksheetXmlModule.loadWorksheetXml>> =>
+  vi.mocked(loadWorksheetXmlModule.loadWorksheetXml);
+
+function setupMocks(opts: MockOpts = {}): { applied: () => string | null } {
+  const source = opts.source ?? SOURCE;
+  let lastApplied: string | null = null;
+  let getCalls = 0;
+
+  getMock().mockImplementation(async (): Promise<GetResult> => {
+    getCalls += 1;
+    if (getCalls === 1) {
+      // The fetch.
+      return (opts.fetchErr ? Err(opts.fetchErr) : Ok(source)) as GetResult;
+    }
+    // The readback.
+    return (opts.readback === 'source' ? Ok(source) : Ok(lastApplied ?? source)) as GetResult;
+  });
+
+  loadMock().mockImplementation(async ({ xml }: { xml: string }): Promise<LoadResult> => {
+    lastApplied = xml;
+    return (opts.applyErr ? Err(opts.applyErr) : Ok.EMPTY) as LoadResult;
+  });
+
+  return { applied: () => lastApplied };
+}
+
+describe('refineWorksheetTool — instance', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('creates a tool instance with the expected properties', () => {
+    const tool = getRefineWorksheetTool(new DesktopMcpServer());
+    expect(tool.name).toBe('refine-worksheet');
+    expect(tool.description).toContain('Refine an EXISTING worksheet');
+    expect(tool.paramsSchema).toMatchObject({
+      session: expect.any(Object),
+      worksheetName: expect.any(Object),
+      operation: expect.any(Object),
+      topN: expect.any(Object),
+      sortDirection: expect.any(Object),
+    });
+    expect(tool.annotations).toMatchObject({
+      title: 'Refine Worksheet',
+      readOnlyHint: false,
+      destructiveHint: true,
+    });
+  });
+});
+
+describe('refineWorksheetTool — top_n happy path', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('fetches, patches, applies once, and confirms the Top-N filter on readback', async () => {
+    const { applied } = setupMocks();
+    const result = await getToolResult({
+      worksheetName: 'Sales by Region',
+      operation: 'top_n',
+      topN: { n: 5 },
+    });
+
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+    const parsed = successSchema.parse(JSON.parse(result.content[0].text));
+    expect(parsed.refined).toBe(true);
+    expect(parsed.message).toMatch(/Applied top_n/);
+
+    // Applied exactly once (never a second apply).
+    expect(loadMock()).toHaveBeenCalledTimes(1);
+
+    // The applied XML carries the native Top-N filter + a slices entry.
+    const out = applied()!;
+    expect(out).toMatch(/function='end'\s+end='top'\s+count='5'/);
+    expect(out).toContain('<slices><column>[Superstore].[none:Region:nk]</column></slices>');
+  });
+});
+
+describe('refineWorksheetTool — sort_direction happy path', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('flips the computed-sort direction and confirms it on readback', async () => {
+    const { applied } = setupMocks();
+    const result = await getToolResult({
+      worksheetName: 'Sales by Region',
+      operation: 'sort_direction',
+      sortDirection: { direction: 'ASC' },
+    });
+
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+    const parsed = successSchema.parse(JSON.parse(result.content[0].text));
+    expect(parsed.message).toMatch(/Applied sort_direction/);
+    expect(loadMock()).toHaveBeenCalledTimes(1);
+    expect(applied()!).toContain("direction='ASC'");
+    expect(applied()!).not.toContain("direction='DESC'");
+  });
+});
+
+describe('refineWorksheetTool — refusals and errors', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('errors on a missing worksheetName and never touches Tableau', async () => {
+    setupMocks();
+    const result = await getToolResult({
+      worksheetName: '',
+      operation: 'top_n',
+      topN: { n: 5 },
+    });
+    expect(result.isError).toBe(true);
+    invariant(result.content[0].type === 'text');
+    expect(result.content[0].text).toBe(
+      new ArgsValidationError('worksheetName is required.').message,
+    );
+    expect(getMock()).not.toHaveBeenCalled();
+    expect(loadMock()).not.toHaveBeenCalled();
+  });
+
+  it('errors when the worksheet cannot be fetched (not found) — no apply', async () => {
+    const fetchErr = {
+      type: 'get-worksheet-xml-error' as const,
+      error: { type: 'no-worksheet-found' as const, message: 'No worksheet found for Ghost.' },
+    };
+    setupMocks({ fetchErr });
+    const result = await getToolResult({
+      worksheetName: 'Ghost',
+      operation: 'top_n',
+      topN: { n: 5 },
+    });
+    expect(result.isError).toBe(true);
+    invariant(result.content[0].type === 'text');
+    expect(result.content[0].text).toBe(new GetWorksheetXmlFailedError(fetchErr.error).message);
+    expect(loadMock()).not.toHaveBeenCalled();
+  });
+
+  it('refuses on preflight failure and NEVER applies', async () => {
+    setupMocks({ source: PREFLIGHT_FAIL_SOURCE });
+    const result = await getToolResult({
+      worksheetName: 'Sales by Region',
+      operation: 'top_n',
+      topN: { n: 5 },
+    });
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+    const parsed = refusalSchema.parse(JSON.parse(result.content[0].text));
+    expect(parsed.reason).toMatch(/preflight validation failed/);
+    expect(parsed.reason).toMatch(/invalid-derivation-string/);
+    expect(loadMock()).not.toHaveBeenCalled();
+  });
+
+  it('errors when the single apply fails, with no second apply', async () => {
+    const applyErr = {
+      type: 'load-worksheet-xml-error' as const,
+      error: { type: 'load-rejected' as const, message: 'rejected' },
+    };
+    setupMocks({ applyErr });
+    const result = await getToolResult({
+      worksheetName: 'Sales by Region',
+      operation: 'top_n',
+      topN: { n: 5 },
+    });
+    expect(result.isError).toBe(true);
+    invariant(result.content[0].type === 'text');
+    expect(result.content[0].text).toBe(new WorksheetXmlLoadFailedError(applyErr.error).message);
+    expect(loadMock()).toHaveBeenCalledTimes(1);
+  });
+
+  it('refuses when readback does not confirm the expected node (applied once)', async () => {
+    // Apply succeeds, but readback returns the un-patched source (Tableau silently
+    // dropped the filter) → confirmation fails → refuse, no retry.
+    setupMocks({ readback: 'source' });
+    const result = await getToolResult({
+      worksheetName: 'Sales by Region',
+      operation: 'top_n',
+      topN: { n: 5 },
+    });
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+    const parsed = refusalSchema.parse(JSON.parse(result.content[0].text));
+    expect(parsed.reason).toMatch(/readback did not contain/);
+    expect(loadMock()).toHaveBeenCalledTimes(1);
+  });
+
+  it('refuses an out-of-range n (kill criterion surfaced through the tool)', async () => {
+    setupMocks();
+    const result = await getToolResult({
+      worksheetName: 'Sales by Region',
+      operation: 'top_n',
+      topN: { n: 999 },
+    });
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+    const parsed = refusalSchema.parse(JSON.parse(result.content[0].text));
+    expect(parsed.reason).toMatch(/between 1 and 50/);
+    expect(loadMock()).not.toHaveBeenCalled();
+  });
+});
+
+const successSchema = z.object({
+  refined: z.literal(true),
+  operation: z.enum(['top_n', 'sort_direction']),
+  worksheetName: z.string(),
+  message: z.string(),
+});
+
+const refusalSchema = z.object({
+  refined: z.literal(false),
+  operation: z.enum(['top_n', 'sort_direction']),
+  worksheetName: z.string(),
+  reason: z.string(),
+});
+
+async function getToolResult({
+  worksheetName,
+  operation,
+  topN,
+  sortDirection,
+  session = '12345',
+}: {
+  worksheetName: string;
+  operation: 'top_n' | 'sort_direction';
+  topN?: { n: number; end?: 'top' | 'bottom' };
+  sortDirection?: { direction: 'ASC' | 'DESC' };
+  session?: string;
+}): Promise<CallToolResult> {
+  const tool = getRefineWorksheetTool(new DesktopMcpServer());
+  const callback = await Provider.from(tool.callback);
+
+  const extra = {
+    ...getMockRequestHandlerExtra(),
+    getExecutor: vi.fn().mockResolvedValue({}),
+  };
+
+  return await callback({ session, worksheetName, operation, topN, sortDirection }, extra);
+}

--- a/src/tools/desktop/worksheet/refineWorksheet.test.ts
+++ b/src/tools/desktop/worksheet/refineWorksheet.test.ts
@@ -107,7 +107,7 @@ describe('refineWorksheetTool — instance', () => {
   it('creates a tool instance with the expected properties', () => {
     const tool = getRefineWorksheetTool(new DesktopMcpServer());
     expect(tool.name).toBe('refine-worksheet');
-    expect(tool.description).toContain('Refine an EXISTING worksheet');
+    expect(tool.description).toContain('Refine a worksheet');
     expect(tool.paramsSchema).toMatchObject({
       session: expect.any(Object),
       worksheetName: expect.any(Object),

--- a/src/tools/desktop/worksheet/refineWorksheet.ts
+++ b/src/tools/desktop/worksheet/refineWorksheet.ts
@@ -62,37 +62,28 @@ function formatValidationErrors(issues: ValidationIssue[]): string {
 }
 
 const paramsSchema = {
-  session: z.string().optional().describe('Session ID; optional if pinned or unique.'),
-  worksheetName: z.string().min(1).describe('Existing worksheet name to refine.'),
-  operation: z
-    .enum(['top_n', 'sort_direction'])
-    .describe(
-      'top_n: top/bottom N of the single dimension by the single measure. sort_direction: flip the single computed-sort.',
-    ),
+  session: z.string().optional().describe('Session ID.'),
+  worksheetName: z.string().min(1).describe('Worksheet name.'),
+  operation: z.enum(['top_n', 'sort_direction']).describe('Refinement.'),
   topN: z
     .object({
-      n: z.number().int().min(1).max(50).describe('Members to keep (integer 1..50).'),
-      end: z.enum(['top', 'bottom']).optional().describe('top (default) or bottom.'),
+      n: z.number().int().min(1).max(50).describe('Members.'),
+      end: z.enum(['top', 'bottom']).optional().describe('Default top.'),
     })
     .optional()
-    .describe('Required when operation=top_n.'),
+    .describe('For top_n.'),
   sortDirection: z
     .object({
-      direction: z.enum(['ASC', 'DESC']).describe('ASC or DESC.'),
+      direction: z.enum(['ASC', 'DESC']).describe('Sort order.'),
     })
     .optional()
-    .describe('Required when operation=sort_direction.'),
+    .describe('For sort_direction.'),
 };
 
 const title = 'Refine Worksheet';
 
-export const REFINE_WORKSHEET_DESCRIPTION = [
-  'Refine an EXISTING worksheet with ONE bounded, validated mutation (applies once, then reads',
-  'back to confirm). Use WHEN the user asks to limit an existing chart to its top/bottom N',
-  'members, or to flip its sort direction — NOT to build a new chart. REFUSES (defer to the',
-  'normal build path) on anything ambiguous/out of envelope: multiple dims/measures, n outside',
-  '1..50, sets/params/calcs, an existing Top-N, or a nested/absent/multiple computed-sort.',
-].join(' ');
+export const REFINE_WORKSHEET_DESCRIPTION =
+  'Refine a worksheet: top/bottom N or flip sort; else refuses to normal path.';
 
 export const getRefineWorksheetTool = (
   server: DesktopMcpServer,

--- a/src/tools/desktop/worksheet/refineWorksheet.ts
+++ b/src/tools/desktop/worksheet/refineWorksheet.ts
@@ -1,0 +1,259 @@
+// refine-worksheet — the refine fast lane. Routes refine-shaped follow-ups ("make that
+// the top five", "flip the sort") to ONE bounded, validated, worksheet-level mutation
+// instead of whole-workbook XML surgery.
+//
+// Flow: get-worksheet-xml (ONE fetch) -> pure minimal patch (envelope check inside the
+// planner) -> ensureUserNamespace -> preflight validation -> load-worksheet-xml (apply
+// ONCE, itself validated) -> get-worksheet-xml readback -> confirm the expected node.
+// On ANY out-of-envelope condition it REFUSES with a precise reason and hands back to the
+// standard authoring path — it never retries, never applies twice, never falls back to
+// whole-workbook XML. The WHAT (which nodes, which refusals) lives in the pure planners
+// under src/desktop/refine/refineWorksheet.ts; this file is the I/O wrapper + registration.
+
+import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { Ok } from 'ts-results-es';
+import { z } from 'zod';
+
+import { getWorksheetXml } from '../../../desktop/commands/workbook/getWorksheetXml.js';
+import { loadWorksheetXml } from '../../../desktop/commands/workbook/loadWorksheetXml.js';
+import {
+  confirmSortDirectionApplied,
+  confirmTopNApplied,
+  planSortDirection,
+  planTopN,
+  type SortDirection,
+  type TopNEnd,
+} from '../../../desktop/refine/refineWorksheet.js';
+import { resolveSession } from '../../../desktop/sessionResolution.js';
+import { ensureUserNamespace } from '../../../desktop/templates/injectTemplateCore.js';
+import { runValidation } from '../../../desktop/validation/registry.js';
+import { ValidationIssue } from '../../../desktop/validation/types.js';
+import {
+  ArgsValidationError,
+  DesktopCommandExecutionError,
+  GetWorksheetXmlFailedError,
+  UnknownError,
+  WorksheetXmlLoadFailedError,
+} from '../../../errors/mcpToolError.js';
+import { DesktopMcpServer } from '../../../server.desktop.js';
+import { DesktopTool } from '../tool.js';
+
+type RefineOperation = 'top_n' | 'sort_direction';
+
+type RefineWorksheetToolResult =
+  | { refined: true; operation: RefineOperation; worksheetName: string; message: string }
+  | { refined: false; operation: RefineOperation; worksheetName: string; reason: string };
+
+/** A hand-back-to-the-standard-path refusal — not an error, so isError stays false. */
+function refusal(
+  operation: RefineOperation,
+  worksheetName: string,
+  reason: string,
+): Ok<RefineWorksheetToolResult> {
+  return new Ok({ refined: false, operation, worksheetName, reason });
+}
+
+/** Compact one-line summary of the error-severity preflight issues (rule id + message). */
+function formatValidationErrors(issues: ValidationIssue[]): string {
+  return issues
+    .filter((issue) => issue.severity === 'error')
+    .map((issue) => `${issue.ruleId}: ${issue.message}`)
+    .join('; ');
+}
+
+const paramsSchema = {
+  session: z.string().optional().describe('Session ID; optional if pinned or unique.'),
+  worksheetName: z.string().min(1).describe('Existing worksheet name to refine.'),
+  operation: z
+    .enum(['top_n', 'sort_direction'])
+    .describe(
+      'top_n: top/bottom N of the single dimension by the single measure. sort_direction: flip the single computed-sort.',
+    ),
+  topN: z
+    .object({
+      n: z.number().int().min(1).max(50).describe('Members to keep (integer 1..50).'),
+      end: z.enum(['top', 'bottom']).optional().describe('top (default) or bottom.'),
+    })
+    .optional()
+    .describe('Required when operation=top_n.'),
+  sortDirection: z
+    .object({
+      direction: z.enum(['ASC', 'DESC']).describe('ASC or DESC.'),
+    })
+    .optional()
+    .describe('Required when operation=sort_direction.'),
+};
+
+const title = 'Refine Worksheet';
+
+export const REFINE_WORKSHEET_DESCRIPTION = [
+  'Refine an EXISTING worksheet with ONE bounded, validated mutation (applies once, then reads',
+  'back to confirm). Use WHEN the user asks to limit an existing chart to its top/bottom N',
+  'members, or to flip its sort direction — NOT to build a new chart. REFUSES (defer to the',
+  'normal build path) on anything ambiguous/out of envelope: multiple dims/measures, n outside',
+  '1..50, sets/params/calcs, an existing Top-N, or a nested/absent/multiple computed-sort.',
+].join(' ');
+
+export const getRefineWorksheetTool = (
+  server: DesktopMcpServer,
+): DesktopTool<typeof paramsSchema> => {
+  const refineWorksheetTool = new DesktopTool({
+    server,
+    name: 'refine-worksheet',
+    title,
+    description: REFINE_WORKSHEET_DESCRIPTION,
+    paramsSchema,
+    annotations: {
+      title,
+      readOnlyHint: false,
+      openWorldHint: false,
+      destructiveHint: true, // mutates the named worksheet
+      idempotentHint: false,
+    },
+    callback: async (
+      { session, worksheetName, operation, topN, sortDirection },
+      extra,
+    ): Promise<CallToolResult> => {
+      return await refineWorksheetTool.logAndExecute<RefineWorksheetToolResult>({
+        extra,
+        args: { session, worksheetName, operation, topN, sortDirection },
+        callback: async () => {
+          if (!worksheetName || !worksheetName.trim()) {
+            return new ArgsValidationError('worksheetName is required.').toErr();
+          }
+
+          const sessionResult = resolveSession(session);
+          if (sessionResult.isErr()) {
+            return sessionResult.error.toErr();
+          }
+          const resolvedSession = sessionResult.value;
+          const executor = await extra.getExecutor(resolvedSession);
+
+          // 1. ONE fetch of the target worksheet.
+          const fetched = await getWorksheetXml({
+            worksheetName,
+            executor,
+            signal: extra.signal,
+          });
+          if (fetched.isErr()) {
+            const { type, error } = fetched.error;
+            switch (type) {
+              case 'get-worksheet-xml-error':
+                return new GetWorksheetXmlFailedError(error).toErr();
+              case 'execute-command-error':
+                return new DesktopCommandExecutionError(error).toErr();
+              default: {
+                const _: never = type;
+                return new UnknownError(error).toErr();
+              }
+            }
+          }
+          const sourceXml = fetched.value;
+
+          // 2. Pure minimal patch + the readback confirmation target for this operation.
+          let patched: string;
+          let confirm: (readback: string) => boolean;
+          let nodeLabel: string;
+
+          if (operation === 'top_n') {
+            const plan = planTopN(sourceXml, {
+              n: topN?.n as number,
+              end: topN?.end as TopNEnd | undefined,
+            });
+            if (!plan.ok) {
+              return refusal(operation, worksheetName, plan.reason);
+            }
+            patched = plan.xml;
+            const col = plan.filterColumn;
+            confirm = (rb) => confirmTopNApplied(rb, col);
+            nodeLabel = `Top-N filter (function="end") on ${col}`;
+          } else {
+            const plan = planSortDirection(sourceXml, {
+              direction: sortDirection?.direction as SortDirection,
+            });
+            if (!plan.ok) {
+              return refusal(operation, worksheetName, plan.reason);
+            }
+            patched = plan.xml;
+            const col = plan.column;
+            const dir = plan.direction;
+            confirm = (rb) => confirmSortDirectionApplied(rb, col, dir);
+            nodeLabel = `<computed-sort direction="${dir}">${col ? ` on ${col}` : ''}`;
+          }
+
+          // 3. Declare the user: namespace before the patch is parsed/applied.
+          const prepared = ensureUserNamespace(patched);
+
+          // 4. Preflight validation — an error-severity issue means we do NOT apply.
+          const validation = runValidation(prepared, 'worksheet');
+          if (!validation.valid) {
+            return refusal(
+              operation,
+              worksheetName,
+              `preflight validation failed — not applying. ${formatValidationErrors(validation.issues)}`,
+            );
+          }
+
+          // 5. Apply ONCE through the shared, validated worksheet apply path. On failure:
+          // STOP, no retry, no whole-workbook fallback.
+          const applied = await loadWorksheetXml({
+            worksheetName,
+            xml: prepared,
+            executor,
+            signal: extra.signal,
+          });
+          if (applied.isErr()) {
+            const { type, error } = applied.error;
+            switch (type) {
+              case 'execute-command-error':
+                return new DesktopCommandExecutionError(error).toErr();
+              case 'load-worksheet-xml-error':
+                return new WorksheetXmlLoadFailedError(error).toErr();
+              default: {
+                const _: never = type;
+                return new UnknownError(String(type)).toErr();
+              }
+            }
+          }
+
+          // 6. Read back and confirm the expected node landed durably.
+          const readback = await getWorksheetXml({
+            worksheetName,
+            executor,
+            signal: extra.signal,
+          });
+          if (readback.isErr()) {
+            const { type, error } = readback.error;
+            switch (type) {
+              case 'get-worksheet-xml-error':
+                return new GetWorksheetXmlFailedError(error).toErr();
+              case 'execute-command-error':
+                return new DesktopCommandExecutionError(error).toErr();
+              default: {
+                const _: never = type;
+                return new UnknownError(error).toErr();
+              }
+            }
+          }
+          if (!confirm(readback.value)) {
+            return refusal(
+              operation,
+              worksheetName,
+              `applied, but the readback did not contain the expected ${nodeLabel} — the ` +
+                'refinement was not durable. Not retrying; fall back to the standard path.',
+            );
+          }
+
+          return new Ok({
+            refined: true,
+            operation,
+            worksheetName,
+            message: `Applied ${operation} to worksheet "${worksheetName}" and confirmed the ${nodeLabel} on readback.`,
+          });
+        },
+      });
+    },
+  });
+
+  return refineWorksheetTool;
+};


### PR DESCRIPTION
Ports the a2td refine/route switchboard stack, completing the fast-lane story on feature/authoring.

**Slice A — `refine-worksheet`:** pure planner (`planTopN`/`planSortDirection` + readback confirms) with a2td's full kill-criteria set — no criterion weakened or dropped (parity table in the planner tests). Refusals return `refined:false` (defer to the normal path); one fetch, one apply, never a whole-workbook fallback. Adds XML-escaping of derived insertion values over a2td. Full profile only, not in `DEMO_TOOL_PROFILE`.

**Slice B — route layer, inert until wired:** `route-spec` (verbatim registry), selector-only `ask-router` with a hand-mirrored CHART_NOUN set + set-equality parity test against `classify.ts` (includes `timeline` from #484), session-keyed route state (tmcp has no episode layer), and a flag-gated one-shot deflection gate. `ROUTE_ENFORCEMENT` defaults OFF with inertness test-pinned; deflection text is runtime-generated. **Deliberately not wired to a handler** — tmcp slow-path tools never receive the ask text; the wiring choice (bind-first sequence detection vs an ask param) is a product decision this PR does not make.

**Phase 3 adversarial review applied:** quote-safe readback confirms (column refs like `[none:O'Brien:nk]` previously broke an interpolated XPath literal *after* the apply, and quote-bearing names could false-confirm — now attribute-compared in JS with injection-shaped tests), and per-session route-state FIFO cap (200) on top of the 500-session cap.

**Budget discipline:** refine-worksheet trimmed to **1,197** serialized bytes (per-tool budget 1,200 — no grandfather entry); total surface **44,015 / 46,000**.

**Validation:** full suite 3,317 passed; both budget tests, CHART_NOUN parity, and the lockstep hash gate green; tsc/eslint clean on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)