### PR TITLE
fix(metadata): detail→lod normalization + SQL string-fn knowledge + field-tool title scrub (desktop twin of #503)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "2.25.0",
+  "version": "2.25.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/resources/desktop/knowledge/tactics/data/sql-translation.md
+++ b/resources/desktop/knowledge/tactics/data/sql-translation.md
@@ -42,6 +42,37 @@ SQL aggregations with `GROUP BY` translate to Tableau FIXED LODs. The `GROUP BY`
 
 ---
 
+## String functions
+
+SQL string functions map to Tableau scalar string functions. Two differences bite most often: **Tableau has no `CONCAT` — use `+`** (and every non-string operand must be wrapped in `STR()`), and **all position/length arguments are 1-based** (`MID`, `FIND`, `LEFT` count from 1, not 0).
+
+| SQL | Tableau | Notes |
+|---|---|---|
+| `col1 \|\| col2` / `CONCAT(a, b)` | `[A] + [B]` | No `CONCAT` function; `+` only. Wrap non-strings: `[Name] + " (" + STR([Id]) + ")"` |
+| `SUBSTRING(str, start, len)` | `MID([Str], start, len)` | 1-based `start`; `len` optional (`MID([Str], 5)` → to end) |
+| `LEFT(str, n)` / `RIGHT(str, n)` | `LEFT([Str], n)` / `RIGHT([Str], n)` | identical |
+| `CHARINDEX(sub, str)` / `POSITION(sub IN str)` | `FIND([Str], sub)` | **arg order flips** (string first); returns `0` when not found |
+| `LEN(str)` / `LENGTH(str)` | `LEN([Str])` | character count |
+| `UPPER` / `LOWER` | `UPPER([Str])` / `LOWER([Str])` | identical |
+| `TRIM` / `LTRIM` / `RTRIM` | `TRIM([Str])` / `LTRIM([Str])` / `RTRIM([Str])` | trims spaces only |
+| `REPLACE(str, from, to)` | `REPLACE([Str], from, to)` | identical |
+| `CONTAINS` / `LIKE '%x%'` | `CONTAINS([Str], "x")` | returns boolean |
+| `str LIKE 'x%'` / `LIKE '%x'` | `STARTSWITH([Str], "x")` / `ENDSWITH([Str], "x")` | anchored match |
+| `REGEXP_SUBSTR` / `REGEXP_EXTRACT` | `REGEXP_EXTRACT([Str], pattern)` | first capture group |
+| `REGEXP_REPLACE(str, pat, rep)` | `REGEXP_REPLACE([Str], pat, rep)` | identical |
+| `str REGEXP pat` / `RLIKE` | `REGEXP_MATCH([Str], pat)` | returns boolean |
+| `SPLIT_PART(str, delim, n)` | `SPLIT([Str], delim, n)` | 1-based token index |
+| `CAST(x AS VARCHAR)` | `STR([X])` | any type → string |
+| `ISNULL(x, y)` (SQL Server 2-arg) | `IFNULL([X], [Y])` | 2-arg fallback; **not** `ISNULL` (Tableau `ISNULL` is 1-arg boolean) |
+
+**What does NOT work:**
+- `CONCAT([A], [B])` — there is no `CONCAT` function in Tableau; it errors. Use `[A] + [B]`.
+- `"Order " + [Order Id]` where `[Order Id]` is numeric — `+` on mixed types errors. Wrap: `"Order " + STR([Order Id])`.
+- Assuming `FIND` is 0-based or takes `(substring, string)` order — it is 1-based and takes `([Str], substring)`, the reverse of `CHARINDEX`.
+- Treating Tableau `ISNULL([X])` as the SQL Server 2-arg `ISNULL(x, y)` — Tableau's is a 1-arg boolean test; use `IFNULL`/`ZN` for a fallback value.
+
+---
+
 ## Window functions
 
 SQL window functions have limited direct equivalents in Tableau. Key translations:

--- a/src/desktop/metadata/fields.test.ts
+++ b/src/desktop/metadata/fields.test.ts
@@ -204,6 +204,40 @@ describe('addFieldToEncoding / removeFieldFromEncoding', () => {
   });
 });
 
+describe('detail encoding normalizes to <lod> (regression: coordinate map single-centroid blank)', () => {
+  // W-23447710 follow-up: an agent placed a dimension on the level-of-detail
+  // shelf via encoding_type="detail" → the tool wrote <detail>, which Tableau
+  // silently strips on apply (canonical LOD tag is <lod>). The pill vanished,
+  // the map collapsed to one AVG(lat)/AVG(lon) centroid, and rendered blank.
+  // Normalizing detail→lod at the metadata layer keeps the pill on the round-trip.
+  it('writes <lod> (not <detail>) when adding a field with encoding_type="detail"', () => {
+    const out = addFieldToEncoding(WORKSHEET_XML, 'detail', '[Sample].[none:Category:nk]');
+    expect(out).toMatch(/<lod\b[^>]*column=["']\[Sample\]\.\[none:Category:nk\]["']/);
+    expect(out).not.toMatch(/<detail\b/);
+  });
+
+  it('adding "detail" then "lod" for the same field is a duplicate (they are one shelf)', () => {
+    const withDetail = addFieldToEncoding(WORKSHEET_XML, 'detail', '[Sample].[none:Category:nk]');
+    // Because detail is normalized to lod, re-adding the same field as lod collides.
+    expect(() => addFieldToEncoding(withDetail, 'lod', '[Sample].[none:Category:nk]')).toThrow(
+      /already exists/,
+    );
+  });
+
+  it('removes a lod-shelf field addressed as encoding_type="detail" (add/remove symmetric)', () => {
+    const withLod = addFieldToEncoding(WORKSHEET_XML, 'lod', '[Sample].[none:Category:nk]');
+    expect(withLod).toMatch(/<lod\b[^>]*column=["']\[Sample\]\.\[none:Category:nk\]["']/);
+    // Address the same shelf with the "detail" alias — normalization means it hits <lod>.
+    const removed = removeFieldFromEncoding(withLod, 'detail', '[Sample].[none:Category:nk]');
+    expect(removed).not.toMatch(/<lod\b/);
+  });
+
+  it('leaves other encoding types (color/size) unchanged', () => {
+    const out = addFieldToEncoding(WORKSHEET_XML, 'size', '[Sample].[sum:Profit:qk]');
+    expect(out).toMatch(/<size\b[^>]*column=["']\[Sample\]\.\[sum:Profit:qk\]["']/);
+  });
+});
+
 describe('moveFieldInRows', () => {
   it('should move a field to a new position', () => {
     const twoRowsXml = addFieldToRows(WORKSHEET_XML, '[Sample].[sum:Profit:qk]');

--- a/src/desktop/metadata/fields.ts
+++ b/src/desktop/metadata/fields.ts
@@ -8,6 +8,18 @@ import { normalizeArray, parseXML, serializeXML } from './parser.js';
 import type { EncodingType, FieldInfo, ParsedEncoding, ParsedWorksheet } from './types.js';
 
 /**
+ * Tableau's Marks card labels the level-of-detail shelf "Detail", so an agent
+ * naturally picks encoding_type="detail" — but Tableau persists LOD only as the
+ * `<lod>` tag and SILENTLY STRIPS `<detail>` on apply (W-23447710 follow-up: a
+ * lat/lon symbol map lost its Location pill this way and collapsed to a single
+ * AVG-coordinate centroid — a blank map with a green apply). Normalize the alias
+ * to the round-trip-stable tag so add/remove/move all address the same shelf.
+ */
+function canonicalEncodingType(encodingType: EncodingType): EncodingType {
+  return encodingType === 'detail' ? 'lod' : encodingType;
+}
+
+/**
  * Helper to get worksheet from parsed XML
  */
 function getWorksheet(parsed: any): ParsedWorksheet | null {
@@ -46,6 +58,7 @@ export function addFieldToEncoding(
   index?: number,
   workbookXml?: string,
 ): string {
+  encodingType = canonicalEncodingType(encodingType);
   const parsed = parseXML(worksheetXml);
   const worksheet = getWorksheet(parsed);
 
@@ -208,6 +221,7 @@ export function removeFieldFromEncoding(
   encodingType: EncodingType,
   columnRef: string,
 ): string {
+  encodingType = canonicalEncodingType(encodingType);
   const parsed = parseXML(worksheetXml);
   const worksheet = getWorksheet(parsed);
 
@@ -257,6 +271,7 @@ export function moveFieldInEncoding(
   columnRef: string,
   newIndex: number,
 ): string {
+  encodingType = canonicalEncodingType(encodingType);
   const parsed = parseXML(worksheetXml);
   const worksheet = getWorksheet(parsed);
 

--- a/src/tools/desktop/fields/addField.ts
+++ b/src/tools/desktop/fields/addField.ts
@@ -45,7 +45,7 @@ const paramsSchema = {
   workbookFile: z.string().optional().describe('Optional workbook cache file for caption.'),
 };
 
-const title = 'Add Field to a Shelf or Encoding';
+const title = 'Add Field';
 export const getAddFieldTool = (server: DesktopMcpServer): DesktopTool<typeof paramsSchema> => {
   const addFieldTool = new DesktopTool({
     server,

--- a/src/tools/desktop/fields/removeField.test.ts
+++ b/src/tools/desktop/fields/removeField.test.ts
@@ -38,7 +38,7 @@ describe('removeFieldTool', () => {
   it('should create a tool instance with correct properties', () => {
     const tool = getRemoveFieldTool(new DesktopMcpServer());
     expect(tool.name).toBe('remove-field');
-    expect(tool.description).toContain('Rows shelf, Columns shelf, or an encoding');
+    expect(tool.description).toContain('Rows, Columns, or an encoding');
     expect(tool.paramsSchema).toMatchObject({
       worksheetFile: expect.any(Object),
       target: expect.any(Object),

--- a/src/tools/desktop/fields/removeField.ts
+++ b/src/tools/desktop/fields/removeField.ts
@@ -45,14 +45,14 @@ const paramsSchema = {
     .describe("Encoding channel ('text'=labels); required when target=encoding, else ignored."),
 };
 
-const title = 'Remove Field from a Shelf or Encoding';
+const title = 'Remove Field';
 export const getRemoveFieldTool = (server: DesktopMcpServer): DesktopTool<typeof paramsSchema> => {
   const removeFieldTool = new DesktopTool({
     server,
     name: 'remove-field',
     title,
     description:
-      'Remove a field from the Rows shelf, Columns shelf, or an encoding on a worksheet locally. Reads from and writes to cache file. Use apply-worksheet to apply changes.',
+      'Remove a field from Rows, Columns, or an encoding on a worksheet locally. Reads from and writes to cache file. Use apply-worksheet to apply changes.',
     paramsSchema,
     annotations: {
       title,


### PR DESCRIPTION
## Summary

Desktop twin of #503. The #504 content resync snapshot predates #503, so its delta never reached feature/desktop; this PR re-applies it there. #503 itself is being merged to feature/authoring separately.

- **detail→lod encoding normalization** (`src/desktop/metadata/fields.ts` + 4 regression tests): Tableau's Marks card labels the LOD shelf "Detail", so agents naturally pass `encoding_type="detail"` — but Tableau persists only `<lod>` and silently strips `<detail>` on apply (W-23447710 follow-up: a lat/lon symbol map lost its Location pill and collapsed to a single AVG-coordinate centroid — blank map, green apply). `canonicalEncodingType()` normalizes the alias at the entry of add/remove/move so all three address the same shelf.
- **SQL string-functions knowledge section** in `resources/desktop/knowledge/tactics/data/sql-translation.md` (CONCAT→`+`, 1-based positions, FIND arg order, ISNULL semantics).
- **add-field / remove-field title + description scrub** (tableau-speak reduction), with the matching test expectation update.

Deltas vs #503, both deliberate:
- `package.json`: desktop line is 2.25.x → bumped **2.25.1** (not #503's 2.12.1).
- `getStaleContentReport.test.ts` fake-timers pin: **already present** on feature/desktop — excluded.

## Validation

- `vitest run` on the 7 touched/adjacent suites — 81 tests green
- desktop binder invariants (portability.invariant, bind-behavior-matrix, carrier-uniqueness) — 210 tests green
- `server.desktop.test.ts` + `server.combined-lean.test.ts` (surface/ratchet) — 25 tests green
- `eslint --no-cache` on touched files + `tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)