### PR TITLE
@W-23415681: make FeatureGateProvider.isFeatureEnabled async

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "2.26.0",
+  "version": "2.27.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "2.26.0",
+      "version": "2.27.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.7.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "2.26.0",
+  "version": "2.27.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/src/features/featureGateProvider.ts
+++ b/src/features/featureGateProvider.ts
@@ -11,7 +11,11 @@
  */
 export interface FeatureGateProvider {
   /**
-   * Check if a feature is enabled
+   * Check if a feature is enabled.
+   *
+   * Returns a Promise so providers can perform a real async lookup per invocation
+   * (e.g. a cloud provider querying DynamoDB). Synchronous providers simply resolve
+   * an already-in-memory value.
    */
-  isFeatureEnabled(featureName: string): boolean;
+  isFeatureEnabled(featureName: string): Promise<boolean>;
 }

--- a/src/features/init.test.ts
+++ b/src/features/init.test.ts
@@ -125,41 +125,6 @@ describe('FeatureGate', () => {
     });
   });
 
-  describe('with test fixtures', () => {
-    it('should load all-enabled fixture correctly', async () => {
-      const config = { mcpapps: true, pulse: true, 'oauth-embedded': true };
-      vi.mocked(readFileSync).mockReturnValue(JSON.stringify(config));
-
-      const gate = getFeatureGate();
-
-      await expect(gate.isFeatureEnabled('mcpapps')).resolves.toBe(true);
-      await expect(gate.isFeatureEnabled('pulse')).resolves.toBe(true);
-      await expect(gate.isFeatureEnabled('oauth-embedded')).resolves.toBe(true);
-    });
-
-    it('should load all-disabled fixture correctly', async () => {
-      const config = { mcpapps: false, pulse: false, 'oauth-embedded': false };
-      vi.mocked(readFileSync).mockReturnValue(JSON.stringify(config));
-
-      const gate = getFeatureGate();
-
-      await expect(gate.isFeatureEnabled('mcpapps')).resolves.toBe(false);
-      await expect(gate.isFeatureEnabled('pulse')).resolves.toBe(false);
-      await expect(gate.isFeatureEnabled('oauth-embedded')).resolves.toBe(false);
-    });
-
-    it('should load mixed fixture correctly', async () => {
-      const config = { mcpapps: false, pulse: true, 'oauth-embedded': false };
-      vi.mocked(readFileSync).mockReturnValue(JSON.stringify(config));
-
-      const gate = getFeatureGate();
-
-      await expect(gate.isFeatureEnabled('mcpapps')).resolves.toBe(false);
-      await expect(gate.isFeatureEnabled('pulse')).resolves.toBe(true);
-      await expect(gate.isFeatureEnabled('oauth-embedded')).resolves.toBe(false);
-    });
-  });
-
   describe('provider selection', () => {
     beforeEach(() => {
       resetFeatureGate();

--- a/src/features/init.test.ts
+++ b/src/features/init.test.ts
@@ -44,19 +44,19 @@ describe('FeatureGate', () => {
       );
     });
 
-    it('should load valid feature config file', () => {
+    it('should load valid feature config file', async () => {
       const config = { mcpapps: true, pulse: false };
       vi.mocked(readFileSync).mockReturnValue(JSON.stringify(config));
 
       const gate = getFeatureGate();
 
-      expect(gate.isFeatureEnabled('mcpapps')).toBe(true);
-      expect(gate.isFeatureEnabled('pulse')).toBe(false);
+      await expect(gate.isFeatureEnabled('mcpapps')).resolves.toBe(true);
+      await expect(gate.isFeatureEnabled('pulse')).resolves.toBe(false);
     });
   });
 
   describe('missing file handling', () => {
-    it('should handle missing file gracefully', () => {
+    it('should handle missing file gracefully', async () => {
       const error: NodeJS.ErrnoException = new Error('ENOENT: no such file or directory');
       error.code = 'ENOENT';
       vi.mocked(readFileSync).mockImplementation(() => {
@@ -65,21 +65,21 @@ describe('FeatureGate', () => {
 
       const gate = getFeatureGate();
 
-      expect(gate.isFeatureEnabled('mcpapps')).toBe(false);
-      expect(gate.isFeatureEnabled('pulse')).toBe(false);
+      await expect(gate.isFeatureEnabled('mcpapps')).resolves.toBe(false);
+      await expect(gate.isFeatureEnabled('pulse')).resolves.toBe(false);
     });
   });
 
   describe('invalid JSON handling', () => {
-    it('should handle invalid JSON gracefully', () => {
+    it('should handle invalid JSON gracefully', async () => {
       vi.mocked(readFileSync).mockReturnValue('{ invalid json }');
 
       const gate = getFeatureGate();
 
-      expect(gate.isFeatureEnabled('mcpapps')).toBe(false);
+      await expect(gate.isFeatureEnabled('mcpapps')).resolves.toBe(false);
     });
 
-    it('should skip invalid values and load valid ones', () => {
+    it('should skip invalid values and load valid ones', async () => {
       const config = {
         mcpapps: true,
         validFeature: false,
@@ -93,70 +93,70 @@ describe('FeatureGate', () => {
       const gate = getFeatureGate();
 
       // Valid features should be loaded
-      expect(gate.isFeatureEnabled('mcpapps')).toBe(true);
-      expect(gate.isFeatureEnabled('validFeature')).toBe(false);
+      await expect(gate.isFeatureEnabled('mcpapps')).resolves.toBe(true);
+      await expect(gate.isFeatureEnabled('validFeature')).resolves.toBe(false);
 
       // Invalid features should be skipped (disabled)
-      expect(gate.isFeatureEnabled('invalidString')).toBe(false);
-      expect(gate.isFeatureEnabled('invalidNull')).toBe(false);
-      expect(gate.isFeatureEnabled('invalidNumber')).toBe(false);
-      expect(gate.isFeatureEnabled('invalidArray')).toBe(false);
+      await expect(gate.isFeatureEnabled('invalidString')).resolves.toBe(false);
+      await expect(gate.isFeatureEnabled('invalidNull')).resolves.toBe(false);
+      await expect(gate.isFeatureEnabled('invalidNumber')).resolves.toBe(false);
+      await expect(gate.isFeatureEnabled('invalidArray')).resolves.toBe(false);
     });
   });
 
   describe('edge cases', () => {
-    it('should handle empty JSON object', () => {
+    it('should handle empty JSON object', async () => {
       vi.mocked(readFileSync).mockReturnValue('{}');
 
       const gate = getFeatureGate();
 
-      expect(gate.isFeatureEnabled('mcpapps')).toBe(false);
-      expect(gate.isFeatureEnabled('any-feature')).toBe(false);
+      await expect(gate.isFeatureEnabled('mcpapps')).resolves.toBe(false);
+      await expect(gate.isFeatureEnabled('any-feature')).resolves.toBe(false);
     });
 
-    it('should return false for unknown features', () => {
+    it('should return false for unknown features', async () => {
       const config = { mcpapps: true };
       vi.mocked(readFileSync).mockReturnValue(JSON.stringify(config));
 
       const gate = getFeatureGate();
 
-      expect(gate.isFeatureEnabled('unknown-feature')).toBe(false);
-      expect(gate.isFeatureEnabled('nonexistent')).toBe(false);
+      await expect(gate.isFeatureEnabled('unknown-feature')).resolves.toBe(false);
+      await expect(gate.isFeatureEnabled('nonexistent')).resolves.toBe(false);
     });
   });
 
   describe('with test fixtures', () => {
-    it('should load all-enabled fixture correctly', () => {
+    it('should load all-enabled fixture correctly', async () => {
       const config = { mcpapps: true, pulse: true, 'oauth-embedded': true };
       vi.mocked(readFileSync).mockReturnValue(JSON.stringify(config));
 
       const gate = getFeatureGate();
 
-      expect(gate.isFeatureEnabled('mcpapps')).toBe(true);
-      expect(gate.isFeatureEnabled('pulse')).toBe(true);
-      expect(gate.isFeatureEnabled('oauth-embedded')).toBe(true);
+      await expect(gate.isFeatureEnabled('mcpapps')).resolves.toBe(true);
+      await expect(gate.isFeatureEnabled('pulse')).resolves.toBe(true);
+      await expect(gate.isFeatureEnabled('oauth-embedded')).resolves.toBe(true);
     });
 
-    it('should load all-disabled fixture correctly', () => {
+    it('should load all-disabled fixture correctly', async () => {
       const config = { mcpapps: false, pulse: false, 'oauth-embedded': false };
       vi.mocked(readFileSync).mockReturnValue(JSON.stringify(config));
 
       const gate = getFeatureGate();
 
-      expect(gate.isFeatureEnabled('mcpapps')).toBe(false);
-      expect(gate.isFeatureEnabled('pulse')).toBe(false);
-      expect(gate.isFeatureEnabled('oauth-embedded')).toBe(false);
+      await expect(gate.isFeatureEnabled('mcpapps')).resolves.toBe(false);
+      await expect(gate.isFeatureEnabled('pulse')).resolves.toBe(false);
+      await expect(gate.isFeatureEnabled('oauth-embedded')).resolves.toBe(false);
     });
 
-    it('should load mixed fixture correctly', () => {
+    it('should load mixed fixture correctly', async () => {
       const config = { mcpapps: false, pulse: true, 'oauth-embedded': false };
       vi.mocked(readFileSync).mockReturnValue(JSON.stringify(config));
 
       const gate = getFeatureGate();
 
-      expect(gate.isFeatureEnabled('mcpapps')).toBe(false);
-      expect(gate.isFeatureEnabled('pulse')).toBe(true);
-      expect(gate.isFeatureEnabled('oauth-embedded')).toBe(false);
+      await expect(gate.isFeatureEnabled('mcpapps')).resolves.toBe(false);
+      await expect(gate.isFeatureEnabled('pulse')).resolves.toBe(true);
+      await expect(gate.isFeatureEnabled('oauth-embedded')).resolves.toBe(false);
     });
   });
 
@@ -166,7 +166,7 @@ describe('FeatureGate', () => {
       vi.clearAllMocks();
     });
 
-    it('should use server provider by default and load from file', () => {
+    it('should use server provider by default and load from file', async () => {
       const config = { mcpapps: true, pulse: false };
       vi.mocked(readFileSync).mockReturnValue(JSON.stringify(config));
       vi.mocked(getConfig).mockReturnValue({ featureGate: { provider: 'server' } } as any);
@@ -174,12 +174,12 @@ describe('FeatureGate', () => {
       initializeFeatureGate();
       const gate = getFeatureGate();
 
-      expect(gate.isFeatureEnabled('mcpapps')).toBe(true);
-      expect(gate.isFeatureEnabled('pulse')).toBe(false);
+      await expect(gate.isFeatureEnabled('mcpapps')).resolves.toBe(true);
+      await expect(gate.isFeatureEnabled('pulse')).resolves.toBe(false);
       expect(readFileSync).toHaveBeenCalled();
     });
 
-    it('should fall back to server provider when custom provider module fails to load', () => {
+    it('should fall back to server provider when custom provider module fails to load', async () => {
       const config = { mcpapps: true };
       vi.mocked(readFileSync).mockReturnValue(JSON.stringify(config));
       vi.mocked(getConfig).mockReturnValue({
@@ -193,11 +193,11 @@ describe('FeatureGate', () => {
       const gate = getFeatureGate();
 
       // Should fall back to server provider
-      expect(gate.isFeatureEnabled('mcpapps')).toBe(true);
+      await expect(gate.isFeatureEnabled('mcpapps')).resolves.toBe(true);
       expect(readFileSync).toHaveBeenCalled();
     });
 
-    it('should fall back to server provider on error', () => {
+    it('should fall back to server provider on error', async () => {
       const config = { mcpapps: true };
       vi.mocked(readFileSync).mockReturnValue(JSON.stringify(config));
       vi.mocked(getConfig).mockImplementation(() => {
@@ -207,18 +207,34 @@ describe('FeatureGate', () => {
       initializeFeatureGate();
       const gate = getFeatureGate();
 
-      expect(gate.isFeatureEnabled('mcpapps')).toBe(true);
+      await expect(gate.isFeatureEnabled('mcpapps')).resolves.toBe(true);
       expect(readFileSync).toHaveBeenCalled();
     });
 
-    it('should support lazy initialization without initializeFeatureGate call', () => {
+    it('should support lazy initialization without initializeFeatureGate call', async () => {
       const config = { mcpapps: true };
       vi.mocked(readFileSync).mockReturnValue(JSON.stringify(config));
       vi.mocked(getConfig).mockReturnValue({ featureGate: { provider: 'server' } } as any);
 
       const gate = getFeatureGate();
 
-      expect(gate.isFeatureEnabled('mcpapps')).toBe(true);
+      await expect(gate.isFeatureEnabled('mcpapps')).resolves.toBe(true);
+    });
+
+    it('should expose an async isFeatureEnabled that must be awaited', async () => {
+      // Proves the async contract end-to-end: isFeatureEnabled returns a Promise<boolean>
+      // (not a bare boolean), so a downstream cloud provider can do a real async lookup
+      // per invocation. The server provider resolves its in-memory value.
+      const config = { mcpapps: true, pulse: false };
+      vi.mocked(readFileSync).mockReturnValue(JSON.stringify(config));
+      vi.mocked(getConfig).mockReturnValue({ featureGate: { provider: 'server' } } as any);
+
+      const gate = getFeatureGate();
+
+      const pending = gate.isFeatureEnabled('mcpapps');
+      expect(pending).toBeInstanceOf(Promise);
+      await expect(pending).resolves.toBe(true);
+      await expect(gate.isFeatureEnabled('pulse')).resolves.toBe(false);
     });
   });
 

--- a/src/features/serverFeatureGate.ts
+++ b/src/features/serverFeatureGate.ts
@@ -22,8 +22,11 @@ export class ServerFeatureGate implements FeatureGateProvider {
    * Check if a feature is enabled
    * @param featureName - Name of the feature to check
    * @returns true if enabled, false if disabled or not found
+   *
+   * Async to satisfy the FeatureGateProvider contract; the value is already
+   * in memory (loaded once in the constructor), so this just resolves it.
    */
-  isFeatureEnabled(featureName: string): boolean {
+  async isFeatureEnabled(featureName: string): Promise<boolean> {
     return this.features.get(featureName) ?? false;
   }
 

--- a/src/scripts/createClaudeMcpBundleManifest.ts
+++ b/src/scripts/createClaudeMcpBundleManifest.ts
@@ -744,8 +744,10 @@ async function getEnabledTools(): Promise<Array<string>> {
     // Best effort to get enabled tools.
     // Won't work if any tools are disabled based off some user config value,
     // like Tableau Server version. This script should fail if there was ever the case.
-    const tools = webToolFactories.map((toolFactory) =>
-      toolFactory({} as unknown as WebMcpServer, { value: '0.0.0', build: '0.0.0' }),
+    const tools = await Promise.all(
+      webToolFactories.map((toolFactory) =>
+        toolFactory({} as unknown as WebMcpServer, { value: '0.0.0', build: '0.0.0' }),
+      ),
     );
 
     const disabledResults = await Promise.all(tools.map((tool) => Provider.from(tool.disabled)));

--- a/src/server.web.test.ts
+++ b/src/server.web.test.ts
@@ -86,7 +86,9 @@ describe('server', () => {
     const server = getServer();
     await server.registerTools();
 
-    const allTools = webToolFactories.map((toolFactory) => toolFactory(server, testProductVersion));
+    const allTools = await Promise.all(
+      webToolFactories.map((toolFactory) => toolFactory(server, testProductVersion)),
+    );
     const disabledFlags = await Promise.all(allTools.map((tool) => Provider.from(tool.disabled)));
     const tools = allTools.filter((_, i) => !disabledFlags[i]);
     for (const tool of tools) {
@@ -111,8 +113,8 @@ describe('server', () => {
     const server = getServer();
     await server.registerTools();
 
-    const allDisabledTools = webToolFactories.map((toolFactory) =>
-      toolFactory(server, testProductVersion),
+    const allDisabledTools = await Promise.all(
+      webToolFactories.map((toolFactory) => toolFactory(server, testProductVersion)),
     );
     const disabledToolFlags = await Promise.all(
       allDisabledTools.map((tool) => Provider.from(tool.disabled)),
@@ -150,7 +152,9 @@ describe('server', () => {
     const server = getServer();
     await server.registerTools();
 
-    const tools = webToolFactories.map((toolFactory) => toolFactory(server, testProductVersion));
+    const tools = await Promise.all(
+      webToolFactories.map((toolFactory) => toolFactory(server, testProductVersion)),
+    );
     const excludeDisabledFlags = await Promise.all(
       tools.map((tool) => Provider.from(tool.disabled)),
     );

--- a/src/server.web.ts
+++ b/src/server.web.ts
@@ -44,7 +44,7 @@ export class WebMcpServer extends Server {
   registerTools = async (tableauAuthInfo?: TableauAuthInfo): Promise<void> => {
     const config = getConfig();
 
-    const mcpAppsEnabled = getFeatureGate().isFeatureEnabled('mcp-apps');
+    const mcpAppsEnabled = await getFeatureGate().isFeatureEnabled('mcp-apps');
 
     for (const tool of await this._getToolsToRegister(tableauAuthInfo)) {
       const toolCallback: ToolCallback<typeof tool.paramsSchema> = async (
@@ -127,8 +127,8 @@ export class WebMcpServer extends Server {
 
     const { includeTools, excludeTools } = configOverrides;
 
-    const allTools = webToolFactories.map((toolFactory) =>
-      toolFactory(this, tableauServerInfo.productVersion),
+    const allTools = await Promise.all(
+      webToolFactories.map((toolFactory) => toolFactory(this, tableauServerInfo.productVersion)),
     );
     const toolsToRegister: typeof allTools = [];
     for (const tool of allTools) {

--- a/src/server/oauth/.well-known/oauth-authorization-server.ts
+++ b/src/server/oauth/.well-known/oauth-authorization-server.ts
@@ -10,7 +10,7 @@ import { getSupportedScopes } from '../scopes.js';
  * available endpoints, supported flows, and capabilities.
  */
 export function oauthAuthorizationServer(app: express.Application): void {
-  app.get('/.well-known/oauth-authorization-server', (_req, res) => {
+  app.get('/.well-known/oauth-authorization-server', async (_req, res) => {
     const { issuer, advertiseApiScopes, enforceScopes, clientIdSecretPairs } = getConfig().oauth;
 
     const grant_types_supported = ['authorization_code', 'refresh_token'];
@@ -32,7 +32,7 @@ export function oauthAuthorizationServer(app: express.Application): void {
       grant_types_supported,
       code_challenge_methods_supported: ['S256'],
       scopes_supported: enforceScopes
-        ? getSupportedScopes({ includeApiScopes: advertiseApiScopes })
+        ? await getSupportedScopes({ includeApiScopes: advertiseApiScopes })
         : [],
       token_endpoint_auth_methods_supported,
       subject_types_supported: ['public'],

--- a/src/server/oauth/.well-known/oauth-protected-resource.ts
+++ b/src/server/oauth/.well-known/oauth-protected-resource.ts
@@ -12,14 +12,14 @@ import { getSupportedScopes } from '../scopes.js';
  * WWW-Authenticate header in 401 response.
  */
 export function oauthProtectedResource(app: express.Application): void {
-  app.get('/.well-known/oauth-protected-resource', (_req, res) => {
+  app.get('/.well-known/oauth-protected-resource', async (_req, res) => {
     const { issuer, advertiseApiScopes, resourceUri, enforceScopes } = getConfig().oauth;
     res.json({
       resource: buildResourceIdentifier(resourceUri),
       authorization_servers: [issuer],
       bearer_methods_supported: ['header'],
       scopes_supported: enforceScopes
-        ? getSupportedScopes({ includeApiScopes: advertiseApiScopes })
+        ? await getSupportedScopes({ includeApiScopes: advertiseApiScopes })
         : [],
     });
   });

--- a/src/server/oauth/authMiddleware.ts
+++ b/src/server/oauth/authMiddleware.ts
@@ -54,8 +54,8 @@ export function authMiddleware(accessTokenValidator: AccessTokenValidator): Requ
       const { enforceScopes, advertiseApiScopes, resourceUri } = getConfig().oauth;
       const baseUrl = new URL(resourceUri).origin;
       const resourceMetadataUrl = `${baseUrl}${protectedResourceMetadataPath}`;
-      const requiredMcpScopes = getRequiredMcpScopesForRequest(req.body);
-      const requiredApiScopes = getRequiredApiScopesForRequest(req.body, advertiseApiScopes);
+      const requiredMcpScopes = await getRequiredMcpScopesForRequest(req.body);
+      const requiredApiScopes = await getRequiredApiScopesForRequest(req.body, advertiseApiScopes);
       const scopeParam =
         enforceScopes && requiredMcpScopes.length > 0
           ? `, scope="${formatScopes([...requiredMcpScopes, ...requiredApiScopes])}"`
@@ -105,8 +105,8 @@ export function authMiddleware(accessTokenValidator: AccessTokenValidator): Requ
     const authInfo = result.value;
     const { enforceScopes, advertiseApiScopes } = getConfig().oauth;
     if (enforceScopes) {
-      const requiredMcpScopes = getRequiredMcpScopesForRequest(req.body);
-      const requiredApiScopes = getRequiredApiScopesForRequest(req.body, advertiseApiScopes);
+      const requiredMcpScopes = await getRequiredMcpScopesForRequest(req.body);
+      const requiredApiScopes = await getRequiredApiScopesForRequest(req.body, advertiseApiScopes);
       const missingMcpScopes = requiredMcpScopes.filter(
         (scope) => !authInfo.scopes.includes(scope),
       );
@@ -160,7 +160,7 @@ export function authMiddleware(accessTokenValidator: AccessTokenValidator): Requ
   };
 }
 
-function getRequiredMcpScopesForRequest(body: unknown): string[] {
+async function getRequiredMcpScopesForRequest(body: unknown): Promise<string[]> {
   if (isInitializeRequest(body)) {
     return getSupportedMcpScopes();
   }
@@ -178,7 +178,10 @@ function getRequiredMcpScopesForRequest(body: unknown): string[] {
   return Array.from(scopes);
 }
 
-function getRequiredApiScopesForRequest(body: unknown, includeApiScopes: boolean): string[] {
+async function getRequiredApiScopesForRequest(
+  body: unknown,
+  includeApiScopes: boolean,
+): Promise<string[]> {
   if (!includeApiScopes) {
     return [];
   }

--- a/src/server/oauth/authorize.ts
+++ b/src/server/oauth/authorize.ts
@@ -117,7 +117,7 @@ export function authorize(
     const requestedScopes = parseScopes(scope);
     const { valid: validScopes, invalid: invalidScopes } = validateScopes(
       requestedScopes,
-      getSupportedScopes({ includeApiScopes: advertiseApiScopes }),
+      await getSupportedScopes({ includeApiScopes: advertiseApiScopes }),
     );
 
     if (invalidScopes.length > 0) {
@@ -132,7 +132,7 @@ export function authorize(
       validScopes.length > 0
         ? validScopes
         : enforceScopes
-          ? getSupportedScopes({ includeApiScopes: advertiseApiScopes })
+          ? await getSupportedScopes({ includeApiScopes: advertiseApiScopes })
           : [];
 
     // Generate Tableau state and store pending authorization

--- a/src/server/oauth/scopes.test.ts
+++ b/src/server/oauth/scopes.test.ts
@@ -16,66 +16,66 @@ const mockGetConfig = vi.mocked(configModule.getConfig);
 
 describe('scopes', () => {
   describe('getSupportedMcpScopes', () => {
-    it('should include tableau:mcp:tasks:read when adminToolsEnabled is true', () => {
+    it('should include tableau:mcp:tasks:read when adminToolsEnabled is true', async () => {
       mockGetConfig.mockReturnValue({
         adminToolsEnabled: true,
       } as any);
 
-      const scopes = getSupportedMcpScopes();
+      const scopes = await getSupportedMcpScopes();
       expect(scopes).toContain('tableau:mcp:tasks:read');
     });
 
-    it('should exclude tableau:mcp:tasks:read when adminToolsEnabled is false', () => {
+    it('should exclude tableau:mcp:tasks:read when adminToolsEnabled is false', async () => {
       mockGetConfig.mockReturnValue({
         adminToolsEnabled: false,
       } as any);
 
-      const scopes = getSupportedMcpScopes();
+      const scopes = await getSupportedMcpScopes();
       expect(scopes).not.toContain('tableau:mcp:tasks:read');
     });
 
-    it('should include tableau:mcp:tasks:write when adminToolsEnabled is true', () => {
+    it('should include tableau:mcp:tasks:write when adminToolsEnabled is true', async () => {
       mockGetConfig.mockReturnValue({
         adminToolsEnabled: true,
       } as any);
 
-      const scopes = getSupportedMcpScopes();
+      const scopes = await getSupportedMcpScopes();
       expect(scopes).toContain('tableau:mcp:tasks:write');
     });
 
-    it('should exclude tableau:mcp:tasks:write when adminToolsEnabled is false', () => {
+    it('should exclude tableau:mcp:tasks:write when adminToolsEnabled is false', async () => {
       mockGetConfig.mockReturnValue({
         adminToolsEnabled: false,
       } as any);
 
-      const scopes = getSupportedMcpScopes();
+      const scopes = await getSupportedMcpScopes();
       expect(scopes).not.toContain('tableau:mcp:tasks:write');
     });
 
-    it('should include tableau:mcp:jobs:read when adminToolsEnabled is true', () => {
+    it('should include tableau:mcp:jobs:read when adminToolsEnabled is true', async () => {
       mockGetConfig.mockReturnValue({
         adminToolsEnabled: true,
       } as any);
 
-      const scopes = getSupportedMcpScopes();
+      const scopes = await getSupportedMcpScopes();
       expect(scopes).toContain('tableau:mcp:jobs:read');
     });
 
-    it('should exclude tableau:mcp:jobs:read when adminToolsEnabled is false', () => {
+    it('should exclude tableau:mcp:jobs:read when adminToolsEnabled is false', async () => {
       mockGetConfig.mockReturnValue({
         adminToolsEnabled: false,
       } as any);
 
-      const scopes = getSupportedMcpScopes();
+      const scopes = await getSupportedMcpScopes();
       expect(scopes).not.toContain('tableau:mcp:jobs:read');
     });
 
-    it('should always include other MCP scopes regardless of adminToolsEnabled', () => {
+    it('should always include other MCP scopes regardless of adminToolsEnabled', async () => {
       mockGetConfig.mockReturnValue({
         adminToolsEnabled: false,
       } as any);
 
-      const scopes = getSupportedMcpScopes();
+      const scopes = await getSupportedMcpScopes();
       expect(scopes).toContain('tableau:mcp:datasource:read');
       expect(scopes).toContain('tableau:mcp:workbook:read');
       expect(scopes).toContain('tableau:mcp:view:read');
@@ -87,116 +87,116 @@ describe('scopes', () => {
   });
 
   describe('getSupportedApiScopes', () => {
-    it('should include tableau:tasks:read when adminToolsEnabled is true', () => {
+    it('should include tableau:tasks:read when adminToolsEnabled is true', async () => {
       mockGetConfig.mockReturnValue({
         adminToolsEnabled: true,
       } as any);
 
-      const scopes = getSupportedApiScopes();
+      const scopes = await getSupportedApiScopes();
       expect(scopes).toContain('tableau:tasks:read');
     });
 
-    it('should exclude tableau:tasks:read when adminToolsEnabled is false', () => {
+    it('should exclude tableau:tasks:read when adminToolsEnabled is false', async () => {
       mockGetConfig.mockReturnValue({
         adminToolsEnabled: false,
       } as any);
 
-      const scopes = getSupportedApiScopes();
+      const scopes = await getSupportedApiScopes();
       expect(scopes).not.toContain('tableau:tasks:read');
     });
 
-    it('should include tableau:tasks:write when adminToolsEnabled is true', () => {
+    it('should include tableau:tasks:write when adminToolsEnabled is true', async () => {
       mockGetConfig.mockReturnValue({
         adminToolsEnabled: true,
       } as any);
 
-      const scopes = getSupportedApiScopes();
+      const scopes = await getSupportedApiScopes();
       expect(scopes).toContain('tableau:tasks:write');
     });
 
-    it('should exclude tableau:tasks:write when adminToolsEnabled is false', () => {
+    it('should exclude tableau:tasks:write when adminToolsEnabled is false', async () => {
       mockGetConfig.mockReturnValue({
         adminToolsEnabled: false,
       } as any);
 
-      const scopes = getSupportedApiScopes();
+      const scopes = await getSupportedApiScopes();
       expect(scopes).not.toContain('tableau:tasks:write');
     });
 
-    it('should include tableau:jobs:read when adminToolsEnabled is true', () => {
+    it('should include tableau:jobs:read when adminToolsEnabled is true', async () => {
       mockGetConfig.mockReturnValue({
         adminToolsEnabled: true,
       } as any);
 
-      const scopes = getSupportedApiScopes();
+      const scopes = await getSupportedApiScopes();
       expect(scopes).toContain('tableau:jobs:read');
     });
 
-    it('should exclude tableau:jobs:read when adminToolsEnabled is false', () => {
+    it('should exclude tableau:jobs:read when adminToolsEnabled is false', async () => {
       mockGetConfig.mockReturnValue({
         adminToolsEnabled: false,
       } as any);
 
-      const scopes = getSupportedApiScopes();
+      const scopes = await getSupportedApiScopes();
       expect(scopes).not.toContain('tableau:jobs:read');
     });
 
-    it('should include tableau:users:read when adminToolsEnabled is true', () => {
+    it('should include tableau:users:read when adminToolsEnabled is true', async () => {
       mockGetConfig.mockReturnValue({
         adminToolsEnabled: true,
       } as any);
 
-      const scopes = getSupportedApiScopes();
+      const scopes = await getSupportedApiScopes();
       expect(scopes).toContain('tableau:users:read');
     });
 
-    it('should exclude tableau:users:read when adminToolsEnabled is false', () => {
+    it('should exclude tableau:users:read when adminToolsEnabled is false', async () => {
       mockGetConfig.mockReturnValue({
         adminToolsEnabled: false,
       } as any);
 
-      const scopes = getSupportedApiScopes();
+      const scopes = await getSupportedApiScopes();
       expect(scopes).not.toContain('tableau:users:read');
     });
 
-    it('should always include other API scopes regardless of adminToolsEnabled', () => {
+    it('should always include other API scopes regardless of adminToolsEnabled', async () => {
       mockGetConfig.mockReturnValue({
         adminToolsEnabled: false,
       } as any);
 
-      const scopes = getSupportedApiScopes();
+      const scopes = await getSupportedApiScopes();
       expect(scopes).toContain('tableau:content:read');
       expect(scopes).toContain('tableau:mcp_site_settings:read');
     });
   });
 
   describe('getSupportedScopes', () => {
-    it('should return only MCP scopes when includeApiScopes is false', () => {
+    it('should return only MCP scopes when includeApiScopes is false', async () => {
       mockGetConfig.mockReturnValue({
         adminToolsEnabled: true,
       } as any);
 
-      const scopes = getSupportedScopes({ includeApiScopes: false });
+      const scopes = await getSupportedScopes({ includeApiScopes: false });
       expect(scopes).toContain('tableau:mcp:datasource:read');
       expect(scopes).not.toContain('tableau:content:read');
     });
 
-    it('should return both MCP and API scopes when includeApiScopes is true', () => {
+    it('should return both MCP and API scopes when includeApiScopes is true', async () => {
       mockGetConfig.mockReturnValue({
         adminToolsEnabled: true,
       } as any);
 
-      const scopes = getSupportedScopes({ includeApiScopes: true });
+      const scopes = await getSupportedScopes({ includeApiScopes: true });
       expect(scopes).toContain('tableau:mcp:datasource:read');
       expect(scopes).toContain('tableau:content:read');
     });
 
-    it('should respect adminToolsEnabled flag when includeApiScopes is true', () => {
+    it('should respect adminToolsEnabled flag when includeApiScopes is true', async () => {
       mockGetConfig.mockReturnValue({
         adminToolsEnabled: false,
       } as any);
 
-      const scopes = getSupportedScopes({ includeApiScopes: true });
+      const scopes = await getSupportedScopes({ includeApiScopes: true });
       expect(scopes).not.toContain('tableau:mcp:tasks:read');
       expect(scopes).not.toContain('tableau:mcp:tasks:write');
       expect(scopes).not.toContain('tableau:mcp:jobs:read');
@@ -208,57 +208,57 @@ describe('scopes', () => {
   });
 
   describe('isValidScope', () => {
-    it('should return true for valid MCP scopes when adminToolsEnabled is true', () => {
+    it('should return true for valid MCP scopes when adminToolsEnabled is true', async () => {
       mockGetConfig.mockReturnValue({
         adminToolsEnabled: true,
       } as any);
 
-      expect(isValidScope('tableau:mcp:tasks:read')).toBe(true);
-      expect(isValidScope('tableau:mcp:tasks:write')).toBe(true);
-      expect(isValidScope('tableau:mcp:jobs:read')).toBe(true);
-      expect(isValidScope('tableau:mcp:datasource:read')).toBe(true);
+      await expect(isValidScope('tableau:mcp:tasks:read')).resolves.toBe(true);
+      await expect(isValidScope('tableau:mcp:tasks:write')).resolves.toBe(true);
+      await expect(isValidScope('tableau:mcp:jobs:read')).resolves.toBe(true);
+      await expect(isValidScope('tableau:mcp:datasource:read')).resolves.toBe(true);
     });
 
-    it('should return false for tableau:mcp:tasks:read when adminToolsEnabled is false', () => {
+    it('should return false for tableau:mcp:tasks:read when adminToolsEnabled is false', async () => {
       mockGetConfig.mockReturnValue({
         adminToolsEnabled: false,
       } as any);
 
-      expect(isValidScope('tableau:mcp:tasks:read')).toBe(false);
+      await expect(isValidScope('tableau:mcp:tasks:read')).resolves.toBe(false);
     });
 
-    it('should return false for tableau:mcp:tasks:write when adminToolsEnabled is false', () => {
+    it('should return false for tableau:mcp:tasks:write when adminToolsEnabled is false', async () => {
       mockGetConfig.mockReturnValue({
         adminToolsEnabled: false,
       } as any);
 
-      expect(isValidScope('tableau:mcp:tasks:write')).toBe(false);
+      await expect(isValidScope('tableau:mcp:tasks:write')).resolves.toBe(false);
     });
 
-    it('should return false for tableau:mcp:jobs:read when adminToolsEnabled is false', () => {
+    it('should return false for tableau:mcp:jobs:read when adminToolsEnabled is false', async () => {
       mockGetConfig.mockReturnValue({
         adminToolsEnabled: false,
       } as any);
 
-      expect(isValidScope('tableau:mcp:jobs:read')).toBe(false);
+      await expect(isValidScope('tableau:mcp:jobs:read')).resolves.toBe(false);
     });
 
-    it('should return true for other valid MCP scopes when adminToolsEnabled is false', () => {
+    it('should return true for other valid MCP scopes when adminToolsEnabled is false', async () => {
       mockGetConfig.mockReturnValue({
         adminToolsEnabled: false,
       } as any);
 
-      expect(isValidScope('tableau:mcp:datasource:read')).toBe(true);
-      expect(isValidScope('tableau:mcp:workbook:read')).toBe(true);
+      await expect(isValidScope('tableau:mcp:datasource:read')).resolves.toBe(true);
+      await expect(isValidScope('tableau:mcp:workbook:read')).resolves.toBe(true);
     });
 
-    it('should return false for invalid scopes', () => {
+    it('should return false for invalid scopes', async () => {
       mockGetConfig.mockReturnValue({
         adminToolsEnabled: true,
       } as any);
 
-      expect(isValidScope('invalid:scope')).toBe(false);
-      expect(isValidScope('tableau:invalid:scope')).toBe(false);
+      await expect(isValidScope('invalid:scope')).resolves.toBe(false);
+      await expect(isValidScope('tableau:invalid:scope')).resolves.toBe(false);
     });
   });
 });

--- a/src/server/oauth/scopes.ts
+++ b/src/server/oauth/scopes.ts
@@ -84,8 +84,8 @@ export const RESOURCE_ACCESS_CHECKER_REQUIRED_API_SCOPES: ReadonlyArray<TableauA
 /**
  * Validates that a scope string is a valid MCP scope
  */
-export function isValidScope(scope: string): scope is McpScope {
-  return getSupportedMcpScopes().some((supported) => supported === scope);
+export async function isValidScope(scope: string): Promise<boolean> {
+  return (await getSupportedMcpScopes()).some((supported) => supported === scope);
 }
 
 const toolScopeMap: Record<
@@ -365,10 +365,11 @@ const toolScopeMap: Record<
   },
 };
 
-function getEnabledToolNames(): Set<WebToolName> {
+async function getEnabledToolNames(): Promise<Set<WebToolName>> {
   const config = getConfig();
   const featureGate = getFeatureGate();
   const enabledTools = new Set<WebToolName>(Object.keys(toolScopeMap) as WebToolName[]);
+  const mcpAppsEnabled = await featureGate.isFeatureEnabled('mcp-apps');
 
   // Remove disabled tools based on feature flags
   if (!config.adminToolsEnabled) {
@@ -393,7 +394,7 @@ function getEnabledToolNames(): Set<WebToolName> {
 
   // Remove the MCP-Apps-only tools if the mcp-apps feature is disabled. The confirm-* tools are the
   // human-gesture confirm steps for their preview tools and only exist when the iframe can render.
-  if (!featureGate.isFeatureEnabled('mcp-apps')) {
+  if (!mcpAppsEnabled) {
     enabledTools.delete('get-embed-token');
     enabledTools.delete('confirm-delete-workbook');
     enabledTools.delete('confirm-delete-datasource');
@@ -404,8 +405,8 @@ function getEnabledToolNames(): Set<WebToolName> {
   return enabledTools;
 }
 
-export function getSupportedMcpScopes(): McpScope[] {
-  const enabledTools = getEnabledToolNames();
+export async function getSupportedMcpScopes(): Promise<McpScope[]> {
+  const enabledTools = await getEnabledToolNames();
   const scopes = new Set<McpScope>();
 
   for (const [toolName, scopeConfig] of Object.entries(toolScopeMap)) {
@@ -419,8 +420,8 @@ export function getSupportedMcpScopes(): McpScope[] {
   return Array.from(scopes);
 }
 
-export function getSupportedApiScopes(): TableauApiScope[] {
-  const enabledTools = getEnabledToolNames();
+export async function getSupportedApiScopes(): Promise<TableauApiScope[]> {
+  const enabledTools = await getEnabledToolNames();
   const scopes = new Set<TableauApiScope>();
 
   for (const [toolName, scopeConfig] of Object.entries(toolScopeMap)) {
@@ -434,9 +435,13 @@ export function getSupportedApiScopes(): TableauApiScope[] {
   return Array.from(scopes);
 }
 
-export function getSupportedScopes({ includeApiScopes }: { includeApiScopes: boolean }): string[] {
-  const mcpScopes = getSupportedMcpScopes();
-  const apiScopes = getSupportedApiScopes();
+export async function getSupportedScopes({
+  includeApiScopes,
+}: {
+  includeApiScopes: boolean;
+}): Promise<string[]> {
+  const mcpScopes = await getSupportedMcpScopes();
+  const apiScopes = await getSupportedApiScopes();
   return includeApiScopes ? [...mcpScopes, ...apiScopes] : mcpScopes;
 }
 

--- a/src/server/oauth/token.ts
+++ b/src/server/oauth/token.ts
@@ -145,7 +145,7 @@ export function token(
           const requestedScopes = parseScopes(result.data.scope);
           const { valid: validScopes, invalid: invalidScopes } = validateScopes(
             requestedScopes,
-            getSupportedScopes({ includeApiScopes: advertiseApiScopes }),
+            await getSupportedScopes({ includeApiScopes: advertiseApiScopes }),
           );
 
           if (invalidScopes.length > 0) {
@@ -160,7 +160,7 @@ export function token(
             validScopes.length > 0
               ? validScopes
               : enforceScopes
-                ? getSupportedScopes({ includeApiScopes: advertiseApiScopes })
+                ? await getSupportedScopes({ includeApiScopes: advertiseApiScopes })
                 : [];
 
           // Generate access token for client credentials grant type.

--- a/src/tools/web/_lib/deleteContent.test.ts
+++ b/src/tools/web/_lib/deleteContent.test.ts
@@ -132,11 +132,11 @@ describe('deleteContentTool', () => {
     mocks.mockDeleteDatasource.mockResolvedValue(undefined);
     mocks.mockDeleteExtractRefreshTask.mockResolvedValue(undefined);
     mocks.mockGraphql.mockResolvedValue({ publishedDatasources: [] });
-    mocks.mockIsFeatureEnabled.mockReturnValue(false);
+    mocks.mockIsFeatureEnabled.mockResolvedValue(false);
   });
 
-  it('exposes the consolidated tool name and paramsSchema', () => {
-    const tool = getDeleteContentTool(new WebMcpServer());
+  it('exposes the consolidated tool name and paramsSchema', async () => {
+    const tool = await getDeleteContentTool(new WebMcpServer());
     expect(tool.name).toBe('delete-content');
     expect(tool.paramsSchema).toHaveProperty('resourceType');
     expect(tool.paramsSchema).toHaveProperty('resourceId');
@@ -150,12 +150,12 @@ describe('deleteContentTool', () => {
     vi.mocked(getConfig).mockReturnValueOnce({
       adminToolsEnabled: false,
     } as ReturnType<typeof getConfig>);
-    const tool = getDeleteContentTool(new WebMcpServer());
+    const tool = await getDeleteContentTool(new WebMcpServer());
     expect(await Provider.from(tool.disabled)).toBe(true);
   });
 
-  it('carries destructive annotations', () => {
-    const tool = getDeleteContentTool(new WebMcpServer());
+  it('carries destructive annotations', async () => {
+    const tool = await getDeleteContentTool(new WebMcpServer());
     expect(tool.annotations).toEqual({
       title: 'Delete Tableau Content',
       readOnlyHint: false,
@@ -359,11 +359,11 @@ describe('deleteContentTool', () => {
 
   describe('with mcp-apps flag ON', () => {
     beforeEach(() => {
-      mocks.mockIsFeatureEnabled.mockReturnValue(true);
+      mocks.mockIsFeatureEnabled.mockResolvedValue(true);
     });
 
-    it('carries the delete-content app config', () => {
-      const tool = getDeleteContentTool(new WebMcpServer());
+    it('carries the delete-content app config', async () => {
+      const tool = await getDeleteContentTool(new WebMcpServer());
       expect(tool.app).toBeDefined();
       expect(tool.app?.resourceUri).toContain('delete-content');
     });
@@ -431,7 +431,7 @@ async function getToolResult(args: {
   tag?: string;
   confirmationToken?: string;
 }): Promise<CallToolResult> {
-  const tool = getDeleteContentTool(new WebMcpServer());
+  const tool = await getDeleteContentTool(new WebMcpServer());
   const callback = await Provider.from(tool.callback);
   return await callback(
     {

--- a/src/tools/web/_lib/deleteContent.ts
+++ b/src/tools/web/_lib/deleteContent.ts
@@ -110,9 +110,11 @@ type DeleteContentResult =
   | AppToolResult<DeleteDatasourceConfirmPanel>
   | AppToolResult<DeleteExtractRefreshTaskConfirmPanel>;
 
-export const getDeleteContentTool = (server: WebMcpServer): WebTool<typeof paramsSchema> => {
+export const getDeleteContentTool = async (
+  server: WebMcpServer,
+): Promise<WebTool<typeof paramsSchema>> => {
   const config = getConfig();
-  const mcpAppsEnabled = getFeatureGate().isFeatureEnabled('mcp-apps');
+  const mcpAppsEnabled = await getFeatureGate().isFeatureEnabled('mcp-apps');
 
   const tool = new WebTool({
     server,

--- a/src/tools/web/datasources/confirmDeleteDatasource.test.ts
+++ b/src/tools/web/datasources/confirmDeleteDatasource.test.ts
@@ -125,7 +125,7 @@ describe('confirmDeleteDatasourceTool', () => {
     });
     mocks.mockDeleteDatasource.mockResolvedValue(undefined);
     // The confirm tool is gated on mcp-apps ON (+ admin); registration tests flip this.
-    mocks.mockIsFeatureEnabled.mockReturnValue(true);
+    mocks.mockIsFeatureEnabled.mockResolvedValue(true);
   });
 
   it('is a model-invisible app-only tool gated on adminToolsEnabled && mcp-apps', () => {
@@ -152,7 +152,7 @@ describe('confirmDeleteDatasourceTool', () => {
   });
 
   it('is disabled when the mcp-apps flag is OFF', async () => {
-    mocks.mockIsFeatureEnabled.mockReturnValue(false);
+    mocks.mockIsFeatureEnabled.mockResolvedValue(false);
     const tool = getConfirmDeleteDatasourceTool(new WebMcpServer());
     expect(await Provider.from(tool.disabled)).toBe(true);
   });

--- a/src/tools/web/datasources/confirmDeleteDatasource.ts
+++ b/src/tools/web/datasources/confirmDeleteDatasource.ts
@@ -8,6 +8,7 @@ import { getFeatureGate } from '../../../features/init.js';
 import { useRestApi } from '../../../restApiInstance.js';
 import { WebMcpServer } from '../../../server.web.js';
 import { getExceptionMessage } from '../../../utils/getExceptionMessage.js';
+import { Provider } from '../../../utils/provider.js';
 import {
   AllEvidence,
   AppApprovalEvidence,
@@ -54,7 +55,10 @@ export const getConfirmDeleteDatasourceTool = (
   const confirmDeleteDatasourceTool = new WebTool({
     server,
     name: 'confirm-delete-datasource',
-    disabled: !config.adminToolsEnabled || !getFeatureGate().isFeatureEnabled('mcp-apps'),
+    disabled: new Provider(
+      async () =>
+        !config.adminToolsEnabled || !(await getFeatureGate().isFeatureEnabled('mcp-apps')),
+    ),
     description: `
 Confirms and permanently deletes a published data source previously previewed by \`delete-datasource\`.
 This tool is **not visible to the model** — it is invoked only by an explicit human confirmation

--- a/src/tools/web/datasources/deleteDatasource.test.ts
+++ b/src/tools/web/datasources/deleteDatasource.test.ts
@@ -141,11 +141,11 @@ describe('deleteDatasourceTool', () => {
     mocks.mockAddTagsToDatasource.mockResolvedValue(undefined);
     mocks.mockDeleteDatasource.mockResolvedValue(undefined);
     // Default: mcp-apps flag OFF → today's exact tag/confirm behavior (no iframe, no approval).
-    mocks.mockIsFeatureEnabled.mockReturnValue(false);
+    mocks.mockIsFeatureEnabled.mockResolvedValue(false);
   });
 
-  it('should create a tool instance with correct properties', () => {
-    const tool = getDeleteDatasourceTool(new WebMcpServer());
+  it('should create a tool instance with correct properties', async () => {
+    const tool = await getDeleteDatasourceTool(new WebMcpServer());
     expect(tool.name).toBe('delete-datasource');
     expect(tool.description).toContain('deletes a published data source');
     expect(tool.paramsSchema).toHaveProperty('datasourceId');
@@ -157,12 +157,12 @@ describe('deleteDatasourceTool', () => {
     vi.mocked(getConfig).mockReturnValueOnce({
       adminToolsEnabled: false,
     } as ReturnType<typeof getConfig>);
-    const tool = getDeleteDatasourceTool(new WebMcpServer());
+    const tool = await getDeleteDatasourceTool(new WebMcpServer());
     expect(await Provider.from(tool.disabled)).toBe(true);
   });
 
-  it('should have correct annotations for destructive operation', () => {
-    const tool = getDeleteDatasourceTool(new WebMcpServer());
+  it('should have correct annotations for destructive operation', async () => {
+    const tool = await getDeleteDatasourceTool(new WebMcpServer());
     expect(tool.annotations).toEqual({
       title: 'Delete Datasource',
       readOnlyHint: false,
@@ -339,15 +339,15 @@ describe('deleteDatasourceTool', () => {
     });
   });
 
-  it('should reject a tag that exceeds the schema length cap', () => {
-    const tool = getDeleteDatasourceTool(new WebMcpServer());
+  it('should reject a tag that exceeds the schema length cap', async () => {
+    const tool = await getDeleteDatasourceTool(new WebMcpServer());
     const tagSchema = (tool.paramsSchema as { tag: z.ZodOptional<z.ZodString> }).tag;
     expect(tagSchema.safeParse('a'.repeat(200)).success).toBe(true);
     expect(tagSchema.safeParse('a'.repeat(201)).success).toBe(false);
   });
 
-  it('should reject a tag with characters outside the safe class (prompt-injection guard)', () => {
-    const tool = getDeleteDatasourceTool(new WebMcpServer());
+  it('should reject a tag with characters outside the safe class (prompt-injection guard)', async () => {
+    const tool = await getDeleteDatasourceTool(new WebMcpServer());
     const tagSchema = (tool.paramsSchema as { tag: z.ZodOptional<z.ZodString> }).tag;
     // Allowed: letters, numbers, spaces, underscores, dashes.
     expect(tagSchema.safeParse('stale pending-deletion_2024').success).toBe(true);
@@ -601,11 +601,11 @@ describe('deleteDatasourceTool', () => {
 
   describe('with mcp-apps flag ON', () => {
     beforeEach(() => {
-      mocks.mockIsFeatureEnabled.mockReturnValue(true);
+      mocks.mockIsFeatureEnabled.mockResolvedValue(true);
     });
 
-    it('carries the delete-datasource app config so the host renders the confirm iframe', () => {
-      const tool = getDeleteDatasourceTool(new WebMcpServer());
+    it('carries the delete-datasource app config so the host renders the confirm iframe', async () => {
+      const tool = await getDeleteDatasourceTool(new WebMcpServer());
       expect(tool.app).toBeDefined();
       expect(tool.app?.resourceUri).toContain('delete-datasource');
     });
@@ -670,7 +670,7 @@ async function getToolResult(args: {
   confirm?: boolean;
   tag?: string;
 }): Promise<CallToolResult> {
-  const tool = getDeleteDatasourceTool(new WebMcpServer());
+  const tool = await getDeleteDatasourceTool(new WebMcpServer());
   const callback = await Provider.from(tool.callback);
   return await callback(
     {

--- a/src/tools/web/datasources/deleteDatasource.ts
+++ b/src/tools/web/datasources/deleteDatasource.ts
@@ -78,12 +78,14 @@ const paramsSchema = {
     ),
 };
 
-export const getDeleteDatasourceTool = (server: WebMcpServer): WebTool<typeof paramsSchema> => {
+export const getDeleteDatasourceTool = async (
+  server: WebMcpServer,
+): Promise<WebTool<typeof paramsSchema>> => {
   const config = getConfig();
   // MCP-Apps HITL: when the flag is ON, the preview carries an app so the host renders an iframe
   // confirm panel and the destructive step runs as a human gesture (confirm-delete-datasource).
   // Flag OFF → no `app`, byte-identical to today's tag/confirm behavior.
-  const mcpAppsEnabled = getFeatureGate().isFeatureEnabled('mcp-apps');
+  const mcpAppsEnabled = await getFeatureGate().isFeatureEnabled('mcp-apps');
 
   const deleteDatasourceTool = new WebTool({
     server,

--- a/src/tools/web/extractRefreshTasks/confirmDeleteExtractRefreshTask.test.ts
+++ b/src/tools/web/extractRefreshTasks/confirmDeleteExtractRefreshTask.test.ts
@@ -90,7 +90,7 @@ describe('confirmDeleteExtractRefreshTaskTool', () => {
     mocks.mockAssertAdmin.mockResolvedValue(new Ok(true));
     mocks.mockQueryUserOnSite.mockResolvedValue({ siteRole: 'SiteAdministratorCreator' });
     mocks.mockDeleteExtractRefreshTask.mockResolvedValue(undefined);
-    mocks.mockIsFeatureEnabled.mockReturnValue(true);
+    mocks.mockIsFeatureEnabled.mockResolvedValue(true);
   });
 
   it('is a model-invisible app-only tool gated on adminToolsEnabled && mcp-apps', async () => {
@@ -111,7 +111,7 @@ describe('confirmDeleteExtractRefreshTaskTool', () => {
   });
 
   it('is disabled when the mcp-apps flag is OFF', async () => {
-    mocks.mockIsFeatureEnabled.mockReturnValue(false);
+    mocks.mockIsFeatureEnabled.mockResolvedValue(false);
     const tool = getConfirmDeleteExtractRefreshTaskTool(new WebMcpServer());
     expect(await Provider.from(tool.disabled)).toBe(true);
   });

--- a/src/tools/web/extractRefreshTasks/confirmDeleteExtractRefreshTask.ts
+++ b/src/tools/web/extractRefreshTasks/confirmDeleteExtractRefreshTask.ts
@@ -7,6 +7,7 @@ import { getFeatureGate } from '../../../features/init.js';
 import { useRestApi } from '../../../restApiInstance.js';
 import { WebMcpServer } from '../../../server.web.js';
 import { getExceptionMessage } from '../../../utils/getExceptionMessage.js';
+import { Provider } from '../../../utils/provider.js';
 import { AppApprovalEvidence } from '../_lib/evidence.js';
 import { guardMutation, MutationTarget } from '../_lib/mutationGuard.js';
 import { WebTool } from '../tool.js';
@@ -44,7 +45,10 @@ export const getConfirmDeleteExtractRefreshTaskTool = (
   const confirmDeleteExtractRefreshTaskTool = new WebTool({
     server,
     name: 'confirm-delete-extract-refresh-task',
-    disabled: !config.adminToolsEnabled || !getFeatureGate().isFeatureEnabled('mcp-apps'),
+    disabled: new Provider(
+      async () =>
+        !config.adminToolsEnabled || !(await getFeatureGate().isFeatureEnabled('mcp-apps')),
+    ),
     description: `
 Confirms and permanently deletes an extract refresh task previously previewed by
 \`delete-extract-refresh-task\`. This tool is **not visible to the model** — it is invoked only by an

--- a/src/tools/web/extractRefreshTasks/confirmUpdateCloudExtractRefreshTask.test.ts
+++ b/src/tools/web/extractRefreshTasks/confirmUpdateCloudExtractRefreshTask.test.ts
@@ -118,7 +118,7 @@ describe('confirmUpdateCloudExtractRefreshTaskTool', () => {
     mocks.mockAssertAdmin.mockResolvedValue(new Ok(true));
     mocks.mockQueryUserOnSite.mockResolvedValue({ siteRole: 'SiteAdministratorCreator' });
     mocks.mockUpdateCloudExtractRefreshTask.mockResolvedValue(new Ok(updatedTask));
-    mocks.mockIsFeatureEnabled.mockReturnValue(true);
+    mocks.mockIsFeatureEnabled.mockResolvedValue(true);
   });
 
   it('is a model-invisible app-only tool gated on adminToolsEnabled && mcp-apps', () => {
@@ -139,7 +139,7 @@ describe('confirmUpdateCloudExtractRefreshTaskTool', () => {
   });
 
   it('is disabled when the mcp-apps flag is OFF', async () => {
-    mocks.mockIsFeatureEnabled.mockReturnValue(false);
+    mocks.mockIsFeatureEnabled.mockResolvedValue(false);
     const tool = getConfirmUpdateCloudExtractRefreshTaskTool(new WebMcpServer());
     expect(await Provider.from(tool.disabled)).toBe(true);
   });

--- a/src/tools/web/extractRefreshTasks/confirmUpdateCloudExtractRefreshTask.ts
+++ b/src/tools/web/extractRefreshTasks/confirmUpdateCloudExtractRefreshTask.ts
@@ -8,6 +8,7 @@ import { getFeatureGate } from '../../../features/init.js';
 import { useRestApi } from '../../../restApiInstance.js';
 import { updateCloudExtractRefreshScheduleSchema } from '../../../sdks/tableau/types/extractRefreshTask.js';
 import { WebMcpServer } from '../../../server.web.js';
+import { Provider } from '../../../utils/provider.js';
 import { AppApprovalEvidence } from '../_lib/evidence.js';
 import { guardMutation, MutationTarget } from '../_lib/mutationGuard.js';
 import { WebTool } from '../tool.js';
@@ -46,7 +47,10 @@ export const getConfirmUpdateCloudExtractRefreshTaskTool = (
   const confirmUpdateCloudExtractRefreshTaskTool = new WebTool({
     server,
     name: 'confirm-update-cloud-extract-refresh-task',
-    disabled: !config.adminToolsEnabled || !getFeatureGate().isFeatureEnabled('mcp-apps'),
+    disabled: new Provider(
+      async () =>
+        !config.adminToolsEnabled || !(await getFeatureGate().isFeatureEnabled('mcp-apps')),
+    ),
     description: `
 Confirms and applies a schedule change to an extract refresh task on Tableau Cloud, previously
 previewed by \`update-cloud-extract-refresh-task\`. This tool is **not visible to the model** — it is

--- a/src/tools/web/extractRefreshTasks/deleteExtractRefreshTask.test.ts
+++ b/src/tools/web/extractRefreshTasks/deleteExtractRefreshTask.test.ts
@@ -96,11 +96,11 @@ describe('deleteExtractRefreshTaskTool', () => {
     mocks.mockQueryUserOnSite.mockResolvedValue({ siteRole: 'SiteAdministratorCreator' });
     mocks.mockDeleteExtractRefreshTask.mockResolvedValue(undefined);
     // Default: mcp-apps flag OFF → today's exact nonce/confirmationToken behavior.
-    mocks.mockIsFeatureEnabled.mockReturnValue(false);
+    mocks.mockIsFeatureEnabled.mockResolvedValue(false);
   });
 
-  it('should create a tool instance with correct properties', () => {
-    const tool = getDeleteExtractRefreshTaskTool(new WebMcpServer());
+  it('should create a tool instance with correct properties', async () => {
+    const tool = await getDeleteExtractRefreshTaskTool(new WebMcpServer());
     expect(tool.name).toBe('delete-extract-refresh-task');
     expect(tool.description).toContain('Deletes an extract refresh task from the Tableau site');
     expect(tool.paramsSchema).toHaveProperty('taskId');
@@ -108,8 +108,8 @@ describe('deleteExtractRefreshTaskTool', () => {
     expect(tool.paramsSchema).toHaveProperty('confirmationToken');
   });
 
-  it('should have correct annotations for destructive operation', () => {
-    const tool = getDeleteExtractRefreshTaskTool(new WebMcpServer());
+  it('should have correct annotations for destructive operation', async () => {
+    const tool = await getDeleteExtractRefreshTaskTool(new WebMcpServer());
     expect(tool.annotations).toEqual({
       title: 'Delete Extract Refresh Task',
       readOnlyHint: false,
@@ -269,8 +269,8 @@ describe('deleteExtractRefreshTaskTool', () => {
     expect(failed.failureDetail).toContain(errorMessage);
   });
 
-  it('should reject a non-UUID taskId at the schema boundary', () => {
-    const tool = getDeleteExtractRefreshTaskTool(new WebMcpServer());
+  it('should reject a non-UUID taskId at the schema boundary', async () => {
+    const tool = await getDeleteExtractRefreshTaskTool(new WebMcpServer());
     const taskIdSchema = (
       tool.paramsSchema as { taskId: { safeParse: (v: unknown) => { success: boolean } } }
     ).taskId;
@@ -278,8 +278,8 @@ describe('deleteExtractRefreshTaskTool', () => {
     expect(taskIdSchema.safeParse(validTaskId).success).toBe(true);
   });
 
-  it('should reject a non-UUID taskId at the schema boundary', () => {
-    const tool = getDeleteExtractRefreshTaskTool(new WebMcpServer());
+  it('should reject a non-UUID taskId at the schema boundary', async () => {
+    const tool = await getDeleteExtractRefreshTaskTool(new WebMcpServer());
     const taskIdSchema = (
       tool.paramsSchema as { taskId: { safeParse: (v: unknown) => { success: boolean } } }
     ).taskId;
@@ -291,11 +291,11 @@ describe('deleteExtractRefreshTaskTool', () => {
 
   describe('with mcp-apps flag ON', () => {
     beforeEach(() => {
-      mocks.mockIsFeatureEnabled.mockReturnValue(true);
+      mocks.mockIsFeatureEnabled.mockResolvedValue(true);
     });
 
-    it('carries the delete-extract-refresh-task app config so the host renders the confirm iframe', () => {
-      const tool = getDeleteExtractRefreshTaskTool(new WebMcpServer());
+    it('carries the delete-extract-refresh-task app config so the host renders the confirm iframe', async () => {
+      const tool = await getDeleteExtractRefreshTaskTool(new WebMcpServer());
       expect(tool.app).toBeDefined();
       expect(tool.app?.resourceUri).toContain('delete-extract-refresh-task');
     });
@@ -340,7 +340,7 @@ async function getToolResult(args: {
   confirm?: boolean;
   confirmationToken?: string;
 }): Promise<CallToolResult> {
-  const tool = getDeleteExtractRefreshTaskTool(new WebMcpServer());
+  const tool = await getDeleteExtractRefreshTaskTool(new WebMcpServer());
   const callback = await Provider.from(tool.callback);
   return await callback(
     {

--- a/src/tools/web/extractRefreshTasks/deleteExtractRefreshTask.ts
+++ b/src/tools/web/extractRefreshTasks/deleteExtractRefreshTask.ts
@@ -49,14 +49,14 @@ const paramsSchema = {
     ),
 };
 
-export const getDeleteExtractRefreshTaskTool = (
+export const getDeleteExtractRefreshTaskTool = async (
   server: WebMcpServer,
-): WebTool<typeof paramsSchema> => {
+): Promise<WebTool<typeof paramsSchema>> => {
   const config = getConfig();
   // MCP-Apps HITL: when the flag is ON, the preview carries an app so the host renders an iframe
   // confirm panel and the destructive step runs as a human gesture (confirm-delete-extract-refresh-task).
   // Flag OFF → no `app`, byte-identical to today's nonce/confirmationToken behavior.
-  const mcpAppsEnabled = getFeatureGate().isFeatureEnabled('mcp-apps');
+  const mcpAppsEnabled = await getFeatureGate().isFeatureEnabled('mcp-apps');
 
   const deleteExtractRefreshTaskTool = new WebTool({
     server,

--- a/src/tools/web/extractRefreshTasks/updateCloudExtractRefreshTask.test.ts
+++ b/src/tools/web/extractRefreshTasks/updateCloudExtractRefreshTask.test.ts
@@ -123,19 +123,19 @@ describe('updateCloudExtractRefreshTaskTool', () => {
     mocks.mockQueryUserOnSite.mockResolvedValue({ siteRole: 'SiteAdministratorCreator' });
     mocks.mockUpdateCloudExtractRefreshTask.mockResolvedValue(new Ok(updatedTask));
     // Default: mcp-apps flag OFF → today's exact confirm-only behavior.
-    mocks.mockIsFeatureEnabled.mockReturnValue(false);
+    mocks.mockIsFeatureEnabled.mockResolvedValue(false);
   });
 
-  it('should create a tool instance with correct properties', () => {
-    const tool = getUpdateCloudExtractRefreshTaskTool(new WebMcpServer());
+  it('should create a tool instance with correct properties', async () => {
+    const tool = await getUpdateCloudExtractRefreshTaskTool(new WebMcpServer());
     expect(tool.name).toBe('update-cloud-extract-refresh-task');
     expect(tool.description).toContain('Updates the schedule of an extract refresh task');
     expect(tool.paramsSchema).toHaveProperty('taskId');
     expect(tool.paramsSchema).toHaveProperty('schedule');
   });
 
-  it('should have correct annotations', () => {
-    const tool = getUpdateCloudExtractRefreshTaskTool(new WebMcpServer());
+  it('should have correct annotations', async () => {
+    const tool = await getUpdateCloudExtractRefreshTaskTool(new WebMcpServer());
     expect(tool.annotations).toEqual({
       title: 'Update Cloud Extract Refresh Task',
       readOnlyHint: false,
@@ -150,7 +150,7 @@ describe('updateCloudExtractRefreshTaskTool', () => {
     vi.mocked(getConfig).mockReturnValueOnce({
       adminToolsEnabled: false,
     } as ReturnType<typeof getConfig>);
-    const tool = getUpdateCloudExtractRefreshTaskTool(new WebMcpServer());
+    const tool = await getUpdateCloudExtractRefreshTaskTool(new WebMcpServer());
     expect(await Provider.from(tool.disabled)).toBe(true);
   });
 
@@ -680,11 +680,11 @@ describe('updateCloudExtractRefreshTaskTool', () => {
 
   describe('with mcp-apps flag ON', () => {
     beforeEach(() => {
-      mocks.mockIsFeatureEnabled.mockReturnValue(true);
+      mocks.mockIsFeatureEnabled.mockResolvedValue(true);
     });
 
-    it('carries the update-cloud-extract-refresh-task app config so the host renders the confirm iframe', () => {
-      const tool = getUpdateCloudExtractRefreshTaskTool(new WebMcpServer());
+    it('carries the update-cloud-extract-refresh-task app config so the host renders the confirm iframe', async () => {
+      const tool = await getUpdateCloudExtractRefreshTaskTool(new WebMcpServer());
       expect(tool.app).toBeDefined();
       expect(tool.app?.resourceUri).toContain('update-cloud-extract-refresh-task');
     });
@@ -739,7 +739,7 @@ async function getToolResult(args: {
   confirm?: boolean;
   confirmationToken?: string;
 }): Promise<CallToolResult> {
-  const tool = getUpdateCloudExtractRefreshTaskTool(new WebMcpServer());
+  const tool = await getUpdateCloudExtractRefreshTaskTool(new WebMcpServer());
   const callback = await Provider.from(tool.callback);
   return await callback(
     {

--- a/src/tools/web/extractRefreshTasks/updateCloudExtractRefreshTask.ts
+++ b/src/tools/web/extractRefreshTasks/updateCloudExtractRefreshTask.ts
@@ -102,15 +102,15 @@ export function scheduleBinding(schedule: UpdateCloudExtractRefreshSchedule): st
     .digest('hex');
 }
 
-export const getUpdateCloudExtractRefreshTaskTool = (
+export const getUpdateCloudExtractRefreshTaskTool = async (
   server: WebMcpServer,
-): WebTool<typeof paramsSchema> => {
+): Promise<WebTool<typeof paramsSchema>> => {
   const config = getConfig();
   // MCP-Apps HITL: when the flag is ON, the preview carries an app so the host renders an iframe
   // confirm panel and the schedule change is applied as a human gesture
   // (confirm-update-cloud-extract-refresh-task). Flag OFF → no `app`, byte-identical to today's
   // confirm-only behavior.
-  const mcpAppsEnabled = getFeatureGate().isFeatureEnabled('mcp-apps');
+  const mcpAppsEnabled = await getFeatureGate().isFeatureEnabled('mcp-apps');
 
   const updateCloudExtractRefreshTaskTool = new WebTool({
     server,

--- a/src/tools/web/getEmbedToken/getEmbedToken.ts
+++ b/src/tools/web/getEmbedToken/getEmbedToken.ts
@@ -5,6 +5,7 @@ import { EmbedTokenNotAvailableError } from '../../../errors/mcpToolError.js';
 import { getFeatureGate } from '../../../features/init.js';
 import { buildAuthConfig } from '../../../sdks/tableau/buildAuthConfig.js';
 import { WebMcpServer } from '../../../server.web.js';
+import { Provider } from '../../../utils/provider.js';
 import { WebTool } from '../tool.js';
 import { EMBED_SCOPE, resolveEmbedToken } from './resolveEmbedToken.js';
 
@@ -39,7 +40,7 @@ This tool resolves the embed token from the current session's signing material â
         visibility: ['app'], // Only visible to the app, not the model
       },
     },
-    disabled: !getFeatureGate().isFeatureEnabled('mcp-apps'),
+    disabled: new Provider(async () => !(await getFeatureGate().isFeatureEnabled('mcp-apps'))),
     callback: async (_args, extra): Promise<CallToolResult> => {
       return getEmbedTokenTool.logAndExecute<{ token: string }>({
         extra,

--- a/src/tools/web/workbooks/confirmDeleteWorkbook.test.ts
+++ b/src/tools/web/workbooks/confirmDeleteWorkbook.test.ts
@@ -116,7 +116,7 @@ describe('confirmDeleteWorkbookTool', () => {
       email: 'owner@example.com',
     });
     mocks.mockDeleteWorkbook.mockResolvedValue(undefined);
-    mocks.mockIsFeatureEnabled.mockReturnValue(true);
+    mocks.mockIsFeatureEnabled.mockResolvedValue(true);
   });
 
   it('creates a tool instance with the app-only confirm name and workbookId param', () => {
@@ -144,7 +144,7 @@ describe('confirmDeleteWorkbookTool', () => {
   });
 
   it('is disabled when the mcp-apps feature flag is off', async () => {
-    mocks.mockIsFeatureEnabled.mockReturnValue(false);
+    mocks.mockIsFeatureEnabled.mockResolvedValue(false);
     const tool = getConfirmDeleteWorkbookTool(new WebMcpServer());
     expect(await Provider.from(tool.disabled)).toBe(true);
   });

--- a/src/tools/web/workbooks/confirmDeleteWorkbook.ts
+++ b/src/tools/web/workbooks/confirmDeleteWorkbook.ts
@@ -8,6 +8,7 @@ import { getFeatureGate } from '../../../features/init.js';
 import { useRestApi } from '../../../restApiInstance.js';
 import { WebMcpServer } from '../../../server.web.js';
 import { getExceptionMessage } from '../../../utils/getExceptionMessage.js';
+import { Provider } from '../../../utils/provider.js';
 import {
   AllEvidence,
   AppApprovalEvidence,
@@ -53,7 +54,10 @@ export const getConfirmDeleteWorkbookTool = (
   const confirmDeleteWorkbookTool = new WebTool({
     server,
     name: 'confirm-delete-workbook',
-    disabled: !config.adminToolsEnabled || !getFeatureGate().isFeatureEnabled('mcp-apps'),
+    disabled: new Provider(
+      async () =>
+        !config.adminToolsEnabled || !(await getFeatureGate().isFeatureEnabled('mcp-apps')),
+    ),
     description: `
 Confirms and permanently deletes a workbook previously previewed by \`delete-workbook\`. This tool is
 **not visible to the model** — it is invoked only by an explicit human confirmation gesture inside

--- a/src/tools/web/workbooks/deleteWorkbook.test.ts
+++ b/src/tools/web/workbooks/deleteWorkbook.test.ts
@@ -105,11 +105,11 @@ describe('deleteWorkbookTool', () => {
     mocks.mockAddTagsToWorkbook.mockResolvedValue(undefined);
     mocks.mockDeleteWorkbook.mockResolvedValue(undefined);
     // Default: mcp-apps flag OFF → today's exact behavior (no iframe, no approval recorded).
-    mocks.mockIsFeatureEnabled.mockReturnValue(false);
+    mocks.mockIsFeatureEnabled.mockResolvedValue(false);
   });
 
-  it('should create a tool instance with correct properties', () => {
-    const tool = getDeleteWorkbookTool(new WebMcpServer());
+  it('should create a tool instance with correct properties', async () => {
+    const tool = await getDeleteWorkbookTool(new WebMcpServer());
     expect(tool.name).toBe('delete-workbook');
     expect(tool.description).toContain('deletes a workbook');
     expect(tool.paramsSchema).toHaveProperty('workbookId');
@@ -121,12 +121,12 @@ describe('deleteWorkbookTool', () => {
     vi.mocked(getConfig).mockReturnValueOnce({
       adminToolsEnabled: false,
     } as ReturnType<typeof getConfig>);
-    const tool = getDeleteWorkbookTool(new WebMcpServer());
+    const tool = await getDeleteWorkbookTool(new WebMcpServer());
     expect(await Provider.from(tool.disabled)).toBe(true);
   });
 
-  it('should have correct annotations for destructive operation', () => {
-    const tool = getDeleteWorkbookTool(new WebMcpServer());
+  it('should have correct annotations for destructive operation', async () => {
+    const tool = await getDeleteWorkbookTool(new WebMcpServer());
     expect(tool.annotations).toEqual({
       title: 'Delete Workbook',
       readOnlyHint: false,
@@ -136,15 +136,15 @@ describe('deleteWorkbookTool', () => {
     });
   });
 
-  it('should reject a tag that exceeds the schema length cap', () => {
-    const tool = getDeleteWorkbookTool(new WebMcpServer());
+  it('should reject a tag that exceeds the schema length cap', async () => {
+    const tool = await getDeleteWorkbookTool(new WebMcpServer());
     const tagSchema = (tool.paramsSchema as { tag: z.ZodOptional<z.ZodString> }).tag;
     expect(tagSchema.safeParse('a'.repeat(200)).success).toBe(true);
     expect(tagSchema.safeParse('a'.repeat(201)).success).toBe(false);
   });
 
-  it('should reject a tag with characters outside the safe class (prompt-injection guard)', () => {
-    const tool = getDeleteWorkbookTool(new WebMcpServer());
+  it('should reject a tag with characters outside the safe class (prompt-injection guard)', async () => {
+    const tool = await getDeleteWorkbookTool(new WebMcpServer());
     const tagSchema = (tool.paramsSchema as { tag: z.ZodOptional<z.ZodString> }).tag;
     // Allowed: letters, numbers, spaces, underscores, dashes.
     expect(tagSchema.safeParse('stale pending-deletion_2024').success).toBe(true);
@@ -508,11 +508,11 @@ describe('deleteWorkbookTool', () => {
 
   describe('with mcp-apps flag ON', () => {
     beforeEach(() => {
-      mocks.mockIsFeatureEnabled.mockReturnValue(true);
+      mocks.mockIsFeatureEnabled.mockResolvedValue(true);
     });
 
-    it('carries the delete-workbook app config so the host renders the confirm iframe', () => {
-      const tool = getDeleteWorkbookTool(new WebMcpServer());
+    it('carries the delete-workbook app config so the host renders the confirm iframe', async () => {
+      const tool = await getDeleteWorkbookTool(new WebMcpServer());
       expect(tool.app).toBeDefined();
       expect(tool.app?.resourceUri).toContain('delete-workbook');
     });
@@ -565,7 +565,7 @@ async function getToolResult(args: {
   confirm?: boolean;
   tag?: string;
 }): Promise<CallToolResult> {
-  const tool = getDeleteWorkbookTool(new WebMcpServer());
+  const tool = await getDeleteWorkbookTool(new WebMcpServer());
   const callback = await Provider.from(tool.callback);
   return await callback(
     {

--- a/src/tools/web/workbooks/deleteWorkbook.ts
+++ b/src/tools/web/workbooks/deleteWorkbook.ts
@@ -71,12 +71,14 @@ const paramsSchema = {
     ),
 };
 
-export const getDeleteWorkbookTool = (server: WebMcpServer): WebTool<typeof paramsSchema> => {
+export const getDeleteWorkbookTool = async (
+  server: WebMcpServer,
+): Promise<WebTool<typeof paramsSchema>> => {
   const config = getConfig();
   // MCP-Apps HITL (AC-5): when the flag is ON, the preview carries an app so the host renders an
   // iframe confirm panel and the destructive step runs as a human gesture (confirm-delete-workbook).
   // Flag OFF → no `app`, byte-identical to today's tag/confirm behavior.
-  const mcpAppsEnabled = getFeatureGate().isFeatureEnabled('mcp-apps');
+  const mcpAppsEnabled = await getFeatureGate().isFeatureEnabled('mcp-apps');
 
   const deleteWorkbookTool = new WebTool({
     server,

--- a/tests/oauth/tableau-authz/tests/getEmbedToken.test.ts
+++ b/tests/oauth/tableau-authz/tests/getEmbedToken.test.ts
@@ -10,7 +10,10 @@ const tokenResponseSchema = z.object({
 
 test.describe('get-embed-token', () => {
   test('should return Bearer token', async ({ client }) => {
-    test.skip(!getFeatureGate().isFeatureEnabled('mcp-apps'), 'mcp-apps feature is disabled');
+    test.skip(
+      !(await getFeatureGate().isFeatureEnabled('mcp-apps')),
+      'mcp-apps feature is disabled',
+    );
     const result = await client.callTool('get-embed-token', {
       schema: tokenResponseSchema,
       toolArgs: {},


### PR DESCRIPTION
## What

`FeatureGateProvider.isFeatureEnabled` becomes async: `boolean` → `Promise<boolean>`.

## Why

Lets a custom provider resolve gate state from an async source (e.g. a network-backed store, read fresh per call). The sync contract made that impossible. Async is a superset — the built-in `ServerFeatureGate` satisfies it by becoming `async`.

## Breaking change

Custom `FeatureGateProvider` implementers must return `Promise<boolean>`. Version 2.26.0 → 2.27.0.

## Tests

Full suite passes (2276); `tsc` and lint clean. Adds an async-contract test; scope tests migrated to `.resolves` with values preserved.
