### PR TITLE
W64 P0 port: dogfood bug-wave fixes (wrong-chart bind + ATTR-blank) from the a2td lab

### DIFF
--- a/lockstep.hashes.json
+++ b/lockstep.hashes.json
@@ -1,6 +1,6 @@
 {
   "src/desktop/binder/calc-derivation.ts": "5105d466e3c31019affa91320edf3047259301ca5cd27aeb5883ba1faa251098",
-  "src/desktop/binder/classify.ts": "4a49e134a6c4e683ce9d728728bc67c3e8e4098a2656e35973d31811e918a657",
+  "src/desktop/binder/classify.ts": "64ca40297eb5ff64423d28eba3ce3e4cf7eb970ad218717e01717e0e26d073dc",
   "src/desktop/binder/escape.ts": "3c79bcf77c33fad64975e95ea57df5fb3e416008633e15dc7a585018fbc92d3f",
   "src/desktop/binder/manifest-types.ts": "9ce310c1e294d3784084b854edf52ef4f7c4cf7a8e13ebba7071dc3957c6114d",
   "src/desktop/binder/manifest-validation.ts": "e29ecfa9e10e57593a4f72e498f35ca8b1b28a1227fc0cb4aed057870566df60",

--- a/lockstep.hashes.json
+++ b/lockstep.hashes.json
@@ -1,6 +1,6 @@
 {
   "src/desktop/binder/calc-derivation.ts": "5105d466e3c31019affa91320edf3047259301ca5cd27aeb5883ba1faa251098",
-  "src/desktop/binder/classify.ts": "64ca40297eb5ff64423d28eba3ce3e4cf7eb970ad218717e01717e0e26d073dc",
+  "src/desktop/binder/classify.ts": "2fdf604ddff4a7f364e15599ba34d73cedf5c951fca5f90fdb9259555b1787fd",
   "src/desktop/binder/escape.ts": "3c79bcf77c33fad64975e95ea57df5fb3e416008633e15dc7a585018fbc92d3f",
   "src/desktop/binder/manifest-types.ts": "9ce310c1e294d3784084b854edf52ef4f7c4cf7a8e13ebba7071dc3957c6114d",
   "src/desktop/binder/manifest-validation.ts": "e29ecfa9e10e57593a4f72e498f35ca8b1b28a1227fc0cb4aed057870566df60",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "2.11.0",
+  "version": "2.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "2.11.0",
+      "version": "2.12.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.7.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "2.11.0",
+  "version": "2.12.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/resources/desktop/knowledge/_index.md
+++ b/resources/desktop/knowledge/_index.md
@@ -39,6 +39,7 @@ Entries show the tactics slug and, where one exists, its strategy companion.
 - Overlaying / stacking / nesting multiple pie charts (readability pushback + alternatives) → `strategy/viz-design/overlaid-and-stacked-pie-readability`
 - Filters → `tactics/viz/filters` · strategy: `strategy/viz-design/filter-strategy`
 - Marks, encodings, color/size/label, sorts → `tactics/viz/marks-and-encodings` · strategy: `strategy/viz-design/encoding-strategy`
+- Tooltip encodings (dimensions need `attr:` in aggregated views — blank-render hazard) → `tactics/viz/tooltip`
 - Discrete groups vs. gradient (color "which group", not the raw measure) → strategy: `strategy/viz-design/discrete-groups-vs-gradient` · tactics: `tactics/viz/marks-and-encodings` ("Discrete-tier color")
 - Worksheet + window structure → `tactics/viz/worksheets` · strategy: `strategy/viz-design/worksheet-strategy`
 - Year-over-year / period comparison → `tactics/viz/workbook-date-yoy-comparison`

--- a/resources/desktop/knowledge/tactics/viz/marks-and-encodings.md
+++ b/resources/desktop/knowledge/tactics/viz/marks-and-encodings.md
@@ -1,6 +1,6 @@
 # Workbook XML: Encodings and Mark Types
 
-Enforced-by: computed-sort-crash, redundant-color-encoding
+Enforced-by: computed-sort-crash, redundant-color-encoding, tooltip-dimension-requires-attr
 
 Expert reference for all Tableau marks card encodings, mark types, label styling, color palettes, and chart-type-specific patterns (Gantt, map, aggregation, sorting). All patterns confirmed via `tableau-get-workbook` observation after manual authoring.
 
@@ -618,6 +618,8 @@ A single pane can have **multiple elements of the same encoding type** — this 
 ```
 
 Each referenced field still needs a column def + column-instance in `<datasource-dependencies>`.
+
+Tooltip dimensions in aggregated views need `attr:`, not `none:` — see `tactics/viz/tooltip.md`.
 
 ---
 

--- a/resources/desktop/knowledge/tactics/viz/tooltip.md
+++ b/resources/desktop/knowledge/tactics/viz/tooltip.md
@@ -1,0 +1,59 @@
+# Tooltip Encodings
+
+Tooltip is the one marks-card property that does NOT join the view's level of detail. That makes it the one place where a raw dimension reference is a render hazard: in an aggregated view Tableau must convert a tooltip dimension via `ATTR()`, and a directly-authored `none:` column-instance defeats that conversion — the XML applies "successfully", then the sheet renders BLANK with `cannot be converted to a measure using ATTR()` on the pill.
+
+Related: `tactics/viz/marks-and-encodings.md` (general encoding XML, multiple encoding instances). Preflight backstop: validation rule `tooltip-dimension-requires-attr` blocks the broken shape at apply time.
+
+## When to Use
+
+- Adding a dimension to Tooltip as hover context on an aggregated view (bar/line/map at a coarser grain than the dimension) — use `attr:` derivation, this file's core rule.
+- Any tooltip authoring where the view has aggregate refs (`sum:`, `avg:`, `cnt:`, …) on shelves or encodings.
+- NOT needed for measures on tooltip (they aggregate normally) or for fully disaggregated views (`<aggregation value="false"/>`), where `none:` tooltip dimensions are legal.
+
+## Best Practices
+
+- **Dimension on Tooltip in an aggregated view → `derivation="Attribute"`, prefix `attr:`.** Declare the Attribute column-instance and reference it from `<tooltip>`:
+
+```xml
+<column-instance column="[Segment]" derivation="Attribute" name="[attr:Segment:nk]" pivot="key" type="nominal"/>
+
+<encodings>
+  <tooltip column="[DS].[attr:Segment:nk]"/>
+  <tooltip column="[DS].[sum:Sales:qk]"/>
+</encodings>
+```
+
+- Keep the suffix aligned to the instance type: string/nominal `:nk`, ordinal `:ok`, quantitative ATTR `:qk` (confirmed shape: `[attr:...:nk]` tooltip fields in aggregated worksheets, e.g. Tableau Public "Trellis Chart" example).
+- The canonical derivation string is `Attribute` — `Attr` is invalid and gets silently rewritten by Tableau (see the `invalid-derivation-string` rule).
+- If the tooltip value must be computed at the aggregate level, a `usr:` (derivation="User") aggregated calc is the alternative to `attr:`.
+
+## Common Mistakes
+
+- **`none:` dimension on `<tooltip>` in an aggregated view — blanks the sheet (confirmed P0, GUS W-23447711).** This FAILS at render after applying cleanly:
+
+```xml
+<view>
+  <datasource-dependencies datasource="DS">
+    <column datatype="string" name="[Segment]" role="dimension" type="nominal"/>
+    <column datatype="real" name="[Sales]" role="measure" type="quantitative"/>
+    <column-instance column="[Segment]" derivation="None" name="[none:Segment:nk]" pivot="key" type="nominal"/>
+    <column-instance column="[Sales]" derivation="Sum" name="[sum:Sales:qk]" pivot="key" type="quantitative"/>
+  </datasource-dependencies>
+  <aggregation value="true"/>
+</view>
+<panes><pane><encodings>
+  <tooltip column="[DS].[none:Segment:nk]"/>
+  <tooltip column="[DS].[sum:Sales:qk]"/>
+</encodings></pane></panes>
+```
+
+- Retrying the same XML because `tableau-apply-workbook` reported success — apply success does NOT mean the sheet rendered; this shape is the canonical false-PASS.
+- Confusing tooltip with text/label: dimensions on Text/Label JOIN the view grain (like Detail), so `none:` is legitimate there. Do not "fix" text encodings to `attr:` by analogy.
+- Using `derivation="Attr"` instead of `Attribute`.
+
+## Implementation
+
+1. Author the Attribute column-instance for the dimension alongside the existing declarations in `<datasource-dependencies>`.
+2. Point the `<tooltip>` encoding at the `attr:` instance name (never the `none:` instance) whenever the view is aggregated.
+3. Disaggregated exception: with `<aggregation value="false"/>` (one mark per row), `none:` tooltip dimensions are valid — Tableau is not ATTR-converting at an aggregated mark grain.
+4. Preflight: the `tooltip-dimension-requires-attr` validation rule errors on the broken shape with a FIX line; do not acknowledge past it — change the derivation.

--- a/src/desktop/binder/ask-router.test.ts
+++ b/src/desktop/binder/ask-router.test.ts
@@ -110,3 +110,36 @@ describe('ask-router — CHART_NOUN_KEYWORDS lockstep parity with classify.ts', 
     expect(src).not.toMatch(/import\(\s*['"][^'"]*\/classify[^'"]*['"]\s*\)/);
   });
 });
+
+describe('ask-router — spatial-intent family guard (W-23447710)', () => {
+  it('selectEligible refuses a non-spatial winner when the ask carries map intent', () => {
+    const ms = [
+      mkManifest({ template: 'rank-map-trap', family: 'ranking', intent_keywords: ['top', 'highest'] }),
+      mkManifest({ template: 'spatial-carrier', family: 'spatial', intent_keywords: ['map'] }),
+    ];
+    const ask = 'map of top sales by region, highest first';
+    expect(selectEligible(ask, ms, ask)).toBeNull();
+  });
+
+  it('selectEligible still binds non-map asks decisively', () => {
+    const ms = [
+      mkManifest({ template: 'rank-bar', family: 'ranking', intent_keywords: ['bar'] }),
+      mkManifest({ template: 'spatial-carrier', family: 'spatial', intent_keywords: ['map'] }),
+    ];
+    const ask = 'bar chart of sales by region';
+    expect(selectEligible(ask, ms, ask)?.template).toBe('rank-bar');
+  });
+
+  it('SPATIAL_INTENT_ALIASES stays lockstep with classify.ts (set equality)', () => {
+    function extractAliases(file: string): Set<string> {
+      const src = fs.readFileSync(file, 'utf8');
+      const m = src.match(/const\s+SPATIAL_INTENT_ALIASES[^=]*=\s*new Set\(\[([\s\S]*?)\]\)/);
+      expect(m, `SPATIAL_INTENT_ALIASES Set literal not found in ${file}`).not.toBeNull();
+      const body = m![1].replace(/\/\/[^\n]*/g, '');
+      return new Set([...body.matchAll(/['"]([^'"]+)['"]/g)].map((x) => x[1].toLowerCase()));
+    }
+    const askRouterAliases = extractAliases(path.join(repoRoot, 'src', 'desktop', 'binder', 'ask-router.ts'));
+    const classifyAliases = extractAliases(path.join(repoRoot, 'src', 'desktop', 'binder', 'classify.ts'));
+    expect([...askRouterAliases].sort()).toEqual([...classifyAliases].sort());
+  });
+});

--- a/src/desktop/binder/ask-router.test.ts
+++ b/src/desktop/binder/ask-router.test.ts
@@ -114,7 +114,11 @@ describe('ask-router — CHART_NOUN_KEYWORDS lockstep parity with classify.ts', 
 describe('ask-router — spatial-intent family guard (W-23447710)', () => {
   it('selectEligible refuses a non-spatial winner when the ask carries map intent', () => {
     const ms = [
-      mkManifest({ template: 'rank-map-trap', family: 'ranking', intent_keywords: ['top', 'highest'] }),
+      mkManifest({
+        template: 'rank-map-trap',
+        family: 'ranking',
+        intent_keywords: ['top', 'highest'],
+      }),
       mkManifest({ template: 'spatial-carrier', family: 'spatial', intent_keywords: ['map'] }),
     ];
     const ask = 'map of top sales by region, highest first';
@@ -138,8 +142,12 @@ describe('ask-router — spatial-intent family guard (W-23447710)', () => {
       const body = m![1].replace(/\/\/[^\n]*/g, '');
       return new Set([...body.matchAll(/['"]([^'"]+)['"]/g)].map((x) => x[1].toLowerCase()));
     }
-    const askRouterAliases = extractAliases(path.join(repoRoot, 'src', 'desktop', 'binder', 'ask-router.ts'));
-    const classifyAliases = extractAliases(path.join(repoRoot, 'src', 'desktop', 'binder', 'classify.ts'));
+    const askRouterAliases = extractAliases(
+      path.join(repoRoot, 'src', 'desktop', 'binder', 'ask-router.ts'),
+    );
+    const classifyAliases = extractAliases(
+      path.join(repoRoot, 'src', 'desktop', 'binder', 'classify.ts'),
+    );
     expect([...askRouterAliases].sort()).toEqual([...classifyAliases].sort());
   });
 });

--- a/src/desktop/binder/ask-router.ts
+++ b/src/desktop/binder/ask-router.ts
@@ -131,6 +131,56 @@ function wonChartNoun(maskedAsk: string, keywords: string[]): boolean {
 }
 
 /**
+ * FAMILY-LEVEL spatial intent guard vocabulary — hand-mirrored from classify.ts
+ * (this file must not import the classifier); a parity test enforces set equality.
+ * See classify.ts for the full rationale (W-23447710, Cluster A selection half).
+ */
+const SPATIAL_INTENT_ALIASES: ReadonlySet<string> = new Set([
+  'geo',
+  'geographic',
+  'geographical',
+  'geographically',
+  'coordinate',
+  'coordinates',
+  'gps',
+  'lat/long',
+  'lat/lon',
+  'lat-long',
+  'lat-lon',
+]);
+
+function spatialIntentPhrases(manifests: TemplateManifest[]): Set<string> {
+  const phrases = new Set<string>(SPATIAL_INTENT_ALIASES);
+  for (const m of manifests) {
+    if (m.family !== 'spatial') continue;
+    for (const kw of m.intent_keywords) phrases.add(kw.toLowerCase());
+  }
+  return phrases;
+}
+
+/** Lat+lon named together is coordinate intent even without a map noun. */
+function hasCoordinatePairIntent(rawAsk: string): boolean {
+  const hasLat = phraseIndexInAsk(rawAsk, 'latitude') >= 0 || phraseIndexInAsk(rawAsk, 'lat') >= 0;
+  const hasLon =
+    phraseIndexInAsk(rawAsk, 'longitude') >= 0 ||
+    phraseIndexInAsk(rawAsk, 'lon') >= 0 ||
+    phraseIndexInAsk(rawAsk, 'lng') >= 0 ||
+    phraseIndexInAsk(rawAsk, 'long') >= 0;
+  return hasLat && hasLon;
+}
+
+function askCarriesSpatialIntent(
+  rawAsk: string,
+  maskedAsk: string,
+  manifests: TemplateManifest[],
+): boolean {
+  for (const phrase of spatialIntentPhrases(manifests)) {
+    if (phraseIndexInAsk(maskedAsk, phrase) >= 0) return true;
+  }
+  return hasCoordinatePairIntent(rawAsk);
+}
+
+/**
  * BIND-path template selection over the ELIGIBLE pool. Fail-closed: bind only on a UNIQUE
  * keyword-argmax winner that is DECISIVE (won a family-native keyword OR a distinctive chart
  * noun). Any keyword-score tie ⇒ null. `selectEligible` enforces the `fast_path_eligible`
@@ -142,6 +192,7 @@ function wonChartNoun(maskedAsk: string, keywords: string[]): boolean {
 export function selectEligible(
   maskedAsk: string,
   manifests: TemplateManifest[],
+  rawAsk = maskedAsk,
 ): TemplateManifest | null {
   const scored = manifests
     .filter((m) => m.fast_path_eligible)
@@ -152,6 +203,8 @@ export function selectEligible(
   const top = scored.filter((s) => s.score === maxScore);
   if (top.length !== 1) return null; // fail-closed on any tie
   const m = top[0].m;
+  // Family guard (W-23447710): a spatial-intent ask never binds a non-spatial winner.
+  if (m.family !== 'spatial' && askCarriesSpatialIntent(rawAsk, maskedAsk, manifests)) return null;
   const native = familyNativeKeywords(m.family, manifests);
   const won = matchedKeywords(maskedAsk, m.intent_keywords);
   const decisive =

--- a/src/desktop/binder/classify.ts
+++ b/src/desktop/binder/classify.ts
@@ -531,6 +531,60 @@ function familyNativeKeywords(
 }
 
 /**
+ * FAMILY-LEVEL spatial intent guard vocabulary (W-23447710, Cluster A selection half).
+ * The source of truth is the manifest set itself: any keyword carried by a
+ * spatial-family manifest is spatial intent — INCLUDING non-eligible spatial supply,
+ * so a lat/lon ask is protected even while spatial-symbol-map-latlon is unproven.
+ * The alias set covers bare words users say that are not standalone manifest keywords.
+ * Bare "map" stays OUT of CHART_NOUN_KEYWORDS (dual-carrier within spatial); this
+ * guard operates only at family granularity, never picking a template.
+ */
+const SPATIAL_INTENT_ALIASES: ReadonlySet<string> = new Set([
+  'geo',
+  'geographic',
+  'geographical',
+  'geographically',
+  'coordinate',
+  'coordinates',
+  'gps',
+  'lat/long',
+  'lat/lon',
+  'lat-long',
+  'lat-lon',
+]);
+
+function spatialIntentPhrases(manifests: Map<string, TemplateManifest>): Set<string> {
+  const phrases = new Set<string>(SPATIAL_INTENT_ALIASES);
+  for (const m of manifests.values()) {
+    if (m.family !== 'spatial') continue;
+    for (const kw of m.intent_keywords) phrases.add(kw.toLowerCase());
+  }
+  return phrases;
+}
+
+/** Lat+lon named together is coordinate intent even without a map noun. */
+function hasCoordinatePairIntent(rawAsk: string): boolean {
+  const hasLat = phraseIndexInAsk(rawAsk, 'latitude') >= 0 || phraseIndexInAsk(rawAsk, 'lat') >= 0;
+  const hasLon =
+    phraseIndexInAsk(rawAsk, 'longitude') >= 0 ||
+    phraseIndexInAsk(rawAsk, 'lon') >= 0 ||
+    phraseIndexInAsk(rawAsk, 'lng') >= 0 ||
+    phraseIndexInAsk(rawAsk, 'long') >= 0;
+  return hasLat && hasLon;
+}
+
+function askCarriesSpatialIntent(
+  rawAsk: string,
+  maskedAsk: string,
+  manifests: Map<string, TemplateManifest>,
+): boolean {
+  for (const phrase of spatialIntentPhrases(manifests)) {
+    if (phraseIndexInAsk(maskedAsk, phrase) >= 0) return true;
+  }
+  return hasCoordinatePairIntent(rawAsk);
+}
+
+/**
  * Every field name / caption / bare column name in the schema, lowercased. Feeds
  * fieldNameMatchInAsk's EXACT-FIRST tie-break: a field's plural alias is suppressed
  * at any token another field claims by its exact name (so with both "Region" and
@@ -1277,6 +1331,11 @@ export function classifyNoLlm(
 
   const chosen = selectWithinFamily(top, maskedAsk, matched, aggOverride, manifests, schemaDims);
   if (!chosen) return null;
+
+  // DEMOTE (family guard, W-23447710): a spatial-intent ask must never bind a
+  // non-spatial keyword-count winner. Bare "map" stays out of CHART_NOUN_KEYWORDS
+  // because it is dual-carrier within spatial; this guard is family-granular only.
+  if (askCarriesSpatialIntent(ask, maskedAsk, manifests) && chosen.family !== 'spatial') return null;
 
   // DEMOTE (never hard-block): when the selected winner carries avoid_when
   // guidance whose terms appear in the ask, fall through to the propose leg so

--- a/src/desktop/binder/classify.ts
+++ b/src/desktop/binder/classify.ts
@@ -1335,7 +1335,9 @@ export function classifyNoLlm(
   // DEMOTE (family guard, W-23447710): a spatial-intent ask must never bind a
   // non-spatial keyword-count winner. Bare "map" stays out of CHART_NOUN_KEYWORDS
   // because it is dual-carrier within spatial; this guard is family-granular only.
-  if (askCarriesSpatialIntent(ask, maskedAsk, manifests) && chosen.family !== 'spatial') return null;
+  if (askCarriesSpatialIntent(ask, maskedAsk, manifests) && chosen.family !== 'spatial') {
+    return null;
+  }
 
   // DEMOTE (never hard-block): when the selected winner carries avoid_when
   // guidance whose terms appear in the ask, fall through to the propose leg so

--- a/src/desktop/binder/explicit-bind.test.ts
+++ b/src/desktop/binder/explicit-bind.test.ts
@@ -1,0 +1,268 @@
+import { describe, expect, it } from 'vitest';
+
+import { bindExplicitTemplate, schemaSummaryFromAvailableFields } from './explicit-bind.js';
+import type { TemplateManifest } from './manifest-types.js';
+import type { SchemaField, SchemaSummary } from './schema-summary.js';
+
+function field(p: {
+  name: string;
+  role: 'dimension' | 'measure';
+  type: string;
+  datatype: string;
+  refDerivation?: string;
+}): SchemaField {
+  const suffix = p.type === 'quantitative' ? 'qk' : p.type === 'ordinal' ? 'ok' : 'nk';
+  const deriv = p.refDerivation ?? (p.role === 'measure' ? 'sum' : 'none');
+  return {
+    name: p.name,
+    columnName: `[${p.name}]`,
+    role: p.role,
+    type: p.type,
+    datatype: p.datatype,
+    datasource: 'Superstore',
+    isAggregated: false,
+    column_ref: `[Superstore].[${deriv}:${p.name}:${suffix}]`,
+  };
+}
+
+const SUMMARY: SchemaSummary = {
+  datasource: 'Superstore',
+  fields: [
+    field({ name: 'Longitude', role: 'measure', type: 'quantitative', datatype: 'real' }),
+    field({ name: 'Latitude', role: 'measure', type: 'quantitative', datatype: 'real' }),
+    field({ name: 'City', role: 'dimension', type: 'nominal', datatype: 'string' }),
+    field({ name: 'Sales', role: 'measure', type: 'quantitative', datatype: 'real' }),
+    field({ name: 'Order Date', role: 'dimension', type: 'ordinal', datatype: 'date' }),
+    field({ name: 'Segment', role: 'dimension', type: 'nominal', datatype: 'string' }),
+  ],
+};
+
+const LATLON = {
+  template: 'x-latlon',
+  family: 'spatial',
+  readiness: 'YELLOW',
+  fast_path_eligible: false,
+  fast_path_blockers: [],
+  portability_evidence: { fixture_bind: true, render_verified: 'none' },
+  datasource_placeholder: true,
+  placeholders: ['TITLE', 'DATASOURCE'],
+  intent_keywords: ['latlon'],
+  description: 'test lat/lon map',
+  slots: [
+    {
+      slot_id: 'longitude',
+      template_field: 'Longitude',
+      derivation: 'avg',
+      role: ['cols'],
+      kind: 'quantitative',
+      bindable: true,
+      required: true,
+    },
+    {
+      slot_id: 'latitude',
+      template_field: 'Latitude',
+      derivation: 'avg',
+      role: ['rows'],
+      kind: 'quantitative',
+      bindable: true,
+      required: true,
+    },
+    {
+      slot_id: 'detail',
+      template_field: 'Detail',
+      derivation: 'none',
+      role: ['detail'],
+      kind: 'categorical',
+      bindable: true,
+      required: true,
+    },
+    {
+      slot_id: 'measure',
+      template_field: 'Measure',
+      derivation: 'sum',
+      role: ['size'],
+      kind: 'quantitative',
+      bindable: true,
+      required: true,
+    },
+  ],
+  calcs: [],
+  hazards: [],
+} as unknown as TemplateManifest;
+
+const manifests = (m: TemplateManifest): Map<string, TemplateManifest> => new Map([[m.template, m]]);
+
+describe('bindExplicitTemplate', () => {
+  it('emits manifest derivations over caller SUM refs', () => {
+    const result = bindExplicitTemplate(
+      'x-latlon',
+      [
+        '[Superstore].[sum:Longitude:qk]',
+        '[Superstore].[sum:Latitude:qk]',
+        '[Superstore].[none:City:nk]',
+        '[Superstore].[sum:Sales:qk]',
+      ],
+      SUMMARY,
+      { manifests: manifests(LATLON) },
+    );
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.fieldMapping.Longitude).toBe('[Superstore].[avg:Longitude:qk]');
+      expect(result.fieldMapping.Latitude).toBe('[Superstore].[avg:Latitude:qk]');
+      expect(result.fieldMapping.Detail).toBe('[Superstore].[none:City:nk]');
+      expect(result.fieldMapping.Measure).toBe('[Superstore].[sum:Sales:qk]');
+      expect(result.passthrough).toBe(false);
+    }
+  });
+
+  it('passes through unchanged with warning when the template has no manifest', () => {
+    const mapping = { Sales: '[Superstore].[sum:Sales:qk]' };
+    const result = bindExplicitTemplate('missing-template', mapping, SUMMARY, {
+      manifests: new Map(),
+      datasource: 'Superstore',
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.passthrough).toBe(true);
+      expect(result.fieldMapping).toEqual(mapping);
+      expect(result.warnings.some((w) => w.includes('no-manifest'))).toBe(true);
+    }
+  });
+
+  it('surfaces ineligible render evidence and hazards as warnings', () => {
+    const hazardous = {
+      ...LATLON,
+      hazards: [{ code: 'coordinate-slot-affinity-unproven', detail: 'coordinate slots can swap' }],
+    } as unknown as TemplateManifest;
+
+    const result = bindExplicitTemplate(
+      'x-latlon',
+      [
+        '[Superstore].[sum:Longitude:qk]',
+        '[Superstore].[sum:Latitude:qk]',
+        '[Superstore].[none:City:nk]',
+        '[Superstore].[sum:Sales:qk]',
+      ],
+      SUMMARY,
+      { manifests: manifests(hazardous) },
+    );
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.warnings.some((w) => w.includes('fast_path_eligible:false'))).toBe(true);
+      expect(result.warnings.some((w) => w.includes('render_verified:none'))).toBe(true);
+      expect(
+        result.warnings.some((w) => w.includes('hazard:coordinate-slot-affinity-unproven')),
+      ).toBe(true);
+    }
+  });
+
+  it('returns FIX-style blockers for missing required manifest slots', () => {
+    const result = bindExplicitTemplate(
+      'x-latlon',
+      { Longitude: '[Superstore].[sum:Longitude:qk]' },
+      SUMMARY,
+      { manifests: manifests(LATLON) },
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.blockers.some((b) => b.code === 'missing-required-slot')).toBe(true);
+      expect(result.errors.every((e) => e.fix.length > 0)).toBe(true);
+    }
+  });
+
+  it('handles qualified-key slots for one field reused at two derivations', () => {
+    const highlight = {
+      ...LATLON,
+      template: 'x-highlight',
+      family: 'correlation',
+      intent_keywords: ['highlight'],
+      slots: [
+        {
+          slot_id: 'order_date_month',
+          template_field: 'Order Date',
+          derivation: 'mn',
+          role: ['rows'],
+          kind: 'temporal',
+          bindable: true,
+          required: true,
+          qualified_key_required: true,
+        },
+        {
+          slot_id: 'segment',
+          template_field: 'Segment',
+          derivation: 'none',
+          role: ['cols'],
+          kind: 'categorical',
+          bindable: true,
+          required: true,
+        },
+        {
+          slot_id: 'order_date_year',
+          template_field: 'Order Date',
+          derivation: 'yr',
+          role: ['cols'],
+          kind: 'temporal',
+          bindable: true,
+          required: true,
+          qualified_key_required: true,
+        },
+      ],
+    } as unknown as TemplateManifest;
+
+    const result = bindExplicitTemplate(
+      'x-highlight',
+      {
+        'Order Date@mn': '[Superstore].[none:Order Date:ok]',
+        Segment: '[Superstore].[none:Segment:nk]',
+        'Order Date@yr': '[Superstore].[none:Order Date:ok]',
+      },
+      SUMMARY,
+      { manifests: manifests(highlight) },
+    );
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.fieldMapping['Order Date@mn']).toBe('[Superstore].[mn:Order Date:ok]');
+      expect(result.fieldMapping['Order Date@yr']).toBe('[Superstore].[yr:Order Date:ok]');
+    }
+  });
+});
+
+describe('schemaSummaryFromAvailableFields', () => {
+  it('adapts available-fields shape and picks the majority datasource', () => {
+    const summary = schemaSummaryFromAvailableFields([
+      {
+        datasource: 'DS1',
+        columnName: '[Sales]',
+        role: 'measure',
+        type: 'quantitative',
+        datatype: 'real',
+        column_ref: '[DS1].[sum:Sales:qk]',
+      },
+      {
+        datasource: 'DS1',
+        columnName: '[Region]',
+        role: 'dimension',
+        type: 'nominal',
+        datatype: 'string',
+        column_ref: '[DS1].[none:Region:nk]',
+      },
+      {
+        datasource: 'DS2',
+        columnName: '[Other]',
+        role: 'dimension',
+        type: 'nominal',
+        datatype: 'string',
+        column_ref: '[DS2].[none:Other:nk]',
+      },
+    ]);
+
+    expect(summary.datasource).toBe('DS1');
+    expect(summary.fields).toHaveLength(3);
+    expect(summary.fields[0].name).toBe('Sales');
+  });
+});

--- a/src/desktop/binder/explicit-bind.ts
+++ b/src/desktop/binder/explicit-bind.ts
@@ -1,0 +1,481 @@
+import { loadManifests } from './manifest.js';
+import type { Derivation, SlotSpec, TemplateManifest } from './manifest-types.js';
+import { bareName, type SchemaField, type SchemaSummary } from './schema-summary.js';
+import { type BindingProposal, type Blocker, validateBinding } from './validate.js';
+
+export type ExplicitBindInput = string[] | Record<string, string>;
+
+export interface AvailableFieldLike {
+  datasource: string;
+  columnName: string;
+  role: string;
+  type: string;
+  datatype?: string;
+  caption?: string;
+  isAggregated?: boolean;
+  column_ref: string;
+}
+
+export interface ExplicitBindOptions {
+  manifests?: Map<string, TemplateManifest>;
+  title?: string;
+  datasource?: string;
+  passthroughFieldMapping?: Record<string, string>;
+}
+
+export interface ExplicitBindError {
+  code: string;
+  slot_id?: string;
+  detail: string;
+  candidates?: string[];
+  fix: string;
+}
+
+export type ExplicitBindResult =
+  | {
+      ok: true;
+      template: string;
+      datasource: string;
+      fieldMapping: Record<string, string>;
+      fieldMetadata: Record<string, { datatype: string; type: string }>;
+      warnings: string[];
+      passthrough: boolean;
+    }
+  | {
+      ok: false;
+      template: string;
+      errors: ExplicitBindError[];
+      blockers: Blocker[];
+      warnings: string[];
+    };
+
+interface ResolvedSource {
+  raw: string;
+  field: SchemaField;
+}
+
+interface ProposalBuild {
+  proposal: BindingProposal;
+  fieldBySlot: Map<string, SchemaField>;
+  warnings: string[];
+}
+
+export function schemaSummaryFromAvailableFields(fields: AvailableFieldLike[]): SchemaSummary {
+  const summaryFields: SchemaField[] = fields.map((f) => {
+    const bare = bareName(f.columnName);
+    const caption = f.caption && f.caption.length > 0 ? f.caption : undefined;
+    return {
+      name: caption ?? bare,
+      caption,
+      columnName: f.columnName,
+      role: f.role === 'measure' ? 'measure' : 'dimension',
+      type: f.type,
+      datatype: f.datatype ?? '',
+      datasource: f.datasource,
+      isAggregated: !!f.isAggregated,
+      column_ref: f.column_ref,
+    };
+  });
+
+  return { datasource: pickPrimaryDatasource(summaryFields), fields: summaryFields };
+}
+
+export function bindExplicitTemplate(
+  templateName: string,
+  input: ExplicitBindInput,
+  schema: SchemaSummary,
+  opts: ExplicitBindOptions = {},
+): ExplicitBindResult {
+  // Fail-open when the manifest layer is unavailable (e.g. broken disk assets or
+  // heavily-mocked test envs): explicit applies degrade to legacy passthrough with
+  // a warning instead of crashing. SEA builds already fail closed inside
+  // loadManifests when the embedded supply is broken.
+  let manifest: TemplateManifest | undefined;
+  let manifestLayerUnavailable = false;
+  try {
+    const manifests = opts.manifests ?? loadManifests();
+    manifest = manifests.get(templateName);
+  } catch {
+    manifestLayerUnavailable = true;
+  }
+
+  if (!manifest) {
+    return {
+      ok: true,
+      template: templateName,
+      datasource: opts.datasource ?? schema.datasource,
+      fieldMapping: Array.isArray(input) ? (opts.passthroughFieldMapping ?? {}) : input,
+      fieldMetadata: {},
+      warnings: [
+        manifestLayerUnavailable
+          ? `manifest-layer-unavailable: could not load template manifests; caller mapping for '${templateName}' applied without enforcement.`
+          : `no-manifest: template '${templateName}' has no manifest; caller mapping applied without enforcement.`,
+      ],
+      passthrough: true,
+    };
+  }
+
+  const warnings = manifestWarnings(manifest);
+  const built = Array.isArray(input)
+    ? buildProposalFromOrderedRefs(manifest, input, schema, opts.title)
+    : buildProposalFromFieldMapping(manifest, input, schema, opts.title);
+  warnings.push(...built.warnings);
+
+  const validation = validateBinding(manifest, built.proposal, schema);
+  if (!validation.ok) {
+    return {
+      ok: false,
+      template: templateName,
+      blockers: validation.blockers,
+      errors: validation.blockers.map(blockerToFixError),
+      warnings,
+    };
+  }
+
+  return {
+    ok: true,
+    template: templateName,
+    datasource: rawDatasourceFor(built.fieldBySlot, opts.datasource ?? schema.datasource),
+    fieldMapping: emitRawFieldMapping(manifest, built.fieldBySlot),
+    fieldMetadata: fieldMetadataFor(manifest, built.fieldBySlot),
+    warnings: [...warnings, ...(validation.warnings ?? [])],
+    passthrough: false,
+  };
+}
+
+export function formatExplicitBindErrors(
+  templateName: string,
+  errors: ExplicitBindError[],
+): string {
+  const rendered = errors
+    .map((e) => {
+      const slot = e.slot_id ? ` (slot '${e.slot_id}')` : '';
+      const candidates =
+        e.candidates && e.candidates.length > 0
+          ? `\n      candidates: ${e.candidates.join(', ')}`
+          : '';
+      return `  - [${e.code}]${slot} ${e.detail}${candidates}\n    FIX: ${e.fix}`;
+    })
+    .join('\n');
+
+  return `Explicit template binding BLOCKED for '${templateName}'. No worksheet was produced.\n\n${rendered}`;
+}
+
+function buildProposalFromOrderedRefs(
+  manifest: TemplateManifest,
+  refs: string[],
+  schema: SchemaSummary,
+  title?: string,
+): ProposalBuild {
+  const warnings: string[] = [];
+  const sources: ResolvedSource[] = [];
+
+  for (const ref of refs) {
+    const resolved = resolveSource(ref, schema);
+    if ('field' in resolved) sources.push(resolved);
+    else warnings.push(`unresolved-column-ref: ${resolved.detail}`);
+  }
+
+  const used = new Set<SchemaField>();
+  const reusableByTemplateField = new Map<string, ResolvedSource>();
+  const fieldBySlot = new Map<string, SchemaField>();
+  const bindings: BindingProposal['bindings'] = [];
+
+  for (const slot of manifest.slots) {
+    if (!slot.bindable) continue;
+    const source = takeCompatibleSource(slot, sources, used, reusableByTemplateField);
+    if (!source) continue;
+    reusableByTemplateField.set(slot.template_field, source);
+    fieldBySlot.set(slot.slot_id, source.field);
+    bindings.push({ slot_id: slot.slot_id, field: source.field.name });
+  }
+
+  return {
+    proposal: { template: manifest.template, title: title ?? manifest.template, bindings },
+    fieldBySlot,
+    warnings,
+  };
+}
+
+function buildProposalFromFieldMapping(
+  manifest: TemplateManifest,
+  mapping: Record<string, string>,
+  schema: SchemaSummary,
+  title?: string,
+): ProposalBuild {
+  const warnings: string[] = [];
+  const usedKeys = new Set<string>();
+  const usedFields = new Set<SchemaField>();
+  const fieldBySlot = new Map<string, SchemaField>();
+  const bindings: BindingProposal['bindings'] = [];
+
+  for (const slot of manifest.slots) {
+    if (!slot.bindable) continue;
+    const key = mappingKeyForSlot(slot, manifest, mapping);
+    if (!key) continue;
+
+    const resolved = resolveSource(mapping[key], schema);
+    if (!('field' in resolved)) {
+      warnings.push(`unresolved-field-mapping: key '${key}' -> ${resolved.detail}`);
+      continue;
+    }
+
+    usedKeys.add(key);
+    usedFields.add(resolved.field);
+    fieldBySlot.set(slot.slot_id, resolved.field);
+    bindings.push({ slot_id: slot.slot_id, field: resolved.field.name });
+  }
+
+  const remainingSources: ResolvedSource[] = [];
+  for (const [key, value] of Object.entries(mapping)) {
+    if (usedKeys.has(key)) continue;
+    const resolved = resolveSource(value, schema);
+    if ('field' in resolved) remainingSources.push(resolved);
+  }
+
+  for (const slot of manifest.slots) {
+    if (!slot.bindable || !slot.required || fieldBySlot.has(slot.slot_id)) continue;
+    const source = takeCompatibleSource(slot, remainingSources, usedFields, new Map());
+    if (!source) continue;
+    usedFields.add(source.field);
+    fieldBySlot.set(slot.slot_id, source.field);
+    bindings.push({ slot_id: slot.slot_id, field: source.field.name });
+  }
+
+  return {
+    proposal: { template: manifest.template, title: title ?? manifest.template, bindings },
+    fieldBySlot,
+    warnings,
+  };
+}
+
+function takeCompatibleSource(
+  slot: SlotSpec,
+  sources: ResolvedSource[],
+  used: Set<SchemaField>,
+  reusableByTemplateField: Map<string, ResolvedSource>,
+): ResolvedSource | null {
+  const reusable = reusableByTemplateField.get(slot.template_field);
+  if (reusable && kindCompatible(slot.kind, reusable.field)) return reusable;
+
+  for (const source of sources) {
+    if (used.has(source.field)) continue;
+    if (!kindCompatible(slot.kind, source.field)) continue;
+    used.add(source.field);
+    return source;
+  }
+
+  return null;
+}
+
+function mappingKeyForSlot(
+  slot: SlotSpec,
+  manifest: TemplateManifest,
+  mapping: Record<string, string>,
+): string | null {
+  const qualified = `${slot.template_field}@${slot.derivation}`;
+  if (Object.prototype.hasOwnProperty.call(mapping, qualified)) return qualified;
+  if (Object.prototype.hasOwnProperty.call(mapping, slot.slot_id)) return slot.slot_id;
+
+  const duplicateTemplateField =
+    manifest.slots.filter((s) => s.bindable && s.template_field === slot.template_field).length > 1;
+  if (
+    !duplicateTemplateField &&
+    Object.prototype.hasOwnProperty.call(mapping, slot.template_field)
+  ) {
+    return slot.template_field;
+  }
+
+  return null;
+}
+
+function resolveSource(raw: string, schema: SchemaSummary): ResolvedSource | ExplicitBindError {
+  const exact = schema.fields.find((f) => f.column_ref === raw);
+  if (exact) return { raw, field: exact };
+
+  const parsed = parseColumnRef(raw);
+  if (parsed) {
+    const matches = schema.fields.filter(
+      (f) =>
+        bareName(f.columnName) === parsed.base &&
+        (!parsed.datasource || f.datasource === parsed.datasource),
+    );
+    if (matches.length === 1) return { raw, field: matches[0] };
+    if (matches.length > 1) {
+      return {
+        code: 'ambiguous-field',
+        detail: `"${raw}" matches ${matches.length} fields in schema`,
+        candidates: matches.map((f) => f.column_ref),
+        fix: 'Pass a fully qualified column_ref or resolve the field before applying the template.',
+      };
+    }
+    return {
+      code: 'field-not-found',
+      detail: `no schema field matches "${raw}"`,
+      fix: 'Use list-available-fields or resolve-field, then retry with a valid column_ref.',
+    };
+  }
+
+  const named = schema.fields.filter(
+    (f) => f.name === raw || f.caption === raw || bareName(f.columnName) === bareName(raw),
+  );
+  if (named.length === 1) return { raw, field: named[0] };
+  if (named.length > 1) {
+    return {
+      code: 'ambiguous-field',
+      detail: `"${raw}" matches ${named.length} fields in schema`,
+      candidates: named.map((f) => f.column_ref),
+      fix: 'Pass an exact column_ref instead of a bare field name.',
+    };
+  }
+
+  return {
+    code: 'field-not-found',
+    detail: `no schema field matches "${raw}"`,
+    fix: 'Use list-available-fields or resolve-field, then retry with a valid field.',
+  };
+}
+
+function parseColumnRef(raw: string): { datasource?: string; base: string } | null {
+  const match = /^(?:\[([^\]]+)\]\.)?\[(.+)\]$/.exec(raw.trim());
+  if (!match) return null;
+  const first = match[2].indexOf(':');
+  const last = match[2].lastIndexOf(':');
+  if (first <= 0 || last <= first) return null;
+  const base = match[2].slice(first + 1, last);
+  return base ? { datasource: match[1], base } : null;
+}
+
+const TEMPORAL_DATATYPES: ReadonlySet<string> = new Set(['date', 'datetime']);
+const TRUNCATION_DERIVATIONS: ReadonlySet<string> = new Set(['tyr', 'tqr', 'tmn', 'tdy']);
+
+function kindCompatible(kind: SlotSpec['kind'], f: SchemaField): boolean {
+  switch (kind) {
+    case 'quantitative':
+      return f.role === 'measure' || f.isAggregated;
+    case 'categorical':
+      return f.role === 'dimension' && (f.type === 'nominal' || f.type === 'ordinal');
+    case 'temporal':
+      return TEMPORAL_DATATYPES.has(f.datatype);
+    case 'geo':
+      return f.role === 'dimension';
+    default:
+      return false;
+  }
+}
+
+function suffixFor(derivation: Derivation, type: string): string {
+  if (TRUNCATION_DERIVATIONS.has(derivation)) return 'qk';
+  if (type === 'quantitative') return 'qk';
+  if (type === 'ordinal') return 'ok';
+  return 'nk';
+}
+
+function emitRawFieldMapping(
+  manifest: TemplateManifest,
+  fieldBySlot: Map<string, SchemaField>,
+): Record<string, string> {
+  const mapping: Record<string, string> = {};
+  for (const slot of manifest.slots) {
+    if (!slot.bindable) continue;
+    const field = fieldBySlot.get(slot.slot_id);
+    if (!field) continue;
+    const deriv = field.isAggregated ? 'usr' : slot.derivation;
+    const key = slot.qualified_key_required
+      ? `${slot.template_field}@${slot.derivation}`
+      : slot.template_field;
+    mapping[key] =
+      `[${field.datasource}].[${deriv}:${bareName(field.columnName)}:${suffixFor(deriv, field.type)}]`;
+  }
+  return mapping;
+}
+
+function fieldMetadataFor(
+  manifest: TemplateManifest,
+  fieldBySlot: Map<string, SchemaField>,
+): Record<string, { datatype: string; type: string }> {
+  const metadata: Record<string, { datatype: string; type: string }> = {};
+  for (const slot of manifest.slots) {
+    const field = fieldBySlot.get(slot.slot_id);
+    if (!field) continue;
+    const key = slot.qualified_key_required
+      ? `${slot.template_field}@${slot.derivation}`
+      : slot.template_field;
+    metadata[key] = { datatype: field.datatype, type: field.type };
+  }
+  return metadata;
+}
+
+function rawDatasourceFor(fieldBySlot: Map<string, SchemaField>, fallback: string): string {
+  return fieldBySlot.values().next().value?.datasource ?? fallback;
+}
+
+function manifestWarnings(m: TemplateManifest): string[] {
+  const warnings: string[] = [];
+  if (!m.fast_path_eligible) {
+    warnings.push(
+      `fast_path_eligible:false: explicit template apply is proceeding outside the fast path (readiness=${m.readiness}).`,
+    );
+    for (const blocker of m.fast_path_blockers ?? []) warnings.push(`fast_path_blocker:${blocker}`);
+  }
+  if (m.portability_evidence.render_verified === 'none') {
+    warnings.push(`render_verified:none: template '${m.template}' has no live render stamp.`);
+  }
+  for (const hazard of m.hazards ?? []) {
+    warnings.push(`hazard:${hazard.code}: ${hazard.detail}`);
+  }
+  return warnings;
+}
+
+function blockerToFixError(b: Blocker): ExplicitBindError {
+  return {
+    code: String(b.code),
+    slot_id: b.slot_id,
+    detail: b.detail,
+    candidates: b.candidates,
+    fix: fixForBlocker(b),
+  };
+}
+
+function fixForBlocker(b: Blocker): string {
+  switch (b.code) {
+    case 'field-not-found':
+      return 'Choose a candidate from list-available-fields or resolve the field, then retry.';
+    case 'ambiguous-field':
+      return 'Disambiguate with resolve-field and retry with an exact column_ref.';
+    case 'missing-required-slot':
+      return 'Provide a compatible field for this required manifest slot.';
+    case 'kind-mismatch':
+      return 'Bind a field whose role/type/datatype matches the manifest slot kind.';
+    case 'derivation-illegal':
+      return 'Drop the illegal derivation override or bind a field whose datatype supports it.';
+    case 'base-column-conflict':
+      return 'Use the same base column for all qualified derivations of one template field.';
+    case 'cross-datasource-binding':
+      return 'Bind all template slots from a single datasource.';
+    case 'calc-dependency-unmet':
+      return 'Bind every manifest slot required by the template-owned calculation.';
+    default:
+      return 'Fall back to plan-dashboard-creation and the general worksheet build tools.';
+  }
+}
+
+function pickPrimaryDatasource(fields: SchemaField[]): string {
+  const counts = new Map<string, number>();
+  const order: string[] = [];
+  for (const field of fields) {
+    if (!counts.has(field.datasource)) order.push(field.datasource);
+    counts.set(field.datasource, (counts.get(field.datasource) ?? 0) + 1);
+  }
+
+  let best = '';
+  let bestCount = -1;
+  for (const datasource of order) {
+    const count = counts.get(datasource) ?? 0;
+    if (count > bestCount) {
+      best = datasource;
+      bestCount = count;
+    }
+  }
+  return best;
+}

--- a/src/desktop/binder/route-spec.ts
+++ b/src/desktop/binder/route-spec.ts
@@ -225,7 +225,7 @@ export function classifyAskRoute(
 
   // Wrap (never fork) selectEligible's input with a light normalization pass so a reworded,
   // keyword-bearing near-paraphrase classifies the same as the canonical ask.
-  const eligible = selectEligible(normalizeAskForMatch(text), manifests);
+  const eligible = selectEligible(normalizeAskForMatch(text), manifests, text);
   if (eligible) {
     return decide(
       'bind-first-template',

--- a/src/desktop/binder/within-family-disambiguation.test.ts
+++ b/src/desktop/binder/within-family-disambiguation.test.ts
@@ -442,7 +442,9 @@ describe('classifyNoLlm — spatial-intent family guard (W-23447710)', () => {
   });
 
   it('does not demote a spatial winner — choropleth binds as before', () => {
-    const m = mapOf(synth('choropleth', 'spatial', ['choropleth', 'filled-map', 'map'], geoTriple()));
+    const m = mapOf(
+      synth('choropleth', 'spatial', ['choropleth', 'filled-map', 'map'], geoTriple()),
+    );
     const res = classifyNoLlm(
       'Build a choropleth filled map of Profit by State/Province within Country/Region.',
       m,
@@ -472,11 +474,15 @@ describe('classifyNoLlm — spatial-intent family guard (W-23447710)', () => {
       ],
     };
     const m = mapOf(
-      synth('scatter-latlon-trap', 'correlation', ['scatter', 'plot'], [
-        slot('x', 'quantitative'),
-        slot('y', 'quantitative'),
-      ]),
+      synth(
+        'scatter-latlon-trap',
+        'correlation',
+        ['scatter', 'plot'],
+        [slot('x', 'quantitative'), slot('y', 'quantitative')],
+      ),
     );
-    expect(classifyNoLlm('scatter plot of Latitude and Longitude by Location', m, coordSummary)).toBeNull();
+    expect(
+      classifyNoLlm('scatter plot of Latitude and Longitude by Location', m, coordSummary),
+    ).toBeNull();
   });
 });

--- a/src/desktop/binder/within-family-disambiguation.test.ts
+++ b/src/desktop/binder/within-family-disambiguation.test.ts
@@ -431,3 +431,52 @@ describe('classifyNoLlm — determinism', () => {
     expect(JSON.stringify(a)).toBe(JSON.stringify(b));
   });
 });
+
+describe('classifyNoLlm — spatial-intent family guard (W-23447710)', () => {
+  it('demotes a non-spatial keyword-count winner when the ask carries bare map intent', () => {
+    const m = mapOf(
+      synth('rank-map-trap', 'ranking', ['top', 'highest'], catVal()),
+      synth('spatial-map-carrier', 'spatial', ['map'], catVal()),
+    );
+    expect(classifyNoLlm('Map of top Sales by Region, highest first.', m, SUMMARY)).toBeNull();
+  });
+
+  it('does not demote a spatial winner — choropleth binds as before', () => {
+    const m = mapOf(synth('choropleth', 'spatial', ['choropleth', 'filled-map', 'map'], geoTriple()));
+    const res = classifyNoLlm(
+      'Build a choropleth filled map of Profit by State/Province within Country/Region.',
+      m,
+      SUMMARY,
+    );
+    expect(res).not.toBeNull();
+    expect(res!.template).toBe('choropleth');
+  });
+
+  it('leaves non-map asks unaffected', () => {
+    const m = mapOf(
+      synth('rank', 'ranking', ['bar'], catVal()),
+      synth('spatial-map-carrier', 'spatial', ['map'], catVal()),
+    );
+    const res = classifyNoLlm('bar chart of Sales by Region', m, SUMMARY);
+    expect(res).not.toBeNull();
+    expect(res!.template).toBe('rank');
+  });
+
+  it('demotes on a lat+lon coordinate-pair ask even without a map noun', () => {
+    const coordSummary: SchemaSummary = {
+      datasource: 'DS',
+      fields: [
+        field('Location', 'dimension', 'nominal', 'string'),
+        field('Latitude', 'measure', 'quantitative', 'real'),
+        field('Longitude', 'measure', 'quantitative', 'real'),
+      ],
+    };
+    const m = mapOf(
+      synth('scatter-latlon-trap', 'correlation', ['scatter', 'plot'], [
+        slot('x', 'quantitative'),
+        slot('y', 'quantitative'),
+      ]),
+    );
+    expect(classifyNoLlm('scatter plot of Latitude and Longitude by Location', m, coordSummary)).toBeNull();
+  });
+});

--- a/src/desktop/validation/rules/rules.ts
+++ b/src/desktop/validation/rules/rules.ts
@@ -24,6 +24,7 @@ import { rankAsMembershipRule } from './rankAsMembership.js';
 import { redundantColorEncodingRule } from './redundantColorEncoding.js';
 import { selfReferentialFixedLodRule } from './selfReferentialFixedLod.js';
 import { setCountMalformedParameterRule } from './setCountMalformedParameter.js';
+import { tooltipDimensionRequiresAttrRule } from './tooltipDimensionRequiresAttr.js';
 import { undeclaredAggregateOkRefRule } from './undeclaredAggregateOkRef.js';
 import { undeclaredCalcReferenceRule } from './undeclaredCalcReference.js';
 import { undeclaredSetReferenceRule } from './undeclaredSetReference.js';
@@ -52,6 +53,7 @@ export const validationRules = [
   calcNameFieldCollisionRule,
   mixedAggregationCalcRule,
   aggregateCalcDerivationRule,
+  tooltipDimensionRequiresAttrRule,
   selfReferentialFixedLodRule,
   rankAsMembershipRule,
   hardcodedDateFilterRule,

--- a/src/desktop/validation/rules/tooltipDimensionRequiresAttr.test.ts
+++ b/src/desktop/validation/rules/tooltipDimensionRequiresAttr.test.ts
@@ -64,15 +64,21 @@ describe('tooltip-dimension-requires-attr rule', () => {
   });
 
   it('does not fire when the tooltip dimension is already an attr: instance', () => {
-    expect(tooltipDimensionRequiresAttrRule.validate(ws({ tooltipRef: '[DS].[attr:Segment:nk]' }))).toEqual([]);
+    expect(
+      tooltipDimensionRequiresAttrRule.validate(ws({ tooltipRef: '[DS].[attr:Segment:nk]' })),
+    ).toEqual([]);
   });
 
   it('does not fire when the tooltip carries a measure aggregate', () => {
-    expect(tooltipDimensionRequiresAttrRule.validate(ws({ tooltipRef: '[DS].[sum:Sales:qk]' }))).toEqual([]);
+    expect(
+      tooltipDimensionRequiresAttrRule.validate(ws({ tooltipRef: '[DS].[sum:Sales:qk]' })),
+    ).toEqual([]);
   });
 
   it('does not fire in a disaggregated view (no aggregate refs anywhere)', () => {
-    const issues = tooltipDimensionRequiresAttrRule.validate(ws({ cols: '[DS].[none:Region:nk]', rows: '' }));
+    const issues = tooltipDimensionRequiresAttrRule.validate(
+      ws({ cols: '[DS].[none:Region:nk]', rows: '' }),
+    );
     expect(issues).toEqual([]);
   });
 
@@ -81,11 +87,16 @@ describe('tooltip-dimension-requires-attr rule', () => {
   });
 
   it('skips none:...:qk refs (bins / exact-date quantitative instances)', () => {
-    expect(tooltipDimensionRequiresAttrRule.validate(ws({ tooltipRef: '[DS].[none:Sales (bin):qk]' }))).toEqual([]);
+    expect(
+      tooltipDimensionRequiresAttrRule.validate(ws({ tooltipRef: '[DS].[none:Sales (bin):qk]' })),
+    ).toEqual([]);
   });
 
   it('dedupes repeated identical tooltip refs to one issue', () => {
-    const xml = ws().replace('</encodings>', '<tooltip column="[DS].[none:Segment:nk]"/></encodings>');
+    const xml = ws().replace(
+      '</encodings>',
+      '<tooltip column="[DS].[none:Segment:nk]"/></encodings>',
+    );
     expect(tooltipDimensionRequiresAttrRule.validate(xml).length).toBe(1);
   });
 });

--- a/src/desktop/validation/rules/tooltipDimensionRequiresAttr.test.ts
+++ b/src/desktop/validation/rules/tooltipDimensionRequiresAttr.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+
+import { runValidation } from '../registry.js';
+import { tooltipDimensionRequiresAttrRule } from './tooltipDimensionRequiresAttr.js';
+
+/**
+ * P0 (GUS W-23447711, Lee Graber dogfood 2026-07-14): a none:/derivation="None"
+ * dimension on <tooltip> in an aggregated view applies "successfully", then the
+ * sheet renders blank with "cannot be converted to a measure using ATTR()" — the
+ * only confirmed green-trace/failed-outcome shape in the dogfood backlog. Tooltip
+ * is grain-neutral, so Tableau must ATTR()-wrap raw dimensions there; the authored
+ * none: instance defeats that. The rule fires ONLY on tooltip (text/label join the
+ * view grain, so none: is legitimate there) and ONLY in aggregated views.
+ */
+
+function ws({
+  tooltipRef = '[DS].[none:Segment:nk]',
+  rows = '[DS].[none:Region:nk]',
+  cols = '[DS].[sum:Sales:qk]',
+  encodingTag = 'tooltip',
+}: {
+  tooltipRef?: string;
+  rows?: string;
+  cols?: string;
+  encodingTag?: string;
+} = {}): string {
+  return `<worksheet name="W"><table>
+    <view>
+      <datasource-dependencies datasource="DS">
+        <column name="[Segment]" role="dimension" type="nominal" datatype="string" />
+        <column-instance column="[Segment]" derivation="None" name="[none:Segment:nk]" pivot="key" type="nominal" />
+        <column name="[Region]" role="dimension" type="nominal" datatype="string" />
+        <column-instance column="[Region]" derivation="None" name="[none:Region:nk]" pivot="key" type="nominal" />
+        <column name="[Sales]" role="measure" type="quantitative" datatype="real" />
+        <column-instance column="[Sales]" derivation="Sum" name="[sum:Sales:qk]" pivot="key" type="quantitative" />
+      </datasource-dependencies>
+    </view>
+    <panes><pane><mark class="Bar"/><encodings><${encodingTag} column="${tooltipRef}"/></encodings></pane></panes>
+    <rows>${rows}</rows>
+    <cols>${cols}</cols>
+  </table></worksheet>`;
+}
+
+describe('tooltip-dimension-requires-attr rule', () => {
+  it('errors on a none: dimension tooltip in an aggregated worksheet (the W-23447711 shape)', () => {
+    const issues = tooltipDimensionRequiresAttrRule.validate(ws());
+    expect(issues.length).toBe(1);
+    expect(issues[0].ruleId).toBe('tooltip-dimension-requires-attr');
+    expect(issues[0].severity).toBe('error');
+    expect(issues[0].message).toContain('[DS].[none:Segment:nk]');
+    expect(issues[0].message).toContain('cannot be converted to a measure using ATTR()');
+    expect(issues[0].message).toContain('FIX:');
+    expect(issues[0].message).toContain('[DS].[attr:Segment:nk]');
+  });
+
+  it('blocks validation when registered and the broken shape is present', () => {
+    const result = runValidation(ws(), 'worksheet');
+    expect(result.valid).toBe(false);
+    expect(
+      result.issues.some(
+        (issue) => issue.ruleId === 'tooltip-dimension-requires-attr' && issue.severity === 'error',
+      ),
+    ).toBe(true);
+  });
+
+  it('does not fire when the tooltip dimension is already an attr: instance', () => {
+    expect(tooltipDimensionRequiresAttrRule.validate(ws({ tooltipRef: '[DS].[attr:Segment:nk]' }))).toEqual([]);
+  });
+
+  it('does not fire when the tooltip carries a measure aggregate', () => {
+    expect(tooltipDimensionRequiresAttrRule.validate(ws({ tooltipRef: '[DS].[sum:Sales:qk]' }))).toEqual([]);
+  });
+
+  it('does not fire in a disaggregated view (no aggregate refs anywhere)', () => {
+    const issues = tooltipDimensionRequiresAttrRule.validate(ws({ cols: '[DS].[none:Region:nk]', rows: '' }));
+    expect(issues).toEqual([]);
+  });
+
+  it('does not fire for none: dimensions on TEXT (text joins the view grain — legitimate)', () => {
+    expect(tooltipDimensionRequiresAttrRule.validate(ws({ encodingTag: 'text' }))).toEqual([]);
+  });
+
+  it('skips none:...:qk refs (bins / exact-date quantitative instances)', () => {
+    expect(tooltipDimensionRequiresAttrRule.validate(ws({ tooltipRef: '[DS].[none:Sales (bin):qk]' }))).toEqual([]);
+  });
+
+  it('dedupes repeated identical tooltip refs to one issue', () => {
+    const xml = ws().replace('</encodings>', '<tooltip column="[DS].[none:Segment:nk]"/></encodings>');
+    expect(tooltipDimensionRequiresAttrRule.validate(xml).length).toBe(1);
+  });
+});

--- a/src/desktop/validation/rules/tooltipDimensionRequiresAttr.ts
+++ b/src/desktop/validation/rules/tooltipDimensionRequiresAttr.ts
@@ -1,0 +1,153 @@
+/**
+ * Validation rule: tooltip-dimension-requires-attr
+ *
+ * A dimension referenced with none:/derivation="None" on a TOOLTIP encoding in an
+ * aggregated worksheet must be an Attribute column-instance (attr:) or a usr: calc.
+ * Tooltip is the one marks-card property that does NOT participate in the view's
+ * level of detail, so Tableau must convert a raw dimension there via ATTR() — and a
+ * directly-authored none: instance fails that conversion at render time: the XML
+ * applies "successfully", then the sheet blanks with "cannot be converted to a
+ * measure using ATTR()".
+ *
+ * Confirmed P0 (GUS W-23447711, Lee Graber dogfood 2026-07-14): none: dimension on
+ * <tooltip> in an aggregated view → ATTR conversion pill errors + blank sheet, with
+ * the agent retrying the same broken shape because nothing rejected it. This rule is
+ * the preflight backstop that makes the failure visible BEFORE Desktop renders.
+ *
+ * Severity: error — same class as the other applies-clean-renders-blank rules
+ * (aggregate-calc-derivation, undeclared-calc-reference).
+ *
+ * Scope: <tooltip> ONLY. Text/label encodings are deliberately excluded — dimensions
+ * there DO join the view grain (like detail), so none: is legitimate on them.
+ * none:...:qk refs are skipped so bin/exact-date quantitative instances never match.
+ */
+import * as xpath from 'xpath';
+
+import type { ValidationIssue, ValidationRule } from '../types.js';
+import { parseXml } from './parseXml.js';
+
+const FIELD_REF = /\[[^\]]+\]\.\[[^\]]+\]/g;
+
+/** Column-instance prefixes that mark a ref as aggregate (the view is aggregated). */
+const AGGREGATE_PREFIXES = new Set([
+  'sum',
+  'avg',
+  'cnt',
+  'ctd',
+  'med',
+  'min',
+  'max',
+  'std',
+  'stp',
+  'var',
+  'vrp',
+  'attr',
+  'usr',
+]);
+
+interface ParsedRef {
+  datasource: string;
+  instance: string;
+  derivation: string;
+  field: string;
+  pivot: string;
+}
+
+/** Parse `[ds].[deriv:Field:pk]` into its parts; null for anything else (bare refs, calcs). */
+function parseFieldRef(ref: string): ParsedRef | null {
+  const outer = String(ref ?? '')
+    .trim()
+    .match(/^\[([^\]]+)\]\.(\[[^\]]+\])$/);
+  if (!outer) return null;
+  const instance = outer[2];
+  const ci = instance.match(/^\[([^:\]]+):([^:\]]+):([^:\]]+)\]$/);
+  if (!ci) return null;
+  return { datasource: outer[1], instance, derivation: ci[1], field: ci[2], pivot: ci[3] };
+}
+
+function isAggregateRef(ref: string): boolean {
+  const parsed = parseFieldRef(ref);
+  return parsed !== null && AGGREGATE_PREFIXES.has(parsed.derivation.toLowerCase());
+}
+
+/** True when the ref is a none: dimension instance (nk/ok pivot — qk = bins/exact dates, skipped). */
+function isNoneDimensionRef(ref: string): boolean {
+  const parsed = parseFieldRef(ref);
+  if (!parsed) return false;
+  if (parsed.derivation.toLowerCase() !== 'none') return false;
+  const pivot = parsed.pivot.toLowerCase();
+  return pivot === 'nk' || pivot === 'ok';
+}
+
+/** The view is aggregated when any rows/cols/encoding ref carries an aggregate prefix. */
+function worksheetHasAggregateRef(wsNode: Element): boolean {
+  for (const node of xpath.select(
+    './/rows/text() | .//cols/text()',
+    wsNode as unknown as Node,
+  ) as Node[]) {
+    for (const ref of String(node.nodeValue ?? '').match(FIELD_REF) ?? []) {
+      if (isAggregateRef(ref)) return true;
+    }
+  }
+  for (const attr of xpath.select('.//encodings/*/@column', wsNode as unknown as Node) as Attr[]) {
+    if (isAggregateRef(attr.value)) return true;
+  }
+  return false;
+}
+
+/** Suggest the attr: form of the same instance, preserving the original pivot suffix. */
+function suggestedAttrRef(ref: string): string {
+  const parsed = parseFieldRef(ref);
+  if (!parsed) return 'an attr: column-instance';
+  return `[${parsed.datasource}].[attr:${parsed.field}:${parsed.pivot}]`;
+}
+
+export const tooltipDimensionRequiresAttrRule: ValidationRule = {
+  id: 'tooltip-dimension-requires-attr',
+  description:
+    'Errors when a tooltip encoding references a none:/derivation="None" dimension in an aggregated worksheet — ' +
+    "Tableau applies the XML, then blanks the sheet with 'cannot be converted to a measure using ATTR()'.",
+  contexts: ['workbook', 'worksheet'],
+
+  validate(xml: string): ValidationIssue[] {
+    const doc = parseXml(xml);
+    if (!doc || !doc.documentElement) return [];
+
+    const issues: ValidationIssue[] = [];
+    const worksheets = xpath.select('//worksheet', doc as unknown as Node) as Element[];
+    const scope = worksheets.length > 0 ? worksheets : [doc.documentElement];
+
+    for (const wsNode of scope) {
+      if (!worksheetHasAggregateRef(wsNode)) continue; // disaggregated view: none: on tooltip is legal
+
+      const seen = new Set<string>();
+      for (const attr of xpath.select(
+        './/encodings/tooltip/@column',
+        wsNode as unknown as Node,
+      ) as Attr[]) {
+        const ref = String(attr.value ?? '').trim();
+        if (!ref || seen.has(ref) || !isNoneDimensionRef(ref)) continue;
+        seen.add(ref);
+
+        const fixRef = suggestedAttrRef(ref);
+        issues.push({
+          ruleId: 'tooltip-dimension-requires-attr',
+          severity: 'error',
+          message:
+            `Tooltip encoding references dimension ${ref} with none:/derivation="None" in an aggregated worksheet. ` +
+            'Tableau accepts this XML, then blanks the sheet at render with "cannot be converted to a measure using ' +
+            `ATTR()". FIX: reference the tooltip dimension as an Attribute column-instance — ${fixRef} with a ` +
+            'matching <column-instance derivation="Attribute"> declaration — or use a usr: calc that is valid at ' +
+            'the aggregate level.',
+          xpath: '//encodings/tooltip/@column',
+          suggestion:
+            `Declare <column-instance column="[${parseFieldRef(ref)?.field}]" derivation="Attribute" ` +
+            `name="[attr:${parseFieldRef(ref)?.field}:${parseFieldRef(ref)?.pivot}]" .../> and point the <tooltip> ` +
+            `at ${fixRef}. Do not put none:/derivation="None" dimensions on Tooltip in an aggregated view — tooltip ` +
+            'does not join the view grain, so Tableau must ATTR()-wrap it.',
+        });
+      }
+    }
+    return issues;
+  },
+};

--- a/src/tools/desktop/coordination/buildAndApplyWorksheet.ts
+++ b/src/tools/desktop/coordination/buildAndApplyWorksheet.ts
@@ -4,6 +4,11 @@ import { existsSync, readFileSync } from 'fs';
 import { Ok } from 'ts-results-es';
 import { z } from 'zod';
 
+import {
+  bindExplicitTemplate,
+  formatExplicitBindErrors,
+  schemaSummaryFromAvailableFields,
+} from '../../../desktop/binder/explicit-bind.js';
 import { loadWorksheetXml } from '../../../desktop/commands/workbook/loadWorksheetXml.js';
 import { listAvailableFields } from '../../../desktop/metadata/index.js';
 import {
@@ -169,15 +174,17 @@ export const getBuildAndApplyWorksheetTool = (
           const templateDimensions = templateRequirements.filter((c) => c.role === 'dimension');
           const templateMeasures = templateRequirements.filter((c) => c.role === 'measure');
 
-          const fieldMapping: Record<string, string> = {};
-          const fieldMetadata: Record<string, { datatype: string; type: string }> = {};
+          // Legacy positional mapping — kept ONLY as the no-manifest passthrough.
+          // Manifest-backed templates get their mapping from bindExplicitTemplate below.
+          const passthroughFieldMapping: Record<string, string> = {};
+          const passthroughFieldMetadata: Record<string, { datatype: string; type: string }> = {};
 
           for (let i = 0; i < templateDimensions.length && i < dimensionFields.length; i++) {
             const columnRef = dimensionFields[i];
             const field = availableFields.find((f) => f.column_ref === columnRef);
-            fieldMapping[templateDimensions[i].name] = columnRef;
+            passthroughFieldMapping[templateDimensions[i].name] = columnRef;
             if (field?.datatype && field.type) {
-              fieldMetadata[templateDimensions[i].name] = {
+              passthroughFieldMetadata[templateDimensions[i].name] = {
                 datatype: field.datatype,
                 type: field.type,
               };
@@ -187,9 +194,9 @@ export const getBuildAndApplyWorksheetTool = (
           for (let i = 0; i < templateMeasures.length && i < measureFields.length; i++) {
             const columnRef = measureFields[i];
             const field = availableFields.find((f) => f.column_ref === columnRef);
-            fieldMapping[templateMeasures[i].name] = columnRef;
+            passthroughFieldMapping[templateMeasures[i].name] = columnRef;
             if (field?.datatype && field.type) {
-              fieldMetadata[templateMeasures[i].name] = {
+              passthroughFieldMetadata[templateMeasures[i].name] = {
                 datatype: field.datatype,
                 type: field.type,
               };
@@ -208,6 +215,33 @@ export const getBuildAndApplyWorksheetTool = (
               `Measure field "${dropped}" was dropped: template "${template}" exposes only ${templateMeasures.length} measure slot(s).`,
             );
           }
+
+          // Manifest enforcement (P0 W-23447710): slot derivations/keys come from the
+          // manifest, never the caller's positional refs. Blockers stop the apply —
+          // stricter than the old behavior, which left sample fields in unmapped slots.
+          const explicitBind = bindExplicitTemplate(
+            template,
+            fields,
+            schemaSummaryFromAvailableFields(availableFields),
+            {
+              title: worksheetName,
+              datasource: datasourceName,
+              passthroughFieldMapping,
+            },
+          );
+
+          if (!explicitBind.ok) {
+            return new ArgsValidationError(
+              formatExplicitBindErrors(template, explicitBind.errors),
+            ).toErr();
+          }
+
+          warnings.push(...explicitBind.warnings);
+          const fieldMapping = explicitBind.fieldMapping;
+          const fieldMetadata =
+            Object.keys(explicitBind.fieldMetadata).length > 0
+              ? explicitBind.fieldMetadata
+              : passthroughFieldMetadata;
 
           // Inject title and replace field references. Per-apply calc namespacing is
           // wired at this tool boundary: the shared core defaults namespacing OFF and

--- a/src/tools/desktop/template/injectTemplate.ts
+++ b/src/tools/desktop/template/injectTemplate.ts
@@ -5,6 +5,11 @@ import { resolve } from 'path';
 import { Ok } from 'ts-results-es';
 import { z } from 'zod';
 
+import {
+  bindExplicitTemplate,
+  formatExplicitBindErrors,
+} from '../../../desktop/binder/explicit-bind.js';
+import { summarizeSchema } from '../../../desktop/binder/schema-summary.js';
 import { buildInjectedWorkbookXml } from '../../../desktop/templates/injectTemplateCore.js';
 import { listTemplateNames, readTemplate } from '../../../desktop/templates/templatePath.js';
 import {
@@ -100,6 +105,33 @@ export const getInjectTemplateTool = (
             // one. inject-template has no session, so the per-apply identity is the
             // target workbook file + apply timestamp; a randomUUID guards against
             // same-millisecond collisions.
+            // Manifest enforcement (P0 W-23447710): a caller-supplied mapping for a
+            // manifest-backed template is validated/corrected through the binder
+            // contract — slot derivations come from the manifest, not the caller.
+            let appliedFieldMapping = fieldMapping;
+            const explicitTemplateWarnings: string[] = [];
+            if (
+              templateParameters?.DATASOURCE &&
+              fieldMapping &&
+              Object.keys(fieldMapping).length > 0
+            ) {
+              const explicitBind = bindExplicitTemplate(
+                templateName,
+                fieldMapping,
+                summarizeSchema(workbookXml),
+                { title, datasource: templateParameters.DATASOURCE },
+              );
+
+              if (!explicitBind.ok) {
+                return new ArgsValidationError(
+                  formatExplicitBindErrors(templateName, explicitBind.errors),
+                ).toErr();
+              }
+
+              if (!explicitBind.passthrough) appliedFieldMapping = explicitBind.fieldMapping;
+              explicitTemplateWarnings.push(...explicitBind.warnings);
+            }
+
             const applyNonce = `${workbookFile}:${Date.now()}:${randomUUID()}`;
             const result = buildInjectedWorkbookXml({
               workbookXml,
@@ -107,7 +139,7 @@ export const getInjectTemplateTool = (
               title,
               sheetType,
               templateParameters,
-              fieldMapping,
+              fieldMapping: appliedFieldMapping,
               insertPosition,
               relativeSheetName,
               applyNonce,
@@ -119,16 +151,27 @@ export const getInjectTemplateTool = (
 
             writeFileSync(resolve(workbookFile), result.xml, 'utf-8');
 
-            return new Ok({ workbookFile, templateName, title, sheetType });
+            return new Ok({
+              workbookFile,
+              templateName,
+              title,
+              sheetType,
+              warnings: explicitTemplateWarnings,
+            });
           } catch (err) {
             return new FileReadError(err).toErr();
           }
         },
-        getSuccessResult: ({ workbookFile, templateName, title, sheetType }) => ({
+        getSuccessResult: ({ workbookFile, templateName, title, sheetType, warnings }) => ({
           content: [
             {
               type: 'text',
-              text: `Injected template "${templateName}" as "${title}" (${sheetType}).\n\nUpdated file: ${workbookFile}\n\nUse apply-workbook to apply changes to Tableau.`,
+              text:
+                `Injected template "${templateName}" as "${title}" (${sheetType}).` +
+                (warnings.length > 0
+                  ? `\n\nTemplate advisory warnings:\n${warnings.map((w) => `  - ${w}`).join('\n')}`
+                  : '') +
+                `\n\nUpdated file: ${workbookFile}\n\nUse apply-workbook to apply changes to Tableau.`,
             },
           ],
         }),


### PR DESCRIPTION
Ports the 2026-07-14 bug-focus wave from agent-to-tableau-desktop (a2td PR #203) — the two dogfood P0s from Lee Graber's run, fixed at the shape level.

## W-23447710 — wrong-chart bind (map→scatter)
- **Spatial-intent family guard** — lockstep engine update: `classify.ts` copied byte-identical from the lab via `check-lockstep --update` (hashes regenerated both sides), `ask-router` mirror + `SPATIAL_INTENT_ALIASES` set-equality parity test. A map/geo/lat+lon ask can never bind a non-spatial keyword-count winner; bare `map` stays out of CHART_NOUN_KEYWORDS (dual-carrier).
- **`bindExplicitTemplate` adapter** (`src/desktop/binder/explicit-bind.ts`) — `build-and-apply-worksheet`'s template branch and `inject-template` mapped caller column_refs positionally, dropping manifest slot derivations (SUM(lat)/SUM(lon) instead of avg) and every other slot directive. Explicit calls now route through `validateBinding`'s manifest enforcement without `bindTemplate`'s fast-path gate: manifest derivations always win; eligibility/evidence/hazards become advisory warnings; blockers stop the apply with FIX-style errors; no-manifest templates pass through with a warning. tmcp adaptations: raw mapping emission per the rewriter contract; fail-open passthrough when the manifest asset layer is unavailable (SEA still fails closed upstream).

## W-23447711 — ATTR-blank false-PASS
- **`tooltip-dimension-requires-attr` rule** — a `none:` dimension on `<tooltip>` in an aggregated view applies cleanly then blanks the sheet ("cannot be converted to a measure using ATTR()"). Error-severity preflight backstop; tooltip-only scope (text/label join the view grain). Adapted to the tmcp rule interface (static barrel, no triggers).
- **Knowledge**: new `tactics/viz/tooltip.md` + cross-link + `_index` route; marks-and-encodings `Enforced-by` line extended.

## Validation
Full suite 3,652 green; lockstep gate OK; invariant belt (portability, bind-behavior-matrix, carrier-uniqueness, stampHash) green; characterization suites green (mocked envs exercise the passthrough leg); lint clean except the known deferred classify.ts prettier drift. `package.json` 2.11.0 → 2.12.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)