### PR TITLE
desktop: wire the route gate — bind-first sequence detection

### DIFF
--- a/src/desktop/route/route-gate.test.ts
+++ b/src/desktop/route/route-gate.test.ts
@@ -17,6 +17,7 @@ import type { TemplateManifest } from '../binder/manifest-types.js';
 import {
   BIND_TEMPLATE_TOOL,
   checkRouteGate,
+  checkRouteGateForScratchEntry,
   decideRouteGate,
   deflectionText,
   REFINE_WORKSHEET_TOOL,
@@ -310,5 +311,129 @@ describe('checkRouteGate — no-op cases (fail-open, flag ON)', () => {
     });
     expect(r).toBeNull();
     expect(sessionRouteState.get('S1')).toBeUndefined();
+  });
+});
+
+describe('checkRouteGateForScratchEntry — session-state-driven gate', () => {
+  const pendingBindFirst = {
+    ask: 'bar chart of sales by region',
+    route: 'bind-first' as const,
+    shape: 'bind-first-template' as const,
+    template: 'ranking-ordered-bar',
+  };
+
+  it('flag OFF returns null even when session state has a pending bind-first ask', () => {
+    sessionRouteState.recordAskClassification('S1', pendingBindFirst);
+
+    const r = checkRouteGateForScratchEntry('build-and-apply-worksheet', 'S1');
+
+    expect(r).toBeNull();
+    expect(sessionRouteState.get('S1')?.deflections).toEqual([]);
+  });
+
+  it('flag ON with no session id returns null (fail-open)', () => {
+    enable();
+
+    expect(checkRouteGateForScratchEntry('build-and-apply-worksheet', undefined)).toBeNull();
+  });
+
+  it('flag ON with no current_ask returns null (fail-open)', () => {
+    enable();
+    sessionRouteState.recordDeflection('S1', {
+      tool: 'build-and-apply-worksheet',
+      ts: '',
+      ask: 'prior ask',
+      template: 'ranking-ordered-bar',
+      next_route: 'bind-first',
+      text: 'prior deflection',
+    });
+
+    expect(checkRouteGateForScratchEntry('build-and-apply-worksheet', 'S1')).toBeNull();
+  });
+
+  it('flag ON deflects a pending bind-first current_ask and records the deflection', () => {
+    enable();
+    sessionRouteState.recordAskClassification('S1', pendingBindFirst);
+
+    const r = checkRouteGateForScratchEntry('build-and-apply-worksheet', 'S1');
+
+    expect(r).not.toBeNull();
+    expect(r!.isError).toBe(false);
+    expect(r!.content[0].text).toBe(deflectionText('ranking-ordered-bar'));
+    expect(marker(r!)).toEqual({ next_route: 'bind-first', template: 'ranking-ordered-bar' });
+    const s = sessionRouteState.get('S1')!;
+    expect(s.deflections).toHaveLength(1);
+    expect(s.deflections[0]).toMatchObject({
+      tool: 'build-and-apply-worksheet',
+      ask: 'bar chart of sales by region',
+      template: 'ranking-ordered-bar',
+      next_route: 'bind-first',
+      text: deflectionText('ranking-ordered-bar'),
+    });
+  });
+
+  it('second identical scratch-entry call executes and records exactly one route_override', () => {
+    enable();
+    sessionRouteState.recordAskClassification('S1', pendingBindFirst);
+
+    checkRouteGateForScratchEntry('build-and-apply-worksheet', 'S1');
+    const second = checkRouteGateForScratchEntry('build-and-apply-worksheet', 'S1');
+    const third = checkRouteGateForScratchEntry('build-and-apply-worksheet', 'S1');
+
+    expect(second).toBeNull();
+    expect(third).toBeNull();
+    const s = sessionRouteState.get('S1')!;
+    expect(s.deflections).toHaveLength(1);
+    expect(s.route_overrides).toHaveLength(1);
+    expect(s.route_overrides[0]).toMatchObject({
+      tool: 'build-and-apply-worksheet',
+      ask: 'bar chart of sales by region',
+      template: 'ranking-ordered-bar',
+    });
+  });
+
+  it.each(['bound', 'propose', 'escalate'] as const)(
+    'last_outcome=%s no-ops because bind-template already had its chance',
+    (outcome) => {
+      enable();
+      sessionRouteState.recordAskClassification('S1', pendingBindFirst);
+      sessionRouteState.recordAskOutcome('S1', pendingBindFirst.ask, outcome);
+
+      expect(checkRouteGateForScratchEntry('build-and-apply-worksheet', 'S1')).toBeNull();
+      expect(sessionRouteState.get('S1')!.deflections).toEqual([]);
+    },
+  );
+
+  it.each(['scratch-pipeline', 'free'] as const)(
+    'route=%s no-ops because it is not enforced',
+    (route) => {
+      enable();
+      sessionRouteState.recordAskClassification('S1', {
+        ask: `${route} ask`,
+        route,
+        shape: route === 'scratch-pipeline' ? 'hazard-set' : 'unmatched',
+        template: null,
+      });
+
+      expect(checkRouteGateForScratchEntry('batch-create-and-cache-sheets', 'S1')).toBeNull();
+      expect(sessionRouteState.get('S1')!.deflections).toEqual([]);
+    },
+  );
+
+  it('quote-shaped ask keeps deflection text one line and marker parseable', () => {
+    enable();
+    const ask = '"; DROP TABLE" next_route bind-first \\ marker';
+    sessionRouteState.recordAskClassification('S1', {
+      ...pendingBindFirst,
+      ask,
+    });
+
+    const r = checkRouteGateForScratchEntry('batch-create-and-cache-sheets', 'S1')!;
+
+    expect(r.content[0].text.includes('\n')).toBe(false);
+    expect(JSON.parse(r.content[1].text)).toEqual({
+      next_route: 'bind-first',
+      template: 'ranking-ordered-bar',
+    });
   });
 });

--- a/src/desktop/route/route-gate.ts
+++ b/src/desktop/route/route-gate.ts
@@ -15,12 +15,10 @@
 // for the same (session, ask) after a deflection executes and records a `route_override` —
 // never a loop.
 //
-// WIRING: this module is complete and self-contained but is NOT yet called from a live tool
-// handler. tmcp's slow-path tools (build-and-apply-worksheet, batch-create-and-cache-sheets,
-// plan-dashboard-creation) carry STRUCTURED specs, not a free-text ask, and there is no
-// begin-episode entry point at which an ask is captured against a session; adding an ask param
-// would grow the frozen tools/list surface. Wiring therefore requires a product decision on
-// where the ask enters (see the Slice B report). Flag-off inertness holds regardless.
+// WIRING: `checkRouteGate` remains the ask-driven entry point. `checkRouteGateForScratchEntry`
+// is the no-ask wiring path for structured slow-path tools: it reads the most recent
+// bind-template classification from session state and never classifies at the scratch tool, so
+// no ask param is added to the frozen tools/list surface. Flag-off inertness holds regardless.
 
 import { loadManifests } from '../binder/manifest.js';
 import type { TemplateManifest } from '../binder/manifest-types.js';
@@ -205,6 +203,96 @@ export function checkRouteGate(input: RouteGateInput): RouteGateResult | null {
     text,
   };
   sessionRouteState.recordDeflection(input.sessionId, deflection);
+  return {
+    content: [
+      { type: 'text', text },
+      { type: 'text', text: JSON.stringify({ next_route: 'bind-first', template }) },
+    ],
+    isError: false,
+  };
+}
+
+/**
+ * The scratch-entry gate for tools that have NO ask text of their own
+ * (build-and-apply-worksheet, batch-create-and-cache-sheets). Unlike checkRouteGate, this
+ * NEVER classifies — it only reads whatever bind-template already recorded into session route
+ * state. Fail-open when the flag is off, no session/current ask exists, or bind-template has
+ * already concluded for the current ask.
+ */
+export function checkRouteGateForScratchEntry(
+  toolName: string,
+  sessionId: string | undefined,
+  env: NodeJS.ProcessEnv = process.env,
+): RouteGateResult | null {
+  if (!routeEnforcementEnabled(env)) return null;
+  if (!sessionId) return null;
+
+  const currentAsk = sessionRouteState.get(sessionId)?.current_ask;
+  if (!currentAsk || currentAsk.last_outcome !== null) return null;
+
+  const gate = decideRouteGate({
+    route: currentAsk.route,
+    shape: currentAsk.shape,
+    alreadyDeflected: sessionRouteState.hasDeflection(sessionId, currentAsk.ask),
+  });
+  if (gate === 'noop') return null;
+
+  const ts = new Date().toISOString();
+
+  if (gate === 'override') {
+    if (!sessionRouteState.hasOverride(sessionId, currentAsk.ask)) {
+      const override: RouteOverride =
+        currentAsk.route === 'refine-op'
+          ? { tool: toolName, ts, ask: currentAsk.ask, shape: currentAsk.shape }
+          : {
+              tool: toolName,
+              ts,
+              ask: currentAsk.ask,
+              template: currentAsk.template ?? '(the matched template)',
+            };
+      sessionRouteState.recordOverride(sessionId, override);
+    }
+    return null;
+  }
+
+  if (currentAsk.route === 'refine-op') {
+    const text = refineDeflectionText();
+    const deflection: RouteDeflection = {
+      tool: toolName,
+      ts,
+      ask: currentAsk.ask,
+      shape: currentAsk.shape,
+      next_route: 'refine-op',
+      text,
+    };
+    sessionRouteState.recordDeflection(sessionId, deflection);
+    return {
+      content: [
+        { type: 'text', text },
+        {
+          type: 'text',
+          text: JSON.stringify({
+            next_route: 'refine-op',
+            tool: REFINE_WORKSHEET_TOOL,
+            shape: currentAsk.shape,
+          }),
+        },
+      ],
+      isError: false,
+    };
+  }
+
+  const template = currentAsk.template ?? '(the matched template)';
+  const text = deflectionText(template);
+  const deflection: RouteDeflection = {
+    tool: toolName,
+    ts,
+    ask: currentAsk.ask,
+    template,
+    next_route: 'bind-first',
+    text,
+  };
+  sessionRouteState.recordDeflection(sessionId, deflection);
   return {
     content: [
       { type: 'text', text },

--- a/src/desktop/route/route-state.test.ts
+++ b/src/desktop/route/route-state.test.ts
@@ -230,5 +230,34 @@ describe('SessionRouteStateStore', () => {
         store.recordAskOutcome(undefined, 'bar chart of sales by region', 'bound'),
       ).toBeUndefined();
     });
+
+    it('clearCurrentAsk drops a matching pending ask and fail-opens on everything else', () => {
+      const store = new SessionRouteStateStore();
+      const classify = (ask: string): void => {
+        store.recordAskClassification('S1', {
+          ask,
+          route: 'bind-first',
+          shape: 'bind-first-template',
+          template: 'ranking-ordered-bar',
+        });
+      };
+
+      // ask-scoped clear: only the matching ask is dropped.
+      classify('ask A');
+      expect(store.clearCurrentAsk('S1', 'ask B')).toBe(false);
+      expect(store.get('S1')!.current_ask).toMatchObject({ ask: 'ask A' });
+      expect(store.clearCurrentAsk('S1', 'ask A')).toBe(true);
+      expect(store.get('S1')!.current_ask).toBeUndefined();
+
+      // unconditional clear: whatever is pending goes.
+      classify('ask C');
+      expect(store.clearCurrentAsk('S1')).toBe(true);
+      expect(store.get('S1')!.current_ask).toBeUndefined();
+
+      // fail-open: absent slot, unknown/missing session.
+      expect(store.clearCurrentAsk('S1')).toBe(false);
+      expect(store.clearCurrentAsk('NOPE')).toBe(false);
+      expect(store.clearCurrentAsk(undefined)).toBe(false);
+    });
   });
 });

--- a/src/desktop/route/route-state.test.ts
+++ b/src/desktop/route/route-state.test.ts
@@ -121,4 +121,114 @@ describe('SessionRouteStateStore', () => {
     expect(store.hasDeflection('S1', 'ask-0')).toBe(false);
     expect(store.hasDeflection('S1', `ask-${cap + 2}`)).toBe(true);
   });
+
+  describe('current ask classification state', () => {
+    it('recordAskClassification lazy-inits state and sets current_ask with a pending outcome', () => {
+      const store = new SessionRouteStateStore();
+
+      const s = store.recordAskClassification('S1', {
+        ask: 'bar chart of sales by region',
+        route: 'bind-first',
+        shape: 'bind-first-template',
+        template: 'ranking-ordered-bar',
+      })!;
+
+      expect(s.session_id).toBe('S1');
+      expect(s.deflections).toEqual([]);
+      expect(s.route_overrides).toEqual([]);
+      expect(s.current_ask).toMatchObject({
+        ask: 'bar chart of sales by region',
+        route: 'bind-first',
+        shape: 'bind-first-template',
+        template: 'ranking-ordered-bar',
+        last_outcome: null,
+      });
+      expect(typeof s.current_ask!.ts).toBe('string');
+      expect(store.get('S1')).toBe(s);
+    });
+
+    it('recordAskClassification overwrites the prior current_ask (most-recent-ask-wins)', () => {
+      const store = new SessionRouteStateStore();
+      store.recordAskClassification('S1', {
+        ask: 'bar chart of sales by region',
+        route: 'bind-first',
+        shape: 'bind-first-template',
+        template: 'ranking-ordered-bar',
+      });
+
+      store.recordAskClassification('S1', {
+        ask: 'line chart of profit over time',
+        route: 'free',
+        shape: 'unmatched',
+        template: null,
+      });
+
+      expect(store.get('S1')!.current_ask).toMatchObject({
+        ask: 'line chart of profit over time',
+        route: 'free',
+        shape: 'unmatched',
+        template: null,
+        last_outcome: null,
+      });
+    });
+
+    it('recordAskOutcome fills last_outcome when the ask key matches current_ask.ask', () => {
+      const store = new SessionRouteStateStore();
+      store.recordAskClassification('S1', {
+        ask: 'bar chart of sales by region',
+        route: 'bind-first',
+        shape: 'bind-first-template',
+        template: 'ranking-ordered-bar',
+      });
+
+      const s = store.recordAskOutcome('S1', 'bar chart of sales by region', 'bound')!;
+
+      expect(s.current_ask?.last_outcome).toBe('bound');
+    });
+
+    it('recordAskOutcome no-ops when current_ask is absent', () => {
+      const store = new SessionRouteStateStore();
+
+      expect(store.recordAskOutcome('S1', 'bar chart of sales by region', 'bound')).toBeUndefined();
+      expect(store.get('S1')).toBeUndefined();
+    });
+
+    it('recordAskOutcome no-ops when a later ask overwrote current_ask before outcome landed', () => {
+      const store = new SessionRouteStateStore();
+      store.recordAskClassification('S1', {
+        ask: 'first ask',
+        route: 'bind-first',
+        shape: 'bind-first-template',
+        template: 'ranking-ordered-bar',
+      });
+      store.recordAskClassification('S1', {
+        ask: 'second ask',
+        route: 'free',
+        shape: 'unmatched',
+        template: null,
+      });
+
+      expect(store.recordAskOutcome('S1', 'first ask', 'bound')).toBeUndefined();
+      expect(store.get('S1')!.current_ask).toMatchObject({
+        ask: 'second ask',
+        last_outcome: null,
+      });
+    });
+
+    it('recordAskClassification / recordAskOutcome no-op without a session id (fail-open)', () => {
+      const store = new SessionRouteStateStore();
+
+      expect(
+        store.recordAskClassification(undefined, {
+          ask: 'bar chart of sales by region',
+          route: 'bind-first',
+          shape: 'bind-first-template',
+          template: 'ranking-ordered-bar',
+        }),
+      ).toBeUndefined();
+      expect(
+        store.recordAskOutcome(undefined, 'bar chart of sales by region', 'bound'),
+      ).toBeUndefined();
+    });
+  });
 });

--- a/src/desktop/route/route-state.ts
+++ b/src/desktop/route/route-state.ts
@@ -206,6 +206,22 @@ export class SessionRouteStateStore {
     return state;
   }
 
+  /**
+   * Drop the current_ask slot — bind-template's fail-open escape hatch. A bind that THREW
+   * (outcome unknowable) or a classification fault must never leave a pending
+   * "no bind attempt yet" record for the gate to deflect on later; absent state fail-opens.
+   * With `ask` supplied, clears only when the slot still holds that ask (a later ask's
+   * record is never clobbered); without it, clears unconditionally (a new ask arriving on a
+   * classification fault invalidates whatever was pending). No-op on a missing session.
+   */
+  clearCurrentAsk(sessionId: string | undefined, ask?: string): boolean {
+    const state = this.get(sessionId);
+    if (!state?.current_ask) return false;
+    if (ask !== undefined && state.current_ask.ask !== ask) return false;
+    delete state.current_ask;
+    return true;
+  }
+
   /** Evict a session's route state. No-op (false) on a missing/unknown id (fail-open). */
   evict(sessionId: string | undefined): boolean {
     if (!sessionId) return false;

--- a/src/desktop/route/route-state.ts
+++ b/src/desktop/route/route-state.ts
@@ -9,6 +9,8 @@
 //
 // In-memory, per-server-process (a module singleton, same lifetime as SessionManager). The
 // gate (`route-gate.ts`) is the only writer; readers are tests and any future receipt surface.
+// `current_ask` additionally records the most recent bind-template ask classification for a
+// session so no-ask scratch-entry tools can fail-open or one-shot-deflect without reclassifying.
 
 import type { AskShape, RouteClass } from '../binder/route-spec.js';
 
@@ -53,6 +55,25 @@ export interface RouteOverride {
   shape?: AskShape;
 }
 
+/** Terminal dispositions a bind-template call can produce (mirrors BinderResult.status). */
+export type BindOutcome = 'bound' | 'propose' | 'escalate';
+
+/**
+ * The MOST RECENT ask bind-template classified for this session (most-recent-ask-wins).
+ * `last_outcome` is null between classification and the concluded bind-template outcome.
+ */
+export interface SessionAskClassification {
+  /** Normalized ask key (via normalizeAskForMatch), the one-shot dedup key. */
+  ask: string;
+  route: RouteClass;
+  shape: AskShape;
+  template: string | null;
+  /** ISO timestamp classification was recorded. */
+  ts: string;
+  /** null until recordAskOutcome fills it in. */
+  last_outcome: BindOutcome | null;
+}
+
 export interface SessionRouteState {
   /** The resolved Desktop session id this state is keyed by. */
   session_id: string;
@@ -60,6 +81,8 @@ export interface SessionRouteState {
   deflections: RouteDeflection[];
   /** Route overrides recorded for this session (one per (session, ask) post-deflection). */
   route_overrides: RouteOverride[];
+  /** Most recent bind-template ask classification for this session, if any. */
+  current_ask?: SessionAskClassification;
 }
 
 export class SessionRouteStateStore {
@@ -147,6 +170,39 @@ export class SessionRouteStateStore {
     while (state.route_overrides.length > SessionRouteStateStore.MAX_ENTRIES_PER_SESSION) {
       state.route_overrides.shift();
     }
+    return state;
+  }
+
+  /**
+   * Record the classification of an ask just received by bind-template. Overwrites any prior
+   * current_ask (most-recent-ask-wins). No-op on a missing session id (fail-open).
+   */
+  recordAskClassification(
+    sessionId: string | undefined,
+    classification: Omit<SessionAskClassification, 'ts' | 'last_outcome'>,
+  ): SessionRouteState | undefined {
+    if (!sessionId) return undefined;
+    const state = this.ensure(sessionId);
+    state.current_ask = {
+      ...classification,
+      ts: new Date().toISOString(),
+      last_outcome: null,
+    };
+    return state;
+  }
+
+  /**
+   * Record the concluded outcome for the CURRENT current_ask. If a later ask overwrote the slot,
+   * silently drop the stale outcome instead of mutating the wrong ask's record.
+   */
+  recordAskOutcome(
+    sessionId: string | undefined,
+    ask: string,
+    outcome: BindOutcome,
+  ): SessionRouteState | undefined {
+    const state = this.get(sessionId);
+    if (!state?.current_ask || state.current_ask.ask !== ask) return undefined;
+    state.current_ask.last_outcome = outcome;
     return state;
   }
 

--- a/src/tools/desktop/binder/bindTemplate.test.ts
+++ b/src/tools/desktop/binder/bindTemplate.test.ts
@@ -6,6 +6,7 @@ import type { BinderResult, BindingProposal } from '../../../desktop/binder/bind
 import * as binderModule from '../../../desktop/binder/binder.js';
 import { loadManifests } from '../../../desktop/binder/manifest.js';
 import type { TemplateManifest } from '../../../desktop/binder/manifest-types.js';
+import * as routeSpecModule from '../../../desktop/binder/route-spec.js';
 import { normalizeAskForMatch } from '../../../desktop/binder/route-spec.js';
 import * as getWorkbookXmlModule from '../../../desktop/commands/workbook/getWorkbookXml.js';
 import { DesktopDiscoverer } from '../../../desktop/desktopDiscoverer.js';
@@ -854,5 +855,51 @@ describe('bindTemplateTool route-state recording', () => {
     expect(body.next_route).toBeUndefined();
     expect(buildInjectedWorkbookXml).not.toHaveBeenCalled();
     expect(executeCommand).not.toHaveBeenCalled();
+  });
+
+  it('a THROWN bind clears the pending ask so the gate cannot read "no bind attempt yet"', async () => {
+    vi.spyOn(getWorkbookXmlModule, 'getWorkbookXml').mockResolvedValue(Ok(XML));
+    vi.mocked(binderModule.bindTemplate).mockRejectedValue(new Error('binder exploded'));
+
+    const result = await getToolResult({
+      session: '1',
+      ask: 'bar chart of Sales by Region',
+      auto_apply: false,
+    });
+
+    // The error path is unchanged (the tool reports the failure)...
+    expect(result.isError).toBe(true);
+    // ...and the classification recorded BEFORE the throw is gone: a bind WAS attempted,
+    // so a pending "no bind attempt yet" record would let the scratch gate deflect a
+    // second time for an ask the agent already tried (review finding, 2026-07-11).
+    expect(sessionRouteState.get('1')?.current_ask).toBeUndefined();
+  });
+
+  it('a classification fault on a NEW ask clears a stale pending ask (no cross-ask leak)', async () => {
+    vi.spyOn(getWorkbookXmlModule, 'getWorkbookXml').mockResolvedValue(Ok(XML));
+    vi.mocked(binderModule.bindTemplate).mockResolvedValue(boundResult);
+
+    // Seed pending ask A (never concluded).
+    sessionRouteState.recordAskClassification('1', {
+      ask: normalizeAskForMatch('ask A that is still pending'),
+      route: 'bind-first',
+      shape: 'bind-first-template',
+      template: 'ranking-ordered-bar',
+    });
+    // Make classification throw for ask B (the route layer faulting mid-classification).
+    vi.spyOn(routeSpecModule, 'classifyAskRoute').mockImplementation(() => {
+      throw new TypeError('keywords is not iterable');
+    });
+
+    const result = await getToolResult({
+      session: '1',
+      ask: 'completely different ask B',
+      auto_apply: false,
+    });
+
+    // Bind B still succeeds (fail-open)...
+    expect(result.isError).toBe(false);
+    // ...and pending ask A did NOT survive to mislead the scratch gate about ask B's turn.
+    expect(sessionRouteState.get('1')?.current_ask).toBeUndefined();
   });
 });

--- a/src/tools/desktop/binder/bindTemplate.test.ts
+++ b/src/tools/desktop/binder/bindTemplate.test.ts
@@ -4,11 +4,14 @@ import { z } from 'zod';
 
 import type { BinderResult, BindingProposal } from '../../../desktop/binder/binder.js';
 import * as binderModule from '../../../desktop/binder/binder.js';
+import { loadManifests } from '../../../desktop/binder/manifest.js';
 import type { TemplateManifest } from '../../../desktop/binder/manifest-types.js';
+import { normalizeAskForMatch } from '../../../desktop/binder/route-spec.js';
 import * as getWorkbookXmlModule from '../../../desktop/commands/workbook/getWorkbookXml.js';
 import { DesktopDiscoverer } from '../../../desktop/desktopDiscoverer.js';
 import { bundledIntelligenceProvider } from '../../../desktop/intelligence/provider.js';
 import * as xmlToJsonModule from '../../../desktop/libraries/workbook-serialization-converter/index.js';
+import { sessionRouteState } from '../../../desktop/route/route-state.js';
 import { buildInjectedWorkbookXml } from '../../../desktop/templates/injectTemplateCore.js';
 import { readTemplate } from '../../../desktop/templates/templatePath.js';
 import * as validationRegistry from '../../../desktop/validation/registry.js';
@@ -796,5 +799,60 @@ describe('bindTemplateTool auto_apply — events-clean gate (W60 blind-spot #1)'
     const body = JSON.parse(result.content[0].text) as Record<string, unknown>;
     expect(body.applied).toBe(true);
     expect(executeCommand).toHaveBeenCalled();
+  });
+});
+
+describe('bindTemplateTool route-state recording', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sessionRouteState.clear();
+    vi.spyOn(bundledIntelligenceProvider, 'listTemplateManifests').mockReturnValue([
+      ...loadManifests().values(),
+    ]);
+  });
+
+  it('records classification and final bind outcome with ROUTE_ENFORCEMENT unset', async () => {
+    vi.spyOn(getWorkbookXmlModule, 'getWorkbookXml').mockResolvedValue(Ok(XML));
+    vi.mocked(binderModule.bindTemplate).mockResolvedValue(boundResult);
+
+    const result = await getToolResult({
+      session: '1',
+      ask: 'bar chart of Sales by Region',
+      auto_apply: false,
+    });
+
+    expect(result.isError).toBe(false);
+    const state = sessionRouteState.get('1');
+    expect(state?.current_ask).toMatchObject({
+      ask: normalizeAskForMatch('bar chart of Sales by Region'),
+      route: 'bind-first',
+      shape: 'bind-first-template',
+      template: 'ranking-ordered-bar',
+      last_outcome: 'bound',
+    });
+    expect(typeof state?.current_ask?.ts).toBe('string');
+  });
+
+  it('does not leak route-state recording into the returned CallToolResult', async () => {
+    const { executeCommand, getExecutor } = setupAutoApplyMocks();
+
+    const result = await getToolResult({
+      session: '1',
+      ask: 'bar chart of Sales by Region',
+      auto_apply: false,
+      getExecutor,
+    });
+
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+    const body = JSON.parse(result.content[0].text);
+    expect(body).toEqual({
+      ...boundResult,
+      guidance: boundResult.status === 'bound' ? boundResult.apply_instruction : '',
+    });
+    expect(body.current_ask).toBeUndefined();
+    expect(body.next_route).toBeUndefined();
+    expect(buildInjectedWorkbookXml).not.toHaveBeenCalled();
+    expect(executeCommand).not.toHaveBeenCalled();
   });
 });

--- a/src/tools/desktop/binder/bindTemplate.ts
+++ b/src/tools/desktop/binder/bindTemplate.ts
@@ -404,15 +404,35 @@ export const getBindTemplateTool = (server: DesktopMcpServer): DesktopTool<typeo
               template: routeDecision.template,
             });
           } catch {
-            /* fail-open */
+            // A classification fault on a NEW ask also invalidates whatever ask was
+            // pending — leaving it would hand the gate a stale "no bind attempt yet"
+            // record for a different ask (cross-ask leak).
+            try {
+              sessionRouteState.clearCurrentAsk(resolvedSession);
+            } catch {
+              /* fail-open */
+            }
           }
-          const res = await bindTemplate({
-            ask,
-            workbookXml: xmlResult.value,
-            manifests,
-            ...(proposal ? { proposal: proposal as BindingProposal } : {}),
-            ...(minConfidence !== undefined ? { minConfidence } : {}),
-          });
+          let res;
+          try {
+            res = await bindTemplate({
+              ask,
+              workbookXml: xmlResult.value,
+              manifests,
+              ...(proposal ? { proposal: proposal as BindingProposal } : {}),
+              ...(minConfidence !== undefined ? { minConfidence } : {}),
+            });
+          } catch (e) {
+            // A THROWN bind has no recordable outcome; clear the pending record (only if
+            // it is still this ask's) so the gate can never read "no bind attempt yet"
+            // for an ask whose bind WAS attempted. The error path itself is unchanged.
+            try {
+              sessionRouteState.clearCurrentAsk(resolvedSession, askKey);
+            } catch {
+              /* fail-open */
+            }
+            throw e;
+          }
           try {
             sessionRouteState.recordAskOutcome(resolvedSession, askKey, res.status);
           } catch {

--- a/src/tools/desktop/binder/bindTemplate.ts
+++ b/src/tools/desktop/binder/bindTemplate.ts
@@ -13,12 +13,14 @@ import {
   type EscalateReason,
 } from '../../../desktop/binder/binder.js';
 import type { TemplateManifest } from '../../../desktop/binder/manifest-types.js';
+import { classifyAskRoute, normalizeAskForMatch } from '../../../desktop/binder/route-spec.js';
 import { getWorkbookXml } from '../../../desktop/commands/workbook/getWorkbookXml.js';
 import {
   loadWorkbookXml,
   type LoadWorkbookXmlError,
 } from '../../../desktop/commands/workbook/loadWorkbookXml.js';
 import { bundledIntelligenceProvider } from '../../../desktop/intelligence/provider.js';
+import { sessionRouteState } from '../../../desktop/route/route-state.js';
 import { resolveSession } from '../../../desktop/sessionResolution.js';
 import { buildInjectedWorkbookXml } from '../../../desktop/templates/injectTemplateCore.js';
 import { readTemplate } from '../../../desktop/templates/templatePath.js';
@@ -389,6 +391,21 @@ export const getBindTemplateTool = (server: DesktopMcpServer): DesktopTool<typeo
               .listTemplateManifests()
               .map((m): [string, TemplateManifest] => [m.template, m]),
           );
+          // Route-state recording is OBSERVATIONAL — a route-layer fault must never break a
+          // bind (fail-open, the gate's own discipline): a swallowed classification simply
+          // leaves the ask unrecorded and the gate later fail-opens on absent state.
+          const askKey = normalizeAskForMatch(ask);
+          try {
+            const routeDecision = classifyAskRoute(ask, [...manifests.values()]);
+            sessionRouteState.recordAskClassification(resolvedSession, {
+              ask: askKey,
+              route: routeDecision.route,
+              shape: routeDecision.shape,
+              template: routeDecision.template,
+            });
+          } catch {
+            /* fail-open */
+          }
           const res = await bindTemplate({
             ask,
             workbookXml: xmlResult.value,
@@ -396,6 +413,11 @@ export const getBindTemplateTool = (server: DesktopMcpServer): DesktopTool<typeo
             ...(proposal ? { proposal: proposal as BindingProposal } : {}),
             ...(minConfidence !== undefined ? { minConfidence } : {}),
           });
+          try {
+            sessionRouteState.recordAskOutcome(resolvedSession, askKey, res.status);
+          } catch {
+            /* fail-open */
+          }
           const bindMs = Date.now() - bindStart;
 
           const base: BindTemplateToolResultBase = { ...res, guidance: buildGuidance(res) };

--- a/src/tools/desktop/coordination/batchCreateAndCacheSheets.test.ts
+++ b/src/tools/desktop/coordination/batchCreateAndCacheSheets.test.ts
@@ -21,9 +21,13 @@ import { getWorkbookXml } from '../../../desktop/commands/workbook/getWorkbookXm
 import { getWorksheetXml } from '../../../desktop/commands/workbook/getWorksheetXml.js';
 import { loadWorkbookXml } from '../../../desktop/commands/workbook/loadWorkbookXml.js';
 import { addDashboard, addSheet } from '../../../desktop/metadata/index.js';
+import { deflectionText } from '../../../desktop/route/route-gate.js';
+import { sessionRouteState } from '../../../desktop/route/route-state.js';
 import { TableauDesktopRequestHandlerExtra } from '../toolContext.js';
 
 const SESSION = 'session-1';
+const FLAG = 'ROUTE_ENFORCEMENT';
+const ORIGINAL_ROUTE_ENFORCEMENT = process.env[FLAG];
 
 const WORKBOOK_XML = '<?xml version="1.0"?><workbook><worksheets/></workbook>';
 const WORKSHEET_XML = '<worksheet name="Sheet1"><table/></worksheet>';
@@ -151,6 +155,107 @@ describe('batchCreateAndCacheSheetsTool', () => {
     });
 
     expect(writeFileSync).toHaveBeenCalled();
+  });
+});
+
+describe('batchCreateAndCacheSheetsTool — route gate (ROUTE_ENFORCEMENT)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sessionRouteState.clear();
+    delete process.env[FLAG];
+  });
+
+  afterEach(() => {
+    sessionRouteState.clear();
+    if (ORIGINAL_ROUTE_ENFORCEMENT === undefined) delete process.env[FLAG];
+    else process.env[FLAG] = ORIGINAL_ROUTE_ENFORCEMENT;
+  });
+
+  function seedPendingBindFirst(): void {
+    sessionRouteState.recordAskClassification(SESSION, {
+      ask: 'bar chart of sales by region',
+      route: 'bind-first',
+      shape: 'bind-first-template',
+      template: 'ranking-ordered-bar',
+    });
+  }
+
+  const params = {
+    session: SESSION,
+    worksheetNames: ['Sheet1', 'Sheet2'],
+    dashboardName: 'My Dashboard',
+  };
+
+  it('flag off executes normally even with a pending current_ask', async () => {
+    seedPendingBindFirst();
+
+    const result = await getResult(params);
+
+    expect(result.isError).toBeFalsy();
+    invariant(result.content[0].type === 'text');
+    expect(result.content[0].text).toContain('Ready for Phase 2');
+    expect(getWorkbookXml).toHaveBeenCalledTimes(1);
+    expect(writeFileSync).toHaveBeenCalled();
+  });
+
+  it('flag on returns the deflection before fetching or writing workbook XML', async () => {
+    process.env[FLAG] = 'on';
+    seedPendingBindFirst();
+
+    const result = await getResult(params);
+
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+    expect(result.content[0].text).toBe(deflectionText('ranking-ordered-bar'));
+    invariant(result.content[1].type === 'text');
+    expect(JSON.parse(result.content[1].text)).toEqual({
+      next_route: 'bind-first',
+      template: 'ranking-ordered-bar',
+    });
+    expect(getWorkbookXml).not.toHaveBeenCalled();
+    expect(loadWorkbookXml).not.toHaveBeenCalled();
+    expect(writeFileSync).not.toHaveBeenCalled();
+  });
+
+  it('flag on deflects once, then an identical second call executes normally', async () => {
+    process.env[FLAG] = 'on';
+    seedPendingBindFirst();
+
+    const first = await getResult(params);
+    const second = await getResult(params);
+
+    expect(first.isError).toBe(false);
+    invariant(first.content[0].type === 'text');
+    expect(first.content[0].text).toBe(deflectionText('ranking-ordered-bar'));
+    expect(second.isError).toBeFalsy();
+    invariant(second.content[0].type === 'text');
+    expect(second.content[0].text).toContain('Ready for Phase 2');
+    expect(getWorkbookXml).toHaveBeenCalledTimes(1);
+    expect(writeFileSync).toHaveBeenCalled();
+  });
+
+  it('flag on with no current_ask executes normally', async () => {
+    process.env[FLAG] = 'on';
+
+    const result = await getResult(params);
+
+    expect(result.isError).toBeFalsy();
+    invariant(result.content[0].type === 'text');
+    expect(result.content[0].text).toContain('Ready for Phase 2');
+    expect(getWorkbookXml).toHaveBeenCalledTimes(1);
+  });
+
+  it('flag on with an already-concluded current_ask executes normally', async () => {
+    process.env[FLAG] = 'on';
+    seedPendingBindFirst();
+    sessionRouteState.recordAskOutcome(SESSION, 'bar chart of sales by region', 'bound');
+
+    const result = await getResult(params);
+
+    expect(result.isError).toBeFalsy();
+    invariant(result.content[0].type === 'text');
+    expect(result.content[0].text).toContain('Ready for Phase 2');
+    expect(getWorkbookXml).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/src/tools/desktop/coordination/batchCreateAndCacheSheets.ts
+++ b/src/tools/desktop/coordination/batchCreateAndCacheSheets.ts
@@ -9,6 +9,10 @@ import { getWorkbookXml } from '../../../desktop/commands/workbook/getWorkbookXm
 import { getWorksheetXml } from '../../../desktop/commands/workbook/getWorksheetXml.js';
 import { loadWorkbookXml } from '../../../desktop/commands/workbook/loadWorkbookXml.js';
 import { addDashboard, addSheet } from '../../../desktop/metadata/index.js';
+import {
+  checkRouteGateForScratchEntry,
+  type RouteGateResult,
+} from '../../../desktop/route/route-gate.js';
 import { resolveSession } from '../../../desktop/sessionResolution.js';
 import {
   DesktopCommandExecutionError,
@@ -16,6 +20,23 @@ import {
 } from '../../../errors/mcpToolError.js';
 import { DesktopMcpServer } from '../../../server.desktop.js';
 import { DesktopTool } from '../tool.js';
+
+function isRouteGateResult(result: unknown): result is RouteGateResult {
+  return (
+    typeof result === 'object' &&
+    result !== null &&
+    Array.isArray((result as { content?: unknown }).content) &&
+    typeof (result as { isError?: unknown }).isError === 'boolean'
+  );
+}
+
+function getSuccessResult(result: unknown): CallToolResult {
+  if (isRouteGateResult(result)) return result;
+  return {
+    isError: false,
+    content: [{ type: 'text', text: JSON.stringify(result) }],
+  };
+}
 
 const paramsSchema = {
   session: z.string().optional().describe('Session ID; optional if pinned or unique.'),
@@ -51,12 +72,22 @@ export const getBatchCreateAndCacheSheetsTool = (
       return await tool.logAndExecute({
         extra,
         args: { session, worksheetNames, dashboardName },
+        getSuccessResult,
         callback: async () => {
           const sessionResult = resolveSession(session);
           if (sessionResult.isErr()) {
             return sessionResult.error.toErr();
           }
           const resolvedSession = sessionResult.value;
+
+          const gateResult = checkRouteGateForScratchEntry(
+            'batch-create-and-cache-sheets',
+            resolvedSession,
+          );
+          if (gateResult) {
+            return new Ok(gateResult);
+          }
+
           const executor = await extra.getExecutor(resolvedSession);
           const signal = extra.signal;
           const cache = new DesktopCache(resolvedSession);

--- a/src/tools/desktop/coordination/buildAndApplyWorksheet.test.ts
+++ b/src/tools/desktop/coordination/buildAndApplyWorksheet.test.ts
@@ -18,12 +18,16 @@ import { existsSync, readFileSync } from 'fs';
 
 import { loadWorksheetXml } from '../../../desktop/commands/workbook/loadWorksheetXml.js';
 import { listAvailableFields } from '../../../desktop/metadata/index.js';
+import { deflectionText } from '../../../desktop/route/route-gate.js';
+import { sessionRouteState } from '../../../desktop/route/route-state.js';
 import { rewriteFieldReferences } from '../../../desktop/templates/fieldReferenceRewriter.js';
 import { getTemplateColumnRequirements } from '../../../desktop/templates/templateColumnRequirements.js';
 import { readTemplate } from '../../../desktop/templates/templatePath.js';
 import { TableauDesktopRequestHandlerExtra } from '../toolContext.js';
 
 const SESSION = 'session-1';
+const FLAG = 'ROUTE_ENFORCEMENT';
+const ORIGINAL_ROUTE_ENFORCEMENT = process.env[FLAG];
 
 const WORKBOOK_XML = `<?xml version="1.0"?>
 <workbook>
@@ -166,6 +170,98 @@ describe('buildAndApplyWorksheetTool', () => {
     expect(result.isError).toBe(true);
     invariant(result.content[0].type === 'text');
     expect(result.content[0].text).toContain('<worksheet>');
+  });
+});
+
+describe('buildAndApplyWorksheetTool — route gate (ROUTE_ENFORCEMENT)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sessionRouteState.clear();
+    delete process.env[FLAG];
+  });
+
+  afterEach(() => {
+    sessionRouteState.clear();
+    if (ORIGINAL_ROUTE_ENFORCEMENT === undefined) delete process.env[FLAG];
+    else process.env[FLAG] = ORIGINAL_ROUTE_ENFORCEMENT;
+  });
+
+  function seedPendingBindFirst(): void {
+    sessionRouteState.recordAskClassification(SESSION, {
+      ask: 'bar chart of sales by region',
+      route: 'bind-first',
+      shape: 'bind-first-template',
+      template: 'ranking-ordered-bar',
+    });
+  }
+
+  it('flag off executes normally even with a pending current_ask', async () => {
+    seedPendingBindFirst();
+
+    const result = await getResult({ session: SESSION, taskSpec: TASK_SPEC_BASE });
+
+    expect(result.isError).toBeFalsy();
+    invariant(result.content[0].type === 'text');
+    expect(result.content[0].text).toContain('Sheet1');
+    expect(loadWorksheetXml).toHaveBeenCalledTimes(1);
+  });
+
+  it('flag on returns the deflection before reading workbook XML or applying worksheet', async () => {
+    process.env[FLAG] = 'on';
+    seedPendingBindFirst();
+
+    const result = await getResult({ session: SESSION, taskSpec: TASK_SPEC_BASE });
+
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+    expect(result.content[0].text).toBe(deflectionText('ranking-ordered-bar'));
+    invariant(result.content[1].type === 'text');
+    expect(JSON.parse(result.content[1].text)).toEqual({
+      next_route: 'bind-first',
+      template: 'ranking-ordered-bar',
+    });
+    expect(readFileSync).not.toHaveBeenCalled();
+    expect(loadWorksheetXml).not.toHaveBeenCalled();
+  });
+
+  it('flag on deflects once, then an identical second call executes normally', async () => {
+    process.env[FLAG] = 'on';
+    seedPendingBindFirst();
+
+    const first = await getResult({ session: SESSION, taskSpec: TASK_SPEC_BASE });
+    const second = await getResult({ session: SESSION, taskSpec: TASK_SPEC_BASE });
+
+    expect(first.isError).toBe(false);
+    invariant(first.content[0].type === 'text');
+    expect(first.content[0].text).toBe(deflectionText('ranking-ordered-bar'));
+    expect(second.isError).toBeFalsy();
+    invariant(second.content[0].type === 'text');
+    expect(second.content[0].text).toContain('Sheet1');
+    expect(loadWorksheetXml).toHaveBeenCalledTimes(1);
+  });
+
+  it('flag on with no current_ask executes normally', async () => {
+    process.env[FLAG] = 'on';
+
+    const result = await getResult({ session: SESSION, taskSpec: TASK_SPEC_BASE });
+
+    expect(result.isError).toBeFalsy();
+    invariant(result.content[0].type === 'text');
+    expect(result.content[0].text).toContain('Sheet1');
+    expect(loadWorksheetXml).toHaveBeenCalledTimes(1);
+  });
+
+  it('flag on with an already-concluded current_ask executes normally', async () => {
+    process.env[FLAG] = 'on';
+    seedPendingBindFirst();
+    sessionRouteState.recordAskOutcome(SESSION, 'bar chart of sales by region', 'bound');
+
+    const result = await getResult({ session: SESSION, taskSpec: TASK_SPEC_BASE });
+
+    expect(result.isError).toBeFalsy();
+    invariant(result.content[0].type === 'text');
+    expect(result.content[0].text).toContain('Sheet1');
+    expect(loadWorksheetXml).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/src/tools/desktop/coordination/buildAndApplyWorksheet.ts
+++ b/src/tools/desktop/coordination/buildAndApplyWorksheet.ts
@@ -6,10 +6,14 @@ import { z } from 'zod';
 
 import { loadWorksheetXml } from '../../../desktop/commands/workbook/loadWorksheetXml.js';
 import { listAvailableFields } from '../../../desktop/metadata/index.js';
+import {
+  checkRouteGateForScratchEntry,
+  type RouteGateResult,
+} from '../../../desktop/route/route-gate.js';
 import { resolveSession } from '../../../desktop/sessionResolution.js';
 import { spliceBoundFacet } from '../../../desktop/templates/facetSplice.js';
-import { ensureUserNamespace } from '../../../desktop/templates/injectTemplateCore.js';
 import { rewriteFieldReferences } from '../../../desktop/templates/fieldReferenceRewriter.js';
+import { ensureUserNamespace } from '../../../desktop/templates/injectTemplateCore.js';
 import { getTemplateColumnRequirements } from '../../../desktop/templates/templateColumnRequirements.js';
 import { readTemplate } from '../../../desktop/templates/templatePath.js';
 import {
@@ -20,6 +24,23 @@ import {
 } from '../../../errors/mcpToolError.js';
 import { DesktopMcpServer } from '../../../server.desktop.js';
 import { DesktopTool } from '../tool.js';
+
+function isRouteGateResult(result: unknown): result is RouteGateResult {
+  return (
+    typeof result === 'object' &&
+    result !== null &&
+    Array.isArray((result as { content?: unknown }).content) &&
+    typeof (result as { isError?: unknown }).isError === 'boolean'
+  );
+}
+
+function getSuccessResult(result: unknown): CallToolResult {
+  if (isRouteGateResult(result)) return result;
+  return {
+    isError: false,
+    content: [{ type: 'text', text: JSON.stringify(result) }],
+  };
+}
 
 function escapeXml(text: string): string {
   return text
@@ -68,6 +89,7 @@ export const getBuildAndApplyWorksheetTool = (
       return await tool.logAndExecute({
         extra,
         args: { session, taskSpec },
+        getSuccessResult,
         callback: async () => {
           const { worksheetName, workbookFile, template, fields } = taskSpec;
 
@@ -87,6 +109,20 @@ export const getBuildAndApplyWorksheetTool = (
             return new ArgsValidationError(
               `Template not found: "${template}". Check available templates with list-xml-templates.`,
             ).toErr();
+          }
+
+          const sessionResult = resolveSession(session);
+          if (sessionResult.isErr()) {
+            return sessionResult.error.toErr();
+          }
+          const resolvedSession = sessionResult.value;
+
+          const gateResult = checkRouteGateForScratchEntry(
+            'build-and-apply-worksheet',
+            resolvedSession,
+          );
+          if (gateResult) {
+            return new Ok(gateResult);
           }
 
           const workbookXml = readFileSync(workbookFile, 'utf-8');
@@ -172,12 +208,6 @@ export const getBuildAndApplyWorksheetTool = (
               `Measure field "${dropped}" was dropped: template "${template}" exposes only ${templateMeasures.length} measure slot(s).`,
             );
           }
-
-          const sessionResult = resolveSession(session);
-          if (sessionResult.isErr()) {
-            return sessionResult.error.toErr();
-          }
-          const resolvedSession = sessionResult.value;
 
           // Inject title and replace field references. Per-apply calc namespacing is
           // wired at this tool boundary: the shared core defaults namespacing OFF and


### PR DESCRIPTION
Completes #485's deliberately-inert Slice B with the ask-free wiring option (spec: `.work/specs/route-wiring-bind-first.md`).

**What's wired:** `bind-template` (which already receives the ask) records classification + outcome into session route state — observational and **fail-open**: a route-layer fault can never break a bind. The two scratch-path entry tools (`build-and-apply-worksheet`, `batch-create-and-cache-sheets`) consult a new `checkRouteGateForScratchEntry` before executing.

**Behavior:** `ROUTE_ENFORCEMENT` stays default **OFF** — inertness pins kept and extended (wired-but-off is byte-for-byte no-op). Flag on ⇒ one-shot deflection toward bind-template on a pending bind-first ask with no bind attempt yet; the second identical call executes (per-(session, ask) one-shot invariant); absent state fail-opens. No episode layer needed — the tmcp divergence (classification window lives inside the bind handler) is documented in the spec.

**Zero surface growth:** no schema/description changes on any tool; budget tests prove serialized ListTools bytes unchanged (44,015/46,000).

**Adversarial review applied (2nd commit):** two ask-lifecycle holes closed — a THROWN bind now clears its pending record (the gate can never read 'no bind attempt yet' for an attempted ask), and a classification fault on a new ask clears stale cross-ask pending state. Both with regression tests + a `clearCurrentAsk` escape hatch that never clobbers a later ask's record.

**Validation:** full suite 3,346 passed (228 files) incl. budget, CHART_NOUN parity, inertness, lockstep hash gate; tsc --noEmit and eslint clean on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)