### PR TITLE
port: tableau-speak scrub — no user-visible 'XML', vocabulary knowledge, guard test

### DIFF
--- a/resources/desktop/knowledge/tactics/workflow/tableau-vocabulary.md
+++ b/resources/desktop/knowledge/tactics/workflow/tableau-vocabulary.md
@@ -1,0 +1,79 @@
+# Tableau Vocabulary for User-Facing Narration
+
+Tableau users should hear product vocabulary, not implementation vocabulary, in agent narration, tool explanations, and errors.
+
+## Scope Check
+
+- Primary audience: Tableau agent and end-user communication
+- Authoring outcome improved: clearer status, errors, and tool explanations
+- In-scope reason: Tableau users should hear product vocabulary, not implementation vocabulary.
+- Out-of-scope risk: Internal code, parameter names, tool identifiers, API fields, and stored workbook formats can still use implementation terms where required.
+- Tags: vocabulary, user-facing, tableau-speak, narration, errors, shelves, data-types
+- Relevant user prompts/search terms: "never say XML", "use Tableau vocabulary", "Columns not cols", "Rows shelf", "viz not chart", "Number (whole)", "Number (decimal)", "Text", "True/False"
+
+## When to Use
+
+Use this whenever composing text that a Tableau user may see: progress updates, error messages, final summaries, clarification questions, tool titles, and tool descriptions. The rule applies even when the underlying implementation is manipulating workbook markup or a failure happened in the parser/serializer layer. Translate the implementation detail into the Tableau object the user recognizes.
+
+## Best Practices
+
+- Say **workbook**, **worksheet**, **dashboard**, **sheet**, **viz**, **field**, **Rows**, **Columns**, **Marks**, or **filter** instead of naming the underlying file format.
+- Use the product shelf names **Rows** and **Columns** in user-facing narration. If a tool parameter must remain `rows` or `cols`, explain it as `target=rows` for the Rows shelf or `target=cols` for the Columns shelf.
+- Say **viz** instead of **chart** unless quoting a user, a file name, or a fixed tool or template identifier that cannot be renamed.
+- Use Tableau UI data type names: **Number (whole)**, **Number (decimal)**, **Date**, **Date & Time**, **Text**, and **True/False**.
+- Phrase failures around the affected Tableau object and next action: "The workbook update failed validation" or "The worksheet could not be applied" gives the user a useful anchor.
+
+| Banned or internal wording | Preferred user-facing wording |
+| --- | --- |
+| XML | workbook, worksheet, dashboard, sheet, viz, or field, depending on what changed |
+| XML validation failed | workbook update failed validation / worksheet update failed validation |
+| cols | Columns |
+| rows | Rows |
+| chart | viz |
+| integer | Number (whole) |
+| real / float / decimal | Number (decimal) |
+| datetime | Date & Time |
+| string | Text |
+| boolean / bool | True/False |
+
+Confirmed-working rewrite example:
+
+```text
+Bad: The modified XML failed validation, so I could not load the chart with cols set to Sales.
+Good: The worksheet update failed validation, so I could not update the viz with Sales on Columns.
+```
+
+## Common Mistakes
+
+1. **Exposing the implementation layer in an error.** "The XML failed validation" may be technically precise, but it does not tell a Tableau user what object is affected.
+2. **Using shorthand shelf names.** "cols" and "rows" are useful inside code and parameter names, but users see **Columns** and **Rows** in Tableau.
+3. **Calling every viz a chart.** Tableau's product language and design feedback prefer **viz** for user-facing narration.
+4. **Leaking raw datatypes.** "string" and "integer" are implementation or datastore words; Tableau presents these as **Text** and **Number (whole)**.
+
+What does NOT work: replacing every internal occurrence globally. Tool parameter names, command names, cache filenames, and source-code variables may contain fixed implementation vocabulary. Only translate the text that can reach a user or an agent-facing instruction surface.
+
+## Implementation
+
+Before returning a user-facing message, scan for implementation vocabulary and translate it to the closest Tableau object:
+
+1. Identify the affected object: workbook, worksheet, dashboard, viz, field, shelf, filter, or Marks card.
+2. Replace internal format terms with that object name.
+3. Replace shelf shorthand with **Rows** or **Columns**.
+4. Replace raw data type names with the Tableau UI names.
+5. Keep fixed API names unchanged when required, but surround them with user vocabulary: "Set `target=cols` to put the field on Columns."
+
+For validation errors, use this pattern:
+
+```text
+The <workbook/worksheet/dashboard> update failed validation with <N> error(s).
+<details if useful>
+Fix these issues before applying the update.
+```
+
+## Source and Confidence
+
+- Source/evidence type: design-partner feedback
+- Source: Ginger feedback that Tableau users should not see implementation vocabulary; product vocabulary confirmed by Tableau UI labels
+- Customer-identifying details removed: yes
+- Confidence: SME-reviewed
+- Last reviewed: 2026-07-12

--- a/src/desktop/knowledge/resources.test.ts
+++ b/src/desktop/knowledge/resources.test.ts
@@ -25,4 +25,20 @@ describe('desktop knowledge resources', () => {
     expect(content).toContain('get-worksheet-xml');
     expect(content).toContain('apply-worksheet');
   });
+
+  it('surfaces the Tableau vocabulary entry for user-facing narration prompts', () => {
+    const resource = listKnowledgeResources().find(
+      (entry) => entry.uri === 'expertise://tableau/tactics/workflow/tableau-vocabulary',
+    );
+
+    expect(resource?.name).toBe('Tableau Vocabulary for User-Facing Narration');
+    expect(resource?.description).toContain('Tableau users should hear product vocabulary');
+
+    const content = readKnowledgeResource(resource!.uri);
+    expect(content).toContain('never say XML');
+    expect(content).toContain('Columns');
+    expect(content).toContain('Rows');
+    expect(content).toContain('Number (whole)');
+    expect(content).toContain('True/False');
+  });
 });

--- a/src/desktop/routeTable.ts
+++ b/src/desktop/routeTable.ts
@@ -30,18 +30,18 @@ export const DESKTOP_ROUTE_TABLE: readonly DesktopInstructionEntry[] = [
   {
     kind: 'prose',
     id: 'preamble',
-    text: 'You are controlling Tableau Desktop.',
+    text: 'You are controlling Tableau Desktop. Use Tableau vocabulary in your narration: say workbook, viz, sheet, or field rather than implementation formats; shelf names are Columns and Rows. Use product data type names like Number (whole), Number (decimal), Text, and True/False.',
   },
   {
     kind: 'route',
     id: 'plain-chart',
     trigger:
-      'a plain chart ask (bar, column, line, treemap, waterfall, scatter, filled map, KPI, funnel, box plot)',
+      'a plain viz ask (bar, column, line, treemap, waterfall, scatter, filled map, KPI, funnel, box plot)',
     action:
-      "FIRST call bind-template with the user's ask and auto_apply: true — a confident bind renders the chart in ONE call (~2s server-side, no further tool calls). On propose/escalate, fall back to the general authoring tools (get-workbook-xml -> edit -> apply-workbook, or inject-template for a known template).",
+      "FIRST call bind-template with the user's ask and auto_apply: true — a confident bind renders the viz in ONE call (~2s server-side, no further tool calls). On propose/escalate, fall back to the general authoring tools (get-workbook-xml -> edit -> apply-workbook, or inject-template for a known template).",
     toolSequence: ['bind-template', 'get-workbook-xml', 'apply-workbook', 'inject-template'],
     stopConditions: [
-      'a confident bind renders the chart in ONE call (~2s server-side, no further tool calls)',
+      'a confident bind renders the viz in ONE call (~2s server-side, no further tool calls)',
       'On propose/escalate, fall back to the general authoring tools',
     ],
     requiredEvidence: [
@@ -52,9 +52,9 @@ export const DESKTOP_ROUTE_TABLE: readonly DesktopInstructionEntry[] = [
     kind: 'route',
     id: 'dashboard',
     trigger:
-      'a dashboard ask with 2-6 charts (e.g. "a dashboard with sales by region and profit by category")',
+      'a dashboard ask with 2-6 vizzes (e.g. "a dashboard with sales by region and profit by category")',
     action:
-      "FIRST call dashboard-auto-apply with one { ask, title? } per chart and a dashboardName — it binds and composes every chart into one dashboard in ONE call. If any ask fails to deterministically bind, nothing is applied and each ask's outcome is returned; fall back to bind-template per chart, or build-and-apply-dashboard for KPI strips / custom zone layouts.",
+      "FIRST call dashboard-auto-apply with one { ask, title? } per viz and a dashboardName — it binds and composes every viz into one dashboard in ONE call. If any ask fails to deterministically bind, nothing is applied and each ask's outcome is returned; fall back to bind-template per viz, or build-and-apply-dashboard for KPI strips / custom zone layouts.",
     toolSequence: ['dashboard-auto-apply', 'bind-template', 'build-and-apply-dashboard'],
     stopConditions: [
       "If any ask fails to deterministically bind, nothing is applied and each ask's outcome is returned",
@@ -68,7 +68,7 @@ export const DESKTOP_ROUTE_TABLE: readonly DesktopInstructionEntry[] = [
     id: 'data-value-question',
     trigger: 'a data-value question ("what was revenue in Q3?")',
     action:
-      'do NOT answer with a number — this server cannot read data values. Say so, then offer the chart that would show it (a plain chart ask via bind-template) instead.',
+      'do NOT answer with a number — this server cannot read data values. Say so, then offer the viz that would show it (a plain viz ask via bind-template) instead.',
     toolSequence: ['bind-template'],
     stopConditions: ['do NOT answer with a number — this server cannot read data values'],
     requiredEvidence: [],
@@ -81,7 +81,7 @@ export const DESKTOP_ROUTE_TABLE: readonly DesktopInstructionEntry[] = [
   {
     kind: 'prose',
     id: 'preflight-rejection',
-    text: 'If an apply is rejected by preflight validation, fix the XML per the FIX lines in the error and re-apply. Prefer file mode for large workbooks.',
+    text: 'If an apply is rejected by preflight validation, fix the workbook content per the FIX lines in the error and re-apply. Prefer file mode for large workbooks.',
   },
 ];
 

--- a/src/server.desktop.test.ts
+++ b/src/server.desktop.test.ts
@@ -91,17 +91,25 @@ describe('DesktopMcpServer', () => {
 describe('DESKTOP_INSTRUCTIONS (generated from DESKTOP_ROUTE_TABLE)', () => {
   // Snapshot-style pin: any route-table edit must surface here as a reviewable diff.
   it('matches the pinned instructions string', () => {
-    expect(DESKTOP_INSTRUCTIONS).toBe(`You are controlling Tableau Desktop.
+    expect(DESKTOP_INSTRUCTIONS).toBe(
+      `You are controlling Tableau Desktop. Use Tableau vocabulary in your narration: say workbook, viz, sheet, or field rather than implementation formats; shelf names are Columns and Rows. Use product data type names like Number (whole), Number (decimal), Text, and True/False.
 
-For a plain chart ask (bar, column, line, treemap, waterfall, scatter, filled map, KPI, funnel, box plot), FIRST call bind-template with the user's ask and auto_apply: true — a confident bind renders the chart in ONE call (~2s server-side, no further tool calls). On propose/escalate, fall back to the general authoring tools (get-workbook-xml -> edit -> apply-workbook, or inject-template for a known template).
+For a plain viz ask (bar, column, line, treemap, waterfall, scatter, filled map, KPI, funnel, box plot), FIRST call bind-template with the user's ask and auto_apply: true — a confident bind renders the viz in ONE call (~2s server-side, no further tool calls). On propose/escalate, fall back to the general authoring tools (get-workbook-xml -> edit -> apply-workbook, or inject-template for a known template).
 
-For a dashboard ask with 2-6 charts (e.g. "a dashboard with sales by region and profit by category"), FIRST call dashboard-auto-apply with one { ask, title? } per chart and a dashboardName — it binds and composes every chart into one dashboard in ONE call. If any ask fails to deterministically bind, nothing is applied and each ask's outcome is returned; fall back to bind-template per chart, or build-and-apply-dashboard for KPI strips / custom zone layouts.
+For a dashboard ask with 2-6 vizzes (e.g. "a dashboard with sales by region and profit by category"), FIRST call dashboard-auto-apply with one { ask, title? } per viz and a dashboardName — it binds and composes every viz into one dashboard in ONE call. If any ask fails to deterministically bind, nothing is applied and each ask's outcome is returned; fall back to bind-template per viz, or build-and-apply-dashboard for KPI strips / custom zone layouts.
 
-For a data-value question ("what was revenue in Q3?"), do NOT answer with a number — this server cannot read data values. Say so, then offer the chart that would show it (a plain chart ask via bind-template) instead.
+For a data-value question ("what was revenue in Q3?"), do NOT answer with a number — this server cannot read data values. Say so, then offer the viz that would show it (a plain viz ask via bind-template) instead.
 
 Every session-scoped tool call needs the session id from list-instances — except bind-template and dashboard-auto-apply, which auto-resolve the session when exactly one Desktop instance is running.
 
-If an apply is rejected by preflight validation, fix the XML per the FIX lines in the error and re-apply. Prefer file mode for large workbooks.`);
+If an apply is rejected by preflight validation, fix the workbook content per the FIX lines in the error and re-apply. Prefer file mode for large workbooks.`,
+    );
+  });
+
+  it('tells agents to narrate with Tableau vocabulary', () => {
+    expect(DESKTOP_INSTRUCTIONS).toContain(
+      'Use Tableau vocabulary in your narration: say workbook, viz, sheet, or field rather than implementation formats; shelf names are Columns and Rows.',
+    );
   });
 });
 
@@ -145,6 +153,49 @@ describe('desktop tools/list serialized surface', () => {
   });
 });
 
+async function collectDesktopToolVocabularySurface(): Promise<string[]> {
+  const server = new DesktopMcpServer();
+  const values: string[] = [];
+
+  const collectSchemaDescriptions = (value: unknown): void => {
+    if (Array.isArray(value)) {
+      for (const item of value) collectSchemaDescriptions(item);
+      return;
+    }
+    if (typeof value !== 'object' || value === null) return;
+
+    const record = value as Record<string, unknown>;
+    if (typeof record.description === 'string') values.push(record.description);
+    for (const nested of Object.values(record)) collectSchemaDescriptions(nested);
+  };
+
+  for (const toolFactory of desktopToolFactories) {
+    const tool = toolFactory(server);
+    const title = await Provider.from(tool.title);
+    const description = await Provider.from(tool.description);
+    if (typeof title === 'string') values.push(title);
+    values.push(description);
+    const paramsSchema = await Provider.from(tool.paramsSchema);
+    const obj = normalizeObjectSchema(paramsSchema as any);
+    const inputSchema = obj
+      ? toJsonSchemaCompat(obj, { strictUnions: true, pipeStrategy: 'input' } as any)
+      : { type: 'object', properties: {} };
+    collectSchemaDescriptions(inputSchema);
+  }
+
+  return values;
+}
+
+describe('desktop tools/list Tableau vocabulary', () => {
+  it('does not expose XML in tool titles, descriptions, or parameter descriptions', async () => {
+    const offenders = (await collectDesktopToolVocabularySurface())
+      .filter((value) => /\bxml\b/i.test(value))
+      .sort();
+
+    expect(offenders).toEqual([]);
+  });
+});
+
 describe('desktop tools/list per-tool byte accounting', () => {
   // Per-tool ceiling. The sum test above pins the SURFACE; this pins ATTRIBUTION:
   // when the sum reddens it names WHICH tool got fat, with numbers. Kept well
@@ -156,14 +207,14 @@ describe('desktop tools/list per-tool byte accounting', () => {
   // DO NOT GROW these: trim them down and lower/remove the entry. Never raise a
   // cap, and never add a new entry to dodge the budget without explicit sign-off.
   const GRANDFATHERED: ReadonlyMap<string, number> = new Map([
-    ['bind-template', 2139], // do not grow
-    ['plan-dashboard-creation', 2075], // do not grow
-    ['build-and-apply-dashboard', 2042], // do not grow
+    ['bind-template', 2131], // do not grow
+    ['plan-dashboard-creation', 2043], // do not grow
+    ['build-and-apply-dashboard', 2033], // do not grow
     ['validate-proposal', 2035], // do not grow
-    ['dashboard-auto-apply', 1870], // do not grow
-    ['dashboard-health-check', 1826], // do not grow
-    ['inject-template', 1445], // do not grow
-    ['build-and-apply-worksheet', 1284], // do not grow
+    ['dashboard-auto-apply', 1829], // do not grow
+    ['dashboard-health-check', 1821], // do not grow
+    ['inject-template', 1404], // do not grow
+    ['build-and-apply-worksheet', 1274], // do not grow
   ]);
 
   const measure = async (): Promise<Array<{ name: string; bytes: number }>> => {

--- a/src/server.desktop.ts
+++ b/src/server.desktop.ts
@@ -213,16 +213,13 @@ export class DesktopMcpServer extends Server {
   private _registerDashboardXmlGuide = async (): Promise<void> => {
     const text = readResourceAsset('dashboard-xml-guide.md');
     if (text === null) {
-      throw new McpError(
-        ErrorCode.InternalError,
-        'Dashboard XML guide asset not found: dashboard-xml-guide.md',
-      );
+      throw new McpError(ErrorCode.InternalError, 'Dashboard layout guide asset not found.');
     }
     this.registerResource({
       name: 'dashboard-xml-guide',
       uri: 'tableau://docs/dashboard-xml-guide',
-      title: 'Dashboard XML manipulation guide',
-      description: 'Zone positioning, layouts, best practices for dashboard XML editing',
+      title: 'Dashboard layout editing guide',
+      description: 'Zone positioning, layouts, and best practices for dashboard editing',
       text,
       mimeType: 'text/markdown',
     });

--- a/src/tools/desktop/binder/bindTemplate.test.ts
+++ b/src/tools/desktop/binder/bindTemplate.test.ts
@@ -127,7 +127,7 @@ describe('bindTemplateTool', () => {
       minConfidence: expect.any(Object),
     });
     expect(tool.annotations).toMatchObject({
-      title: 'Bind a Chart Template to an Ask (Fast Path)',
+      title: 'Bind a Viz Template to an Ask (Fast Path)',
       readOnlyHint: true,
       openWorldHint: false,
     });

--- a/src/tools/desktop/binder/bindTemplate.ts
+++ b/src/tools/desktop/binder/bindTemplate.ts
@@ -41,7 +41,7 @@ const paramsSchema = {
     .string()
     .optional()
     .describe('Session ID. Optional only when exactly one Desktop instance is running.'),
-  ask: z.string().describe('Natural-language chart request.'),
+  ask: z.string().describe('Natural-language viz request.'),
   proposal: proposalSchema
     .optional()
     .describe("Call 2 only: filled proposal from a Call-1 'propose' payload."),
@@ -132,7 +132,7 @@ function renderEscalationGuidance(reason: EscalateReason, blockers: Blocker[]): 
     next =
       'This ask is not a fast-path template bind. Author the worksheet with the general field/worksheet build tools instead. ' +
       'If a blocker names a real but not-fast-path-eligible template, that template can still be applied via the manual chain: ' +
-      'get-workbook-xml -> inject-template (that template_name + an explicit field_mapping) -> apply-workbook.';
+      'get workbook structure in file mode -> inject-template (that template_name + an explicit field_mapping) -> apply-workbook.';
   } else {
     next = 'Author the worksheet with the general build tools instead.';
   }
@@ -152,10 +152,10 @@ function buildGuidance(res: BinderResult): string {
         'then call bind-template again with { session, ask, proposal } matching output_schema. ' +
         // W60 pie-anyway gap: candidates carry ONLY fast-path-eligible templates, so an ask naming an
         // unstamped shape (canonically pie) dead-ended here with no honest route — name both exits.
-        'If the asked chart shape is not among the candidates (e.g. pie/donut — no pie template is ' +
+        'If the asked viz shape is not among the candidates (e.g. pie/donut — no pie template is ' +
         'fast-path eligible), do not force a mismatched proposal: bind the nearest candidate and tell the ' +
         'user in one sentence why (for a pie ask, a sorted bar or treemap compares shares more precisely); ' +
-        'if they explicitly want the exact shape anyway, use the manual chain — get-workbook-xml -> ' +
+        'if they explicitly want the exact shape anyway, use the manual chain — get workbook structure in file mode -> ' +
         "inject-template with template_name 'part-to-whole-pie-chart' (field_mapping: Region -> the " +
         'category dimension, Sales -> the measure) -> apply-workbook. ' +
         `${DERIVATION_OVERRIDE_INSTRUCTION}.`
@@ -179,7 +179,7 @@ function describeApplyError(
     if (inner.type === 'load-rejected') {
       return `Tableau rejected the load: ${inner.message}`;
     }
-    return 'invalid workbook XML';
+    return 'invalid workbook content';
   }
   return `workbook load command failed: ${JSON.stringify(error.error)}`;
 }
@@ -203,7 +203,7 @@ function applyFallback(
     ...base,
     guidance:
       guidance ??
-      `Server-side auto-apply did not complete (${apply_error}). The bound args are intact — fall back to the manual chain: get-workbook-xml → inject-template → apply-workbook using the returned args.`,
+      `Server-side auto-apply did not complete (${apply_error}). The bound args are intact — fall back to the manual chain: get workbook structure in file mode → inject-template → apply-workbook using the returned args.`,
     applied: false,
     apply_error,
   };
@@ -311,7 +311,7 @@ async function performAutoApply({
   };
 }
 
-const title = 'Bind a Chart Template to an Ask (Fast Path)';
+const title = 'Bind a Viz Template to an Ask (Fast Path)';
 
 export const getBindTemplateTool = (server: DesktopMcpServer): DesktopTool<typeof paramsSchema> => {
   const bindTemplateTool = new DesktopTool({
@@ -319,7 +319,7 @@ export const getBindTemplateTool = (server: DesktopMcpServer): DesktopTool<typeo
     name: 'bind-template',
     title,
     description: [
-      'Bind a checked-in chart template to an ask and return validated inject args. Model-free.',
+      'Bind a checked-in viz template to an ask and return validated inject args. Model-free.',
       "Call 1 returns 'bound' or 'propose'; Call 2 returns 'bound' or 'escalate'.",
       'auto_apply:true renders deterministic Call-1 binds in one call. Details: expertise://tableau/tactics/workflow/templates.',
     ].join(' '),

--- a/src/tools/desktop/cache/readCachedXml.ts
+++ b/src/tools/desktop/cache/readCachedXml.ts
@@ -15,7 +15,7 @@ import { DesktopTool } from '../tool.js';
 import { getCacheDir, isWithinCacheDir } from './cachePath.js';
 
 const paramsSchema = {
-  filePath: z.string().describe('Cached XML file path.'),
+  filePath: z.string().describe('Cached working-copy file path.'),
   worksheet: z
     .string()
     .optional()
@@ -25,7 +25,7 @@ const paramsSchema = {
   endByte: z.number().int().min(0).optional().describe('Optional raw byte-slice end.'),
 };
 
-const toolTitle = 'Read Cached XML';
+const toolTitle = 'Read Cached Working Copy';
 export const getReadCachedXmlTool = (
   server: DesktopMcpServer,
 ): DesktopTool<typeof paramsSchema> => {
@@ -34,7 +34,7 @@ export const getReadCachedXmlTool = (
     name: 'read-cached-xml',
     title: toolTitle,
     description:
-      'Read cached worksheet/dashboard/workbook XML. For large files, pass exactly ONE selector: ' +
+      'Read cached worksheet, dashboard, or workbook content. For large files, pass exactly ONE selector: ' +
       'worksheet, dashboard, or startByte/endByte range.',
     paramsSchema,
     annotations: {

--- a/src/tools/desktop/cache/validateWorkbookXml.test.ts
+++ b/src/tools/desktop/cache/validateWorkbookXml.test.ts
@@ -14,7 +14,7 @@ describe('validateWorkbookXmlTool', () => {
     expect(tool.paramsSchema).toMatchObject({ xml: expect.any(Object) });
   });
 
-  it('should return success for well-formed XML', async () => {
+  it('should return success for well-formed workbook content', async () => {
     const result = await getResult('<?xml version="1.0"?><workbook><worksheets/></workbook>');
 
     expect(result.isError).toBeFalsy();
@@ -22,12 +22,12 @@ describe('validateWorkbookXmlTool', () => {
     expect(result.content[0].text).toContain('well-formed');
   });
 
-  it('should return error for malformed XML', async () => {
+  it('should return error for malformed workbook content', async () => {
     const result = await getResult('<workbook><worksheets></workbook>');
 
     expect(result.isError).toBe(true);
     invariant(result.content[0].type === 'text');
-    expect(result.content[0].text).toContain('malformed');
+    expect(result.content[0].text).toContain('Workbook structure has');
   });
 
   it('should include fix suggestion referencing apply-workbook', async () => {

--- a/src/tools/desktop/cache/validateWorkbookXml.ts
+++ b/src/tools/desktop/cache/validateWorkbookXml.ts
@@ -7,10 +7,10 @@ import { DesktopMcpServer } from '../../../server.desktop.js';
 import { DesktopTool } from '../tool.js';
 
 const paramsSchema = {
-  xml: z.string().describe('The workbook XML to validate.'),
+  xml: z.string().describe('The workbook content to validate.'),
 };
 
-const toolTitle = 'Validate Workbook XML';
+const toolTitle = 'Check Workbook Structure';
 export const getValidateWorkbookXmlTool = (
   server: DesktopMcpServer,
 ): DesktopTool<typeof paramsSchema> => {
@@ -19,7 +19,7 @@ export const getValidateWorkbookXmlTool = (
     name: 'validate-workbook-xml',
     title: toolTitle,
     description:
-      'Check that workbook XML is well-formed (parseable). Does not validate against XSD schema — Tableau validates that when you apply the XML. Use this before apply-workbook to catch basic XML syntax errors early.',
+      'Check that workbook content is well-formed (parseable). Tableau runs deeper validation when you apply the update. Use this before apply-workbook to catch basic structure errors early.',
     paramsSchema,
     annotations: {
       title: toolTitle,
@@ -33,7 +33,7 @@ export const getValidateWorkbookXmlTool = (
         callback: async () => new Ok(wellFormedXmlRule.validate(xml)),
         getSuccessResult: (issues) => {
           if (issues.length === 0) {
-            return { content: [{ type: 'text', text: 'Workbook XML is well-formed.' }] };
+            return { content: [{ type: 'text', text: 'Workbook structure is well-formed.' }] };
           }
           const errorList = issues.map((issue, i) => `${i + 1}. ${issue.message}`).join('\n');
           return {
@@ -41,7 +41,7 @@ export const getValidateWorkbookXmlTool = (
             content: [
               {
                 type: 'text',
-                text: `Workbook XML is malformed with ${issues.length} error(s):\n\n${errorList}\n\nFix these errors before calling apply-workbook.`,
+                text: `Workbook structure has ${issues.length} error(s):\n\n${errorList}\n\nFix these errors before calling apply-workbook.`,
               },
             ],
           };

--- a/src/tools/desktop/cache/validateWorksheetXml.test.ts
+++ b/src/tools/desktop/cache/validateWorksheetXml.test.ts
@@ -14,7 +14,7 @@ describe('validateWorksheetXmlTool', () => {
     expect(tool.paramsSchema).toMatchObject({ xml: expect.any(Object) });
   });
 
-  it('should return success for well-formed XML', async () => {
+  it('should return success for well-formed worksheet content', async () => {
     const result = await getResult('<worksheet name="Sheet1"><table/></worksheet>');
 
     expect(result.isError).toBeFalsy();
@@ -22,12 +22,12 @@ describe('validateWorksheetXmlTool', () => {
     expect(result.content[0].text).toContain('well-formed');
   });
 
-  it('should return error for malformed XML', async () => {
+  it('should return error for malformed worksheet content', async () => {
     const result = await getResult('<worksheet name="Sheet1"><table></worksheet>');
 
     expect(result.isError).toBe(true);
     invariant(result.content[0].type === 'text');
-    expect(result.content[0].text).toContain('malformed');
+    expect(result.content[0].text).toContain('Worksheet structure has');
     expect(result.content[0].text).toContain('error');
   });
 

--- a/src/tools/desktop/cache/validateWorksheetXml.ts
+++ b/src/tools/desktop/cache/validateWorksheetXml.ts
@@ -7,10 +7,10 @@ import { DesktopMcpServer } from '../../../server.desktop.js';
 import { DesktopTool } from '../tool.js';
 
 const paramsSchema = {
-  xml: z.string().describe('The worksheet XML to validate.'),
+  xml: z.string().describe('The worksheet content to validate.'),
 };
 
-const toolTitle = 'Validate Worksheet XML';
+const toolTitle = 'Check Worksheet Structure';
 export const getValidateWorksheetXmlTool = (
   server: DesktopMcpServer,
 ): DesktopTool<typeof paramsSchema> => {
@@ -19,7 +19,7 @@ export const getValidateWorksheetXmlTool = (
     name: 'validate-worksheet-xml',
     title: toolTitle,
     description:
-      'Check that worksheet XML is well-formed (parseable). Does not validate against XSD schema — Tableau validates that when you apply the XML. Use this before apply-worksheet to catch basic XML syntax errors early.',
+      'Check that worksheet content is well-formed (parseable). Tableau runs deeper validation when you apply the update. Use this before apply-worksheet to catch basic structure errors early.',
     paramsSchema,
     annotations: {
       title: toolTitle,
@@ -33,7 +33,7 @@ export const getValidateWorksheetXmlTool = (
         callback: async () => new Ok(wellFormedXmlRule.validate(xml)),
         getSuccessResult: (issues) => {
           if (issues.length === 0) {
-            return { content: [{ type: 'text', text: 'Worksheet XML is well-formed.' }] };
+            return { content: [{ type: 'text', text: 'Worksheet structure is well-formed.' }] };
           }
           const errorList = issues.map((issue, i) => `${i + 1}. ${issue.message}`).join('\n');
           return {
@@ -41,7 +41,7 @@ export const getValidateWorksheetXmlTool = (
             content: [
               {
                 type: 'text',
-                text: `Worksheet XML is malformed with ${issues.length} error(s):\n\n${errorList}\n\nFix these errors before calling apply-worksheet.`,
+                text: `Worksheet structure has ${issues.length} error(s):\n\n${errorList}\n\nFix these errors before calling apply-worksheet.`,
               },
             ],
           };

--- a/src/tools/desktop/cache/writeCachedXml.ts
+++ b/src/tools/desktop/cache/writeCachedXml.ts
@@ -16,10 +16,10 @@ import { DesktopTool } from '../tool.js';
 import { getCacheDir, isWithinCacheDir } from './cachePath.js';
 
 const paramsSchema = {
-  filePath: z.string().describe('Cached XML file path to write.'),
+  filePath: z.string().describe('Cached working-copy file path to write.'),
   xmlContent: z
     .string()
-    .describe('XML to write: whole file, or replacement element when a selector is provided.'),
+    .describe('Content to write: whole file, or replacement element when a selector is provided.'),
   worksheet: z
     .string()
     .optional()
@@ -27,7 +27,7 @@ const paramsSchema = {
   dashboard: z.string().optional().describe('Optional dashboard splice selector.'),
 };
 
-const toolTitle = 'Write Cached XML';
+const toolTitle = 'Save Cached Working Copy';
 export const getWriteCachedXmlTool = (
   server: DesktopMcpServer,
 ): DesktopTool<typeof paramsSchema> => {
@@ -36,7 +36,7 @@ export const getWriteCachedXmlTool = (
     name: 'write-cached-xml',
     title: toolTitle,
     description:
-      'Write cached XML before apply-* tools (mutates cache file). For large files, pass exactly ' +
+      'Save cached workbook, worksheet, or dashboard content before apply-* tools (mutates cache file). For large files, pass exactly ' +
       'ONE worksheet or dashboard selector to splice one replacement element.',
     paramsSchema,
     annotations: {
@@ -77,7 +77,7 @@ export const getWriteCachedXmlTool = (
           if (issues.length > 0) {
             const errorList = issues.map((issue, i) => `${i + 1}. ${issue.message}`).join('\n');
             return new ArgsValidationError(
-              `XML validation failed with ${issues.length} error(s):\n\n${errorList}\n\nFix these errors before writing.`,
+              `Content validation failed with ${issues.length} error(s):\n\n${errorList}\n\nFix these errors before writing.`,
             ).toErr();
           }
 
@@ -107,7 +107,7 @@ export const getWriteCachedXmlTool = (
               return new ArgsValidationError(
                 `Splice target mismatch: the ${selectorTag} selector is "${selectorName}", so ` +
                   `xmlContent must be a <${selectorTag} name="${selectorName}"> element, but its ` +
-                  `outer element is ${found}. Fix the selector or the xmlContent so both name the ` +
+                  `outer element is ${found}. Fix the selector or content so both name the ` +
                   `same ${selectorTag}; nothing was written.`,
               ).toErr();
             }

--- a/src/tools/desktop/coordination/batchCreateAndCacheSheets.ts
+++ b/src/tools/desktop/coordination/batchCreateAndCacheSheets.ts
@@ -44,7 +44,7 @@ const paramsSchema = {
   dashboardName: z.string().describe('Name of dashboard to create.'),
 };
 
-const toolTitle = 'Batch Create Sheets and Cache XMLs';
+const toolTitle = 'Batch Create Sheets and Cache Working Copies';
 export const getBatchCreateAndCacheSheetsTool = (
   server: DesktopMcpServer,
 ): DesktopTool<typeof paramsSchema> => {
@@ -53,7 +53,7 @@ export const getBatchCreateAndCacheSheetsTool = (
     name: 'batch-create-and-cache-sheets',
     title: toolTitle,
     description: [
-      'Create multiple worksheet sheets and one dashboard in one operation, then cache all empty XMLs.',
+      'Create multiple worksheet sheets and one dashboard in one operation, then cache all empty working copies.',
       'Phase 1 of the parallel dashboard creation workflow.',
       'Returns file paths for use in build-and-apply-worksheet and build-and-apply-dashboard.',
     ].join(' '),
@@ -127,7 +127,7 @@ export const getBatchCreateAndCacheSheetsTool = (
           });
           writeFileSync(workbookFile, workbookXml, 'utf-8');
 
-          // Fetch and cache all worksheet XMLs
+          // Fetch and cache all worksheet working copies.
           const worksheetFiles: Record<string, string> = {};
           const worksheetWarnings: string[] = [];
           for (const name of worksheetNames) {
@@ -147,7 +147,7 @@ export const getBatchCreateAndCacheSheetsTool = (
             worksheetFiles[name] = file;
           }
 
-          // Fetch and cache dashboard XML
+          // Fetch and cache the dashboard working copy.
           let dashboardFile: string | null = null;
           const dashResult = await getDashboardXml({ dashboardName, executor, signal });
           if (dashResult.isErr()) {

--- a/src/tools/desktop/coordination/buildAndApplyWorksheet.ts
+++ b/src/tools/desktop/coordination/buildAndApplyWorksheet.ts
@@ -56,11 +56,11 @@ const paramsSchema = {
   taskSpec: z
     .object({
       worksheetName: z.string(),
-      worksheetFile: z.string().describe('Cached worksheet XML file.'),
+      worksheetFile: z.string().describe('Cached worksheet file.'),
       type: z.enum(['kpi', 'chart']),
       template: z.string().optional().describe('Template name.'),
       fields: z.array(z.string()).describe('Column refs to use.'),
-      workbookFile: z.string().describe('Cached workbook XML file.'),
+      workbookFile: z.string().describe('Cached workbook file.'),
     })
     .describe('Task spec from plan-dashboard-creation.'),
 };
@@ -74,7 +74,7 @@ export const getBuildAndApplyWorksheetTool = (
     name: 'build-and-apply-worksheet',
     title: toolTitle,
     description: [
-      'Build worksheet XML from a template and immediately APPLY it to the live workbook.',
+      'Build a worksheet from a template and immediately APPLY it to the live workbook.',
       'Designed for parallel Phase-2 execution by subagents. Details: expertise://tableau/tactics/viz/worksheets.',
     ].join(' '),
     paramsSchema,
@@ -99,7 +99,7 @@ export const getBuildAndApplyWorksheetTool = (
 
           if (!template) {
             return new ArgsValidationError(
-              'taskSpec.template is required. KPIs default to "kpi-text"; charts should use a chart-specific template (e.g., "ranking-ordered-bar"). Re-run plan-dashboard-creation to get a plan with templates populated.',
+              'taskSpec.template is required. KPIs default to "kpi-text"; viz worksheets should use a viz-specific template (e.g., "ranking-ordered-bar"). Re-run plan-dashboard-creation to get a plan with templates populated.',
             ).toErr();
           }
 
@@ -107,7 +107,7 @@ export const getBuildAndApplyWorksheetTool = (
           let templateXml = readTemplate(template);
           if (!templateXml) {
             return new ArgsValidationError(
-              `Template not found: "${template}". Check available templates with list-xml-templates.`,
+              `Template not found: "${template}". Check available templates with the template list tool.`,
             ).toErr();
           }
 

--- a/src/tools/desktop/coordination/listXmlTemplates.ts
+++ b/src/tools/desktop/coordination/listXmlTemplates.ts
@@ -7,7 +7,7 @@ import { DesktopTool } from '../tool.js';
 
 const paramsSchema = {};
 
-const toolTitle = 'List Available XML Templates';
+const toolTitle = 'List Available Viz Templates';
 export const getListXmlTemplatesTool = (
   server: DesktopMcpServer,
 ): DesktopTool<typeof paramsSchema> => {
@@ -16,7 +16,7 @@ export const getListXmlTemplatesTool = (
     name: 'list-xml-templates',
     title: toolTitle,
     description:
-      'List all available XML visualization templates. Use template names with build-and-apply-worksheet.',
+      'List all available visualization templates. Use template names with build-and-apply-worksheet.',
     paramsSchema,
     annotations: {
       title: toolTitle,

--- a/src/tools/desktop/coordination/planDashboardCreation.ts
+++ b/src/tools/desktop/coordination/planDashboardCreation.ts
@@ -39,9 +39,11 @@ const paramsSchema = {
     .array(
       z.object({
         name: z.string().describe('Worksheet name.'),
-        type: z.enum(['kpi', 'chart']).describe('Worksheet type.'),
+        type: z
+          .enum(['kpi', 'chart'])
+          .describe("Worksheet type: 'kpi' or 'chart' for viz worksheets."),
         template: z.string().optional().describe('Optional template name.'),
-        fields: z.array(z.string()).describe('Visualization field names.'),
+        fields: z.array(z.string()).describe('Viz field names.'),
       }),
     )
     .describe('List of worksheets to create.'),
@@ -61,8 +63,8 @@ export const getPlanDashboardCreationTool = (
     name: 'plan-dashboard-creation',
     title: toolTitle,
     description: [
-      'Plan a dashboard build: Phase 1 caches sheets; Phase 2 builds/applies worksheets and dashboard in parallel.',
-      'Blocks planning if any field is ambiguous across datasources — caller must resolve ambiguity first. Details: expertise://tableau/strategy/dashboard-design/layout-patterns.',
+      'Plan a dashboard build: Phase 1 caches sheets; Phase 2 builds/applies sheets and dashboard in parallel.',
+      'Blocks ambiguous fields; resolve them first. Details: expertise://tableau/strategy/dashboard-design/layout-patterns.',
     ].join(' '),
     paramsSchema,
     annotations: {
@@ -228,7 +230,7 @@ export const getPlanDashboardCreationTool = (
             },
             phase1Prework: {
               description:
-                'Batch create all sheets + dashboard and cache empty XMLs (single tool call)',
+                'Batch create all sheets + dashboard and cache empty working copies (single tool call)',
               tool: 'batch-create-and-cache-sheets',
               params: {
                 worksheetNames: worksheets.map((ws) => ws.name),
@@ -268,7 +270,7 @@ export const getPlanDashboardCreationTool = (
           if (canParallelize) {
             lines.push(
               `Spawn ${allTasks.length} subagents in parallel (${worksheetTasks.length} worksheets + 1 dashboard).`,
-              'Each subagent: reads cached file, builds XML, applies immediately.',
+              'Each subagent: reads cached file, builds the worksheet or dashboard, applies immediately.',
               'Tool: build-and-apply-worksheet (worksheets), build-and-apply-dashboard (dashboard)',
             );
           } else {

--- a/src/tools/desktop/dashboard/applyDashboard.test.ts
+++ b/src/tools/desktop/dashboard/applyDashboard.test.ts
@@ -29,7 +29,7 @@ describe('applyDashboardTool', () => {
   it('should create a tool instance with correct properties', () => {
     const tool = getApplyDashboardTool(new DesktopMcpServer());
     expect(tool.name).toBe('apply-dashboard');
-    expect(tool.description).toContain('Apply modified dashboard XML to Tableau');
+    expect(tool.description).toContain('Apply modified dashboard layout to Tableau');
     expect(tool.paramsSchema).toMatchObject({
       session: expect.any(Object),
       dashboardName: expect.any(Object),
@@ -52,7 +52,7 @@ describe('applyDashboardTool', () => {
     expect(result.isError).toBe(false);
     invariant(result.content[0].type === 'text');
     const resultObj = resultSchema.parse(JSON.parse(result.content[0].text));
-    expect(resultObj.message).toContain('Successfully applied dashboard XML');
+    expect(resultObj.message).toContain('Successfully applied dashboard update');
   });
 
   it('should successfully apply dashboard XML in file mode', async () => {
@@ -68,7 +68,7 @@ describe('applyDashboardTool', () => {
     expect(result.isError).toBe(false);
     invariant(result.content[0].type === 'text');
     const resultObj = resultSchema.parse(JSON.parse(result.content[0].text));
-    expect(resultObj.message).toContain('Successfully applied dashboard XML');
+    expect(resultObj.message).toContain('Successfully applied dashboard update');
     expect(existsSync).toHaveBeenCalledWith(mockFilePath);
     expect(readFileSync).toHaveBeenCalledWith(mockFilePath, 'utf-8');
   });
@@ -79,7 +79,7 @@ describe('applyDashboardTool', () => {
     expect(result.isError).toBe(true);
     invariant(result.content[0].type === 'text');
     expect(result.content[0].text).toBe(
-      new ArgsValidationError('When mode=inline, a non-empty dashboard XML string is required.')
+      new ArgsValidationError('When mode=inline, non-empty dashboard layout content is required.')
         .message,
     );
   });
@@ -144,7 +144,7 @@ describe('applyDashboardTool', () => {
     expect(result.isError).toBe(false);
     invariant(result.content[0].type === 'text');
     const message = JSON.parse(result.content[0].text).message as string;
-    expect(message).toContain('Successfully applied dashboard XML');
+    expect(message).toContain('Successfully applied dashboard update');
     expect(message).toContain('inline cap');
     expect(message).toContain('mode=file');
   });

--- a/src/tools/desktop/dashboard/applyDashboard.ts
+++ b/src/tools/desktop/dashboard/applyDashboard.ts
@@ -29,7 +29,7 @@ const paramsSchema = {
     .default('file')
     .describe('file reads dashboardFile; inline uses dashboardXml.'),
   dashboardFile: z.string().optional().describe('Modified dashboard cache file for mode=file.'),
-  dashboardXml: z.string().optional().describe('Dashboard XML for mode=inline.'),
+  dashboardXml: z.string().optional().describe('Dashboard layout content for mode=inline.'),
 };
 
 const title = 'Apply Dashboard';
@@ -41,7 +41,7 @@ export const getApplyDashboardTool = (
     name: 'apply-dashboard',
     title,
     description: [
-      'Apply modified dashboard XML to Tableau (mutating). mode=file is default; mode=inline is for small XML.',
+      'Apply modified dashboard layout to Tableau (mutating). mode=file is default; mode=inline is for small dashboards.',
       'IMPORTANT: can only UPDATE an existing dashboard, not create one — use apply-workbook to create.',
       'See expertise://tableau/tactics/dashboard/zones for zone structure.',
     ].join(' '),
@@ -65,7 +65,7 @@ export const getApplyDashboardTool = (
             case 'inline': {
               if (!dashboardXml?.trim()) {
                 return new ArgsValidationError(
-                  'When mode=inline, a non-empty dashboard XML string is required.',
+                  'When mode=inline, non-empty dashboard layout content is required.',
                 ).toErr();
               }
               break;
@@ -75,7 +75,7 @@ export const getApplyDashboardTool = (
                 return new ArgsValidationError(
                   [
                     'When mode=file, a non-empty dashboard file path is required.',
-                    'The path can be determined using get-dashboard-xml.',
+                    'The path can be determined using the dashboard layout retrieval tool.',
                   ].join(' '),
                 ).toErr();
               }
@@ -84,7 +84,7 @@ export const getApplyDashboardTool = (
                 return new WorkbookNotFoundError(
                   [
                     `Cached dashboard file not found: ${dashboardFile}`,
-                    'Provide a path determined by get-dashboard-xml.',
+                    'Provide a path determined by the dashboard layout retrieval tool.',
                   ].join(' '),
                 ).toErr();
               }
@@ -132,7 +132,7 @@ export const getApplyDashboardTool = (
               : '';
 
           return new Ok({
-            message: `Successfully applied dashboard XML for "${dashboardName}". The dashboard has been updated.${note}`,
+            message: `Successfully applied dashboard update for "${dashboardName}". The dashboard has been updated.${note}`,
           });
         },
       });

--- a/src/tools/desktop/dashboard/applyDashboardWithViewpoints.ts
+++ b/src/tools/desktop/dashboard/applyDashboardWithViewpoints.ts
@@ -22,7 +22,7 @@ import { DesktopTool } from '../tool.js';
 const paramsSchema = {
   session: z.string().optional().describe('Session ID; optional if pinned or unique.'),
   dashboardName: z.string().describe('Name of the dashboard.'),
-  dashboardFile: z.string().describe('Cached dashboard XML file to apply.'),
+  dashboardFile: z.string().describe('Cached dashboard layout file to apply.'),
   worksheetNames: z.array(z.string()).describe('Worksheet viewpoints to register.'),
 };
 
@@ -35,7 +35,7 @@ export const getApplyDashboardWithViewpointsTool = (
     name: 'apply-dashboard-with-viewpoints',
     title,
     description: [
-      'Apply dashboard XML and register worksheet viewpoints (mutating).',
+      'Apply dashboard layout and register worksheet viewpoints (mutating).',
       'Use after all worksheet files have been applied.',
     ].join(' '),
     paramsSchema,

--- a/src/tools/desktop/dashboard/buildAndApplyDashboard.ts
+++ b/src/tools/desktop/dashboard/buildAndApplyDashboard.ts
@@ -21,10 +21,10 @@ import { buildDashboardXml, computeZones, layoutSpecSchema } from './dashboardZo
 const paramsSchema = {
   session: z.string().optional().describe('Session ID; optional if pinned or unique.'),
   dashboardName: z.string().describe('Name of the dashboard to build and apply.'),
-  dashboardFile: z.string().describe('Cached dashboard XML file.'),
-  workbookFile: z.string().describe('Cached workbook XML file.'),
+  dashboardFile: z.string().describe('Cached dashboard layout file.'),
+  workbookFile: z.string().describe('Cached workbook file.'),
   title: z.string().optional().describe('Optional dashboard title.'),
-  layoutSpec: layoutSpecSchema.describe('KPI/chart layout specification.'),
+  layoutSpec: layoutSpecSchema.describe('KPI/viz layout specification.'),
   worksheetNames: z.array(z.string()).describe('Worksheet viewpoints to register.'),
 };
 
@@ -37,7 +37,7 @@ export const getBuildAndApplyDashboardTool = (
     name: 'build-and-apply-dashboard',
     title,
     description: [
-      'Build dashboard layout XML from a layout spec and APPLY it to the live workbook; registers viewpoints. Use with worksheet builders.',
+      'Build dashboard layout from a layout spec and APPLY it to the live workbook; registers viewpoints. Use with worksheet builders.',
       'Details: expertise://tableau/tactics/dashboard/zones.',
     ].join(' '),
     paramsSchema,

--- a/src/tools/desktop/dashboard/dashboardAutoApply.test.ts
+++ b/src/tools/desktop/dashboard/dashboardAutoApply.test.ts
@@ -422,7 +422,7 @@ describe('dashboardAutoApplyTool all-or-nothing gate matrix', () => {
         'One or more asks did not deterministically bind (Call-1, no-LLM). Nothing was applied to ' +
         'the live workbook. Each ask carries its own bind-template-shaped outcome below: for ' +
         '"propose", fill its output_schema and call bind-template again; for "escalate", follow its ' +
-        'guidance. Once every ask binds, retry dashboard-auto-apply, or fall back to the per-chart ' +
+        'guidance. Once every ask binds, retry dashboard-auto-apply, or fall back to the per-viz ' +
         'bind-template(auto_apply:true) flow using each already-bound ask.',
     };
     expect(result.content[0].text).toBe(JSON.stringify(expectedBody));

--- a/src/tools/desktop/dashboard/dashboardAutoApply.ts
+++ b/src/tools/desktop/dashboard/dashboardAutoApply.ts
@@ -463,7 +463,7 @@ export const getDashboardAutoApplyTool = (
                 'was applied — fall back to the per-viz bind-template(auto_apply:true) flow using each ' +
                 "ask's bound args.",
               describeApplyError(applyResult.error),
-              prefillNextAction('Fall back to per-chart auto-apply'),
+              prefillNextAction('Fall back to per-viz auto-apply'),
             );
           }
           const applyMs = Date.now() - applyStart;

--- a/src/tools/desktop/dashboard/dashboardAutoApply.ts
+++ b/src/tools/desktop/dashboard/dashboardAutoApply.ts
@@ -56,7 +56,7 @@ const MIN_ASKS = 2;
 const MAX_ASKS = 6;
 
 const askSchema = z.object({
-  ask: z.string().min(1).describe('Natural-language chart request.'),
+  ask: z.string().min(1).describe('Natural-language viz request.'),
   title: z.string().min(1).max(80).optional().describe('Optional sheet title override.'),
 });
 
@@ -79,7 +79,7 @@ const paramsSchema = {
     .min(MIN_ASKS)
     .max(MAX_ASKS)
     .describe(
-      `2-${MAX_ASKS} chart asks; every ask must bind deterministically or the whole batch is refused.`,
+      `2-${MAX_ASKS} viz asks; every ask must bind deterministically or the whole batch is refused.`,
     ),
   dashboardName: z.string().min(1).describe('Name of the dashboard to build and apply.'),
   title: z.string().optional().describe('Optional dashboard title text.'),
@@ -135,7 +135,7 @@ function describeApplyError(
     if (inner.type === 'load-rejected') {
       return `Tableau rejected the load: ${inner.message}`;
     }
-    return 'invalid workbook XML';
+    return 'invalid workbook content';
   }
   return `workbook load command failed: ${JSON.stringify(error.error)}`;
 }
@@ -163,7 +163,7 @@ function isReferencedByDashboardZone(workbookXml: string, title: string): boolea
   return new RegExp(`<zone [^>]*name=['"]${nameAttr}['"]`).test(workbookXml);
 }
 
-const title = 'Build a Dashboard From N Asks in One Call (Fast Path)';
+const title = 'Build Dashboard From Viz Asks (Fast Path)';
 
 export const getDashboardAutoApplyTool = (
   server: DesktopMcpServer,
@@ -173,7 +173,7 @@ export const getDashboardAutoApplyTool = (
     name: 'dashboard-auto-apply',
     title,
     description: [
-      'Bind 2-6 chart asks to checked-in templates and APPLY one new/replaced dashboard in one call.',
+      'Bind 2-6 viz asks to templates and APPLY one new/replaced dashboard in one call.',
       'Every ask must bind deterministically; otherwise NOTHING is applied and each outcome is returned.',
       'All-or-nothing: duplicate/zone-used titles, user edits, or preflight failures refuse the WHOLE batch. Details: expertise://tableau/tactics/dashboard/zones.',
     ].join(' '),
@@ -249,7 +249,7 @@ export const getDashboardAutoApplyTool = (
               'One or more asks did not deterministically bind (Call-1, no-LLM). Nothing was applied to ' +
                 'the live workbook. Each ask carries its own bind-template-shaped outcome below: for ' +
                 '"propose", fill its output_schema and call bind-template again; for "escalate", follow its ' +
-                'guidance. Once every ask binds, retry dashboard-auto-apply, or fall back to the per-chart ' +
+                'guidance. Once every ask binds, retry dashboard-auto-apply, or fall back to the per-viz ' +
                 'bind-template(auto_apply:true) flow using each already-bound ask.',
             );
           }
@@ -268,7 +268,7 @@ export const getDashboardAutoApplyTool = (
             return refusal(
               outcomes,
               'One or more bound asks are not eligible for server-side auto-apply (used_llm or ' +
-                'fast_path_eligible gate failed). Nothing was applied. Fall back to the per-chart flow.',
+                'fast_path_eligible gate failed). Nothing was applied. Fall back to the per-viz flow.',
             );
           }
 
@@ -438,7 +438,7 @@ export const getDashboardAutoApplyTool = (
             return refusal(
               outcomes,
               `Server-side auto-apply did not complete (${describeApplyError(applyResult.error)}). Nothing ` +
-                'was applied — fall back to the per-chart bind-template(auto_apply:true) flow using each ' +
+                'was applied — fall back to the per-viz bind-template(auto_apply:true) flow using each ' +
                 "ask's bound args.",
               describeApplyError(applyResult.error),
             );

--- a/src/tools/desktop/dashboard/dashboardZones.ts
+++ b/src/tools/desktop/dashboard/dashboardZones.ts
@@ -16,7 +16,7 @@ export const customZoneSchema = z.object({
 
 export const layoutSpecSchema = z.object({
   kpis: z.array(z.string()).describe('KPI worksheet names'),
-  charts: z.array(z.string()).describe('Chart worksheet names'),
+  charts: z.array(z.string()).describe('Viz worksheet names'),
   layoutType: z.enum(['auto-grid', 'rows', 'columns', 'custom']).optional().default('auto-grid'),
   gridColumns: z.number().optional().describe('Auto-grid column count'),
   kpiStripHeight: z.number().optional().describe('KPI strip height percent'),

--- a/src/tools/desktop/dashboard/getDashboardGuide.ts
+++ b/src/tools/desktop/dashboard/getDashboardGuide.ts
@@ -8,7 +8,7 @@ import { DesktopTool } from '../tool.js';
 
 const paramsSchema = {};
 
-const toolTitle = 'Get Dashboard XML Guide';
+const toolTitle = 'Get Dashboard Layout Editing Guide';
 export const getGetDashboardGuideTool = (
   server: DesktopMcpServer,
 ): DesktopTool<typeof paramsSchema> => {
@@ -17,7 +17,7 @@ export const getGetDashboardGuideTool = (
     name: 'get-dashboard-guide',
     title: toolTitle,
     description:
-      'Get comprehensive documentation on how to manually edit dashboard XML: zones, layouts, viewpoints, sizing, and best practices. Use this before hand-editing dashboard XML.',
+      'Get comprehensive documentation on how to manually edit dashboard layouts: zones, viewpoints, sizing, and best practices. Use this before hand-editing dashboard layouts.',
     paramsSchema,
     annotations: {
       title: toolTitle,
@@ -31,7 +31,7 @@ export const getGetDashboardGuideTool = (
         callback: async () => {
           const guide = readResourceAsset('dashboard-xml-guide.md');
           if (guide === null) {
-            return new FileNotFoundError('dashboard-xml-guide.md').toErr();
+            return new FileNotFoundError('dashboard layout guide').toErr();
           }
           return new Ok(guide);
         },

--- a/src/tools/desktop/dashboard/getDashboardXml.test.ts
+++ b/src/tools/desktop/dashboard/getDashboardXml.test.ts
@@ -37,14 +37,14 @@ describe('getDashboardXmlTool', () => {
   it('should create a tool instance with correct properties', () => {
     const tool = getGetDashboardXmlTool(new DesktopMcpServer());
     expect(tool.name).toBe('get-dashboard-xml');
-    expect(tool.description).toContain('Get XML for an existing dashboard');
+    expect(tool.description).toContain('Get layout for an existing dashboard');
     expect(tool.paramsSchema).toMatchObject({
       session: expect.any(Object),
       dashboardName: expect.any(Object),
       mode: expect.any(Object),
     });
     expect(tool.annotations).toMatchObject({
-      title: 'Get Dashboard XML',
+      title: 'Get Dashboard Layout',
       readOnlyHint: false,
       openWorldHint: false,
     });
@@ -159,7 +159,7 @@ describe('getDashboardXmlTool', () => {
     const resultObj = fileResultSchema.parse(parsed);
     expect(resultObj.message).toContain('inline cap');
     expect(resultObj.message).toContain('Sales Dashboard');
-    expect(resultObj.instructions).toContain('read-cached-xml');
+    expect(resultObj.instructions).toContain('cache read tool');
   });
 
   it('logs a cap-hit receipt when the cap fires', async () => {

--- a/src/tools/desktop/dashboard/getDashboardXml.ts
+++ b/src/tools/desktop/dashboard/getDashboardXml.ts
@@ -29,14 +29,14 @@ const paramsSchema = {
     .enum(['file', 'inline'])
     .optional()
     .default('file')
-    .describe('file writes cache path; inline returns XML.'),
+    .describe('file writes cache path; inline returns dashboard layout content.'),
 };
 
 type InlineResult = { dashboardXml: string };
 type FileResult = { file: string; instructions: string };
 type GetDashboardXmlToolResult = { message: string } & (InlineResult | FileResult);
 
-const title = 'Get Dashboard XML';
+const title = 'Get Dashboard Layout';
 export const getGetDashboardXmlTool = (
   server: DesktopMcpServer,
 ): DesktopTool<typeof paramsSchema> => {
@@ -45,7 +45,7 @@ export const getGetDashboardXmlTool = (
     name: 'get-dashboard-xml',
     title,
     description: [
-      'Get XML for an existing dashboard. mode=file is default; mode=inline returns XML.',
+      'Get layout for an existing dashboard. mode=file is default; mode=inline returns dashboard layout content.',
       'IMPORTANT: only works for an existing dashboard (see list-dashboards); to create one use apply-workbook. Use apply-dashboard to apply changes.',
     ].join(' '),
     paramsSchema,
@@ -90,7 +90,7 @@ export const getGetDashboardXmlTool = (
 
           if (mode === 'inline' && !capFired) {
             return new Ok({
-              message: `Dashboard XML returned inline (${bytes} bytes)`,
+              message: `Dashboard layout returned inline (${bytes} bytes)`,
               dashboardXml,
             });
           }
@@ -113,14 +113,14 @@ export const getGetDashboardXmlTool = (
               }),
               file: cacheFile,
               instructions:
-                'This dashboard exceeds the inline cap. Use read-cached-xml (with a dashboard ' +
-                'selector or startByte/endByte to read a slice), write-cached-xml (same selector to ' +
+                'This dashboard exceeds the inline cap. Use the cache read tool (with a dashboard ' +
+                'selector or startByte/endByte to read a slice), the cache write tool (same selector to ' +
                 'splice edits back), then apply-dashboard with mode=file. Do not request mode=inline.',
             });
           }
 
           log({
-            message: `Saved dashboard XML to cache file: ${cacheFile}`,
+            message: `Saved dashboard layout to cache file: ${cacheFile}`,
             level: 'info',
             logger: 'tool',
             data: { file: cacheFile, size: bytes },
@@ -130,7 +130,7 @@ export const getGetDashboardXmlTool = (
             message: `Dashboard "${dashboardName}" saved to cache file (${bytes} bytes)\n\nArtifact summary:\n${formatArtifactSummary('dashboard', dashboardXml)}`,
             file: cacheFile,
             instructions:
-              'Use this file path with apply-dashboard instead of passing XML directly.',
+              'Use this file path with apply-dashboard instead of passing content directly.',
           });
         },
       });

--- a/src/tools/desktop/fields/addField.test.ts
+++ b/src/tools/desktop/fields/addField.test.ts
@@ -39,7 +39,7 @@ describe('addFieldTool', () => {
   it('should create a tool instance with correct properties', () => {
     const tool = getAddFieldTool(new DesktopMcpServer());
     expect(tool.name).toBe('add-field');
-    expect(tool.description).toContain('rows shelf, columns shelf, or an encoding');
+    expect(tool.description).toContain('Rows, Columns, or an encoding');
     expect(tool.paramsSchema).toMatchObject({
       worksheetFile: expect.any(Object),
       target: expect.any(Object),
@@ -117,7 +117,7 @@ describe('addFieldTool', () => {
     expect(result.isError).toBe(false);
     invariant(result.content[0].type === 'text');
     const body = resultSchema.parse(JSON.parse(result.content[0].text));
-    expect(body.message).toContain('rows shelf');
+    expect(body.message).toContain('Rows shelf');
     expect(body.file).toBe(WORKSHEET_FILE);
     expect(writeFileSync).toHaveBeenCalledWith(WORKSHEET_FILE, MODIFIED_XML, 'utf-8');
   });
@@ -180,7 +180,7 @@ describe('addFieldTool', () => {
     expect(result.isError).toBe(false);
     invariant(result.content[0].type === 'text');
     const body = resultSchema.parse(JSON.parse(result.content[0].text));
-    expect(body.message).toContain('columns shelf');
+    expect(body.message).toContain('Columns shelf');
     expect(body.file).toBe(WORKSHEET_FILE);
     expect(writeFileSync).toHaveBeenCalledWith(WORKSHEET_FILE, MODIFIED_XML, 'utf-8');
   });
@@ -351,7 +351,7 @@ describe('addFieldTool', () => {
 
     expect(result.isError).toBe(false);
     invariant(result.content[0].type === 'text');
-    expect(resultSchema.parse(JSON.parse(result.content[0].text)).message).toContain('rows shelf');
+    expect(resultSchema.parse(JSON.parse(result.content[0].text)).message).toContain('Rows shelf');
     expect(metadataModule.addFieldToRows).toHaveBeenCalledWith(
       '<worksheet/>',
       COLUMN_REF,

--- a/src/tools/desktop/fields/addField.ts
+++ b/src/tools/desktop/fields/addField.ts
@@ -34,8 +34,8 @@ const ENCODING_TYPES = [
 const FIELD_TARGETS = ['rows', 'cols', 'encoding'] as const;
 
 const paramsSchema = {
-  worksheetFile: z.string().describe('Worksheet XML cache file.'),
-  target: z.enum(FIELD_TARGETS).describe('Destination: rows, cols, or encoding.'),
+  worksheetFile: z.string().describe('Worksheet cache file.'),
+  target: z.enum(FIELD_TARGETS).describe('Destination: rows=Rows, cols=Columns, or encoding.'),
   columnRef: z.string().describe('Column reference.'),
   encodingType: z
     .enum(ENCODING_TYPES)
@@ -52,7 +52,7 @@ export const getAddFieldTool = (server: DesktopMcpServer): DesktopTool<typeof pa
     name: 'add-field',
     title,
     description:
-      'Add a field to the rows shelf, columns shelf, or an encoding (mutates cache; adds missing datasource dependency). Apply with apply-worksheet.',
+      'Add a field to Rows, Columns, or an encoding (mutates cache; adds missing datasource dependency). Apply with apply-worksheet.',
     paramsSchema,
     annotations: {
       title,
@@ -103,11 +103,11 @@ export const getAddFieldTool = (server: DesktopMcpServer): DesktopTool<typeof pa
             switch (target) {
               case 'rows':
                 modifiedXml = addFieldToRows(worksheetXml, columnRef, index, workbookXml);
-                placement = 'rows shelf';
+                placement = 'Rows shelf';
                 break;
               case 'cols':
                 modifiedXml = addFieldToCols(worksheetXml, columnRef, index, workbookXml);
-                placement = 'columns shelf';
+                placement = 'Columns shelf';
                 break;
               case 'encoding':
                 modifiedXml = addFieldToEncoding(

--- a/src/tools/desktop/fields/listAvailableFields.test.ts
+++ b/src/tools/desktop/fields/listAvailableFields.test.ts
@@ -98,6 +98,8 @@ describe('listAvailableFieldsTool', () => {
     expect(body.message).toContain('Found 2 fields in "Sample - Superstore"');
     expect(body.message).toContain('DIMENSIONS');
     expect(body.message).toContain('MEASURES');
+    expect(body.message).toContain('Text');
+    expect(body.message).toContain('Number (decimal)');
     expect(body.fields).toHaveLength(2);
   });
 

--- a/src/tools/desktop/fields/listAvailableFields.ts
+++ b/src/tools/desktop/fields/listAvailableFields.ts
@@ -21,6 +21,25 @@ const typeAbbrev = (type: string): string => {
   return type;
 };
 
+const tableauDatatypeLabel = (datatype?: string): string => {
+  switch (datatype) {
+    case 'integer':
+      return 'Number (whole)';
+    case 'real':
+      return 'Number (decimal)';
+    case 'date':
+      return 'Date';
+    case 'datetime':
+      return 'Date & Time';
+    case 'string':
+      return 'Text';
+    case 'boolean':
+      return 'True/False';
+    default:
+      return datatype || 'unknown';
+  }
+};
+
 const title = 'List All Available Fields in Workbook Datasources';
 export const getListAvailableFieldsTool = (
   server: DesktopMcpServer,
@@ -31,7 +50,7 @@ export const getListAvailableFieldsTool = (
     title,
     description: [
       'List ALL fields available in workbook datasources.',
-      'Returns exact column_ref inputs for field tools. Call before adding rows/cols/encodings.',
+      'Returns exact column_ref inputs for field tools. Call before adding fields to Rows, Columns, or encodings.',
       'Reads the workbook cache file, NOT a worksheet file.',
     ].join(' '),
     paramsSchema,
@@ -79,7 +98,7 @@ export const getListAvailableFieldsTool = (
               const displayName = field.caption || field.columnName.replace(/^\[|\]$/g, '');
               const cleanName = field.columnName.replace(/^\[|\]$/g, '');
               const localNameDisplay = displayName === cleanName ? '(same)' : cleanName;
-              const typeInfo = `${typeAbbrev(field.type)} (${field.datatype || 'unknown'})`;
+              const typeInfo = `${typeAbbrev(field.type)} (${tableauDatatypeLabel(field.datatype)})`;
               const aggregated = field.isAggregated ? ' [AGG]' : '';
               output +=
                 pad(displayName, 30) +
@@ -101,7 +120,7 @@ export const getListAvailableFieldsTool = (
               const displayName = field.caption || field.columnName.replace(/^\[|\]$/g, '');
               const cleanName = field.columnName.replace(/^\[|\]$/g, '');
               const localNameDisplay = displayName === cleanName ? '(same)' : cleanName;
-              const typeInfo = `${typeAbbrev(field.type)} (${field.datatype || 'unknown'})`;
+              const typeInfo = `${typeAbbrev(field.type)} (${tableauDatatypeLabel(field.datatype)})`;
               const aggregated = field.isAggregated ? ' [AGG]' : '';
               output +=
                 pad(displayName, 30) +

--- a/src/tools/desktop/fields/listFields.test.ts
+++ b/src/tools/desktop/fields/listFields.test.ts
@@ -88,7 +88,7 @@ describe('listFieldsTool', () => {
     invariant(result.content[0].type === 'text');
     const body = resultSchema.parse(JSON.parse(result.content[0].text));
     expect(body.message).toContain('Found 2 field(s)');
-    expect(body.message).toContain('rows:');
+    expect(body.message).toContain('Rows:');
     expect(body.message).toContain('encodings:color:');
     expect(body.fields).toHaveLength(2);
   });

--- a/src/tools/desktop/fields/listFields.ts
+++ b/src/tools/desktop/fields/listFields.ts
@@ -23,7 +23,7 @@ export const getListFieldsTool = (server: DesktopMcpServer): DesktopTool<typeof 
     name: 'list-fields',
     title,
     description: [
-      'List fields already placed on a worksheet: encodings, rows, cols, positions, column refs.',
+      'List fields already placed on a worksheet: encodings, Rows, Columns, positions, column refs.',
       'For available fields use list-available-fields with the workbook file. Use exact column_ref for removals.',
     ].join(' '),
     paramsSchema,
@@ -73,7 +73,9 @@ export const getListFieldsTool = (server: DesktopMcpServer): DesktopTool<typeof 
 
           const lines: string[] = [`Found ${fields.length} field(s):\n`];
           for (const [location, locationFields] of Object.entries(byLocation)) {
-            lines.push(`\n${location}:`);
+            const displayLocation =
+              location === 'rows' ? 'Rows' : location === 'cols' ? 'Columns' : location;
+            lines.push(`\n${displayLocation}:`);
             for (const field of locationFields) {
               lines.push(`  [${field.index}] ${field.column}`);
             }

--- a/src/tools/desktop/fields/removeField.test.ts
+++ b/src/tools/desktop/fields/removeField.test.ts
@@ -38,7 +38,7 @@ describe('removeFieldTool', () => {
   it('should create a tool instance with correct properties', () => {
     const tool = getRemoveFieldTool(new DesktopMcpServer());
     expect(tool.name).toBe('remove-field');
-    expect(tool.description).toContain('rows shelf, columns shelf, or an encoding');
+    expect(tool.description).toContain('Rows shelf, Columns shelf, or an encoding');
     expect(tool.paramsSchema).toMatchObject({
       worksheetFile: expect.any(Object),
       target: expect.any(Object),
@@ -116,7 +116,7 @@ describe('removeFieldTool', () => {
     expect(result.isError).toBe(false);
     invariant(result.content[0].type === 'text');
     const body = resultSchema.parse(JSON.parse(result.content[0].text));
-    expect(body.message).toContain('rows shelf');
+    expect(body.message).toContain('Rows shelf');
     expect(body.file).toBe(WORKSHEET_FILE);
     expect(writeFileSync).toHaveBeenCalledWith(WORKSHEET_FILE, MODIFIED_XML, 'utf-8');
     expect(metadataModule.removeFieldFromRows).toHaveBeenCalledWith('<worksheet/>', COLUMN_REF);
@@ -158,7 +158,7 @@ describe('removeFieldTool', () => {
     expect(result.isError).toBe(false);
     invariant(result.content[0].type === 'text');
     const body = resultSchema.parse(JSON.parse(result.content[0].text));
-    expect(body.message).toContain('columns shelf');
+    expect(body.message).toContain('Columns shelf');
     expect(body.file).toBe(WORKSHEET_FILE);
     expect(writeFileSync).toHaveBeenCalledWith(WORKSHEET_FILE, MODIFIED_XML, 'utf-8');
     expect(metadataModule.removeFieldFromCols).toHaveBeenCalledWith('<worksheet/>', COLUMN_REF);

--- a/src/tools/desktop/fields/removeField.ts
+++ b/src/tools/desktop/fields/removeField.ts
@@ -34,8 +34,10 @@ const ENCODING_TYPES = [
 const FIELD_TARGETS = ['rows', 'cols', 'encoding'] as const;
 
 const paramsSchema = {
-  worksheetFile: z.string().describe('Worksheet XML cache file (from get-worksheet-xml).'),
-  target: z.enum(FIELD_TARGETS).describe("Source: 'rows' shelf, 'cols' shelf, or 'encoding'."),
+  worksheetFile: z.string().describe('Worksheet cache file.'),
+  target: z
+    .enum(FIELD_TARGETS)
+    .describe("Source: 'rows' for Rows, 'cols' for Columns, or 'encoding'."),
   columnRef: z.string().describe('Column reference to remove.'),
   encodingType: z
     .enum(ENCODING_TYPES)
@@ -50,7 +52,7 @@ export const getRemoveFieldTool = (server: DesktopMcpServer): DesktopTool<typeof
     name: 'remove-field',
     title,
     description:
-      'Remove a field from the rows shelf, columns shelf, or an encoding on a worksheet XML locally. Reads from and writes to cache file. Use apply-worksheet to apply changes.',
+      'Remove a field from the Rows shelf, Columns shelf, or an encoding on a worksheet locally. Reads from and writes to cache file. Use apply-worksheet to apply changes.',
     paramsSchema,
     annotations: {
       title,
@@ -92,11 +94,11 @@ export const getRemoveFieldTool = (server: DesktopMcpServer): DesktopTool<typeof
             switch (target) {
               case 'rows':
                 modifiedXml = removeFieldFromRows(worksheetXml, columnRef);
-                placement = 'rows shelf';
+                placement = 'Rows shelf';
                 break;
               case 'cols':
                 modifiedXml = removeFieldFromCols(worksheetXml, columnRef);
-                placement = 'columns shelf';
+                placement = 'Columns shelf';
                 break;
               case 'encoding':
                 modifiedXml = removeFieldFromEncoding(worksheetXml, encodingType!, columnRef);

--- a/src/tools/desktop/health/dashboardHealthCheck.ts
+++ b/src/tools/desktop/health/dashboardHealthCheck.ts
@@ -106,7 +106,7 @@ export interface DashboardHealthReport {
 }
 
 const D9_REASON =
-  'Live render/visual breakage is not detectable from workbook XML alone; the Desktop Agent ' +
+  'Live render/visual breakage is not detectable from workbook structure alone; the Desktop Agent ' +
   'API exposes no render-diagnostics or screenshot-diff surface today.';
 
 function makeUndetectable(): DashboardHealthReport['undetectable'] {
@@ -396,7 +396,7 @@ export const getDashboardHealthCheckTool = (
     description: [
       'READ-ONLY drift detector for a previously-bound dashboard.',
       'Flags renamed/deleted sheets, changed fields, orphan zones, and datasource changes.',
-      'Flag-only: never repairs. D9 live render breakage is undetectable from XML and disclosed in reports. Details: expertise://tableau/tactics/workflow/recovery.',
+      'Flag-only: never repairs. D9 live render breakage is not structure-detectable and is disclosed. Details: expertise://tableau/tactics/workflow/recovery.',
     ].join(' '),
     paramsSchema,
     annotations: {

--- a/src/tools/desktop/search/searchExamples.ts
+++ b/src/tools/desktop/search/searchExamples.ts
@@ -40,7 +40,7 @@ export const getSearchExamplesTool = (
     name: 'search-examples',
     title,
     description:
-      'Search before/after workbook-change examples. Returns worksheet, dashboard, or workbook XML diffs; prefer focused diffs when available.',
+      'Search before/after workbook-change examples. Returns worksheet, dashboard, or workbook diffs; prefer focused diffs when available.',
     paramsSchema,
     annotations: {
       title,

--- a/src/tools/desktop/search/searchWorkbookExamples.ts
+++ b/src/tools/desktop/search/searchWorkbookExamples.ts
@@ -47,7 +47,7 @@ export const getSearchWorkbookExamplesTool = (
     name: 'search-workbook-examples',
     title,
     description:
-      'Search curated workbook examples and/or the diff corpus. Default source=curated; use diff-corpus or both for XML diffs.',
+      'Search curated workbook examples and/or the diff corpus. Default source=curated; use diff-corpus or both for workbook-change diffs.',
     paramsSchema,
     annotations: {
       title,

--- a/src/tools/desktop/template/injectTemplate.ts
+++ b/src/tools/desktop/template/injectTemplate.ts
@@ -18,7 +18,7 @@ import { DesktopTool } from '../tool.js';
 
 const paramsSchema = {
   workbookFile: z.string().describe('Workbook cache file path.'),
-  templateName: z.string().describe('Template name, without .xml.'),
+  templateName: z.string().describe('Template name.'),
   title: z.string().describe('New sheet name; replaces {{TITLE}}.'),
   sheetType: z.enum(['worksheet', 'dashboard', 'story']).describe('Type of sheet being injected.'),
   templateParameters: z
@@ -42,9 +42,9 @@ export const getInjectTemplateTool = (
     name: 'inject-template',
     title: toolTitle,
     description: [
-      'Inject a worksheet/dashboard/story template into cached workbook XML (mutates the file).',
-      'Use list-xml-templates for names; supports placeholders including {{TITLE}}.',
-      'Workflow: get-workbook-xml (mode=file) → inject-template → apply-workbook.',
+      'Inject a worksheet/dashboard/story template into a cached workbook (mutates file).',
+      'Use template list for names; supports {{TITLE}}.',
+      'Workflow: get workbook structure in file mode → inject-template → apply-workbook.',
     ].join(' '),
     paramsSchema,
     annotations: {
@@ -87,7 +87,7 @@ export const getInjectTemplateTool = (
             const files = listTemplateNames();
             const available = files.length > 0 ? files.join(', ') : 'none';
             return new ArgsValidationError(
-              `Template "${templateName}" not found.\n\nAvailable templates: ${available}\n\nUse list-xml-templates to see all options.`,
+              `Template "${templateName}" not found.\n\nAvailable templates: ${available}\n\nUse the template list tool to see all options.`,
             ).toErr();
           }
 

--- a/src/tools/desktop/workbook/applyWorkbook.test.ts
+++ b/src/tools/desktop/workbook/applyWorkbook.test.ts
@@ -32,7 +32,7 @@ describe('applyWorkbookTool', () => {
   it('should create a tool instance with correct properties', () => {
     const applyWorkbookTool = getApplyWorkbookTool(new DesktopMcpServer());
     expect(applyWorkbookTool.name).toBe('apply-workbook');
-    expect(applyWorkbookTool.description).toContain('Apply modified workbook XML to Tableau');
+    expect(applyWorkbookTool.description).toContain('Apply modified workbook content to Tableau');
     expect(applyWorkbookTool.paramsSchema).toMatchObject({
       session: expect.any(Object),
       mode: expect.any(Object),
@@ -63,7 +63,7 @@ describe('applyWorkbookTool', () => {
     invariant(result.content[0].type === 'text');
 
     const resultObj = resultSchema.parse(JSON.parse(result.content[0].text));
-    expect(resultObj.message).toContain('Successfully applied workbook XML');
+    expect(resultObj.message).toContain('Successfully applied workbook update');
   });
 
   it('should successfully apply workbook XML in file mode', async () => {
@@ -87,7 +87,7 @@ describe('applyWorkbookTool', () => {
     invariant(result.content[0].type === 'text');
 
     const resultObj = resultSchema.parse(JSON.parse(result.content[0].text));
-    expect(resultObj.message).toContain('Successfully applied workbook XML');
+    expect(resultObj.message).toContain('Successfully applied workbook update');
 
     expect(existsSync).toHaveBeenCalledWith(mockFilePath);
     expect(readFileSync).toHaveBeenCalledWith(mockFilePath, 'utf-8');
@@ -126,8 +126,7 @@ describe('applyWorkbookTool', () => {
     expect(result.isError).toBe(true);
     invariant(result.content[0].type === 'text');
     expect(result.content[0].text).toBe(
-      new ArgsValidationError('When mode=inline, a non-empty workbook TWB XML string is required.')
-        .message,
+      new ArgsValidationError('When mode=inline, non-empty workbook content is required.').message,
     );
   });
 
@@ -280,7 +279,7 @@ describe('applyWorkbookTool', () => {
     invariant(result.content[0].type === 'text');
     const resultObj = resultSchema.parse(JSON.parse(result.content[0].text));
     // Still applied (not rejected on size) ...
-    expect(resultObj.message).toContain('Successfully applied workbook XML');
+    expect(resultObj.message).toContain('Successfully applied workbook update');
     // ... but nudged toward file mode for next time.
     expect(resultObj.message).toContain('inline cap');
     expect(resultObj.message).toContain('mode=file');

--- a/src/tools/desktop/workbook/applyWorkbook.ts
+++ b/src/tools/desktop/workbook/applyWorkbook.ts
@@ -28,7 +28,7 @@ const paramsSchema = {
     .default('file')
     .describe('file reads workbookFile; inline uses workbookXml.'),
   workbookFile: z.string().optional().describe('Modified workbook cache file for mode=file.'),
-  workbookXml: z.string().optional().describe('Full workbook XML for mode=inline.'),
+  workbookXml: z.string().optional().describe('Full workbook content for mode=inline.'),
 };
 
 const title = 'Apply Workbook';
@@ -40,8 +40,8 @@ export const getApplyWorkbookTool = (
     name: 'apply-workbook',
     title,
     description: [
-      'Apply modified workbook XML to Tableau (mutating). mode=file is default; mode=inline is for small XML.',
-      'See expertise://tableau/tactics/data/datasources before editing datasource XML.',
+      'Apply modified workbook content to Tableau (mutating). mode=file is default; mode=inline is for small workbooks.',
+      'See expertise://tableau/tactics/data/datasources before editing datasource structure.',
     ].join(' '),
     paramsSchema,
     annotations: {
@@ -63,7 +63,7 @@ export const getApplyWorkbookTool = (
             case 'inline': {
               if (!workbookXml?.trim()) {
                 return new ArgsValidationError(
-                  'When mode=inline, a non-empty workbook TWB XML string is required.',
+                  'When mode=inline, non-empty workbook content is required.',
                 ).toErr();
               }
               break;
@@ -73,7 +73,7 @@ export const getApplyWorkbookTool = (
                 return new ArgsValidationError(
                   [
                     'When mode=file, a non-empty workbook file path is required.',
-                    'The path can be determined using any of the tools that get or modify workbook XML.',
+                    'The path can be determined using any of the tools that get or modify workbook content.',
                   ].join(' '),
                 ).toErr();
               }
@@ -82,7 +82,7 @@ export const getApplyWorkbookTool = (
                 return new WorkbookNotFoundError(
                   [
                     `Cached workbook file not found: ${workbookFile}`,
-                    'Provide a path determined by any of the tools that get or modify workbook XML.',
+                    'Provide a path determined by any of the tools that get or modify workbook content.',
                   ].join(' '),
                 ).toErr();
               }
@@ -131,7 +131,7 @@ export const getApplyWorkbookTool = (
               : '';
 
           return new Ok({
-            message: `Successfully applied workbook XML. The workbook has been updated.${note}`,
+            message: `Successfully applied workbook update. The workbook has been updated.${note}`,
           });
         },
       });

--- a/src/tools/desktop/workbook/getWorkbookXml.test.ts
+++ b/src/tools/desktop/workbook/getWorkbookXml.test.ts
@@ -34,13 +34,13 @@ describe('getWorkbookXmlTool', () => {
   it('should create a tool instance with correct properties', () => {
     const getWorkbookXmlTool = getGetWorkbookXmlTool(new DesktopMcpServer());
     expect(getWorkbookXmlTool.name).toBe('get-workbook-xml');
-    expect(getWorkbookXmlTool.description).toContain('Get current workbook XML');
+    expect(getWorkbookXmlTool.description).toContain('Get current workbook structure');
     expect(getWorkbookXmlTool.paramsSchema).toMatchObject({
       session: expect.any(Object),
       mode: expect.any(Object),
     });
     expect(getWorkbookXmlTool.annotations).toMatchObject({
-      title: 'Get Workbook XML',
+      title: 'Get Workbook Structure',
       readOnlyHint: false,
       openWorldHint: false,
     });
@@ -171,7 +171,7 @@ describe('getWorkbookXmlTool', () => {
     expect(resultObj.message).toContain('inline cap');
     expect(resultObj.message).toContain('Sales');
     expect(resultObj.message).toContain('Superstore');
-    expect(resultObj.instructions).toContain('read-cached-xml');
+    expect(resultObj.instructions).toContain('cache read tool');
   });
 
   it('logs a cap-hit receipt when the cap fires', async () => {

--- a/src/tools/desktop/workbook/getWorkbookXml.ts
+++ b/src/tools/desktop/workbook/getWorkbookXml.ts
@@ -24,7 +24,7 @@ const paramsSchema = {
     .enum(['file', 'inline'])
     .optional()
     .default('file')
-    .describe('file writes cache path; inline returns XML.'),
+    .describe('file writes cache path; inline returns workbook content.'),
 };
 
 type InlineResult = {
@@ -37,7 +37,7 @@ type FileResult = {
 };
 type GetWorkbookXmlToolResult = { message: string } & (InlineResult | FileResult);
 
-const title = 'Get Workbook XML';
+const title = 'Get Workbook Structure';
 export const getGetWorkbookXmlTool = (
   server: DesktopMcpServer,
 ): DesktopTool<typeof paramsSchema> => {
@@ -46,8 +46,8 @@ export const getGetWorkbookXmlTool = (
     name: 'get-workbook-xml',
     title,
     description: [
-      'Get current workbook XML. mode=file is default; mode=inline returns XML.',
-      'PREFERRED: use the field tools (add-field/remove-field) or batch-create-and-cache-sheets instead of editing XML directly; edit XML only as a last resort. Use apply-workbook to apply changes.',
+      'Get current workbook structure. mode=file is default; mode=inline returns workbook content.',
+      'PREFERRED: use the field tools (add-field/remove-field) or batch-create-and-cache-sheets instead of editing workbook content directly; use apply-workbook to apply changes.',
     ].join(' '),
     paramsSchema,
     annotations: {
@@ -83,7 +83,7 @@ export const getGetWorkbookXmlTool = (
 
           if (mode === 'inline' && !capFired) {
             return new Ok({
-              message: `Workbook XML returned inline (${bytes} bytes)`,
+              message: `Workbook content returned inline (${bytes} bytes)`,
               workbookXml,
             });
           }
@@ -104,14 +104,14 @@ export const getGetWorkbookXmlTool = (
               }),
               file: cacheFile,
               instructions:
-                'This workbook exceeds the inline cap. Use read-cached-xml (with a worksheet/dashboard ' +
-                'selector or startByte/endByte to read a slice), write-cached-xml (same selector to ' +
+                'This workbook exceeds the inline cap. Use the cache read tool (with a worksheet/dashboard ' +
+                'selector or startByte/endByte to read a slice), the cache write tool (same selector to ' +
                 'splice edits back), then apply-workbook with mode=file. Do not request mode=inline.',
             });
           }
 
           log({
-            message: `Saved workbook XML to cache file: ${cacheFile}`,
+            message: `Saved workbook content to cache file: ${cacheFile}`,
             level: 'info',
             logger: 'tool',
             data: {
@@ -124,7 +124,7 @@ export const getGetWorkbookXmlTool = (
             message: `Workbook saved to cache file (${bytes} bytes)\n\nArtifact summary:\n${formatArtifactSummary('workbook', workbookXml)}`,
             file: cacheFile,
             instructions:
-              'Use this file path with modification tools instead of passing XML directly.',
+              'Use this file path with modification tools instead of passing content directly.',
           });
         },
       });

--- a/src/tools/desktop/worksheet/applyWorksheet.test.ts
+++ b/src/tools/desktop/worksheet/applyWorksheet.test.ts
@@ -32,7 +32,7 @@ describe('applyWorksheetTool', () => {
   it('should create a tool instance with correct properties', () => {
     const tool = getApplyWorksheetTool(new DesktopMcpServer());
     expect(tool.name).toBe('apply-worksheet');
-    expect(tool.description).toContain('Apply modified worksheet XML to Tableau');
+    expect(tool.description).toContain('Apply modified worksheet content to Tableau');
     expect(tool.paramsSchema).toMatchObject({
       session: expect.any(Object),
       worksheetName: expect.any(Object),
@@ -65,7 +65,7 @@ describe('applyWorksheetTool', () => {
     invariant(result.content[0].type === 'text');
 
     const resultObj = resultSchema.parse(JSON.parse(result.content[0].text));
-    expect(resultObj.message).toContain('Successfully applied worksheet XML');
+    expect(resultObj.message).toContain('Successfully applied worksheet update');
   });
 
   it('should successfully apply worksheet XML in file mode', async () => {
@@ -90,7 +90,7 @@ describe('applyWorksheetTool', () => {
     invariant(result.content[0].type === 'text');
 
     const resultObj = resultSchema.parse(JSON.parse(result.content[0].text));
-    expect(resultObj.message).toContain('Successfully applied worksheet XML');
+    expect(resultObj.message).toContain('Successfully applied worksheet update');
 
     expect(existsSync).toHaveBeenCalledWith(mockFilePath);
     expect(readFileSync).toHaveBeenCalledWith(mockFilePath, 'utf-8');
@@ -109,8 +109,7 @@ describe('applyWorksheetTool', () => {
     expect(result.isError).toBe(true);
     invariant(result.content[0].type === 'text');
     expect(result.content[0].text).toBe(
-      new ArgsValidationError('When mode=inline, a non-empty worksheet XML string is required.')
-        .message,
+      new ArgsValidationError('When mode=inline, non-empty worksheet content is required.').message,
     );
   });
 
@@ -271,7 +270,7 @@ describe('applyWorksheetTool over-cap note', () => {
     expect(result.isError).toBe(false);
     invariant(result.content[0].type === 'text');
     const message = JSON.parse(result.content[0].text).message as string;
-    expect(message).toContain('Successfully applied worksheet XML');
+    expect(message).toContain('Successfully applied worksheet update');
     expect(message).toContain('inline cap');
     expect(message).toContain('mode=file');
   });

--- a/src/tools/desktop/worksheet/applyWorksheet.ts
+++ b/src/tools/desktop/worksheet/applyWorksheet.ts
@@ -29,7 +29,7 @@ const paramsSchema = {
     .default('file')
     .describe('file reads worksheetFile; inline uses worksheetXml.'),
   worksheetFile: z.string().optional().describe('Modified worksheet cache file for mode=file.'),
-  worksheetXml: z.string().optional().describe('Worksheet XML for mode=inline.'),
+  worksheetXml: z.string().optional().describe('Worksheet content for mode=inline.'),
 };
 
 const title = 'Apply Worksheet';
@@ -41,7 +41,7 @@ export const getApplyWorksheetTool = (
     name: 'apply-worksheet',
     title,
     description: [
-      'Apply modified worksheet XML to Tableau (mutating). mode=file is default; mode=inline is for small XML.',
+      'Apply modified worksheet content to Tableau (mutating). mode=file is default; mode=inline is for small worksheets.',
       'IMPORTANT: can only UPDATE an existing worksheet, not create one — use apply-workbook to create.',
     ].join(' '),
     paramsSchema,
@@ -64,7 +64,7 @@ export const getApplyWorksheetTool = (
             case 'inline': {
               if (!worksheetXml?.trim()) {
                 return new ArgsValidationError(
-                  'When mode=inline, a non-empty worksheet XML string is required.',
+                  'When mode=inline, non-empty worksheet content is required.',
                 ).toErr();
               }
               break;
@@ -74,7 +74,7 @@ export const getApplyWorksheetTool = (
                 return new ArgsValidationError(
                   [
                     'When mode=file, a non-empty worksheet file path is required.',
-                    'The path can be determined using get-worksheet-xml.',
+                    'The path can be determined using the worksheet structure retrieval tool.',
                   ].join(' '),
                 ).toErr();
               }
@@ -83,7 +83,7 @@ export const getApplyWorksheetTool = (
                 return new WorksheetNotFoundError(
                   [
                     `Cached worksheet file not found: ${worksheetFile}`,
-                    'Provide a path determined by get-worksheet-xml.',
+                    'Provide a path determined by the worksheet structure retrieval tool.',
                   ].join(' '),
                 ).toErr();
               }
@@ -131,7 +131,7 @@ export const getApplyWorksheetTool = (
               : '';
 
           return new Ok({
-            message: `Successfully applied worksheet XML for "${worksheetName}". The worksheet has been updated.${note}`,
+            message: `Successfully applied worksheet update for "${worksheetName}". The worksheet has been updated.${note}`,
           });
         },
       });

--- a/src/tools/desktop/worksheet/deleteWorksheet.ts
+++ b/src/tools/desktop/worksheet/deleteWorksheet.ts
@@ -211,7 +211,7 @@ export const getDeleteWorksheetTool = (
           const removal = removeWorksheetFromWorkbook(xmlResult.value, worksheetName);
           if (removal.status === 'parse-failed') {
             return new XmlModificationError(
-              `Could not parse the live workbook XML: ${removal.message}`,
+              `Could not parse the live workbook structure: ${removal.message}`,
             ).toErr();
           }
           if (removal.status === 'not-found') {

--- a/src/tools/desktop/worksheet/getWorksheetXml.test.ts
+++ b/src/tools/desktop/worksheet/getWorksheetXml.test.ts
@@ -37,14 +37,14 @@ describe('getWorksheetXmlTool', () => {
   it('should create a tool instance with correct properties', () => {
     const tool = getGetWorksheetXmlTool(new DesktopMcpServer());
     expect(tool.name).toBe('get-worksheet-xml');
-    expect(tool.description).toContain('Get XML for an existing worksheet');
+    expect(tool.description).toContain('Get structure for an existing worksheet');
     expect(tool.paramsSchema).toMatchObject({
       session: expect.any(Object),
       worksheetName: expect.any(Object),
       mode: expect.any(Object),
     });
     expect(tool.annotations).toMatchObject({
-      title: 'Get Worksheet XML',
+      title: 'Get Worksheet Structure',
       readOnlyHint: false,
       openWorldHint: false,
     });
@@ -188,7 +188,7 @@ describe('getWorksheetXmlTool', () => {
     const resultObj = fileResultSchema.parse(parsed);
     expect(resultObj.message).toContain('inline cap');
     expect(resultObj.message).toContain('Sales');
-    expect(resultObj.instructions).toContain('read-cached-xml');
+    expect(resultObj.instructions).toContain('cache read tool');
   });
 
   it('logs a cap-hit receipt when the cap fires', async () => {

--- a/src/tools/desktop/worksheet/getWorksheetXml.ts
+++ b/src/tools/desktop/worksheet/getWorksheetXml.ts
@@ -29,7 +29,7 @@ const paramsSchema = {
     .enum(['file', 'inline'])
     .optional()
     .default('file')
-    .describe('file writes cache path; inline returns XML.'),
+    .describe('file writes cache path; inline returns worksheet content.'),
 };
 
 type InlineResult = {
@@ -43,7 +43,7 @@ type FileResult = {
 
 type GetWorksheetXmlToolResult = { message: string } & (InlineResult | FileResult);
 
-const title = 'Get Worksheet XML';
+const title = 'Get Worksheet Structure';
 export const getGetWorksheetXmlTool = (
   server: DesktopMcpServer,
 ): DesktopTool<typeof paramsSchema> => {
@@ -52,8 +52,8 @@ export const getGetWorksheetXmlTool = (
     name: 'get-worksheet-xml',
     title,
     description: [
-      'Get XML for an existing worksheet. mode=file is default; mode=inline returns XML.',
-      'IMPORTANT: only works for an existing worksheet (see list-worksheets). Prefer the field tools over editing XML directly. Use apply-worksheet to apply changes.',
+      'Get structure for an existing worksheet. mode=file is default; mode=inline returns worksheet content.',
+      'IMPORTANT: only works for an existing worksheet (see list-worksheets). Prefer the field tools over editing worksheet content directly. Use apply-worksheet to apply changes.',
     ].join(' '),
     paramsSchema,
     annotations: {
@@ -97,7 +97,7 @@ export const getGetWorksheetXmlTool = (
 
           if (mode === 'inline' && !capFired) {
             return new Ok({
-              message: `Worksheet XML returned inline (${bytes} bytes)`,
+              message: `Worksheet content returned inline (${bytes} bytes)`,
               worksheetXml,
             });
           }
@@ -120,14 +120,14 @@ export const getGetWorksheetXmlTool = (
               }),
               file: cacheFile,
               instructions:
-                'This worksheet exceeds the inline cap. Use read-cached-xml (with a worksheet ' +
-                'selector or startByte/endByte to read a slice), write-cached-xml (same selector to ' +
+                'This worksheet exceeds the inline cap. Use the cache read tool (with a worksheet ' +
+                'selector or startByte/endByte to read a slice), the cache write tool (same selector to ' +
                 'splice edits back), then apply-worksheet with mode=file. Do not request mode=inline.',
             });
           }
 
           log({
-            message: `Saved worksheet XML to cache file: ${cacheFile}`,
+            message: `Saved worksheet content to cache file: ${cacheFile}`,
             level: 'info',
             logger: 'tool',
             data: {
@@ -140,7 +140,7 @@ export const getGetWorksheetXmlTool = (
             message: `Worksheet "${worksheetName}" saved to cache file (${bytes} bytes)\n\nArtifact summary:\n${formatArtifactSummary('worksheet', worksheetXml)}`,
             file: cacheFile,
             instructions:
-              'Use this file path with modification tools instead of passing XML directly.',
+              'Use this file path with modification tools instead of passing content directly.',
           });
         },
       });


### PR DESCRIPTION
Ports a2td wave33's vocabulary work (design-partner rule: the agent must NEVER surface 'XML'). 14 tool titles plus user-facing descriptions/messages humanized (Get Workbook XML → Get Workbook Structure, Validate → Check Structure, Cache XMLs → Working Copies, chart → viz); field data-type labels use product names (Number (whole)/(decimal), Text, Date & Time); shelf names capitalized; a narration rule lands in DESKTOP_INSTRUCTIONS. New guard test pins that desktop tool metadata never exposes 'XML' again; grandfathered byte caps lowered only — no cap raised. tactics/workflow/tableau-vocabulary.md added to the knowledge corpus. Internal identifiers/tool names/param names unchanged by design.

Validation: knowledge 19/19, server.desktop 17/17, src/tools/desktop 447/447, tsc + eslint clean.

Note for merge order: #491/#492 touch bindTemplate.ts/dashboardAutoApply.ts in different hunks — merge sequentially, trivial conflicts possible.

Lab→product port per the debt ledger. GPT-5.5 minion port, Fable-adjudicated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)