### PR TITLE
port: focus follows the agent — goto-sheet after successful applies

### DIFF
--- a/src/desktop/commands/workbook/focusAppliedSheet.ts
+++ b/src/desktop/commands/workbook/focusAppliedSheet.ts
@@ -1,0 +1,59 @@
+import { log } from '../../../logging/logger.js';
+import { WithExecutorAndAbortSignal } from '../../toolExecutor/toolExecutor.js';
+
+type ApplyCommand = 'load-worksheet' | 'load-dashboard';
+
+export async function focusAppliedSheetBestEffort({
+  sheetName,
+  appliedVia,
+  executor,
+  signal,
+}: {
+  sheetName: string;
+  appliedVia: ApplyCommand;
+} & WithExecutorAndAbortSignal): Promise<void> {
+  try {
+    const result = await executor.executeCommand({
+      namespace: 'tabdoc',
+      command: 'goto-sheet',
+      args: { sheet: sheetName },
+      signal,
+    });
+
+    if (result.isErr()) {
+      log({
+        level: 'warning',
+        message: 'goto-sheet failed after successful apply; continuing',
+        logger: 'workbookCommands',
+        data: { sheetName, appliedVia, error: result.error },
+      });
+      return;
+    }
+
+    if (result.value.status !== 'completed') {
+      log({
+        level: 'warning',
+        message: 'goto-sheet did not complete after successful apply; continuing',
+        logger: 'workbookCommands',
+        data: {
+          sheetName,
+          appliedVia,
+          status: result.value.status,
+          commandId: result.value.command_id,
+          error: result.value.error,
+        },
+      });
+    }
+  } catch (error) {
+    log({
+      level: 'warning',
+      message: 'goto-sheet threw after successful apply; continuing',
+      logger: 'workbookCommands',
+      data: {
+        sheetName,
+        appliedVia,
+        error: error instanceof Error ? error.message : String(error),
+      },
+    });
+  }
+}

--- a/src/desktop/commands/workbook/loadDashboardXml.test.ts
+++ b/src/desktop/commands/workbook/loadDashboardXml.test.ts
@@ -1,6 +1,7 @@
 import { Err, Ok } from 'ts-results-es';
 
 import * as configModule from '../../../config.desktop.js';
+import * as loggerModule from '../../../logging/logger.js';
 import invariant from '../../../utils/invariant.js';
 import { LocalExecutor } from '../../toolExecutor/localToolExecutor.js';
 import { loadDashboardXml } from './loadDashboardXml.js';
@@ -14,6 +15,11 @@ describe('loadDashboardXml (Agent API transport, default)', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.spyOn(loggerModule, 'log').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   it('should successfully load dashboard XML', async () => {
@@ -36,6 +42,64 @@ describe('loadDashboardXml (Agent API transport, default)', () => {
         namespace: 'tabui',
         command: 'load-dashboard',
         args: { dashboardName, dashboardXml: validXml },
+      }),
+    );
+  });
+
+  it('focuses the dashboard after a successful apply', async () => {
+    const mockExecutor = {
+      executeCommand: vi
+        .fn()
+        .mockResolvedValueOnce(Ok({ command_id: 'cmd-123', status: 'completed', submitted_at: '' }))
+        .mockResolvedValueOnce(
+          Ok({ command_id: 'cmd-goto', status: 'completed', submitted_at: '' }),
+        ),
+    } as unknown as LocalExecutor;
+
+    const result = await loadDashboardXml({
+      dashboardName,
+      xml: validXml,
+      executor: mockExecutor,
+      signal: mockSignal,
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(mockExecutor.executeCommand).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        namespace: 'tabdoc',
+        command: 'goto-sheet',
+        args: { sheet: dashboardName },
+        signal: mockSignal,
+      }),
+    );
+  });
+
+  it('keeps dashboard apply successful when focusing the dashboard throws', async () => {
+    const mockExecutor = {
+      executeCommand: vi
+        .fn()
+        .mockResolvedValueOnce(Ok({ command_id: 'cmd-123', status: 'completed', submitted_at: '' }))
+        .mockRejectedValueOnce(new Error('navigation failed')),
+    } as unknown as LocalExecutor;
+
+    const result = await loadDashboardXml({
+      dashboardName,
+      xml: validXml,
+      executor: mockExecutor,
+      signal: mockSignal,
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(loggerModule.log).toHaveBeenCalledWith(
+      expect.objectContaining({
+        level: 'warning',
+        message: expect.stringContaining('goto-sheet'),
+        data: expect.objectContaining({
+          sheetName: dashboardName,
+          appliedVia: 'load-dashboard',
+          error: 'navigation failed',
+        }),
       }),
     );
   });
@@ -224,6 +288,7 @@ describe('loadDashboardXml (External Client API transport, TABLEAU_EXTERNAL_API 
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.spyOn(loggerModule, 'log').mockImplementation(() => undefined);
     const base = configModule.getDesktopConfig();
     vi.spyOn(configModule, 'getDesktopConfig').mockReturnValue({
       ...base,
@@ -259,6 +324,26 @@ describe('loadDashboardXml (External Client API transport, TABLEAU_EXTERNAL_API 
     expect(applied).not.toContain('Other DB');
     // Worksheets are stripped so the POST leaves the live sheets untouched.
     expect(applied).not.toContain('<worksheet');
+  });
+
+  it('focuses the dashboard after a successful minimal-doc apply', async () => {
+    const { executor, calls } = dispatchingExecutor(
+      liveWorkbook(['Sales Dashboard', 'Other DB'], ['Sheet 1']),
+    );
+
+    const result = await loadDashboardXml({
+      dashboardName,
+      xml: validXml,
+      executor,
+      signal: mockSignal,
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(calls.at(-1)).toEqual({
+      namespace: 'tabdoc',
+      command: 'goto-sheet',
+      args: { sheet: dashboardName },
+    });
   });
 
   it('does not reject a per-dashboard apply whose minimal document omits live worksheets referenced by zones', async () => {

--- a/src/desktop/commands/workbook/loadDashboardXml.ts
+++ b/src/desktop/commands/workbook/loadDashboardXml.ts
@@ -11,6 +11,7 @@ import {
 import { runValidation } from '../../validation/registry.js';
 import { ValidationIssue } from '../../validation/types.js';
 import { withApplyLock } from './applyMutex.js';
+import { focusAppliedSheetBestEffort } from './focusAppliedSheet.js';
 import { getWorkbookXml } from './getWorkbookXml.js';
 import { applyWorkbookText, interpretLoadOutcome } from './loadWorkbookXml.js';
 
@@ -134,6 +135,13 @@ async function loadDashboardXmlViaAgentApi({
     },
   });
 
+  await focusAppliedSheetBestEffort({
+    sheetName: dashboardName,
+    appliedVia: 'load-dashboard',
+    executor,
+    signal,
+  });
+
   return Ok.EMPTY;
 }
 
@@ -169,6 +177,13 @@ async function loadDashboardXmlViaExternalApi({
       message: 'load-dashboard completed',
       logger: 'dashboardCommands',
       data: { dashboardName },
+    });
+
+    await focusAppliedSheetBestEffort({
+      sheetName: dashboardName,
+      appliedVia: 'load-dashboard',
+      executor,
+      signal,
     });
 
     return Ok.EMPTY;

--- a/src/desktop/commands/workbook/loadWorksheetXml.test.ts
+++ b/src/desktop/commands/workbook/loadWorksheetXml.test.ts
@@ -1,6 +1,7 @@
 import { Err, Ok } from 'ts-results-es';
 
 import * as configModule from '../../../config.desktop.js';
+import * as loggerModule from '../../../logging/logger.js';
 import invariant from '../../../utils/invariant.js';
 import { LocalExecutor } from '../../toolExecutor/localToolExecutor.js';
 import * as validationRegistry from '../../validation/registry.js';
@@ -16,7 +17,12 @@ describe('loadWorksheetXml (Agent API transport, default)', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.spyOn(loggerModule, 'log').mockImplementation(() => undefined);
     vi.spyOn(validationRegistry, 'runValidation').mockReturnValue({ valid: true, issues: [] });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   it('should successfully load worksheet XML', async () => {
@@ -46,6 +52,68 @@ describe('loadWorksheetXml (Agent API transport, default)', () => {
           worksheetName,
           worksheetXml: validXml,
         },
+      }),
+    );
+  });
+
+  it('focuses the worksheet after a successful apply', async () => {
+    const mockExecutor = {
+      executeCommand: vi
+        .fn()
+        .mockResolvedValueOnce(Ok({ command_id: 'cmd-123', status: 'completed', submitted_at: '' }))
+        .mockResolvedValueOnce(
+          Ok({ command_id: 'cmd-goto', status: 'completed', submitted_at: '' }),
+        ),
+    } as unknown as LocalExecutor;
+
+    const result = await loadWorksheetXml({
+      worksheetName,
+      xml: validXml,
+      executor: mockExecutor,
+      signal: mockSignal,
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(mockExecutor.executeCommand).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        namespace: 'tabdoc',
+        command: 'goto-sheet',
+        args: { sheet: worksheetName },
+        signal: mockSignal,
+      }),
+    );
+  });
+
+  it('keeps worksheet apply successful when focusing the worksheet fails', async () => {
+    const error = {
+      type: 'command-failed' as const,
+      error: { code: 'GOTO_FAILED', message: 'could not navigate', recoverable: true },
+    };
+    const mockExecutor = {
+      executeCommand: vi
+        .fn()
+        .mockResolvedValueOnce(Ok({ command_id: 'cmd-123', status: 'completed', submitted_at: '' }))
+        .mockResolvedValueOnce(Err(error)),
+    } as unknown as LocalExecutor;
+
+    const result = await loadWorksheetXml({
+      worksheetName,
+      xml: validXml,
+      executor: mockExecutor,
+      signal: mockSignal,
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(loggerModule.log).toHaveBeenCalledWith(
+      expect.objectContaining({
+        level: 'warning',
+        message: expect.stringContaining('goto-sheet'),
+        data: expect.objectContaining({
+          sheetName: worksheetName,
+          appliedVia: 'load-worksheet',
+          error,
+        }),
       }),
     );
   });
@@ -270,6 +338,7 @@ describe('loadWorksheetXml (External Client API transport, TABLEAU_EXTERNAL_API 
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.spyOn(loggerModule, 'log').mockImplementation(() => undefined);
     vi.spyOn(validationRegistry, 'runValidation').mockReturnValue({ valid: true, issues: [] });
     const base = configModule.getDesktopConfig();
     vi.spyOn(configModule, 'getDesktopConfig').mockReturnValue({
@@ -303,6 +372,24 @@ describe('loadWorksheetXml (External Client API transport, TABLEAU_EXTERNAL_API 
     // The applied minimal doc carries the edited sheet but not the untouched "Other".
     expect(applyCall?.args?.text).toContain('name="Sheet 1"');
     expect(applyCall?.args?.text).not.toContain('Other');
+  });
+
+  it('focuses the worksheet after a successful minimal-doc apply', async () => {
+    const { executor, calls } = dispatchingExecutor(liveWorkbook(['Sheet 1', 'Other']));
+
+    const result = await loadWorksheetXml({
+      worksheetName,
+      xml: validXml,
+      executor,
+      signal: mockSignal,
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(calls.at(-1)).toEqual({
+      namespace: 'tabdoc',
+      command: 'goto-sheet',
+      args: { sheet: worksheetName },
+    });
   });
 
   it('should apply a minimal document for a brand-new sheet', async () => {

--- a/src/desktop/commands/workbook/loadWorksheetXml.ts
+++ b/src/desktop/commands/workbook/loadWorksheetXml.ts
@@ -11,6 +11,7 @@ import {
 import { runValidation } from '../../validation/registry.js';
 import { ValidationIssue } from '../../validation/types.js';
 import { withApplyLock } from './applyMutex.js';
+import { focusAppliedSheetBestEffort } from './focusAppliedSheet.js';
 import { getWorkbookXml } from './getWorkbookXml.js';
 import { applyWorkbookText, interpretLoadOutcome } from './loadWorkbookXml.js';
 
@@ -134,6 +135,13 @@ async function loadWorksheetXmlViaAgentApi({
     },
   });
 
+  await focusAppliedSheetBestEffort({
+    sheetName: worksheetName,
+    appliedVia: 'load-worksheet',
+    executor,
+    signal,
+  });
+
   return Ok.EMPTY;
 }
 
@@ -169,6 +177,13 @@ async function loadWorksheetXmlViaExternalApi({
       message: 'load-worksheet completed',
       logger: 'worksheetCommands',
       data: { worksheetName },
+    });
+
+    await focusAppliedSheetBestEffort({
+      sheetName: worksheetName,
+      appliedVia: 'load-worksheet',
+      executor,
+      signal,
     });
 
     return Ok.EMPTY;

--- a/src/tools/desktop/fields/addField.test.ts
+++ b/src/tools/desktop/fields/addField.test.ts
@@ -122,6 +122,31 @@ describe('addFieldTool', () => {
     expect(writeFileSync).toHaveBeenCalledWith(WORKSHEET_FILE, MODIFIED_XML, 'utf-8');
   });
 
+  it('does not use the Tableau command channel after a successful field edit', async () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue('<worksheet/>');
+    vi.mocked(metadataModule.addFieldToRows).mockReturnValue(MODIFIED_XML);
+    vi.mocked(writeFileSync).mockReturnValue(undefined);
+    const extra = getMockRequestHandlerExtra();
+    const tool = getAddFieldTool(new DesktopMcpServer());
+    const callback = await Provider.from(tool.callback);
+
+    const result = await callback(
+      {
+        worksheetFile: WORKSHEET_FILE,
+        target: 'rows',
+        columnRef: COLUMN_REF,
+        encodingType: undefined,
+        index: undefined,
+        workbookFile: undefined,
+      },
+      extra,
+    );
+
+    expect(result.isError).toBe(false);
+    expect(extra.getExecutor).not.toHaveBeenCalled();
+  });
+
   it('should pass index and workbookFile to addFieldToRows (target=rows)', async () => {
     vi.mocked(existsSync).mockReturnValue(true);
     vi.mocked(readFileSync).mockImplementation((p) =>

--- a/src/tools/desktop/fields/removeField.test.ts
+++ b/src/tools/desktop/fields/removeField.test.ts
@@ -122,6 +122,29 @@ describe('removeFieldTool', () => {
     expect(metadataModule.removeFieldFromRows).toHaveBeenCalledWith('<worksheet/>', COLUMN_REF);
   });
 
+  it('does not use the Tableau command channel after a successful field edit', async () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue('<worksheet/>');
+    vi.mocked(metadataModule.removeFieldFromRows).mockReturnValue(MODIFIED_XML);
+    vi.mocked(writeFileSync).mockReturnValue(undefined);
+    const extra = getMockRequestHandlerExtra();
+    const tool = getRemoveFieldTool(new DesktopMcpServer());
+    const callback = await Provider.from(tool.callback);
+
+    const result = await callback(
+      {
+        worksheetFile: WORKSHEET_FILE,
+        target: 'rows',
+        columnRef: COLUMN_REF,
+        encodingType: undefined,
+      },
+      extra,
+    );
+
+    expect(result.isError).toBe(false);
+    expect(extra.getExecutor).not.toHaveBeenCalled();
+  });
+
   // --- target=cols (ported from removeFieldFromCols) ---
   it('should return error when removeFieldFromCols throws (target=cols)', async () => {
     vi.mocked(existsSync).mockReturnValue(true);


### PR DESCRIPTION
Ports a2td wave33's focus-follows v1 (top studio-user ask — 'agent built my viz while I stared at a blank tab'). Best-effort tabdoc:goto-sheet fires from a shared focusAppliedSheet helper after successful worksheet/dashboard applies (both Agent-API and minimal-doc paths); refine/composite inherit; field-level edits never navigate (pinned by tests); navigation failure WARN-logs and never breaks an apply.

Validation: vitest src/desktop/commands/workbook 109/109, fields non-navigation tests 32/32, tsc + eslint clean. Live visible-tab behavior needs a live Desktop check (known goto-sheet ack-without-switch caveat — the a2td eval harness now gates this deterministically).

Lab→product port per the debt ledger. GPT-5.5 minion port, Fable-adjudicated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)