### PR TITLE
port: W63 render stamps — connected-scatterplot + slope-chart + ranking-dot-strip-plot live (2026-07-13)

### DIFF
--- a/src/desktop/binder/bind-behavior-matrix.invariant.test.ts
+++ b/src/desktop/binder/bind-behavior-matrix.invariant.test.ts
@@ -38,6 +38,7 @@ const EXPECTED_DATASOURCE = 'Sample - Superstore';
 // extended (per the discover-and-pin contract) rather than silently under-covering.
 const EXPECTED_ELIGIBLE = [
   'box-plot-chart',
+  'connected-scatterplot', // W63 render-stamp port: live-2026-07-13
   'control-chart-xmr',
   'correlation-bubble-chart',
   'correlation-scatter-plot-chart', // W60 parity port: factory stamp crossed
@@ -51,8 +52,10 @@ const EXPECTED_ELIGIBLE = [
   'part-to-whole-treemap-chart',
   'part-to-whole-waterfall',
   'quota-attainment-bullet',
+  'ranking-dot-strip-plot', // W63 render-stamp port: live-2026-07-13
   'ranking-ordered-bar',
   'ranking-ordered-column',
+  'slope-chart', // W63 render-stamp port: live-2026-07-13
   'spatial-choropleth-map',
   'spatial-symbol-map',
   'trend-line-chart',
@@ -89,10 +92,15 @@ const ONE_SHOTS: ReadonlyArray<readonly [ask: string, template: string]> = [
   // from PINNED_PROPOSE (was fail-closed pre-W60) — see resolveGeoSlots widening.
   ['filled map of Profit by State/Province', 'spatial-choropleth-map'],
   ['pie chart of Sales by Segment', 'part-to-whole-pie-chart'],
-  [
-    'symbol map of Sales by Country/Region, State/Province, and City',
-    'spatial-symbol-map',
-  ],
+  ['symbol map of Sales by Country/Region, State/Province, and City', 'spatial-symbol-map'],
+  // W63 render-stamp port: connected-scatterplot one-shots on the 'connected' qualifier +
+  // two measures + a detail dim + a color dim (the 'vs ... by ... and ...' phrasing fills
+  // X/Profit-Ratio/detail/color). The bare 'scatter' noun stays with
+  // correlation-scatter-plot-chart (W63 dropped connected-scatterplot's 'scatter' alias).
+  ['connected scatterplot of Profit vs Sales by Customer Name and Region', 'connected-scatterplot'],
+  // W63 render-stamp port: slope-chart one-shots on the 'slope' chart noun + measure + dim
+  // + temporal [Order Date] filling the endpoint-period slots.
+  ['slope chart of Sales by Region over Order Date', 'slope-chart'],
 ];
 
 // ── KNOWN SAFE-PROPOSES (NOT bound — fail-closed by design; WHY each) ──────────
@@ -177,6 +185,10 @@ const PINNED_PROPOSE: ReadonlyArray<readonly [ask: string, note: string]> = [
   [
     'bubble chart of Profit, Discount, and Sales by Order ID',
     'pinned-current-behavior: W62 stamp made correlation-bubble-chart eligible, but no-LLM classifier still proposes on this phrasing',
+  ],
+  [
+    'dot strip plot of Sales by Sub-Category over Order Date',
+    'pinned-current-behavior: W63 stamp made ranking-dot-strip-plot eligible, but its rows slot needs a MONTH-derivation temporal (deriv=mn) that this phrasing does not fill deterministically → propose (fail-open to the LLM path)',
   ],
   // NB (W60): 'filled map of Profit by State/Province' MOVED to the ONE_SHOTS table — the
   // required country geo slot now auto-completes from the schema (Country/Region) when the

--- a/src/desktop/binder/binder.test.ts
+++ b/src/desktop/binder/binder.test.ts
@@ -632,24 +632,23 @@ describe('binder/buildLlmInput — family-aware truncation (attack 2)', () => {
 
 describe('binder/bindTemplate — evidence gate escalation (attacks 5+10)', () => {
   it('a render-unverified template escalates not-fast-path', async () => {
-    // correlation-scatter-plot-chart binds the fixture but is render_verified:'none'
+    // pareto-chart binds the fixture (Sub-Category + Sales) but is render_verified:'none'
     // ⇒ fast_path_eligible:false ⇒ the binder must refuse it (honest shrink).
-    // W60: fixture swapped correlation-scatter-plot-chart → connected-scatterplot when the
-    // former's factory stamp crossed (it is now legitimately eligible). connected-scatterplot
-    // carries the SAME slot_ids and remains render-unverified — the gate under test.
+    // W60 used correlation-scatter-plot-chart, then connected-scatterplot, as the gate
+    // target; W63's live-2026-07-13 stamp made connected-scatterplot legitimately eligible,
+    // so this swaps to pareto-chart — still genuinely render-unverified — to keep the
+    // not-fast-path escalation exercised.
     const proposal: BindingProposal = {
-      template: 'connected-scatterplot',
-      title: 'Scatter',
+      template: 'pareto-chart',
+      title: 'Pareto',
       bindings: [
+        { slot_id: 'sub_category', field: 'Sub-Category' },
         { slot_id: 'sales', field: 'Sales' },
-        { slot_id: 'profit', field: 'Profit' },
-        { slot_id: 'customer_name', field: 'Customer Name' },
-        { slot_id: 'region', field: 'Region' },
       ],
       confidence: 0.9,
     };
     const res = await bindTemplate({
-      ask: 'scatter of Profit vs Sales',
+      ask: 'pareto chart of Sales by Sub-Category',
       workbookXml: WORKBOOK_XML,
       manifests,
       proposal,

--- a/src/desktop/binder/carrier-uniqueness.invariant.test.ts
+++ b/src/desktop/binder/carrier-uniqueness.invariant.test.ts
@@ -111,7 +111,7 @@ describe('binder/carrier-uniqueness — CHART_NOUN_KEYWORDS ↔ eligible manifes
     expect(carriersOf('dot-strip')).toEqual(['distribution-bar-code-chart']);
   });
 
-  it("the newly stamped pie nouns (pie/donut) are each single-carrier", () => {
+  it('the newly stamped pie nouns (pie/donut) are each single-carrier', () => {
     expect(carriersOf('pie')).toEqual(['part-to-whole-pie-chart']);
     expect(carriersOf('donut')).toEqual(['part-to-whole-pie-chart']);
   });
@@ -132,12 +132,17 @@ describe('binder/carrier-uniqueness — CHART_NOUN_KEYWORDS ↔ eligible manifes
   // ── Pinned-current-behavior: the exact single-carrier / zero-carrier split ───
   // Documents (and locks) the reality that "exactly one carrier" is NOT universal:
   // nouns whose template is not yet fast_path_eligible carry ZERO eligible carriers.
-  // If a future stamp (e.g. distribution-histogram, slope-chart, part-to-whole-pie)
-  // moves a noun from zero → one carrier, this pin fails and forces a deliberate
-  // re-review — which is the intended tripwire, not a false alarm.
+  // If a future stamp (e.g. distribution-histogram) moves a noun from zero → one
+  // carrier, this pin fails and forces a deliberate re-review — which is the intended
+  // tripwire, not a false alarm.
+  // W63: slope/slope-chart/slope-graph moved zero → one carrier (slope-chart stamped
+  // live-2026-07-13, fast-path eligible). connected-scatterplot dropped its bare 'scatter'
+  // alias on the same stamp (canonical scatter = correlation-scatter-plot-chart), so
+  // 'scatter' stays single-carrier; ranking-dot-strip-plot dropped bare 'strip-plot'
+  // (canonical = distribution-bar-code-chart). Only 'histogram' remains zero-carrier.
   it('pins the zero-carrier nouns (templates present but not yet stamped eligible)', () => {
     const zeroCarrier = [...new Set(nouns)].filter((n) => carriersOf(n).length === 0).sort();
-    expect(zeroCarrier).toEqual(['histogram', 'slope', 'slope-chart', 'slope-graph'].sort());
+    expect(zeroCarrier).toEqual(['histogram'].sort());
   });
 
   it('every non-zero-carrier noun has exactly one carrier (no >1 slips past the split)', () => {

--- a/src/desktop/binder/manifest.test.ts
+++ b/src/desktop/binder/manifest.test.ts
@@ -384,7 +384,7 @@ describe('binder/manifest — portability evidence gate (attacks 5+10)', () => {
     }
   });
 
-  it('the fast-path eligible set is exactly the twenty live-proven templates', () => {
+  it('the fast-path eligible set is exactly the twenty-three live-proven templates', () => {
     // W59 template-sync: the seven missing fast-path XMLs were ported from the factory
     // (a2td) with their manifests. fast_path_eligible / render_verified TRAVEL UNCHANGED
     // from the factory (no stamps minted in transit): the factory's 2026-07-06 stamp wave
@@ -397,6 +397,11 @@ describe('binder/manifest — portability evidence gate (attacks 5+10)', () => {
     // W62 render-stamp evidence port: spatial-symbol-map, part-to-whole-pie-chart,
     // correlation-bubble-chart, control-chart-xmr, and magnitude-simple-bar crossed with
     // live 2026-07-11 evidence and XML hashes — 15 → 20.
+    // W63 render-stamp evidence port: connected-scatterplot + slope-chart (composite 94)
+    // and ranking-dot-strip-plot (composite 98) crossed with live 2026-07-13 evidence and
+    // XML hashes — 20 → 23. connected-scatterplot dropped its bare 'scatter' keyword and
+    // ranking-dot-strip-plot dropped bare 'strip-plot' on becoming eligible, so the
+    // canonical scatter/strip-plot nouns keep a single carrier (see carrier-uniqueness).
     // Other templates either ship propose-only (render_verified none) or retain a
     // separate blocker despite render evidence (for example histogram bin-width tuning).
     const eligible = [...manifests.values()]
@@ -406,6 +411,7 @@ describe('binder/manifest — portability evidence gate (attacks 5+10)', () => {
     expect(eligible).toEqual(
       [
         'box-plot-chart',
+        'connected-scatterplot',
         'control-chart-xmr',
         'correlation-bubble-chart',
         'correlation-scatter-plot-chart',
@@ -419,8 +425,10 @@ describe('binder/manifest — portability evidence gate (attacks 5+10)', () => {
         'part-to-whole-treemap-chart',
         'part-to-whole-waterfall',
         'quota-attainment-bullet',
+        'ranking-dot-strip-plot',
         'ranking-ordered-bar',
         'ranking-ordered-column',
+        'slope-chart',
         'spatial-choropleth-map',
         'spatial-symbol-map',
         'trend-line-chart',

--- a/src/desktop/binder/portability.invariant.test.ts
+++ b/src/desktop/binder/portability.invariant.test.ts
@@ -43,6 +43,7 @@ const ADVERSARIAL = loadFixture('adversarial.xml');
 // (a natural ask targeting the new template) rather than silently under-covering.
 const EXPECTED_ELIGIBLE = [
   'box-plot-chart',
+  'connected-scatterplot',
   'control-chart-xmr',
   'correlation-bubble-chart',
   'correlation-scatter-plot-chart',
@@ -56,8 +57,10 @@ const EXPECTED_ELIGIBLE = [
   'part-to-whole-treemap-chart',
   'part-to-whole-waterfall',
   'quota-attainment-bullet',
+  'ranking-dot-strip-plot',
   'ranking-ordered-bar',
   'ranking-ordered-column',
+  'slope-chart',
   'spatial-choropleth-map',
   'spatial-symbol-map',
   'trend-line-chart',
@@ -252,6 +255,27 @@ const SAAS_ASKS: Ask[] = [
     mayBind: null,
     pinned: 'not-bound',
     note: 'GEO REFUSAL #3: symbol map is stamped but SaaS Region Name is not geocodable',
+  },
+  {
+    ask: 'connected scatterplot of ARR vs Seats by Account Name colored by Industry',
+    targets: 'connected-scatterplot',
+    mayBind: 'connected-scatterplot',
+    pinned: 'bound',
+    note: "W63 coverage: two measures (X/Profit-Ratio) + a color dim + a detail dim one-shot the connected-scatterplot; the 'connected' qualifier disambiguates it from the plain correlation-scatter-plot-chart (which owns the bare 'scatter' noun after W63 dropped connected-scatterplot's 'scatter' alias)",
+  },
+  {
+    ask: 'slope chart of ARR by Industry over Renewal Date',
+    targets: 'slope-chart',
+    mayBind: 'slope-chart',
+    pinned: 'bound',
+    note: "W63 coverage: 'slope' chart noun + measure + dim + temporal [Renewal Date] fills the endpoint-period slope slots",
+  },
+  {
+    ask: 'dot strip plot of ARR by Industry over Renewal Date',
+    targets: 'ranking-dot-strip-plot',
+    mayBind: null,
+    pinned: 'not-bound',
+    note: 'W63 coverage: ranking-dot-strip-plot requires a MONTH-derivation temporal on rows (deriv=mn) + measure on cols + a detail dim; the SaaS phrasing does not fill the month-grain rows slot deterministically -> honest propose (fail-open to the LLM path), not a wrong one-shot',
   },
 ];
 

--- a/src/desktop/binder/prewarm.test.ts
+++ b/src/desktop/binder/prewarm.test.ts
@@ -53,13 +53,15 @@ describe('prewarm/prewarmForDatasource', () => {
     expect(fams).toEqual([...fams].sort());
     expect(fams).toContain('ranking');
     expect(fams).toContain('kpi');
-    // A render-unverified template must not appear anywhere. (W60: the negative example
-    // moved from correlation-scatter-plot-chart — whose factory stamp crossed, now
-    // eligible — to its still-unverified sibling connected-scatterplot.)
+    // A render-unverified template must not appear anywhere. (W60 used connected-scatterplot
+    // as the negative; W63's live-2026-07-13 stamp made it eligible, so the negative example
+    // moved to its still-unverified sibling pareto-chart. connected-scatterplot is now
+    // asserted PRESENT below.)
     const allTemplates = r.families.flatMap((f) => f.templates.map((t) => t.template));
     expect(allTemplates).toContain('ranking-ordered-bar');
     expect(allTemplates).toContain('correlation-scatter-plot-chart');
-    expect(allTemplates).not.toContain('connected-scatterplot');
+    expect(allTemplates).toContain('connected-scatterplot');
+    expect(allTemplates).not.toContain('pareto-chart');
   });
 
   it('precomputes per-slot candidate field shortlists by kind', () => {

--- a/src/desktop/data/content-manifest.json
+++ b/src/desktop/data/content-manifest.json
@@ -2,9 +2,9 @@
   "_generated": true,
   "_generator": "src/scripts/buildTemplateManifests.ts",
   "_warning": "GENERATED FILE — do not hand-edit. Re-run `npx tsx src/scripts/buildTemplateManifests.ts`.",
-  "content_version": "2.11.0+content.2026-07-12",
+  "content_version": "2.11.0+content.2026-07-13",
   "schema_version": "1",
-  "generated": "2026-07-12",
+  "generated": "2026-07-13",
   "engine_compat": {
     "server_min": "2.11.0",
     "node": ">=22.7.5"
@@ -252,8 +252,8 @@
     },
     {
       "path": "template-manifests.index.json",
-      "sha256": "598c864c218ddabf0d65e175dd7c5b05376c56b8646366d434d6899eac342af3",
-      "bytes": 268571
+      "sha256": "1f38d342199e480d74fe72b822fb3851c6595aac1e33d0ac00d16c8a330140e1",
+      "bytes": 274432
     },
     {
       "path": "template-manifests/box-plot-chart.manifest.json",
@@ -282,8 +282,8 @@
     },
     {
       "path": "template-manifests/connected-scatterplot.manifest.json",
-      "sha256": "6569269ee10409cd4ce2173cf41ed49050a50f89486ad97e8bb34d59462c8b54",
-      "bytes": 3468
+      "sha256": "a9f5bdfdad0d1358a05a3e47ffbc6590c99350c9b1a083ab3047f00e1c18ae7c",
+      "bytes": 5372
     },
     {
       "path": "template-manifests/control-chart-xmr.manifest.json",
@@ -422,8 +422,8 @@
     },
     {
       "path": "template-manifests/ranking-dot-strip-plot.manifest.json",
-      "sha256": "df44680d837235cd32bf25b4e949b2115d23307cec73ae3f820f13e53c6bee06",
-      "bytes": 2661
+      "sha256": "69f658dab12b0f343e720df1cedee7e2db1c6d7753073fe49b53d85e86e5650e",
+      "bytes": 4487
     },
     {
       "path": "template-manifests/ranking-ordered-bar.manifest.json",
@@ -437,8 +437,8 @@
     },
     {
       "path": "template-manifests/slope-chart.manifest.json",
-      "sha256": "d810b3d3a77af18685d03410faad8b6a51c0186bb109734a5be2aeef7625626b",
-      "bytes": 2689
+      "sha256": "14fb83590611238b4b189135961c3916014551b9af3beb660591e47ad1689df9",
+      "bytes": 4510
     },
     {
       "path": "template-manifests/spatial-choropleth-map.manifest.json",

--- a/src/desktop/data/template-manifests.index.json
+++ b/src/desktop/data/template-manifests.index.json
@@ -6,6 +6,7 @@
   "count": 44,
   "fast_path_templates": [
     "box-plot-chart",
+    "connected-scatterplot",
     "control-chart-xmr",
     "correlation-bubble-chart",
     "correlation-scatter-plot-chart",
@@ -19,8 +20,10 @@
     "part-to-whole-treemap-chart",
     "part-to-whole-waterfall",
     "quota-attainment-bullet",
+    "ranking-dot-strip-plot",
     "ranking-ordered-bar",
     "ranking-ordered-column",
+    "slope-chart",
     "spatial-choropleth-map",
     "spatial-symbol-map",
     "trend-line-chart",
@@ -469,11 +472,31 @@
       "template": "connected-scatterplot",
       "family": "correlation",
       "readiness": "YELLOW",
-      "fast_path_eligible": false,
+      "fast_path_eligible": true,
       "fast_path_blockers": [],
       "portability_evidence": {
         "fixture_bind": true,
-        "render_verified": "none"
+        "render_verified": "live-2026-07-13",
+        "xml_sha256": "a1af2dbcb0101f71e0837623d04ab346f5ef121fd2ba3d740fed209329fc72be",
+        "render_evidence": {
+          "method": "gate-composite",
+          "date": "2026-07-13",
+          "structural": 0.89189,
+          "critical_pass": "5/5",
+          "high_pass": "2/3",
+          "pixel": 1,
+          "pixel_regions": 6,
+          "sanity": "sane",
+          "sanity_signals": [
+            "mark-count=pass reconciled=true (2508=2508, Worksheet>Copy>Data on source and applied sheets — COUNTD([Region],[Customer Name]) on the bundled Sample - Superstore, measured live)",
+            "caption-leak=pass"
+          ],
+          "run": "oracle-leg replay (W63 stamp batch): independent authored oracle on bundled Sample - Superstore; bind gate honestly escalated not-fast-path pre-stamp (recorded); apply via identity fill (native Superstore names + the template's own Profit Ratio calc, no rewrites); all 10 config facets green on the applied readback (mark=Line, cols=Sales, rows=Profit Ratio calc, color=Region, lod=Customer Name).",
+          "basis": "golden-parity gate run 2026-07-13 (oracle-leg): structural 0.89189 (5/5 critical; 2/3 high — the sole s3 miss is label-column-instances on the DISTINCT oracle calc id vs the template's 1368249927221915648, the ORACLE-CONTRACT independence divergence, same honest-miss class as ww-ou-arrow's; s1 resolved-title cosmetic), pixel 1.0 (6 counted ROIs, same-geometry back-to-back captures), composite 94, binding-sanity sane via reconciled Copy>Data 2508=2508 (grain = [Region] x [Customer Name]; data-dependent, measured live).",
+          "lane": "fable-direct stamp batch 2026-07-13 (W63; orchestrator live gate run, oracle-stamp.mjs re-drive on the session's live instances) PID=32915",
+          "pixel_oracle": "source render (same-geometry back-to-back captures on the live instance; 6 counted ROIs). Source and applied are two INDEPENDENT renders of the same data.",
+          "gate_composite": 94
+        }
       },
       "datasource_placeholder": true,
       "placeholders": [
@@ -483,7 +506,6 @@
       "intent_keywords": [
         "connected-scatterplot",
         "connected-scatter",
-        "scatter",
         "trajectory",
         "path",
         "relationship"
@@ -3598,11 +3620,31 @@
       "template": "ranking-dot-strip-plot",
       "family": "ranking",
       "readiness": "YELLOW",
-      "fast_path_eligible": false,
+      "fast_path_eligible": true,
       "fast_path_blockers": [],
       "portability_evidence": {
         "fixture_bind": true,
-        "render_verified": "none"
+        "render_verified": "live-2026-07-13",
+        "xml_sha256": "36aa23b7779995125c486c84ac2fe73d0515adab106d97747e76c6c7d3f2c2b6",
+        "render_evidence": {
+          "method": "gate-composite",
+          "date": "2026-07-13",
+          "structural": 0.97297,
+          "critical_pass": "5/5",
+          "high_pass": "3/3",
+          "pixel": 1,
+          "pixel_regions": 6,
+          "sanity": "sane",
+          "sanity_signals": [
+            "mark-count=pass reconciled=true (203=203, Worksheet>Copy>Data on source and applied sheets — COUNTD(Month(Order Date),[Sub-Category]) <= 12×17=204 on the bundled Sample - Superstore, measured live)",
+            "caption-leak=pass"
+          ],
+          "run": "oracle-leg replay (W63 stamp batch): independent authored oracle on bundled Sample - Superstore; bind gate honestly escalated not-fast-path pre-stamp (recorded); apply via identity fill (native names + neutral level-members month filter, no rewrites); all 15 config facets green on the applied readback (mark=Circle sizing-off, rows=Month, cols=Sales, lod=Sub-Category, per-cell average refline, level-members month slice, no color/size).",
+          "basis": "golden-parity gate run 2026-07-13 (oracle-leg): structural 0.97297 (5/5 critical; 3/3 high — no s3 miss: native names, no divergent calc id; s1 resolved-title cosmetic only), pixel 1.0 (6 counted ROIs, same-geometry back-to-back captures), composite 98, binding-sanity sane via reconciled Copy>Data 203=203 (<= 12 month-members × 17 sub-categories = 204; data-dependent, measured live).",
+          "lane": "fable-direct stamp batch 2026-07-13 (W63; orchestrator live gate run, oracle-stamp.mjs re-drive on the session's live instances) PID=34499",
+          "pixel_oracle": "source render (same-geometry back-to-back captures on the live instance; 6 counted ROIs). Source and applied are two INDEPENDENT renders of the same data.",
+          "gate_composite": 98
+        }
       },
       "datasource_placeholder": true,
       "placeholders": [
@@ -3612,7 +3654,6 @@
       "intent_keywords": [
         "dot-strip-plot",
         "dot-plot",
-        "strip-plot",
         "ranking"
       ],
       "description": "A dot strip plot: one Circle mark per detail-grain member placed along an aggregated-measure axis, grouped by a category on rows, with a per-cell average reference line — a space-efficient way to rank/compare members within each row. Lane W11-F2: the source month filter was PARAMETERIZED (collapsed to level-members) so the date stays a data-driven Filters pill with no source literals.",
@@ -3823,11 +3864,31 @@
       "template": "slope-chart",
       "family": "time-series",
       "readiness": "YELLOW",
-      "fast_path_eligible": false,
+      "fast_path_eligible": true,
       "fast_path_blockers": [],
       "portability_evidence": {
         "fixture_bind": true,
-        "render_verified": "none"
+        "render_verified": "live-2026-07-13",
+        "xml_sha256": "01819256a825acdd3ad9b9478d2af036141d6f687831776fbed4b24e8b5b3a7e",
+        "render_evidence": {
+          "method": "gate-composite",
+          "date": "2026-07-13",
+          "structural": 0.89189,
+          "critical_pass": "5/5",
+          "high_pass": "2/3",
+          "pixel": 1,
+          "pixel_regions": 6,
+          "sanity": "sane",
+          "sanity_signals": [
+            "mark-count=pass reconciled=true (8=8 == EXPECTED_COUNT, Worksheet>Copy>Data on source and applied sheets — 2 endpoint years × COUNTD([Region])=4 on the bundled Sample - Superstore, offline-pinnable absolute)",
+            "caption-leak=pass"
+          ],
+          "run": "oracle-leg replay (W63 stamp batch): independent authored oracle on bundled Sample - Superstore; bind gate honestly escalated not-fast-path pre-stamp (recorded); apply via identity fill with the date-grain rewrite; all 12 config facets green on the applied readback (mark=Line, year-trunc endpoints, Slope Filter calc, endpoint slice, line-end labels, no lod).",
+          "basis": "golden-parity gate run 2026-07-13 (oracle-leg): structural 0.89189 (5/5 critical; 2/3 high — the sole s3 miss is label-column-instances on the DISTINCT Slope Filter calc id, the ORACLE-CONTRACT independence divergence; s1 resolved-title cosmetic), pixel 1.0 (6 counted ROIs, same-geometry back-to-back captures), composite 94, binding-sanity sane via reconciled Copy>Data 8=8 == EXPECTED_COUNT (2 endpoints × 4 Superstore regions).",
+          "lane": "fable-direct stamp batch 2026-07-13 (W63; orchestrator live gate run, oracle-stamp.mjs re-drive on the session's live instances) PID=34497",
+          "pixel_oracle": "source render (same-geometry back-to-back captures on the live instance; 6 counted ROIs). Source and applied are two INDEPENDENT renders of the same data.",
+          "gate_composite": 94
+        }
       },
       "datasource_placeholder": true,
       "placeholders": [

--- a/src/desktop/data/template-manifests/connected-scatterplot.manifest.json
+++ b/src/desktop/data/template-manifests/connected-scatterplot.manifest.json
@@ -2,11 +2,31 @@
   "template": "connected-scatterplot",
   "family": "correlation",
   "readiness": "YELLOW",
-  "fast_path_eligible": false,
+  "fast_path_eligible": true,
   "fast_path_blockers": [],
   "portability_evidence": {
     "fixture_bind": true,
-    "render_verified": "none"
+    "render_verified": "live-2026-07-13",
+    "xml_sha256": "a1af2dbcb0101f71e0837623d04ab346f5ef121fd2ba3d740fed209329fc72be",
+    "render_evidence": {
+      "method": "gate-composite",
+      "date": "2026-07-13",
+      "structural": 0.89189,
+      "critical_pass": "5/5",
+      "high_pass": "2/3",
+      "pixel": 1,
+      "pixel_regions": 6,
+      "sanity": "sane",
+      "sanity_signals": [
+        "mark-count=pass reconciled=true (2508=2508, Worksheet>Copy>Data on source and applied sheets — COUNTD([Region],[Customer Name]) on the bundled Sample - Superstore, measured live)",
+        "caption-leak=pass"
+      ],
+      "run": "oracle-leg replay (W63 stamp batch): independent authored oracle on bundled Sample - Superstore; bind gate honestly escalated not-fast-path pre-stamp (recorded); apply via identity fill (native Superstore names + the template's own Profit Ratio calc, no rewrites); all 10 config facets green on the applied readback (mark=Line, cols=Sales, rows=Profit Ratio calc, color=Region, lod=Customer Name).",
+      "basis": "golden-parity gate run 2026-07-13 (oracle-leg): structural 0.89189 (5/5 critical; 2/3 high — the sole s3 miss is label-column-instances on the DISTINCT oracle calc id vs the template's 1368249927221915648, the ORACLE-CONTRACT independence divergence, same honest-miss class as ww-ou-arrow's; s1 resolved-title cosmetic), pixel 1.0 (6 counted ROIs, same-geometry back-to-back captures), composite 94, binding-sanity sane via reconciled Copy>Data 2508=2508 (grain = [Region] x [Customer Name]; data-dependent, measured live).",
+      "lane": "fable-direct stamp batch 2026-07-13 (W63; orchestrator live gate run, oracle-stamp.mjs re-drive on the session's live instances) PID=32915",
+      "pixel_oracle": "source render (same-geometry back-to-back captures on the live instance; 6 counted ROIs). Source and applied are two INDEPENDENT renders of the same data.",
+      "gate_composite": 94
+    }
   },
   "datasource_placeholder": true,
   "placeholders": [
@@ -16,7 +36,6 @@
   "intent_keywords": [
     "connected-scatterplot",
     "connected-scatter",
-    "scatter",
     "trajectory",
     "path",
     "relationship"

--- a/src/desktop/data/template-manifests/ranking-dot-strip-plot.manifest.json
+++ b/src/desktop/data/template-manifests/ranking-dot-strip-plot.manifest.json
@@ -2,11 +2,31 @@
   "template": "ranking-dot-strip-plot",
   "family": "ranking",
   "readiness": "YELLOW",
-  "fast_path_eligible": false,
+  "fast_path_eligible": true,
   "fast_path_blockers": [],
   "portability_evidence": {
     "fixture_bind": true,
-    "render_verified": "none"
+    "render_verified": "live-2026-07-13",
+    "xml_sha256": "36aa23b7779995125c486c84ac2fe73d0515adab106d97747e76c6c7d3f2c2b6",
+    "render_evidence": {
+      "method": "gate-composite",
+      "date": "2026-07-13",
+      "structural": 0.97297,
+      "critical_pass": "5/5",
+      "high_pass": "3/3",
+      "pixel": 1,
+      "pixel_regions": 6,
+      "sanity": "sane",
+      "sanity_signals": [
+        "mark-count=pass reconciled=true (203=203, Worksheet>Copy>Data on source and applied sheets — COUNTD(Month(Order Date),[Sub-Category]) <= 12×17=204 on the bundled Sample - Superstore, measured live)",
+        "caption-leak=pass"
+      ],
+      "run": "oracle-leg replay (W63 stamp batch): independent authored oracle on bundled Sample - Superstore; bind gate honestly escalated not-fast-path pre-stamp (recorded); apply via identity fill (native names + neutral level-members month filter, no rewrites); all 15 config facets green on the applied readback (mark=Circle sizing-off, rows=Month, cols=Sales, lod=Sub-Category, per-cell average refline, level-members month slice, no color/size).",
+      "basis": "golden-parity gate run 2026-07-13 (oracle-leg): structural 0.97297 (5/5 critical; 3/3 high — no s3 miss: native names, no divergent calc id; s1 resolved-title cosmetic only), pixel 1.0 (6 counted ROIs, same-geometry back-to-back captures), composite 98, binding-sanity sane via reconciled Copy>Data 203=203 (<= 12 month-members × 17 sub-categories = 204; data-dependent, measured live).",
+      "lane": "fable-direct stamp batch 2026-07-13 (W63; orchestrator live gate run, oracle-stamp.mjs re-drive on the session's live instances) PID=34499",
+      "pixel_oracle": "source render (same-geometry back-to-back captures on the live instance; 6 counted ROIs). Source and applied are two INDEPENDENT renders of the same data.",
+      "gate_composite": 98
+    }
   },
   "datasource_placeholder": true,
   "placeholders": [
@@ -16,7 +36,6 @@
   "intent_keywords": [
     "dot-strip-plot",
     "dot-plot",
-    "strip-plot",
     "ranking"
   ],
   "description": "A dot strip plot: one Circle mark per detail-grain member placed along an aggregated-measure axis, grouped by a category on rows, with a per-cell average reference line — a space-efficient way to rank/compare members within each row. Lane W11-F2: the source month filter was PARAMETERIZED (collapsed to level-members) so the date stays a data-driven Filters pill with no source literals.",

--- a/src/desktop/data/template-manifests/slope-chart.manifest.json
+++ b/src/desktop/data/template-manifests/slope-chart.manifest.json
@@ -2,11 +2,31 @@
   "template": "slope-chart",
   "family": "time-series",
   "readiness": "YELLOW",
-  "fast_path_eligible": false,
+  "fast_path_eligible": true,
   "fast_path_blockers": [],
   "portability_evidence": {
     "fixture_bind": true,
-    "render_verified": "none"
+    "render_verified": "live-2026-07-13",
+    "xml_sha256": "01819256a825acdd3ad9b9478d2af036141d6f687831776fbed4b24e8b5b3a7e",
+    "render_evidence": {
+      "method": "gate-composite",
+      "date": "2026-07-13",
+      "structural": 0.89189,
+      "critical_pass": "5/5",
+      "high_pass": "2/3",
+      "pixel": 1,
+      "pixel_regions": 6,
+      "sanity": "sane",
+      "sanity_signals": [
+        "mark-count=pass reconciled=true (8=8 == EXPECTED_COUNT, Worksheet>Copy>Data on source and applied sheets — 2 endpoint years × COUNTD([Region])=4 on the bundled Sample - Superstore, offline-pinnable absolute)",
+        "caption-leak=pass"
+      ],
+      "run": "oracle-leg replay (W63 stamp batch): independent authored oracle on bundled Sample - Superstore; bind gate honestly escalated not-fast-path pre-stamp (recorded); apply via identity fill with the date-grain rewrite; all 12 config facets green on the applied readback (mark=Line, year-trunc endpoints, Slope Filter calc, endpoint slice, line-end labels, no lod).",
+      "basis": "golden-parity gate run 2026-07-13 (oracle-leg): structural 0.89189 (5/5 critical; 2/3 high — the sole s3 miss is label-column-instances on the DISTINCT Slope Filter calc id, the ORACLE-CONTRACT independence divergence; s1 resolved-title cosmetic), pixel 1.0 (6 counted ROIs, same-geometry back-to-back captures), composite 94, binding-sanity sane via reconciled Copy>Data 8=8 == EXPECTED_COUNT (2 endpoints × 4 Superstore regions).",
+      "lane": "fable-direct stamp batch 2026-07-13 (W63; orchestrator live gate run, oracle-stamp.mjs re-drive on the session's live instances) PID=34497",
+      "pixel_oracle": "source render (same-geometry back-to-back captures on the live instance; 6 counted ROIs). Source and applied are two INDEPENDENT renders of the same data.",
+      "gate_composite": 94
+    }
   },
   "datasource_placeholder": true,
   "placeholders": [


### PR DESCRIPTION
## What

Ports the a2td W63 `live-2026-07-13` render stamps into `src/desktop`, taking the desktop corpus to **23 fast-path eligible**. Same class as the #487 W62 evidence sync. Template XML `sha256` verified **byte-identical** a2td↔tmcp for all three, so the `xml_sha256` gate binds to tmcp's own bytes. Evidence blocks use tmcp's richer `render_evidence` schema (`date`/`sanity`/`sanity_signals`/`run`).

| template | composite | structural | pixel | sanity |
|---|---|---|---|---|
| connected-scatterplot | 94 | 0.89189 (5/5, 2/3) | 1.0 (6 ROI) | sane (2508=2508) |
| slope-chart | 94 | 0.89189 (5/5, 2/3) | 1.0 (6 ROI) | sane (8=8, ==EXPECTED_COUNT) |
| ranking-dot-strip-plot | 98 | 0.97297 (5/5, 3/3) | 1.0 (6 ROI) | sane (203=203) |

## Regression caught by tmcp's portability suite (that a2td's thinner tests missed)

Flipping `connected-scatterplot` fast-path-eligible let a plain **"scatter plot of A and B by C and D"** ask bind to it instead of the canonical `correlation-scatter-plot-chart` — both carried the bare `scatter` keyword, and with both eligible the binder picked the wrong sibling. The `portability.invariant` ZERO-WRONG-BINDS suite (which a2td lacks) caught it.

**Fix:** dropped `connected-scatterplot`'s bare `scatter` alias (reachable via `connected-scatter`/`connected-scatterplot`/`trajectory`/`path`); `ranking-dot-strip-plot` likewise drops bare `strip-plot` (canonical owner = `distribution-bar-code-chart`). The same fix was back-ported to a2td. ZERO-WRONG-BINDS is green and the `carrier-uniqueness` ≤1-eligible-carrier invariant holds.

## Test updates

- `portability.invariant` + `bind-behavior-matrix` extended with natural coverage asks for the 3 new templates: connected-scatterplot + slope one-shot; dot-strip **honest-proposes** (its month-grain rows slot isn't ask-fillable in these fixtures — pinned as current behavior, not forced to bind).
- Eligible-set pins 20 → 23; carrier zero-carrier set → `['histogram']`; escalation + prewarm negative examples repointed to still-unverified `pareto-chart`.
- `template-manifests.index.json` + `content-manifest.json` regenerated.
- Full suite **3631 pass / 1 skip**; changed files lint-clean (9 pre-existing lint errors in untouched `feature/authoring` files left as-is).

🤖 Generated with [Claude Code](https://claude.com/claude-code)