### PR TITLE
port: 4 knowledge files from the a2td lab (viz-eval, field-hygiene, audience-budget, connection-schema)

### DIFF
--- a/resources/desktop/knowledge/strategy/dashboard-design/audience-budget-and-question-priority.md
+++ b/resources/desktop/knowledge/strategy/dashboard-design/audience-budget-and-question-priority.md
@@ -1,0 +1,115 @@
+# Audience Budgets & Question Prioritization
+
+Two quantitative scoping tools for the *start* of a dashboard request: a **time/complexity budget per audience** (hard guardrails on filter count, chart complexity, and glance time) and a **P1–P4 question-priority triage** (which questions earn which real estate). These convert the qualitative archetype decision into numeric constraints you can hold a design to — and into a rule for what goes on page one versus behind an interaction.
+
+Tags: audience, time-budget, question-prioritization, scoping, filter-count, dashboard-design, triage
+
+**Related strategy:** pick the *shape* first with `expertise://tableau/strategy/dashboard-design/dashboard-archetypes` (strategic / operational / analytical) — this file adds the *numbers* to that shape. When a dashboard exceeds its budget, `expertise://tableau/strategy/dashboard-design/dashboard-overload` is the split-and-defer remedy; `expertise://tableau/strategy/dashboard-design/dashboard-content-placement-strategy` covers where on the canvas the P1/P2 zones go.
+
+## Scope Check
+
+- Primary audience: Tableau user / SE assisting a Tableau user
+- Authoring outcome improved: create, refine, scope
+- In-scope reason: At the start of a dashboard request, this gives the agent numeric guardrails (how many filters, how complex, how long to read) tied to the audience, and a triage for which questions belong on the first screen — so a dashboard is scoped to its reader instead of accreting every requested chart.
+- Out-of-scope risk: none
+- Tags: audience, time-budget, question-prioritization, scoping, filter-count, dashboard-design, triage, p1-p4, exec-dashboard, analyst-dashboard, progressive-disclosure
+- Relevant user prompts/search terms: "how many filters is too many", "dashboard for executives", "how much detail for an analyst", "what goes on the first screen", "my dashboard has too many charts", "prioritize dashboard content", "which questions go on the dashboard", "exec vs analyst dashboard", "scope a dashboard", "time budget dashboard", "how complex should this dashboard be"
+
+## When to Use
+
+Use this at the *scoping* stage, right after you've picked the archetype and before you place a single chart:
+- **A stakeholder hands you a long list of "can you also show…" requests** — triage them P1–P4 so page one stays focused.
+- **You need to justify saying "not on this screen"** to a request that would blow the audience's budget.
+- **Deciding how many filters/charts is defensible** for this reader.
+- **A dashboard already feels crowded** and you need an objective basis to cut or defer.
+
+This is the numeric layer on top of the archetype taxonomy — it does not replace it. Choose strategic vs. operational vs. analytical first (`dashboard-archetypes`); then apply the budget and triage below.
+
+---
+
+## Audience Time & Complexity Budgets
+
+Each audience reads for a different length of time and tolerates a different complexity. Treat these as **guardrails, not laws** — but a design that violates its audience's budget needs an explicit reason.
+
+| Audience | Glance/read budget | Max visible filters | Chart complexity | Interaction model | KPI priority |
+|---|---|---|---|---|---|
+| **Executive** | 5–30 sec | 0–2 | Low — BANs, trend, bullet | Scan; maybe one date/region filter | Critical — the headline *is* the dashboard |
+| **Manager** | 30 sec–3 min | 2–4 | Medium — add ranking, breakdown | Light filtering + drill to detail | High — KPIs plus the "why" one level down |
+| **Analyst / power user** | 3–15 min | 4–8 | High — scatter, heatmap, cohort, drill | Heavy — filters, parameters, set/param actions | Context — KPIs frame the exploration, aren't the point |
+| **Operations** | continuous, act in seconds | 1–3 | Medium, ruthlessly prioritized to actionable | Alert + light triage drill | High — status, not history |
+| **External / public** | 10–60 sec | 0–2 | Low, plain-language | Minimal, self-explanatory | High — one clear message |
+
+**How to use the budget:**
+- **Filters over budget → convert or defer.** More than the audience's max means either the wrong archetype (an analyst tool handed to an exec) or that some filters belong in a drill/detail view reached by a Navigation button, not on the main screen.
+- **Complexity over budget → split or promote.** An exec dashboard that needs a cohort heatmap is really two dashboards: a strategic glance and an analytical companion.
+- **Reading time is the sanity check.** If the design can't be *read* (not exhaustively explored) inside the budget, the hero metric isn't prominent enough — fix prominence before adding anything. Pairs with the 5-second test in `dashboard-archetypes`.
+
+---
+
+## Question Prioritization: the P1–P4 Triage
+
+A dashboard rarely fails because a chart is wrong — it fails because *every* question got equal real estate. Rank each business question the dashboard is asked to answer, then place it by rank:
+
+| Tier | The question is… | Placement |
+|---|---|---|
+| **P1** | Decision-critical — a viewer acts on it *every* time they open the dashboard | Page one, above the fold, top-left / hero position |
+| **P2** | Monitoring — watched regularly, doesn't always trigger action | Page one, below the P1 zone |
+| **P3** | Diagnostic — asked *only when* a P1/P2 reveals a problem ("why is this down?") | Page two, or behind a drill / Dynamic Zone Visibility / filter action |
+| **P4** | Reference — occasional context, definitions, footnotes | Appendix page, tooltip, or a collapsible detail zone |
+
+**The one rule that matters:** **never let P3/P4 crowd P1/P2 on page one.** Diagnostic and reference content is where progressive disclosure earns its keep — it appears *when summoned* by an interaction, not by default. The most common overload cause is a diagnostic breakdown (P3) sitting permanently next to the headline KPI (P1), so neither reads.
+
+**How to run the triage:**
+1. List every question the dashboard is asked to answer (from the request, not from the charts you imagined).
+2. Tag each P1–P4 by the test above — *acted on every time* (P1) vs. *only when a problem shows* (P3).
+3. Give P1 the hero position, stack P2 below it, and route P3/P4 behind an interaction or onto a second page.
+4. If there are more than ~2–3 P1s, the dashboard is trying to answer too many decision-critical questions — that's a signal to split it, not to shrink the charts.
+
+---
+
+## Implementation
+
+1. **Pick the archetype** (`dashboard-archetypes`) — strategic / operational / analytical — which sets the audience.
+2. **Look up the audience budget** and treat its filter/complexity/time numbers as the design's guardrails.
+3. **Triage the questions P1–P4** against the actual request; assign each a zone by rank.
+4. **Lay out P1 hero, P2 below, P3/P4 deferred** — progressive disclosure via Navigation button, Dynamic Zone Visibility, or a second page for anything P3+.
+5. **Check the design back against the budget** — count visible filters, estimate read time, confirm complexity fits. Over budget → convert filters to drill, split the dashboard, or promote the analytical part to its own surface.
+6. **Verify with the 5-second test** — show it briefly and confirm the viewer recalls the P1 answer, not a P3 detail.
+
+### Confirmed example
+
+Request: an executive sales dashboard, but stakeholders also asked for a rep-level activity breakdown, a data-dictionary, and a churn-driver analysis.
+
+- **Archetype:** strategic → **Executive budget:** 0–2 filters, low complexity, 5–30 sec read.
+- **Triage:** "Are we on track to target?" = **P1** (hero KPI strip + trend). "How are regions tracking?" = **P2** (a bar below). "Why is West down?" (churn drivers) = **P3** — *not* on page one; behind a Navigation button to an analytical companion. Rep-level activity = **P3** (drill). Data-dictionary = **P4** (tooltip / appendix).
+- **Result:** page one holds one date filter, a KPI strip (P1), and a regional bar (P2) — inside budget. The churn/rep/dictionary content, which would have blown both the filter count and the read-time budget, is deferred. The exec gets a 10-second glance; the analyst who needs "why" clicks through.
+
+**What does NOT work:**
+- **Putting the P3 diagnostic next to the P1 KPI "so it's all in one place"** — it crowds the headline and blows the exec's read-time budget; defer it behind an interaction.
+- **Exposing 6 filters on an exec dashboard** — over the 0–2 budget; it signals the wrong archetype or that filtering belongs in a drill view.
+- **Treating the budget as a hard cap with no exceptions** — a manager dashboard can justify a 5th filter *with a reason*; the budget forces the justification, it doesn't forbid the filter.
+- **Triaging by chart instead of by question** — rank the *questions* the dashboard answers, then let that decide the charts; ranking charts you already drew just rationalizes the crowding.
+
+## Best Practices
+
+- **Archetype first, then numbers.** The budget only makes sense once you know who reads it; pick the shape, then hold it to the audience's filter/complexity/time guardrails.
+- **Rank questions, not charts.** P1–P4 is a triage of the *questions*; the charts follow from the ranking.
+- **P3/P4 is progressive-disclosure territory.** Diagnostic and reference content appears when summoned, never crowds page one.
+- **Use the budget to justify "no."** A filter count or complexity level over budget is the objective basis for deferring or splitting — it turns a taste argument into a scoping rule.
+- **More than 2–3 P1s means split, not shrink.** Too many decision-critical questions is a signal for a second dashboard, not smaller charts.
+
+## Common Mistakes
+
+1. **Equal real estate for every question** — the root cause of overload; P3/P4 sitting permanently beside P1/P2.
+2. **Over-budget filters** — handing an exec an analyst's 6-filter control panel.
+3. **Ranking charts instead of questions** — rationalizing the charts you already built rather than triaging what the dashboard must answer.
+4. **Ignoring the read-time budget** — a "glance" dashboard that takes two minutes to parse because the hero metric isn't prominent.
+5. **Treating budgets as absolute** — the numbers are guardrails that *force a justification*, not hard prohibitions; a defended exception is fine, an undefended overage is not.
+
+## Source and Confidence
+
+- Source/evidence type: community-adapted best practice
+- Source: Audience time/complexity budgets and the P1–P4 question-prioritization triage adapted from `adammico-lab/Tableau-Dashboard-Blueprint-BETA` (Adam Mico, Apache 2.0), curated to house format and de-branded. Deliberately scoped to the two frameworks the existing `dashboard-archetypes` module lacks (quantified guardrails; question triage); the source's chart-selection, color, and container guidance was excluded as already covered.
+- Customer-identifying details removed: yes
+- Confidence: SME-reviewed
+- Last reviewed: 2026-07-13

--- a/resources/desktop/knowledge/strategy/data-modeling/field-hygiene-and-naming.md
+++ b/resources/desktop/knowledge/strategy/data-modeling/field-hygiene-and-naming.md
@@ -1,0 +1,123 @@
+# Field Hygiene: Naming & Type/Role Correctness
+
+Heuristics for spotting field-level data-model problems by inspecting the data pane — poor names, and fields whose *stored type or role* contradicts what their *name* says they are. These are portable modeling-hygiene signals (true of any BI tool's field list), used to flag issues before you build on a shaky field, or to advise a customer cleaning up a data source.
+
+Tags: field-naming, data-hygiene, type-mismatch, role-mismatch, schema-quality, data-modeling
+
+**Related strategy:** `expertise://tableau/strategy/data-modeling/datasource-strategy` (the connection/relationship decisions that surround this) and `expertise://tableau/strategy/analytics/field-types-reference` (what roles/types *are*). The publish-time consistency gate is `expertise://tableau/strategy/dashboard-design/dashboard-peer-review-checklist` (Data Pane Hygiene section) — this file is the *detection heuristics*; that file is the *review gate*.
+
+## Scope Check
+
+- Primary audience: Tableau user / SE assisting a Tableau user
+- Authoring outcome improved: validate, refine, troubleshoot
+- In-scope reason: When the agent inspects a data source's fields (before authoring, or when a customer asks "is this data source clean?"), these heuristics let it flag mis-typed, mis-roled, or badly-named fields that will otherwise produce wrong aggregations, broken date logic, or an unmaintainable data pane.
+- Out-of-scope risk: none
+- Tags: field-naming, data-hygiene, type-mismatch, role-mismatch, schema-quality, data-modeling, snake-case, id-as-measure, date-as-string, systemic-finding, naming-convention
+- Relevant user prompts/search terms: "is this data source clean", "why is my date sorting wrong", "my sum is counting IDs", "field names are messy", "clean up my data pane", "date field stored as string", "field naming conventions Tableau", "why is my count field a string", "ID field showing as measure", "field hygiene check", "audit my data source fields"
+
+## When to Use
+
+Use this when:
+- **Inspecting a data source before authoring** — catch a date-stored-as-string or an ID-as-measure *before* you build a broken time series or an inflated total on it.
+- **A customer asks "is this data source clean?"** or wants a hygiene pass over their fields.
+- **A total or a sort looks wrong** and the cause may be a mis-typed field rather than the calc.
+- **Advising on naming standards** for a shared/published data source that many workbooks will consume.
+
+This is a *modeling-hygiene* lens, not a publish gate. The peer-review checklist enforces that field names are *consistent across dashboards* at publish time; this file is about detecting the *intrinsic* problems (wrong type, cryptic name) in the first place.
+
+---
+
+## Type & Role Mismatches (highest impact)
+
+A field whose stored type or role contradicts its name is the most damaging class — it silently produces wrong results, not just an ugly pane. Infer intent from the name, compare to the stored type/role:
+
+| Signal | Name pattern (word-boundary match) | Stored as | Severity | Why it matters |
+|---|---|---|---|---|
+| **Date as string** | `date`, `time`, `created`, `updated`, `timestamp` | `string` | **High** | No date math, no relative-date filters, sorts lexically ("Apr" before "Jan"). Parsing was skipped at connect. |
+| **Number as string** | `count`, `amount`, `qty`, `price`, `total`, `rate`, `pct`, `percent`, `revenue`, `cost` | `string` | **High** | Can't aggregate or put on a continuous axis without a cast; SUM/AVG unavailable. |
+| **ID as measure** | `id`, `key`, `code`, `number`/`nbr` | role = **measure** | **Medium** | Tableau will `SUM` it by default — summing customer IDs is meaningless and can silently appear in totals. IDs should be dimensions. |
+| **Boolean as string** | `is_`, `has_`, `flag`, `active`, `enabled` | `string` | **Low** | `"True"`/`"true"`/`"Y"` won't behave as a boolean; filters and IF tests get brittle. |
+| **Role/category mismatch** | — | role = dimension but data is quantitative, or vice-versa | **Low** | Wrong default shelf behavior (headers vs axis). |
+
+**False-positive guards (apply before flagging):**
+- **Match on word boundaries**, not substrings — `"considered"` must not trip the `id` check; `"update_status"` (a string status) is not a date.
+- **Check for an intentional cast.** A *calculated* field named `date_str` whose formula is `STR([Order Date])` is deliberately a string — inspect the formula; if it shows an intentional conversion, drop the severity or skip.
+- **Parameters are exempt** — they're typed by design, not by the source.
+
+---
+
+## Naming Violations
+
+Portable naming smells, by severity. These hurt readability and maintainability rather than correctness:
+
+| Signal | Pattern | Severity |
+|---|---|---|
+| **System API suffix, un-aliased** | ends in `__c` / `__r` (Salesforce), or similar source-generated tails | Medium |
+| **Cryptic abbreviation** | < 4 chars and not a common exception (`id`, `qty`, `amt`, `pct`, `yr`) | Medium |
+| **Generic placeholder name** | `value`, `field`, `col`, `data`, `info`, `item`, optionally with a trailing digit | Medium |
+| **Raw snake_case, not cleaned** | `three_or_more_words` left as-is | Low |
+| **camelCase / no spaces** | `customerName` | Low |
+| **SCREAMING_CASE** | `TOTAL_REVENUE` | Low |
+| **Table-qualified noise** | field name repeats its logical-table caption | Low |
+
+The goal is human-readable, business-facing names: `Loan Number`, not `loan_nbr` / `LN_NUM` / `__c`. For a *shared* data source, the same field must carry the same name everywhere it's consumed (that consistency rule is enforced at the review gate).
+
+---
+
+## Report Systemically, Not Field-by-Field
+
+A raw list of 60 fields each flagged individually is noise. Aggregate:
+
+- **When more than ~10 fields match the same pattern**, report it as **one systemic finding** with the top 3–5 examples, not 10+ separate items. E.g. *"32 fields are raw snake_case (`order_date`, `customer_region`, `ship_mode`, …) — the source was connected without cleaning field names."*
+- **Escalate severity one level when >50% of fields share the defect** — a source where most fields are un-cast strings is a connection-time problem (wrong parse), not a per-field nit.
+- **Reduce severity for auto-generated fields** (bins, groups, calculated placeholders) and for sandbox/scratch data sources.
+
+---
+
+## Implementation
+
+1. **List the fields** with their role, data type, and (for calcs) formula — via the data pane or a metadata read.
+2. **Run the type/role pass first** — it's the correctness-affecting one. For each field, infer intent from the name and compare to the stored type/role; apply the false-positive guards (word boundaries, intentional-cast check, parameter exemption).
+3. **Run the naming pass** — flag the smells above, but only after confirming there's no alias already fixing the display name.
+4. **Aggregate to systemic findings** — collapse >10 same-pattern hits into one, escalate if >50% affected.
+5. **Report by impact:** high-severity type mismatches first (they produce wrong numbers), then naming (readability). For each, give the fix: *change data type / change to dimension / add an alias / rename at the source*.
+6. **Prefer fixing at the source or published data source**, not per-workbook — a rename or re-type in one embedded copy doesn't help the next workbook.
+
+### Confirmed example
+
+A data source with fields `order_date (string)`, `sales_amt (string)`, `cust_id (measure)`, `customerName (string)`, and 28 other raw snake_case fields:
+
+- **High:** `order_date` is a string → no date math or relative-date filters; re-type to date at the source. `sales_amt` is a string → can't SUM; re-type to real/integer.
+- **Medium:** `cust_id` is a measure → will be summed by default; change to dimension. `cust_id` is also a cryptic abbreviation → alias to `Customer ID`.
+- **Systemic (Low, escalated):** 30 of ~32 fields are raw snake_case (>50%) → connected without name cleaning; recommend aliasing at the source rather than 30 per-workbook renames.
+
+**What does NOT work:**
+- **Substring matching** — flagging `"considered"` as an ID or `"update_frequency"` as a date. Always match on word boundaries.
+- **Flagging an intentional cast** — a calc `STR([Date])` named `date_label` is a string on purpose; read the formula before calling it a mismatch.
+- **Listing every field separately** — 40 individual naming dings read as noise and get ignored; collapse to systemic findings.
+- **Fixing type/role in one workbook's embedded copy** — the next workbook on the same source inherits the same bad field. Fix upstream.
+- **Renaming a Salesforce `__c` field by editing the source schema** — you alias it in Tableau (or the published source); you don't touch the API name.
+
+## Best Practices
+
+- **Type correctness before naming.** A mis-typed field produces *wrong answers*; a badly-named one only produces friction. Triage accordingly.
+- **Infer from the name, verify against the store.** The name is the intent; the stored type/role is the reality; the gap is the finding.
+- **Guard against false positives** — word boundaries, intentional casts, parameter exemptions — before you raise anything.
+- **Aggregate systemically** — one finding for a pervasive pattern, with examples, beats a flat list.
+- **Fix upstream.** Prefer a re-type/alias at the source or published data source so every downstream workbook benefits.
+
+## Common Mistakes
+
+1. **Substring instead of word-boundary matching** — `id` inside `"considered"`, `date` inside `"candidate"`, producing false flags.
+2. **Calling an intentional string cast a "mismatch"** — a calc that deliberately `STR()`s a value is not a defect.
+3. **Field-by-field noise** — reporting 30 individual snake_case fields instead of one systemic finding.
+4. **Fixing per-workbook** — re-typing in one embedded copy while every other workbook on the source keeps the bad field.
+5. **Treating naming smells as correctness bugs** — a `camelCase` name is a readability nit; deducting from it as if it broke a number is miscalibrated.
+
+## Source and Confidence
+
+- Source/evidence type: community-adapted best practice
+- Source: Field naming-violation and type/role-mismatch heuristics adapted from `adammico-lab/Tableau-Data-Quality-Sentinel-BETA` (Adam Mico, Apache 2.0), curated to house format; site-scanning / REST-API mechanics from that source deliberately excluded as out of scope for a Desktop authoring KB. Pattern set and systemic-aggregation rule are the source's, de-branded and condensed.
+- Customer-identifying details removed: yes
+- Confidence: SME-reviewed
+- Last reviewed: 2026-07-13

--- a/resources/desktop/knowledge/strategy/viz-design/viz-evaluation-framework.md
+++ b/resources/desktop/knowledge/strategy/viz-design/viz-evaluation-framework.md
@@ -1,0 +1,151 @@
+# Viz Evaluation Framework: A Weighted Scorecard
+
+A reproducible, weighted rubric for *scoring* a finished visualization or dashboard — the quantitative complement to the pass/fail peer-review gate. Where the peer-review checklist asks "does this clear the bar to publish?", this asks "how good is it, and where specifically does it lose points?" Use it to give calibrated, defensible feedback instead of a bare "looks good" / "looks bad."
+
+Tags: evaluation, scoring, rubric, critique, design-quality, feedback, calibration
+
+**Related strategy:** the *why* behind the domains lives in `expertise://tableau/strategy/viz-design/design-principles` (perceptual rationale), and the applied rules in `expertise://tableau/strategy/viz-design/chart-selection`, `expertise://tableau/strategy/viz-design/color-strategy`, `expertise://tableau/strategy/viz-design/encoding-strategy`. The publish gate is `expertise://tableau/strategy/dashboard-design/dashboard-peer-review-checklist`.
+
+## Scope Check
+
+- Primary audience: Tableau user / SE assisting a Tableau user
+- Authoring outcome improved: validate, refine
+- In-scope reason: When the agent is asked to critique or grade a viz/dashboard (its own output or a user's), this gives a structured, weighted scoring method so feedback is calibrated and actionable rather than vibes-based — and tells the agent where a design actually loses points.
+- Out-of-scope risk: none
+- Tags: evaluation, scoring, rubric, critique, design-quality, feedback, calibration, genre, anti-anchoring, weighted-scorecard, viz-review
+- Relevant user prompts/search terms: "rate my dashboard", "score this viz", "critique this visualization", "how good is this chart", "give me feedback on my dashboard", "evaluate this design", "what's wrong with this viz", "grade my Tableau dashboard", "is this dashboard good", "review the design quality"
+
+## When to Use
+
+Use this when:
+- **A user asks you to rate, score, or critique** a viz or dashboard and wants more than a one-line reaction.
+- **You want to give structured design feedback** on your own generated output before handing it back.
+- **Two designs need comparing** on a consistent basis rather than by taste.
+- **A reviewer needs a defensible number** — "6.5/10, losing most points on Layout and Color" — instead of an unfalsifiable opinion.
+
+This is a *quality* assessment, not a *publish gate*. For the hard yes/no publish decision (classification labels, "All in list" filters, hardcoded dates, PII), run `dashboard-peer-review-checklist` — a design can score 8/10 and still be blocked from production by a governance failure.
+
+---
+
+## Step 0: Classify the Genre First (before scoring)
+
+A design must be scored against what it is *trying to be*. Identify the genre first — it changes how you weight and interpret every domain:
+
+| Genre | Purpose | How it shifts scoring |
+|---|---|---|
+| **Business / operational** | Monitor KPIs, drive decisions | Full weight on chart choice, clarity, and layout; expects KPIs and clear takeaways. |
+| **Analytical / exploratory** | Let an analyst dig | Don't penalize for lacking big headline KPIs; reward depth, interactivity, correct encodings. |
+| **Narrative** | Tell a sequenced story | Weight message and flow higher; a guided path matters more than density. |
+| **Editorial / infographic** | Persuade a broad public | Some "useful chart junk" and annotation is a feature, not a flaw; plain-language text weighs more. |
+| **Data art** | Aesthetic / provocative | Score honestly but note that conventional-clarity rules bend by design. |
+| **Scientific / technical** | Precision for experts | Reward exact encodings, uncertainty, dense reference; low on decoration. |
+
+**Rule:** never score an analytical exploration as if it were an exec dashboard, or vice versa. State the genre you scored against in the output — it makes the score falsifiable.
+
+---
+
+## The Weighted Scorecard
+
+Score each domain 0–10, multiply by its weight, sum for a weighted total. Weights sum to 100%.
+
+| Domain | Weight | What it measures |
+|---|---|---|
+| **Layout & Composition** | 25% | Reading order, alignment, whitespace, grouping, above-the-fold priority, density |
+| **Chart Choice** | 20% | Right chart for the question and data shape; correct encodings; no misleading forms |
+| **Audience Fit** | 15% | Matched to who reads it and how long they have; right filters and depth |
+| **Color** | 15% | Purposeful palette (sequential/diverging/categorical/semantic); CVD-safe; contrast |
+| **Message & Clarity** | 10% | One clear takeaway; titles/annotations state the "so what" |
+| **Text & Labels** | 5% | Concise, meaningful labels; formatted tooltips; no field-name dumps |
+| **Font & Typography** | 5% | Consistent, legible type hierarchy; not decorative for its own sake |
+
+**Weighted total = Σ (domain score × weight).** Round to one decimal using round-half-to-even (banker's rounding) so repeated evaluations don't drift upward.
+
+### Score tiers
+
+| Weighted total | Interpretation |
+|---|---|
+| **9.0–10.0** | Exemplary — publish/showcase quality |
+| **7.5–8.9** | Solid — competent and correct; minor polish left |
+| **6.0–7.4** | Workable — real gaps to fix before it's trusted |
+| **4.0–5.9** | Weak — a core domain (usually layout or chart choice) is failing |
+| **< 4.0** | Broken — rebuild, don't patch |
+
+### Anti-pattern penalties (applied after domain scoring)
+
+Deduct from the weighted total for hard failures, regardless of how the rest scored:
+- **Misleading encoding** (truncated bar axis, dual-axis with mismatched scales presented as comparable, 3-D perspective, area-encoded quantities): −1.0 to −2.0.
+- **Rainbow/decorative color where sequence or category has meaning**: −0.5.
+- **Unreadable density** (marks or text overlapping to illegibility at intended size): −0.5 to −1.0.
+- **No discernible takeaway** on a business/narrative genre: −0.5.
+
+### Bonus detection (rare, additive, cap +0.5 total)
+
+Award only for genuine excellence, not mere competence: exceptional accessibility (CVD-safe + high contrast + labeled), an innovative-yet-clear chart that beats the conventional choice, or annotations that materially raise comprehension.
+
+---
+
+## Calibration: score what's present, then find gaps
+
+The dominant failure mode in scoring is **negativity anchoring** — starting low and hunting for reasons to withhold points. Correct for it explicitly:
+
+- **Floor for competent execution.** A correct chart choice with solid, clean execution starts at **7.5**, not 5. You deduct *from* competence for real problems; you don't build *up* to it from zero.
+- **"Missed opportunity" ≠ "actual problem."** A design that could have added a reference line but reads correctly without one has a suggestion, not a deduction. Only deduct for things that harm comprehension, mislead, or fail the audience.
+- **Proportional deduction.** A single awkward label is a 0.5-point ding on Text (5% weight ≈ 0.025 off the total), not a whole-grade drop. Keep the magnitude of the deduction tied to the domain's weight.
+- **Score the genre, not your preference.** If you'd have made a different-but-equally-valid choice, that's not a deduction.
+
+---
+
+## Implementation
+
+1. **Classify the genre** (Step 0) and state it. This fixes how you'll interpret each domain.
+2. **Score each of the 7 domains 0–10**, writing one concrete sentence of evidence per domain ("Layout: 6 — the two KPI tiles and the trend line compete for the top-left; no clear reading order").
+3. **Start each domain from the competence floor** (7.5 for correct-and-clean) and deduct proportionally for real problems, not missed opportunities.
+4. **Compute the weighted total**, apply anti-pattern penalties and any (rare) bonus, and round half-to-even.
+5. **Report:** the number, the genre it was scored against, the 2–3 lowest-scoring domains with the specific fix each needs, and the single highest-leverage change. Lead with what's working — the floor-first discipline should show in the write-up, not just the math.
+6. **Separate quality from the gate.** If the design also has a publish-blocking governance issue, flag it separately and point to `dashboard-peer-review-checklist` — a high score does not clear the gate.
+
+### Worked example (confirmed pattern)
+
+A regional sales dashboard, classified **business/operational**:
+
+| Domain | Score | Weight | Contribution | Evidence |
+|---|---|---|---|---|
+| Layout | 6.0 | 25% | 1.50 | KPI strip and trend compete for the top; no F-pattern order |
+| Chart Choice | 8.0 | 20% | 1.60 | Bars for regions, line for trend — correct; one needless pie |
+| Audience Fit | 7.5 | 15% | 1.125 | Exec-appropriate KPIs, but 6 filters is too many for a 15-sec scan |
+| Color | 7.0 | 15% | 1.05 | Sequential ramp is fine; one accent color used decoratively |
+| Message | 8.0 | 10% | 0.80 | Title states the takeaway clearly |
+| Text | 8.0 | 5% | 0.40 | Tooltips formatted with numerator/denominator |
+| Font | 8.0 | 5% | 0.40 | Consistent hierarchy |
+
+Weighted subtotal = **6.875**. Anti-pattern penalty: the lone pie is not misleading, just suboptimal → no penalty (missed opportunity, not a problem). Rounded: **6.9/10**. Highest-leverage fix: **Layout** — establish a single reading order and demote the KPI strip's competition, which alone would lift the largest-weighted domain.
+
+**What does NOT work:**
+- **Scoring without declaring the genre** — an analytical viz graded as an exec dashboard reads as "too dense / no KPIs," which is a false negative. Always state the genre.
+- **Averaging the 7 domains unweighted** — Layout (25%) and Chart Choice (20%) carry nearly half the score; a flat average lets a great font rescue a broken layout. Always apply the weights.
+- **Deducting for taste** — "I'd have used a different palette" is not a defect. Deduct only for comprehension harm, misleading encodings, or audience mismatch.
+- **Treating the score as a publish decision** — quality and the governance gate are orthogonal. Report both, separately.
+
+## Best Practices
+
+- **Genre before number.** The single most common calibration error is scoring against the wrong intent.
+- **Floor-first, deduct down.** Competent work starts at 7.5; you take points off for real problems, you don't grant them for the absence of problems.
+- **Weight-proportional deductions.** A Text nit and a Layout failure are not the same size — tie the ding to the domain weight.
+- **Evidence per domain.** Every score needs one concrete, quotable observation, or it's not defensible.
+- **Lead with strengths, then the highest-leverage fix.** A critique that only lists faults gets ignored; name the one change that moves the biggest-weighted domain.
+
+## Common Mistakes
+
+1. **Negativity anchoring** — starting low and looking for reasons to raise. Start from the competence floor and deduct for actual harm.
+2. **Unweighted averaging** — treating a 5%-weight font issue as equal to a 25%-weight layout failure.
+3. **Confusing "missed opportunity" with "problem"** — deducting for a reference line that wasn't added, even though the viz reads correctly without it.
+4. **Genre blindness** — penalizing an exploratory analytical dashboard for lacking headline KPIs.
+5. **Conflating score with gate** — reporting a high score as if it means "safe to publish" when a classification/PII/filter failure is present.
+
+## Source and Confidence
+
+- Source/evidence type: community-adapted best practice
+- Source: Weighted-scorecard evaluation methodology adapted from `adammico-lab/VizCritique-Pro-BETA` (Adam Mico, Apache 2.0), curated to house format and de-branded; cross-referenced against the existing `design-principles` and `dashboard-peer-review-checklist` modules. Domain weights and calibration philosophy are the source's; genre taxonomy is the source's, condensed.
+- Customer-identifying details removed: yes
+- Confidence: SME-reviewed
+- Last reviewed: 2026-07-13

--- a/resources/desktop/knowledge/tactics/data/connection-schema-override-limits.md
+++ b/resources/desktop/knowledge/tactics/data/connection-schema-override-limits.md
@@ -1,0 +1,111 @@
+# Connection Schema Override Limits
+
+Use this when a field's type, role, or default format keeps reverting after worksheet or datasource XML edits, especially with Excel (`excel-direct`) or CSV/text (`textscan`) connections.
+
+## Scope Check
+
+- Primary audience: Tableau agent / SE authoring XML
+- Authoring outcome improved: troubleshoot, safely stop retry loops
+- In-scope reason: Explains when the datasource connection schema can override worksheet or datasource-level field redeclarations, and when to escalate to a data-source/connection fix.
+- Out-of-scope risk: none
+- Tags: datasource, connection-schema, excel-direct, textscan, metadata-records, column-datatype, datatype-override, default-format, schema-inference, typed-parse-calc, stop-condition
+- Relevant user prompts/search terms: "field type keeps reverting", "Excel column inferred as string", "date field shows as text", "worksheet XML datatype change does not stick", "datasource column datatype ignored", "CSV schema override", "connection schema wins", "stop retrying apply", "fix type at data source", "use DATE or INT workaround"
+
+## When to Use
+
+Use this entry when a field's apparent type or format is wrong and the first XML fix does not survive a fresh `tableau-get-workbook` readback. The high-risk pattern is an existing file connection (`excel-direct` or `textscan`) whose connection/relation metadata already carries a schema decision, while the agent is only changing worksheet-level `<column>` definitions inside `datasource-dependencies`.
+
+This is not for normal calculated field authoring. A new Tableau calc declared as a datasource `<column>` can carry its own `datatype` when inserted in the datasource's valid column location. This entry is about pre-existing physical columns whose type or format comes from the connection layer.
+
+## Best Practices
+
+1. **Read the connection before retrying.** Inspect the datasource's `<connection>`, `<named-connections>`, `<relation>`, relation `<columns>`, `<metadata-records>`, datasource `<column>` definitions, and worksheet `<datasource-dependencies>`. The datasource entry documents that these pieces must agree and that Excel uses `class="excel-direct"` while CSV/text uses `class="textscan"`.
+2. **Treat worksheet dependencies as consumers, not the source of physical schema truth.** Worksheet-level `<column>` definitions tell the worksheet how it uses a field; they are not a reliable place to change a physical Excel/CSV field's inferred datatype. <!-- TODO-VERIFY-LIVE -->
+3. **Know where `<column datatype=...>` works.** It is appropriate for authored calculated fields and for a new datasource definition you are constructing. It is not proven to override an existing file connection's physical schema after Tableau has inferred or stored that schema. <!-- TODO-VERIFY-LIVE -->
+4. **Use a typed parse calc as a workaround when the source cannot be changed.** If the user cannot fix the file/data source immediately, add a new calculated field with the target type, such as `DATE(...)`, `DATEPARSE(...)`, `INT(...)`, or `FLOAT(...)`, using the parsing guidance in the date and string parsing entries. Verify the calc on real rows before building the final view.
+5. **Stop and say the limit out loud.** After one targeted worksheet/datasource redeclaration and a readback that still shows the old type/format, do not keep applying variations. Tell the user the type appears controlled by the connection/data-source layer and must be fixed there, or use a typed calc workaround.
+
+### When to STOP and Say So
+
+Stop retrying XML applies when all of these are true:
+
+1. The field is a physical column from an existing connection, especially `excel-direct` or `textscan`.
+2. The worksheet-level `<datasource-dependencies>` or datasource-level `<column datatype=...>` edit applies but disappears, is normalized back, or the field still behaves as the old type after a fresh readback.
+3. The connection/relation/metadata layer still describes the field with the old type, format, or source schema.
+
+Say: "This looks like a connection-level schema decision, not a worksheet XML problem. I should not keep retrying worksheet applies. Please fix the field type in the data source or source file, or I can add a typed Tableau calculated field as a workaround."
+
+## Common Mistakes
+
+1. **Looping at the worksheet layer.** Rewriting the same `<datasource-dependencies><column datatype=...>` shape cannot fix a field whose source schema is controlled by the connection. <!-- TODO-VERIFY-LIVE -->
+2. **Assuming datasource `<column>` redeclaration always wins.** Existing repo evidence confirms connection-level `default-format` can override both worksheet and datasource field formatting. The same limit for physical-column datatype is based on pilot episode evidence and still needs live verification. <!-- TODO-VERIFY-LIVE -->
+3. **Editing live connection nodes to force a type.** The datasource guidance says not to modify `connection` or `named-connections` in an existing datasource; they contain live file paths and authentication details.
+4. **Using `DATEPARSE` without checking connection type.** The date handling entry says `DATEPARSE` silently returns null on live SQL connections. Prefer source-layer casts for live SQL, or verify the calc directly.
+5. **Casting dirty strings wholesale.** `INT([CompoundString])` or `FLOAT([CompoundString])` returns null/zero when the string contains labels or delimiters. Split or regex-extract first.
+
+## Implementation
+
+### Confirmed connection-format limit
+
+The datasource entry documents a confirmed limitation for formatting: an Excel connection-level schema can define a field format that wins over both worksheet-level and datasource-level `default-format` edits. That proves the broad shape of the limit: some field presentation facts are owned by the connection schema, not by the worksheet.
+
+```xml
+<!-- Existing connection-level schema owns the physical field fact. -->
+<connection class="excel-direct" ... />
+
+<!-- These worksheet/datasource redeclarations can be stripped or ignored
+     when the connection schema wins. -->
+<column datatype="date" name="[Order Date]" role="dimension" type="ordinal" />
+```
+
+### Best-evidence datatype example
+
+The following is the best-evidence stop pattern from episode mining, not a live-verified recipe. <!-- TODO-VERIFY-LIVE -->
+
+```xml
+<!-- Source connection has inferred [Ship Date] as string/text. -->
+<connection class="excel-direct" ... />
+<relation connection="excel-direct.orders" name="Orders" table="[Orders$]" type="table">
+  <columns gridOrigin="A1:F5000:no:A1:F5000:0" header="yes" outcome="6">
+    <column datatype="string" name="Ship Date" ordinal="4" />
+  </columns>
+</relation>
+
+<!-- A worksheet-only redeclaration is not the fix. -->
+<datasource-dependencies datasource="Sample Orders">
+  <column datatype="date" name="[Ship Date]" role="dimension" type="ordinal" />
+  <column-instance column="[Ship Date]" derivation="None" name="[none:Ship Date:ok]" pivot="key" type="ordinal" />
+</datasource-dependencies>
+```
+
+What does **not** work: repeatedly changing only the worksheet dependency or shelf column-instance after readback shows the source field is still a string. Stop and escalate to the data source, or author a new calc:
+
+```xml
+<column caption="Ship Date (Parsed)" datatype="date" name="[Ship Date Parsed]" role="dimension" type="ordinal">
+  <calculation class="tableau" formula="DATE([Ship Date])" />
+</column>
+```
+
+Use `DATEPARSE("yyyy-MM-dd", [Ship Date])` only when that function is valid for the connection type; for live SQL, push the cast into SQL or the source layer. For numeric fields stored as text, use `INT([Field])` / `FLOAT([Field])` only after cleaning or extracting the numeric token when needed.
+
+### Decision workflow
+
+1. Re-read the workbook and identify the datasource/field path.
+2. If the field is a generated Tableau calc, fix the datasource calc `<column>` and its `datatype`.
+3. If the field is a physical Excel/CSV column, inspect relation `<columns>` and `<metadata-records>` for the source type.
+4. Make at most one targeted XML correction at the highest safe layer you own, then apply and read back.
+5. If Tableau restores the old type/format, stop. Tell the user the connection schema wins and offer the typed calc workaround.
+
+## Related Knowledge
+
+- Extends [Workbook XML: Adding and Refactoring Datasources](datasources.md): turns the existing connection-level format limitation and metadata-record guidance into a stop rule for type/schema override failures.
+- See [Tableau Date Handling in Workbook XML](tableau-date-handling.md): date parse and `DATEPARSE` connection caveats.
+- See [Parse Numbers Out of a Compound String Field](parse-number-from-compound-string.md): safe numeric parsing before `INT()` / `FLOAT()`.
+
+## Source and Confidence
+
+- Source/evidence type: repo evidence plus pilot episode mining
+- Source: `data/knowledge/tactics/data/datasources.md` connection-class, metadata-record, and connection-level format override guidance; `data/knowledge/tactics/data/tableau-date-handling.md`; `data/knowledge/tactics/data/parse-number-from-compound-string.md`; June 2026 interaction-learning episode reporting an Excel connection-level schema override that worksheet XML could not fix.
+- Customer-identifying details removed: yes
+- Confidence: needs review
+- Last reviewed: 2026-07-12


### PR DESCRIPTION
Ports the last 4 knowledge files that were a2td-only into the product corpus. Verified missing on `feature/authoring` by basename diff against a2td `main` (2026-07-14).

## Files (byte-identical to a2td main)
- `resources/desktop/knowledge/strategy/viz-design/viz-evaluation-framework.md`
- `resources/desktop/knowledge/strategy/data-modeling/field-hygiene-and-naming.md`
- `resources/desktop/knowledge/strategy/dashboard-design/audience-budget-and-question-priority.md`
- `resources/desktop/knowledge/tactics/data/connection-schema-override-limits.md`

First three are the adammico-lab harvest (a2td #202); `connection-schema-override-limits` was a prior lab gap. Path mapping is 1:1 (`data/knowledge/<domain>/x.md` → `resources/desktop/knowledge/<domain>/x.md`); none are in the `analytics/` domain so no top-level dupe was created.

## Verification
- `src/desktop/knowledge/index.test.ts` (house-format gate: 4 required sections, 500–32k chars, title line, balanced fences), `resources.test.ts`, and `listKnowledgeResources.test.ts` all green.
- Broader sweep confirmed this closes the corpus gap: 44/44 template manifests already present with zero `render_verified` drift, validation rules at parity-or-ahead. These 4 files were the only genuine remaining knowledge debt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)