### PR TITLE
@W-23149256: fix publish.yml startup failure from empty ${{ }} in run: block

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,7 +37,7 @@ jobs:
           # Fail CLOSED: if the version can't be read, abort before publishing —
           # a bare publish on an empty version would wrongly move `latest`.
           # VERSION comes from package.json (the repo's own committed value, not
-          # external input) into a shell var — no ${{ }} interpolation here.
+          # external input) into a shell var — no GitHub expression interpolation here.
           VERSION="$(node -p "require('./package.json').version")"
           if [[ -z "$VERSION" || "$VERSION" == "undefined" ]]; then
             echo "::error::Could not read version from package.json — aborting publish (refusing to risk moving 'latest')"


### PR DESCRIPTION
Empty `${{ }}` expression inside a `run: |` script (added by #416, in the prerelease-aware comment block) makes GitHub Actions reject `publish.yml` at load time — every release-triggered run fails at startup with no job, so v2.27.0 (and all releases since #416) never published to npm.

`${{ }}` in `run:` text is evaluated by Actions before the shell sees it, so the shell `#` does not protect it, and an empty expression is invalid. Fix reWords the comment to drop the token.

- `actionlint` clean (broken version fails at `21:1033`, fixed passes)
- diff is comment-only; publish/prerelease logic byte-for-byte unchanged
- independently verified (VERDICT: PASS)