### PR TITLE
port: date-binding rule pair — registry 30 → 32 (from a live eval failure)

### DIFF
--- a/src/desktop/validation/rules/dateFieldBoundAsString.test.ts
+++ b/src/desktop/validation/rules/dateFieldBoundAsString.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest';
+
+import { runValidation } from '../registry.js';
+import { dateFieldBoundAsStringRule } from './dateFieldBoundAsString.js';
+
+function workbook(shelfXml: string, monthDatatype = 'date'): string {
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<workbook>
+  <datasources>
+    <datasource name="ds">
+      <column caption="Month" datatype="${monthDatatype}" name="[month]" role="dimension" type="nominal" />
+      <column caption="Mau" datatype="integer" name="[mau]" role="measure" type="quantitative" />
+    </datasource>
+  </datasources>
+  <worksheets>
+    <worksheet name="MAU">
+      <table>
+        <view>
+          <datasource-dependencies datasource="ds">
+            <column caption="Month" datatype="${monthDatatype}" name="[month]" role="dimension" type="nominal" />
+            <column-instance column="[month]" derivation="None" name="[none:month:nk]" pivot="key" type="nominal" />
+            <column-instance column="[month]" derivation="None" name="[none:month:ok]" pivot="key" type="ordinal" />
+            <column-instance column="[month]" derivation="Month" name="[mn:month:ok]" pivot="key" type="ordinal" />
+            <column-instance column="[month]" derivation="Month-Trunc" name="[tmn:month:qk]" pivot="key" type="quantitative" />
+            <column-instance column="[month]" derivation="Year-Trunc" name="[tyr:month:qk]" pivot="key" type="quantitative" />
+            <column caption="Mau" datatype="integer" name="[mau]" role="measure" type="quantitative" />
+            <column-instance column="[mau]" derivation="Sum" name="[sum:mau:qk]" pivot="key" type="quantitative" />
+          </datasource-dependencies>
+        </view>
+        ${shelfXml}
+      </table>
+    </worksheet>
+  </worksheets>
+</workbook>`;
+}
+
+describe('date-field-bound-as-string rule', () => {
+  it('errors on the MAU-line shape: a date metadata field bound as a raw nominal string axis', () => {
+    const xml = workbook(`
+      <cols>[ds].[none:month:nk]</cols>
+      <rows>[ds].[sum:mau:qk]</rows>
+    `);
+
+    const issues = dateFieldBoundAsStringRule.validate(xml);
+
+    expect(issues).toHaveLength(1);
+    expect(issues[0].ruleId).toBe('date-field-bound-as-string');
+    expect(issues[0].severity).toBe('error');
+    expect(issues[0].message).toContain('flat categorical axis, not a time axis');
+    expect(issues[0].suggestion).toContain('tmn');
+  });
+
+  it.each([
+    ['discrete month', '[ds].[mn:month:ok]'],
+    ['continuous month trunc', '[ds].[tmn:month:qk]'],
+    ['year trunc', '[ds].[tyr:month:qk]'],
+  ])('stays silent for a proper %s date derivation', (_label, ref) => {
+    const xml = workbook(`
+      <cols>${ref}</cols>
+      <rows>[ds].[sum:mau:qk]</rows>
+    `);
+
+    expect(dateFieldBoundAsStringRule.validate(xml)).toHaveLength(0);
+  });
+
+  it('does not flag a genuinely string Month field with no date metadata', () => {
+    const xml = workbook(
+      `
+      <cols>[ds].[none:month:nk]</cols>
+      <rows>[ds].[sum:mau:qk]</rows>
+    `,
+      'string',
+    );
+
+    expect(dateFieldBoundAsStringRule.validate(xml)).toHaveLength(0);
+  });
+
+  it('stays silent when a date field is used on filters or encodings instead of rows/cols', () => {
+    const xml = workbook(`
+      <cols>[ds].[sum:mau:qk]</cols>
+      <rows />
+      <filter class="categorical" column="[ds].[none:month:nk]" />
+      <encodings>
+        <color column="[ds].[none:month:nk]" />
+      </encodings>
+    `);
+
+    expect(dateFieldBoundAsStringRule.validate(xml)).toHaveLength(0);
+  });
+
+  it('surfaces through registered validation as an apply-blocking error', () => {
+    const result = runValidation(
+      workbook(`
+        <cols>[ds].[none:month:ok]</cols>
+        <rows>[ds].[sum:mau:qk]</rows>
+      `),
+      'workbook',
+    );
+
+    expect(result.valid).toBe(false);
+    expect(
+      result.issues.some(
+        (issue) => issue.ruleId === 'date-field-bound-as-string' && issue.severity === 'error',
+      ),
+    ).toBe(true);
+  });
+});

--- a/src/desktop/validation/rules/dateFieldBoundAsString.ts
+++ b/src/desktop/validation/rules/dateFieldBoundAsString.ts
@@ -1,0 +1,166 @@
+/**
+ * Validation rule: date-field-bound-as-string
+ *
+ * Live eval failure (casepack-e4-mau-line): a monthly active users line chart passed
+ * structural checks while binding Month on the time axis as `[none:month:nk]` — a
+ * raw nominal string pill. The visual rendered as a flat categorical axis, not a
+ * temporal axis, so the analytical answer was wrong even though the shelves existed.
+ *
+ * Precision boundary:
+ *   - Only fields whose datasource metadata declares `datatype='date'`/`datetime`
+ *     are judged. A string field named "Month" stays silent.
+ *   - Only Rows/Cols are inspected. Filters and mark encodings can legitimately use
+ *     categorical date members or labels without defining the view's time axis; this
+ *     rule blocks the axis defect that caused the eval failure.
+ *   - Only raw `none:<field>:nk|ok` refs are flagged. Date derivations such as
+ *     `[mn:Date:ok]`, `[tmn:Date:qk]`, and `[tyr:Date:qk]` stay silent.
+ */
+import * as xpath from 'xpath';
+
+import type { ValidationIssue, ValidationRule } from '../types.js';
+import { parseXml } from './parseXml.js';
+
+interface ShelfRef {
+  datasource?: string;
+  field: string;
+  instance: string;
+  pivot: 'nk' | 'ok';
+}
+
+const DATE_DATATYPES = new Set(['date', 'datetime', 'date-time']);
+const RAW_STRING_AXIS_REF = /(?:\[([^\]]+)\]\.)?\[none:([^:\]]+):(nk|ok)\]/gi;
+
+function normalizeFieldName(name: string): string {
+  return name.trim().replace(/^\[/, '').replace(/\]$/, '').toLowerCase();
+}
+
+function datasourceName(el: Element): string | undefined {
+  return el.getAttribute('name') ?? el.getAttribute('datasource') ?? undefined;
+}
+
+function addDateColumns(
+  container: Element,
+  datasource: string | undefined,
+  out: Map<string, Set<string>>,
+): void {
+  const columns = xpath.select(
+    './/column[@datatype and @name]',
+    container as unknown as Node,
+  ) as Element[];
+  const key = datasource ?? '';
+
+  for (const column of columns) {
+    const datatype = (column.getAttribute('datatype') ?? '').toLowerCase();
+    if (!DATE_DATATYPES.has(datatype)) continue;
+
+    const name = normalizeFieldName(column.getAttribute('name') ?? '');
+    if (!name) continue;
+
+    const fields = out.get(key) ?? new Set<string>();
+    fields.add(name);
+    out.set(key, fields);
+  }
+}
+
+function collectDateFieldsByDatasource(doc: Document): Map<string, Set<string>> {
+  const out = new Map<string, Set<string>>();
+
+  for (const datasource of xpath.select(
+    '//datasource[@name]',
+    doc as unknown as Node,
+  ) as Element[]) {
+    addDateColumns(datasource, datasourceName(datasource), out);
+  }
+
+  for (const deps of xpath.select(
+    '//datasource-dependencies',
+    doc as unknown as Node,
+  ) as Element[]) {
+    addDateColumns(deps, datasourceName(deps), out);
+  }
+
+  return out;
+}
+
+function findRawStringDateAxisRefs(text: string): ShelfRef[] {
+  const refs: ShelfRef[] = [];
+
+  for (const match of text.matchAll(RAW_STRING_AXIS_REF)) {
+    const datasource = match[1];
+    const field = match[2].trim();
+    const pivot = match[3].toLowerCase() as 'nk' | 'ok';
+    refs.push({
+      datasource,
+      field,
+      instance: `none:${field}:${pivot}`,
+      pivot,
+    });
+  }
+
+  return refs;
+}
+
+function isDatasourceDeclaredDate(
+  ref: ShelfRef,
+  dateFieldsByDatasource: Map<string, Set<string>>,
+  allDateFields: Set<string>,
+): boolean {
+  const field = normalizeFieldName(ref.field);
+  if (ref.datasource !== undefined) {
+    return dateFieldsByDatasource.get(ref.datasource)?.has(field) ?? false;
+  }
+  return allDateFields.has(field);
+}
+
+export const dateFieldBoundAsStringRule: ValidationRule = {
+  id: 'date-field-bound-as-string',
+  description:
+    'Errors when a datasource-declared date/datetime field is bound to Rows/Cols as a raw none: nominal/ordinal ' +
+    'string pill, producing a categorical axis instead of a time axis.',
+  contexts: ['workbook', 'worksheet'],
+
+  validate(xml: string): ValidationIssue[] {
+    const doc = parseXml(xml);
+    if (!doc?.documentElement) return [];
+
+    const dateFieldsByDatasource = collectDateFieldsByDatasource(doc);
+    const allDateFields = new Set<string>();
+    for (const fields of dateFieldsByDatasource.values()) {
+      for (const field of fields) allDateFields.add(field);
+    }
+    if (allDateFields.size === 0) return [];
+
+    const issues: ValidationIssue[] = [];
+    const issued = new Set<string>();
+    const shelves = xpath.select('//rows | //cols', doc as unknown as Node) as Element[];
+
+    for (const shelf of shelves) {
+      const shelfText = xpath.select('string(.)', shelf as unknown as Node) as string;
+      for (const ref of findRawStringDateAxisRefs(shelfText)) {
+        if (!isDatasourceDeclaredDate(ref, dateFieldsByDatasource, allDateFields)) continue;
+
+        const key = `${shelf.nodeName}:${ref.datasource ?? ''}:${ref.field}:${ref.pivot}`;
+        if (issued.has(key)) continue;
+        issued.add(key);
+
+        const fieldLabel = ref.datasource
+          ? `[${ref.datasource}].[${ref.instance}]`
+          : `[${ref.instance}]`;
+        issues.push({
+          ruleId: 'date-field-bound-as-string',
+          severity: 'error',
+          message:
+            `Date field "${ref.field}" is bound on ${shelf.nodeName} as raw string pill ${fieldLabel}. ` +
+            'It renders as a flat categorical axis, not a time axis, so a line or trend over time is analytically wrong.',
+          xpath: `//${shelf.nodeName}[contains(.,'${ref.instance}')]`,
+          suggestion:
+            `FIX: Bind "${ref.field}" with a date derivation or continuous date pill, e.g. ` +
+            `[tmn:${ref.field}:qk] for continuous month, [tmn:${ref.field}:ok] / [tqr:${ref.field}:ok] / ` +
+            `[tyr:${ref.field}:ok] for discrete truncations, instead of [none:${ref.field}:${ref.pivot}].`,
+        });
+      }
+    }
+
+    return issues;
+  },
+};

--- a/src/desktop/validation/rules/dateLikeStringOnTimeAxis.test.ts
+++ b/src/desktop/validation/rules/dateLikeStringOnTimeAxis.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'vitest';
+
+import { runValidation } from '../registry.js';
+import { dateLikeStringOnTimeAxisRule } from './dateLikeStringOnTimeAxis.js';
+
+const DS = 'federated.1vwr59x1oco9q01gp1gt11f4ntnv';
+const MONTH = `[${DS}].[none:month:nk]`;
+const MONTH_DATE_CALC = `[${DS}].[none:Month Date:nk]`;
+const MONTH_TRUNC = `[${DS}].[tmn:month:qk]`;
+const PRODUCT = `[${DS}].[none:product:nk]`;
+const MAU = `[${DS}].[sum:mau:qk]`;
+
+function anchoredWorksheet({
+  mark = 'Line',
+  cols = MONTH,
+  rows = MAU,
+  encodings = '',
+}: {
+  mark?: string;
+  cols?: string;
+  rows?: string;
+  encodings?: string;
+} = {}): string {
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<workbook>
+  <datasources>
+    <datasource name="${DS}">
+      <column caption="Month" datatype="string" name="[month]" role="dimension" type="nominal" />
+      <column caption="Product" datatype="string" name="[product]" role="dimension" type="nominal" />
+      <column caption="Mau" datatype="integer" name="[mau]" role="measure" type="quantitative" />
+    </datasource>
+  </datasources>
+  <worksheets>
+    <worksheet name="MAU">
+      <table>
+        <view>
+          <datasource-dependencies datasource="${DS}">
+            <column caption="Month" datatype="string" name="[month]" role="dimension" type="nominal" />
+            <column caption="Product" datatype="string" name="[product]" role="dimension" type="nominal" />
+            <column caption="Mau" datatype="integer" name="[mau]" role="measure" type="quantitative" />
+            <column-instance column="[month]" derivation="None" name="[none:month:nk]" pivot="key" type="nominal" />
+            <column-instance column="[Month Date]" derivation="None" name="[none:Month Date:nk]" pivot="key" type="nominal" />
+            <column-instance column="[month]" derivation="Month-Trunc" name="[tmn:month:qk]" pivot="key" type="quantitative" />
+            <column-instance column="[product]" derivation="None" name="[none:product:nk]" pivot="key" type="nominal" />
+            <column-instance column="[mau]" derivation="Sum" name="[sum:mau:qk]" pivot="key" type="quantitative" />
+          </datasource-dependencies>
+        </view>
+        <panes>
+          <pane>
+            <mark class="${mark}" />
+            ${encodings}
+          </pane>
+        </panes>
+        <rows>${rows}</rows>
+        <cols>${cols}</cols>
+      </table>
+    </worksheet>
+  </worksheets>
+</workbook>`;
+}
+
+function withDateParseCalc(xml: string): string {
+  return xml.replace(
+    '<column caption="Month" datatype="string" name="[month]" role="dimension" type="nominal" />',
+    '<column caption="Month" datatype="string" name="[month]" role="dimension" type="nominal" />' +
+      '<column caption="Month Date" datatype="date" name="[Month Date]" role="dimension" type="ordinal">' +
+      '<calculation class="tableau" formula="DATE([month])" />' +
+      '</column>',
+  );
+}
+
+describe('date-like-string-on-time-axis rule', () => {
+  it('WARNs on the MAU line shape: string month on cols with a continuous measure on rows', () => {
+    const issues = dateLikeStringOnTimeAxisRule.validate(anchoredWorksheet());
+
+    expect(issues).toHaveLength(1);
+    expect(issues[0].ruleId).toBe('date-like-string-on-time-axis');
+    expect(issues[0].severity).toBe('warning');
+    expect(issues[0].message).toMatch(/flat categorical labels/i);
+    expect(issues[0].message).toMatch(/time axis/i);
+    expect(issues[0].suggestion).toMatch(/DATE\(\[Month\]\)|categorical intent/i);
+  });
+
+  it('stays silent when a DATE() parse calc supplies a date-typed field', () => {
+    const xml = withDateParseCalc(anchoredWorksheet({ cols: MONTH_DATE_CALC }));
+    expect(dateLikeStringOnTimeAxisRule.validate(xml)).toHaveLength(0);
+  });
+
+  it('stays silent when the pill uses a proper date derivation', () => {
+    expect(
+      dateLikeStringOnTimeAxisRule.validate(anchoredWorksheet({ cols: MONTH_TRUNC })),
+    ).toHaveLength(0);
+  });
+
+  it('stays silent for a bar chart where Month is clearly categorical', () => {
+    const xml = anchoredWorksheet({
+      mark: 'Bar',
+      encodings: `<encodings><color column="${MONTH}" /></encodings>`,
+    });
+
+    expect(dateLikeStringOnTimeAxisRule.validate(xml)).toHaveLength(0);
+  });
+
+  it('stays silent for a non-date-like string field on a line chart', () => {
+    expect(
+      dateLikeStringOnTimeAxisRule.validate(anchoredWorksheet({ cols: PRODUCT })),
+    ).toHaveLength(0);
+  });
+
+  it('stays silent when the date-like string pill appears without time-series intent', () => {
+    expect(
+      dateLikeStringOnTimeAxisRule.validate(anchoredWorksheet({ mark: 'Automatic', rows: '' })),
+    ).toHaveLength(0);
+  });
+
+  it('surfaces as a non-blocking warning through registered validation', () => {
+    const result = runValidation(anchoredWorksheet(), 'workbook');
+
+    expect(result.valid).toBe(true);
+    expect(
+      result.issues.some(
+        (issue) => issue.ruleId === 'date-like-string-on-time-axis' && issue.severity === 'warning',
+      ),
+    ).toBe(true);
+  });
+});

--- a/src/desktop/validation/rules/dateLikeStringOnTimeAxis.ts
+++ b/src/desktop/validation/rules/dateLikeStringOnTimeAxis.ts
@@ -1,0 +1,410 @@
+/**
+ * Validation rule: date-like-string-on-time-axis
+ *
+ * Heuristic companion to the stricter "field is proven date metadata" guard. This one
+ * catches the CSV-inference failure mode where a field like Month is still typed as a
+ * string/nominal dimension, but the worksheet is authored like a time series.
+ *
+ * DETECTION SIGNALS (all required):
+ *   1. A rows/cols pill resolves to string/nominal metadata, or to a none:/nominal
+ *      column-instance with no date derivation.
+ *   2. The field name/caption contains a date-like term from DATE_LIKE_FIELD_NAME_TERMS.
+ *   3. Worksheet intent looks temporal: mark class is Line/Area, or the candidate pill
+ *      sits on Cols while Rows contains a continuous aggregate measure.
+ *
+ * False-positive safety:
+ *   - Date/datetime metadata or a proper date derivation (yr/mn/tmn/tyr/etc.) suppresses
+ *     the warning; the stricter date rule owns those cases.
+ *   - Non-line/area categorical marks are suppressed when the same field is also used on
+ *     a mark encoding such as color/label, which is the clear categorical Month-as-member
+ *     shape.
+ *
+ * Severity: warning. The field name signal is intentionally heuristic, so a legitimate
+ * categorical Month/Period dimension should be confirmable rather than blocked.
+ */
+import * as xpath from 'xpath';
+
+import type { ValidationIssue, ValidationRule } from '../types.js';
+import { parseXml } from './parseXml.js';
+
+export const DATE_LIKE_FIELD_NAME_TERMS = [
+  'month',
+  'date',
+  'day',
+  'week',
+  'quarter',
+  'year',
+  'fecha',
+  'mes',
+  'periodo',
+  'period',
+] as const;
+
+const DATE_DERIVATION_PREFIXES = new Set([
+  'yr',
+  'qr',
+  'mn',
+  'wk',
+  'dy',
+  'hr',
+  'mi',
+  'sc',
+  'tyr',
+  'tqr',
+  'tmn',
+  'tmo',
+  'twk',
+  'tdy',
+]);
+
+const DATE_DERIVATION_NAMES = new Set([
+  'year',
+  'quarter',
+  'month',
+  'week',
+  'weekday',
+  'day',
+  'hour',
+  'minute',
+  'second',
+  'my',
+  'mdy',
+  'iso-year',
+  'iso-qtr',
+  'iso-week',
+  'iso-weekday',
+  'year-trunc',
+  'iso-year-trunc',
+  'quarter-trunc',
+  'iso-qtr-trunc',
+  'iso-week-trunc',
+  'month-trunc',
+  'week-trunc',
+  'day-trunc',
+  'hour-trunc',
+  'minute-trunc',
+  'second-trunc',
+]);
+
+const AGGREGATE_PREFIXES = new Set([
+  'sum',
+  'avg',
+  'cnt',
+  'count',
+  'cntd',
+  'ctd',
+  'countd',
+  'median',
+  'min',
+  'max',
+  'stdev',
+  'stdevp',
+  'var',
+  'varp',
+]);
+
+const FIELD_REF = /\[([^\]]+)\]\.\[([^\]]+)\]/g;
+
+interface ColumnMeta {
+  field: string;
+  caption?: string;
+  datatype?: string;
+  type?: string;
+  role?: string;
+}
+
+interface InstanceMeta {
+  instance: string;
+  column?: string;
+  derivation?: string;
+  type?: string;
+}
+
+interface MetadataIndex {
+  columns: Map<string, ColumnMeta[]>;
+  instances: Map<string, InstanceMeta[]>;
+}
+
+interface PillRef {
+  ref: string;
+  datasource: string;
+  instance: string;
+  derivation: string;
+  field: string;
+  pivot: string;
+}
+
+function normalizeName(s: string): string {
+  return String(s ?? '')
+    .replace(/^\[/, '')
+    .replace(/\]$/, '')
+    .trim()
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '');
+}
+
+function stripOuterBrackets(s: string): string {
+  return String(s ?? '')
+    .replace(/^\[/, '')
+    .replace(/\]$/, '')
+    .trim();
+}
+
+function attr(el: Element, name: string): string | undefined {
+  return el.getAttribute(name) ?? undefined;
+}
+
+function closestDatasourceNames(el: Element): string[] {
+  const names = new Set<string>();
+  let n: Node | null = el;
+
+  while (n && n.nodeType === 1) {
+    const e = n as Element;
+    if (e.nodeName === 'datasource-dependencies') {
+      const ds = attr(e, 'datasource');
+      if (ds) names.add(ds);
+    }
+    if (e.nodeName === 'datasource') {
+      const name = attr(e, 'name');
+      const caption = attr(e, 'caption');
+      if (name) names.add(name);
+      if (caption) names.add(caption);
+    }
+    n = e.parentNode;
+  }
+
+  return [...names];
+}
+
+function addScoped<T extends { field?: string; instance?: string }>(
+  map: Map<string, T[]>,
+  datasourceNames: string[],
+  itemName: string,
+  item: T,
+): void {
+  const fieldKey = normalizeName(itemName);
+  if (!fieldKey) return;
+
+  const scopes = datasourceNames.length > 0 ? datasourceNames : ['*'];
+  for (const ds of scopes) {
+    const key = `${normalizeName(ds)}::${fieldKey}`;
+    const existing = map.get(key) ?? [];
+    existing.push(item);
+    map.set(key, existing);
+  }
+
+  const wildcard = `*::${fieldKey}`;
+  const existing = map.get(wildcard) ?? [];
+  existing.push(item);
+  map.set(wildcard, existing);
+}
+
+function collectMetadata(doc: Document): MetadataIndex {
+  const columns = new Map<string, ColumnMeta[]>();
+  const instances = new Map<string, InstanceMeta[]>();
+
+  for (const col of xpath.select('//column[@name]', doc as unknown as Node) as Element[]) {
+    const field = stripOuterBrackets(attr(col, 'name') ?? '');
+    if (!field) continue;
+
+    const meta: ColumnMeta = {
+      field,
+      caption: attr(col, 'caption'),
+      datatype: attr(col, 'datatype')?.toLowerCase(),
+      type: attr(col, 'type')?.toLowerCase(),
+      role: attr(col, 'role')?.toLowerCase(),
+    };
+    const scope = closestDatasourceNames(col);
+    addScoped(columns, scope, field, meta);
+    if (meta.caption) addScoped(columns, scope, meta.caption, meta);
+  }
+
+  for (const ci of xpath.select('//column-instance[@name]', doc as unknown as Node) as Element[]) {
+    const instance = stripOuterBrackets(attr(ci, 'name') ?? '');
+    if (!instance) continue;
+
+    const meta: InstanceMeta = {
+      instance,
+      column: stripOuterBrackets(attr(ci, 'column') ?? ''),
+      derivation: attr(ci, 'derivation')?.toLowerCase(),
+      type: attr(ci, 'type')?.toLowerCase(),
+    };
+    addScoped(instances, closestDatasourceNames(ci), instance, meta);
+  }
+
+  return { columns, instances };
+}
+
+function parseInstance(instance: string): {
+  derivation: string;
+  field: string;
+  pivot: string;
+} | null {
+  const first = instance.indexOf(':');
+  const last = instance.lastIndexOf(':');
+  if (first <= 0 || last <= first) return null;
+
+  return {
+    derivation: instance.slice(0, first).toLowerCase(),
+    field: instance.slice(first + 1, last).trim(),
+    pivot: instance.slice(last + 1).toLowerCase(),
+  };
+}
+
+function parseShelfRefs(shelfText: string): PillRef[] {
+  const refs: PillRef[] = [];
+
+  for (const match of String(shelfText ?? '').matchAll(FIELD_REF)) {
+    const datasource = match[1];
+    const instance = match[2];
+    const parsed = parseInstance(instance);
+    if (!parsed) continue;
+    refs.push({ ref: match[0], datasource, instance, ...parsed });
+  }
+
+  return refs;
+}
+
+function lookup<T>(map: Map<string, T[]>, datasource: string, name: string): T[] {
+  return [
+    ...(map.get(`${normalizeName(datasource)}::${normalizeName(name)}`) ?? []),
+    ...(map.get(`*::${normalizeName(name)}`) ?? []),
+  ];
+}
+
+function hasDateDerivation(pill: PillRef, instances: InstanceMeta[]): boolean {
+  if (DATE_DERIVATION_PREFIXES.has(pill.derivation)) return true;
+  return instances.some(
+    (ci) => ci.derivation !== undefined && DATE_DERIVATION_NAMES.has(ci.derivation),
+  );
+}
+
+function hasDateDatatype(columns: ColumnMeta[]): boolean {
+  return columns.some((col) => col.datatype === 'date' || col.datatype === 'datetime');
+}
+
+function isStringNominalPill(
+  pill: PillRef,
+  columns: ColumnMeta[],
+  instances: InstanceMeta[],
+): boolean {
+  if (hasDateDatatype(columns) || hasDateDerivation(pill, instances)) return false;
+  if (columns.some((col) => col.datatype === 'string' || col.type === 'nominal')) return true;
+  if (
+    instances.some((ci) => ci.type === 'nominal' && !DATE_DERIVATION_NAMES.has(ci.derivation ?? ''))
+  ) {
+    return true;
+  }
+  return pill.derivation === 'none' && (pill.pivot === 'nk' || pill.pivot === 'ok');
+}
+
+function hasDateLikeName(pill: PillRef, columns: ColumnMeta[]): boolean {
+  const names = [pill.field, ...columns.flatMap((col) => [col.field, col.caption ?? ''])];
+
+  return names.some((name) => {
+    const normalized = normalizeName(name).replace(/[_-]+/g, ' ');
+    return DATE_LIKE_FIELD_NAME_TERMS.some((term) => {
+      const needle = normalizeName(term);
+      return new RegExp(`(^|[^a-z0-9])${needle}([^a-z0-9]|$)`).test(normalized);
+    });
+  });
+}
+
+function isLineOrAreaWorksheet(wsNode: Element): boolean {
+  const markClasses = (xpath.select('.//mark/@class', wsNode as unknown as Node) as Attr[]).map(
+    (a) => a.value.toLowerCase(),
+  );
+  return markClasses.some((markClass) => markClass === 'line' || markClass === 'area');
+}
+
+function isContinuousMeasure(pill: PillRef, columns: ColumnMeta[]): boolean {
+  if (pill.pivot !== 'qk') return false;
+  if (DATE_DERIVATION_PREFIXES.has(pill.derivation)) return false;
+  if (AGGREGATE_PREFIXES.has(pill.derivation)) return true;
+  return columns.some((col) => col.role === 'measure' || col.type === 'quantitative');
+}
+
+function hasContinuousMeasureOnRows(wsNode: Element, metadata: MetadataIndex): boolean {
+  const rowNodes = xpath.select('.//rows/text()', wsNode as unknown as Node) as Node[];
+
+  for (const rowNode of rowNodes) {
+    for (const pill of parseShelfRefs(rowNode.nodeValue ?? '')) {
+      const columns = lookup(metadata.columns, pill.datasource, pill.field);
+      if (isContinuousMeasure(pill, columns)) return true;
+    }
+  }
+
+  return false;
+}
+
+function isAlsoEncoded(wsNode: Element, candidate: PillRef): boolean {
+  const encoded = xpath.select('.//encodings/*/@column', wsNode as unknown as Node) as Attr[];
+  return encoded.some((a) =>
+    parseShelfRefs(a.value).some(
+      (pill) => normalizeName(pill.ref) === normalizeName(candidate.ref),
+    ),
+  );
+}
+
+export const dateLikeStringOnTimeAxisRule: ValidationRule = {
+  id: 'date-like-string-on-time-axis',
+  description:
+    'Warns when a date-like string/nominal field is placed where the worksheet otherwise looks like a time-series axis.',
+  contexts: ['workbook', 'worksheet'],
+
+  validate(xml: string): ValidationIssue[] {
+    const doc = parseXml(xml);
+    if (!doc?.documentElement) return [];
+
+    const metadata = collectMetadata(doc);
+    const worksheets = xpath.select('//worksheet', doc as unknown as Node) as Element[];
+    const scope = worksheets.length > 0 ? worksheets : [doc.documentElement];
+    const issues: ValidationIssue[] = [];
+    const seen = new Set<string>();
+
+    for (const wsNode of scope) {
+      const hasLineOrArea = isLineOrAreaWorksheet(wsNode);
+      const hasMeasureRows = hasContinuousMeasureOnRows(wsNode, metadata);
+      const worksheetName = attr(wsNode, 'name') ?? '(worksheet)';
+
+      for (const shelf of ['rows', 'cols'] as const) {
+        const shelfNodes = xpath.select(`.//${shelf}/text()`, wsNode as unknown as Node) as Node[];
+        for (const shelfNode of shelfNodes) {
+          for (const pill of parseShelfRefs(shelfNode.nodeValue ?? '')) {
+            const columns = lookup(metadata.columns, pill.datasource, pill.field);
+            const instances = lookup(metadata.instances, pill.datasource, pill.instance);
+            if (!isStringNominalPill(pill, columns, instances)) continue;
+            if (!hasDateLikeName(pill, columns)) continue;
+
+            const categoricalEncoding = !hasLineOrArea && isAlsoEncoded(wsNode, pill);
+            const timeIntent =
+              hasLineOrArea || (shelf === 'cols' && hasMeasureRows && !categoricalEncoding);
+            if (!timeIntent) continue;
+
+            const dedupeKey = `${worksheetName}::${pill.ref}`;
+            if (seen.has(dedupeKey)) continue;
+            seen.add(dedupeKey);
+
+            const display = columns.find((col) => col.caption)?.caption ?? pill.field;
+            issues.push({
+              ruleId: 'date-like-string-on-time-axis',
+              severity: 'warning',
+              message:
+                `Field "${display}" is string/nominal but is bound as "${pill.ref}" in a time-series-shaped worksheet ` +
+                `(${worksheetName}). The axis will render as flat categorical labels, not a time axis; correct the ` +
+                "field's data type at the connection, bind a date-parse calc such as DATE([Month]), or confirm the " +
+                'categorical intent.',
+              xpath: `//worksheet[@name="${worksheetName}"]//${shelf}/text()`,
+              suggestion:
+                `Correct "${display}" to a date/datetime at the connection, place a parsed date calc on the shelf ` +
+                '(for example DATE([Month])), or leave it only if Month/Period is intentionally categorical.',
+            });
+          }
+        }
+      }
+    }
+
+    return issues;
+  },
+};

--- a/src/desktop/validation/rules/rules.ts
+++ b/src/desktop/validation/rules/rules.ts
@@ -7,6 +7,8 @@ import { categoricalFilterSlicesRule } from './categoricalFilterSlices.js';
 import { computedSortCrashRule } from './computedSortCrash.js';
 import { connectionsNotAuthorableRule } from './connectionsNotAuthorable.js';
 import { dashboardZonesReferenceIncludedWorksheetsRule } from './dashboardZonesReferenceIncludedWorksheets.js';
+import { dateFieldBoundAsStringRule } from './dateFieldBoundAsString.js';
+import { dateLikeStringOnTimeAxisRule } from './dateLikeStringOnTimeAxis.js';
 import { duplicateEmptyParameterRule } from './duplicateEmptyParameter.js';
 import { duplicateParameterActionRule } from './duplicateParameterAction.js';
 import { filterAllInListRule } from './filterAllInList.js';
@@ -60,4 +62,6 @@ export const validationRules = [
   redundantColorEncodingRule,
   invalidColumnInstancePivotRule,
   parameterFieldOnShelfRule,
+  dateFieldBoundAsStringRule,
+  dateLikeStringOnTimeAxisRule,
 ];


### PR DESCRIPTION
Ports both date-binding validation rules from the a2td lab (merged there in wave33). Origin story: a scored eval case passed structurally at 100% but rendered Month as a flat string axis (judge 28/100). The pair covers both variants: dateFieldBoundAsString (error — metadata proves date, pill binds nominal) and dateLikeStringOnTimeAxis (warning — CSV-inferred string typed field with date-like name on a time-series-shaped viz; multi-signal AND gate so categorical use stays silent).

Full a2td test coverage ported. Overlap-checked against the existing 30 rules — no duplicate fires.

Validation: vitest src/desktop/validation 394/394, commands/workbook 103/103, tsc + eslint clean.

Lab→product port per the debt ledger; branch cut from post-#487–489 origin/feature/authoring. GPT-5.5 minion port, Fable-adjudicated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)