### PR TITLE
port: structuredContent.nextAction on desktop escalation results

### DIFF
--- a/src/tools/desktop/binder/bindTemplate.test.ts
+++ b/src/tools/desktop/binder/bindTemplate.test.ts
@@ -175,6 +175,17 @@ describe('bindTemplateTool', () => {
     // this repo reserves isError for the McpToolError funnel).
     expect(result.isError).toBe(false);
     invariant(result.content[0].type === 'text');
+    const expectedBody = {
+      ...escalateResult,
+      guidance:
+        'Escalated (field-not-found). No worksheet was produced. Blockers: ' +
+        '[field-not-found] slot \'val\' No field named "Revenue".. Next: Resolve the field(s) ' +
+        'with the resolve-field tool, then call bind-template again with a corrected proposal.',
+    };
+    expect(result.content[0].text).toBe(JSON.stringify(expectedBody));
+    expect(result.structuredContent).toEqual({
+      nextAction: { label: 'Resolve the fields first', kind: 'prefill' },
+    });
     const body = JSON.parse(result.content[0].text);
     expect(body.status).toBe('escalate');
     expect(body.reason).toBe('field-not-found');

--- a/src/tools/desktop/binder/bindTemplate.ts
+++ b/src/tools/desktop/binder/bindTemplate.ts
@@ -28,6 +28,13 @@ import { ExecuteCommandError, ToolExecutor } from '../../../desktop/toolExecutor
 import { DesktopCommandExecutionError } from '../../../errors/mcpToolError.js';
 import { DesktopMcpServer } from '../../../server.desktop.js';
 import { getExceptionMessage } from '../../../utils/getExceptionMessage.js';
+import {
+  jsonToolResult,
+  type NextAction,
+  prefillNextAction,
+  type StructuredResult,
+  withNextAction,
+} from '../structuredContent.js';
 import { DesktopTool } from '../tool.js';
 // The nested `proposal` mirrors the binder library's public data contract
 // (`BindingProposal` / `PROPOSAL_OUTPUT_SCHEMA`) verbatim so a Call-1 `propose` payload
@@ -90,6 +97,7 @@ type AppliedFastPathResult = {
 };
 
 type BindTemplateToolResult = BindTemplateToolResultBase | AppliedFastPathResult;
+type StructuredBindTemplateToolResult = StructuredResult<BindTemplateToolResult>;
 
 /** Escalation reasons that route back to the general (non-fast-path) authoring flow. */
 const TIER2_REASONS: ReadonlySet<EscalateReason> = new Set<EscalateReason>([
@@ -105,6 +113,19 @@ const TIER2_REASONS: ReadonlySet<EscalateReason> = new Set<EscalateReason>([
   // route to the general authoring flow.
   'schema-too-large',
 ]);
+
+function nextActionForEscalation(reason: EscalateReason): NextAction {
+  if (reason === 'ambiguous-field' || reason === 'field-not-found') {
+    return prefillNextAction('Resolve the fields first');
+  }
+  if (reason === 'low-confidence') {
+    return prefillNextAction('Pick a higher-confidence proposal');
+  }
+  if (TIER2_REASONS.has(reason)) {
+    return prefillNextAction('Use the general worksheet build tools');
+  }
+  return prefillNextAction('Build the worksheet manually');
+}
 
 function renderBlockers(blockers: Blocker[]): string {
   if (blockers.length === 0) {
@@ -440,7 +461,13 @@ export const getBindTemplateTool = (server: DesktopMcpServer): DesktopTool<typeo
           }
           const bindMs = Date.now() - bindStart;
 
-          const base: BindTemplateToolResultBase = { ...res, guidance: buildGuidance(res) };
+          const base: StructuredBindTemplateToolResult =
+            res.status === 'escalate'
+              ? withNextAction(
+                  { ...res, guidance: buildGuidance(res) },
+                  nextActionForEscalation(res.reason),
+                )
+              : { ...res, guidance: buildGuidance(res) };
 
           // ── Auto-apply gate (defense in depth) ───────────────────────────
           // Only a deterministic Call-1 bind (used_llm === false) of a fast-path-
@@ -472,6 +499,7 @@ export const getBindTemplateTool = (server: DesktopMcpServer): DesktopTool<typeo
             }),
           );
         },
+        getSuccessResult: (result) => jsonToolResult(result, { isError: false }),
       });
     },
   });

--- a/src/tools/desktop/coordination/planDashboardCreation.test.ts
+++ b/src/tools/desktop/coordination/planDashboardCreation.test.ts
@@ -112,9 +112,21 @@ describe('planDashboardCreationTool', () => {
 
     expect(result.isError).toBe(true);
     invariant(result.content[0].type === 'text');
-    expect(result.content[0].text).toContain('BLOCKED');
-    expect(result.content[0].text).toContain('ambiguous');
-    expect(result.content[0].text).toContain('"Sales"');
+    expect(result.content[0].text).toBe(
+      [
+        'BLOCKED: 1 ambiguous field reference — cannot plan dashboard',
+        '',
+        'Ambiguous (matches multiple columns — pick one):',
+        '  • "Sales" → candidates: "[DS1].[sum:Sales:qk]", "[DS2].[sum:Sales:qk]"',
+        '',
+        'Next step: disambiguate each field, then re-call plan-dashboard-creation.',
+        '  • Use resolve-field with an explicit datasource.',
+        '  • For not_found fields, call list-available-fields to see valid names.',
+      ].join('\n'),
+    );
+    expect(result.structuredContent).toEqual({
+      nextAction: { label: 'Disambiguate each field before re-planning', kind: 'prefill' },
+    });
   });
 
   it('should include not_found fields in the blocked response alongside ambiguous', async () => {

--- a/src/tools/desktop/coordination/planDashboardCreation.ts
+++ b/src/tools/desktop/coordination/planDashboardCreation.ts
@@ -9,6 +9,7 @@ import { resolveSession } from '../../../desktop/sessionResolution.js';
 import { listTemplateNames } from '../../../desktop/templates/templatePath.js';
 import { ArgsValidationError, DesktopCommandExecutionError } from '../../../errors/mcpToolError.js';
 import { DesktopMcpServer } from '../../../server.desktop.js';
+import { attachNextAction, prefillNextAction } from '../structuredContent.js';
 import { DesktopTool } from '../tool.js';
 
 const paramsSchema = {
@@ -158,7 +159,10 @@ export const getPlanDashboardCreationTool = (
               '  • Use resolve-field with an explicit datasource.',
               '  • For not_found fields, call list-available-fields to see valid names.',
             );
-            return new ArgsValidationError(lines.join('\n')).toErr();
+            return attachNextAction(
+              new ArgsValidationError(lines.join('\n')),
+              prefillNextAction('Disambiguate each field before re-planning'),
+            ).toErr();
           }
 
           // Cache workbook for subagents

--- a/src/tools/desktop/dashboard/dashboardAutoApply.test.ts
+++ b/src/tools/desktop/dashboard/dashboardAutoApply.test.ts
@@ -412,6 +412,23 @@ describe('dashboardAutoApplyTool all-or-nothing gate matrix', () => {
     });
 
     invariant(result.content[0].type === 'text');
+    const expectedBody = {
+      applied: false,
+      results: [
+        { index: 0, ask: 'bar chart of Sales by Region', result: boundA },
+        { index: 1, ask: 'weird revenue ask', result: escalateResult },
+      ],
+      guidance:
+        'One or more asks did not deterministically bind (Call-1, no-LLM). Nothing was applied to ' +
+        'the live workbook. Each ask carries its own bind-template-shaped outcome below: for ' +
+        '"propose", fill its output_schema and call bind-template again; for "escalate", follow its ' +
+        'guidance. Once every ask binds, retry dashboard-auto-apply, or fall back to the per-chart ' +
+        'bind-template(auto_apply:true) flow using each already-bound ask.',
+    };
+    expect(result.content[0].text).toBe(JSON.stringify(expectedBody));
+    expect(result.structuredContent).toEqual({
+      nextAction: { label: 'Resolve each ask before retrying', kind: 'prefill' },
+    });
     const body = JSON.parse(result.content[0].text);
     expect(body.applied).toBe(false);
     expect(body.results[1].result.reason).toBe('field-not-found');
@@ -466,6 +483,9 @@ describe('dashboardAutoApplyTool all-or-nothing gate matrix', () => {
     expect(body.applied).toBe(false);
     expect(String(body.apply_error)).toMatch(/user changed the workbook.*3 event/);
     expect(String(body.guidance)).toMatch(/re-run dashboard-auto-apply/i);
+    expect(result.structuredContent).toEqual({
+      nextAction: { label: 'Re-run dashboard-auto-apply', kind: 'prefill' },
+    });
     expect(executeCommand).not.toHaveBeenCalled();
   });
 

--- a/src/tools/desktop/dashboard/dashboardAutoApply.ts
+++ b/src/tools/desktop/dashboard/dashboardAutoApply.ts
@@ -36,6 +36,13 @@ import { ExecuteCommandError } from '../../../desktop/toolExecutor/toolExecutor.
 import { DesktopCommandExecutionError } from '../../../errors/mcpToolError.js';
 import { DesktopMcpServer } from '../../../server.desktop.js';
 import { getExceptionMessage } from '../../../utils/getExceptionMessage.js';
+import {
+  jsonToolResult,
+  type NextAction,
+  prefillNextAction,
+  type StructuredResult,
+  withNextAction,
+} from '../structuredContent.js';
 import { DesktopTool } from '../tool.js';
 import { buildDashboardXml, computeZones } from './dashboardZones.js';
 
@@ -120,6 +127,7 @@ type DashboardAutoApplyToolResult =
   | DashboardAutoApplyRefusalResult
   | DashboardAutoApplySuccessResult
   | DashboardAutoApplyPartialResult;
+type StructuredDashboardAutoApplyToolResult = StructuredResult<DashboardAutoApplyToolResult>;
 
 /** Human-readable detail for a loadWorkbookXml failure (mirrors bindTemplate.ts). */
 function describeApplyError(
@@ -144,8 +152,15 @@ function refusal(
   results: AskOutcome[],
   guidance: string,
   apply_error?: string,
-): Ok<DashboardAutoApplyToolResult> {
-  return new Ok({ applied: false, results, guidance, ...(apply_error ? { apply_error } : {}) });
+  nextAction?: NextAction,
+): Ok<StructuredDashboardAutoApplyToolResult> {
+  const result: DashboardAutoApplyRefusalResult = {
+    applied: false,
+    results,
+    guidance,
+    ...(apply_error ? { apply_error } : {}),
+  };
+  return new Ok(nextAction ? withNextAction(result, nextAction) : result);
 }
 
 /** Quote-agnostic (matches injectTemplateCore.ts's own conventions): true when `title`
@@ -189,7 +204,7 @@ export const getDashboardAutoApplyTool = (
       { session, asks, dashboardName, title: titleText, layout },
       extra,
     ): Promise<CallToolResult> => {
-      return await dashboardAutoApplyTool.logAndExecute<DashboardAutoApplyToolResult>({
+      return await dashboardAutoApplyTool.logAndExecute<StructuredDashboardAutoApplyToolResult>({
         extra,
         args: { session, asks, dashboardName, title: titleText, layout },
         callback: async () => {
@@ -251,6 +266,8 @@ export const getDashboardAutoApplyTool = (
                 '"propose", fill its output_schema and call bind-template again; for "escalate", follow its ' +
                 'guidance. Once every ask binds, retry dashboard-auto-apply, or fall back to the per-chart ' +
                 'bind-template(auto_apply:true) flow using each already-bound ask.',
+              undefined,
+              prefillNextAction('Resolve each ask before retrying'),
             );
           }
 
@@ -269,6 +286,8 @@ export const getDashboardAutoApplyTool = (
               outcomes,
               'One or more bound asks are not eligible for server-side auto-apply (used_llm or ' +
                 'fast_path_eligible gate failed). Nothing was applied. Fall back to the per-chart flow.',
+              undefined,
+              prefillNextAction('Use the per-chart flow'),
             );
           }
 
@@ -291,6 +310,7 @@ export const getDashboardAutoApplyTool = (
               `Duplicate resolved title(s) within the batch: ${detail}. Give each ask a distinct 'title' ` +
                 'and retry — nothing was applied.',
               `duplicate title(s): ${detail}`,
+              prefillNextAction('Give each ask a distinct title'),
             );
           }
 
@@ -319,6 +339,7 @@ export const getDashboardAutoApplyTool = (
                 'Applying this batch would silently rewire that dashboard to a replaced sheet. Rename the ' +
                 "ask's title and retry — nothing was applied.",
               `title referenced by existing dashboard zone: ${detail}`,
+              prefillNextAction('Rename the colliding worksheet titles'),
             );
           }
 
@@ -422,6 +443,7 @@ export const getDashboardAutoApplyTool = (
                   'current workbook — do NOT re-apply, the binds were computed against the pre-edit workbook ' +
                   'and re-applying could revert their changes.',
                 `user changed the workbook during the batch (${events.value.count} event(s) since read)`,
+                prefillNextAction('Re-run dashboard-auto-apply'),
               );
             }
           }
@@ -441,6 +463,7 @@ export const getDashboardAutoApplyTool = (
                 'was applied — fall back to the per-chart bind-template(auto_apply:true) flow using each ' +
                 "ask's bound args.",
               describeApplyError(applyResult.error),
+              prefillNextAction('Fall back to per-chart auto-apply'),
             );
           }
           const applyMs = Date.now() - applyStart;
@@ -469,17 +492,22 @@ export const getDashboardAutoApplyTool = (
                 err.type === 'load-dashboard-xml-error'
                   ? JSON.stringify(err.error)
                   : `workbook load command failed: ${JSON.stringify(err.error)}`;
-              return new Ok({
-                applied: 'partial',
-                dashboard: dashboardName,
-                sheets,
-                apply_error: message,
-                guidance:
-                  `The workbook (sheets + an empty "${dashboardName}" dashboard) was applied, but laying ` +
-                  `in the zones failed (${message}). Re-issue the zones via build-and-apply-dashboard — the ` +
-                  'dashboard exists with a valid empty layout, nothing is corrupted.',
-                ...(replaced.dashboard || replaced.sheets.length > 0 ? { replaced } : {}),
-              });
+              return new Ok(
+                withNextAction(
+                  {
+                    applied: 'partial',
+                    dashboard: dashboardName,
+                    sheets,
+                    apply_error: message,
+                    guidance:
+                      `The workbook (sheets + an empty "${dashboardName}" dashboard) was applied, but laying ` +
+                      `in the zones failed (${message}). Re-issue the zones via build-and-apply-dashboard — the ` +
+                      'dashboard exists with a valid empty layout, nothing is corrupted.',
+                    ...(replaced.dashboard || replaced.sheets.length > 0 ? { replaced } : {}),
+                  },
+                  prefillNextAction('Re-issue the zones'),
+                ),
+              );
             }
           }
 
@@ -492,6 +520,7 @@ export const getDashboardAutoApplyTool = (
             ...(replaced.dashboard || replaced.sheets.length > 0 ? { replaced } : {}),
           });
         },
+        getSuccessResult: (result) => jsonToolResult(result, { isError: false }),
       });
     },
   });

--- a/src/tools/desktop/structuredContent.test.ts
+++ b/src/tools/desktop/structuredContent.test.ts
@@ -1,0 +1,33 @@
+import {
+  jsonToolResult,
+  prefillNextAction,
+  textToolResult,
+  withNextAction,
+} from './structuredContent.js';
+
+describe('structuredContent helpers', () => {
+  it('preserves the plain text MCP envelope when there is no next action', () => {
+    expect(textToolResult('hello')).toEqual({
+      content: [{ type: 'text', text: 'hello' }],
+    });
+  });
+
+  it('emits exactly one structured nextAction without changing JSON text', () => {
+    const body = { applied: false, guidance: 'Resolve the fields first.' };
+    const result = jsonToolResult(
+      withNextAction(body, prefillNextAction('Resolve the fields first')),
+      { isError: false },
+    );
+
+    expect(result.content).toEqual([{ type: 'text', text: JSON.stringify(body) }]);
+    expect(result.isError).toBe(false);
+    expect(result.structuredContent).toEqual({
+      nextAction: { label: 'Resolve the fields first', kind: 'prefill' },
+    });
+    expect(Object.keys(result.structuredContent!)).toEqual(['nextAction']);
+  });
+
+  it('rejects labels over 60 characters', () => {
+    expect(() => prefillNextAction('x'.repeat(61))).toThrow('nextAction label');
+  });
+});

--- a/src/tools/desktop/structuredContent.ts
+++ b/src/tools/desktop/structuredContent.ts
@@ -1,0 +1,79 @@
+import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+
+const MAX_NEXT_ACTION_LABEL_LENGTH = 60;
+
+declare const nextActionLabelBrand: unique symbol;
+
+export type NextActionKind = 'execute' | 'prefill';
+
+export type NextActionLabel = string & { readonly [nextActionLabelBrand]: true };
+
+export type NextAction = {
+  readonly label: NextActionLabel;
+  readonly kind: NextActionKind;
+};
+
+export type StructuredContent = {
+  readonly nextAction: NextAction;
+};
+
+type StructuredContentCarrier = {
+  readonly structuredContent?: StructuredContent;
+};
+
+export type StructuredResult<T extends object> = T & StructuredContentCarrier;
+
+export function prefillNextAction(label: string): NextAction {
+  return { label: nextActionLabel(label), kind: 'prefill' };
+}
+
+function nextActionLabel(label: string): NextActionLabel {
+  if (label.length === 0 || label.length > MAX_NEXT_ACTION_LABEL_LENGTH) {
+    throw new RangeError(`nextAction label must be 1-${MAX_NEXT_ACTION_LABEL_LENGTH} characters`);
+  }
+  return label as NextActionLabel;
+}
+
+export function withNextAction<T extends object>(
+  result: T,
+  nextAction: NextAction,
+): StructuredResult<T> {
+  return { ...result, structuredContent: { nextAction } };
+}
+
+export function attachNextAction<T extends object>(
+  result: T,
+  nextAction: NextAction,
+): StructuredResult<T> {
+  return Object.assign(result, { structuredContent: { nextAction } });
+}
+
+export function getStructuredContent(value: unknown): StructuredContent | undefined {
+  if (!value || typeof value !== 'object') {
+    return undefined;
+  }
+  return (value as StructuredContentCarrier).structuredContent;
+}
+
+export function textToolResult(
+  text: string,
+  options: { readonly isError?: boolean; readonly nextAction?: NextAction } = {},
+): CallToolResult {
+  return {
+    ...(options.isError !== undefined ? { isError: options.isError } : {}),
+    content: [{ type: 'text', text }],
+    ...(options.nextAction ? { structuredContent: { nextAction: options.nextAction } } : {}),
+  };
+}
+
+export function jsonToolResult<T extends object>(
+  result: StructuredResult<T>,
+  options: { readonly isError?: boolean } = {},
+): CallToolResult {
+  const { structuredContent, ...body } = result;
+  return {
+    ...(options.isError !== undefined ? { isError: options.isError } : {}),
+    content: [{ type: 'text', text: JSON.stringify(body) }],
+    ...(structuredContent ? { structuredContent } : {}),
+  };
+}

--- a/src/tools/desktop/tool.ts
+++ b/src/tools/desktop/tool.ts
@@ -6,6 +6,7 @@ import { log } from '../../logging/logger.js';
 import { DesktopMcpServer } from '../../server.desktop.js';
 import { getExceptionMessage } from '../../utils/getExceptionMessage.js';
 import { LogAndExecuteParams, Tool } from '../tool.js';
+import { getStructuredContent } from './structuredContent.js';
 import { TableauDesktopRequestHandlerExtra, TableauDesktopToolCallback } from './toolContext.js';
 import { DesktopToolName } from './toolName.js';
 
@@ -51,9 +52,11 @@ export class DesktopTool<Args extends ZodRawShape | undefined = undefined> exten
         return toolResult;
       }
 
+      const structuredContent = getStructuredContent(result.error);
       toolResult = {
         isError: true,
         content: [{ type: 'text', text: result.error.getErrorText() }],
+        ...(structuredContent ? { structuredContent } : {}),
       };
       return toolResult;
     } catch (error) {


### PR DESCRIPTION
Ports a2td wave33's suggestion-button convention: escalation-ending tool results carry structuredContent.nextAction {label, kind} — exactly zero or one (type-enforced), label ≤60 chars imperative, kind:'prefill' until the UI click-behavior decision lands. Wired: binder escalations, dashboard auto-apply outcomes, plan-dashboard ambiguity. Text envelopes byte-identical; structuredContent is additive.

Validation: vitest src/tools/desktop 450/450 (47 files), tsc + eslint clean.

Lab→product port per the debt ledger. GPT-5.5 minion port, Fable-adjudicated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)