### PR TITLE
Port a2td overnight portability+reliability wave (W1/W2/W3/W4/W6/W9) → feature/desktop

### DIFF
--- a/lockstep.hashes.json
+++ b/lockstep.hashes.json
@@ -1,6 +1,6 @@
 {
   "src/desktop/binder/calc-derivation.ts": "5105d466e3c31019affa91320edf3047259301ca5cd27aeb5883ba1faa251098",
-  "src/desktop/binder/classify.ts": "2fdf604ddff4a7f364e15599ba34d73cedf5c951fca5f90fdb9259555b1787fd",
+  "src/desktop/binder/classify.ts": "8f0dc7d25a2ef7878c753b3f8e6f8dd709d323111c257d7efa5795c5bfaf9b54",
   "src/desktop/binder/escape.ts": "3c79bcf77c33fad64975e95ea57df5fb3e416008633e15dc7a585018fbc92d3f",
   "src/desktop/binder/manifest-types.ts": "9ce310c1e294d3784084b854edf52ef4f7c4cf7a8e13ebba7071dc3957c6114d",
   "src/desktop/binder/manifest-validation.ts": "e29ecfa9e10e57593a4f72e498f35ca8b1b28a1227fc0cb4aed057870566df60",

--- a/src/desktop/binder/portability-lane.test.ts
+++ b/src/desktop/binder/portability-lane.test.ts
@@ -1,0 +1,265 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+
+import {
+  type BindingProposal,
+  bindTemplate,
+  classifyNoLlm,
+  PROPOSAL_OUTPUT_SCHEMA,
+  summarizeSchema,
+} from './binder.js';
+import { loadManifests } from './manifest.js';
+import type { TemplateManifest } from './manifest-types.js';
+
+// PORTABILITY-LANE behavioral evidence (ported from a2td src/binder/portability-lane.test.ts).
+// tmcp's richer portability.invariant.test.ts already pins the zero-wrong-bind headline over
+// three alien schemas, but those fixtures deliberately carry NO geo semantic-role and never
+// exercise the histogram bin-width refusal. This suite adds the offline bind assertions that
+// prove the NEW overnight behaviors are live in tmcp:
+//   • W2 — a Territory-class field tagged [State].[Name] binds the choropleth state slot by
+//     SEMANTIC ROLE (token affinity alone cannot see that "Territory" is state-level).
+//   • W3 — a histogram with no live bin-width stats REFUSES rather than binding a
+//     dataset-specific default (tmcp: fast_path gate + DATASET_SPECIFIC_FORMULA blocker; the
+//     a2td Superstore-derived 500 has no home here because tmcp never carried the width adapter).
+//   • W1 — non-Superstore datasources bind end-to-end with their own datasource name; the
+//     field_mapping never leaks "Superstore".
+
+const SAAS_OPS_WORKBOOK_XML = `<?xml version='1.0' encoding='utf-8'?>
+<workbook>
+  <datasources>
+    <datasource name='SaaSOpsDS'>
+      <column name='[Territory]' role='dimension' type='nominal' datatype='string' semantic-role='[State].[Name]' />
+      <column name='[Country]' role='dimension' type='nominal' datatype='string' semantic-role='[Country].[ISO3166_2]' />
+      <column name='[City]' role='dimension' type='nominal' datatype='string' semantic-role='[City].[Name]' />
+      <column name='[Account Segment]' role='dimension' type='nominal' datatype='string' />
+      <column name='[Product Line]' role='dimension' type='nominal' datatype='string' />
+      <column name='[Customer ID]' role='dimension' type='nominal' datatype='string' />
+      <column name='[Signup Date]' role='dimension' type='ordinal' datatype='date' />
+      <column name='[MRR]' role='measure' type='quantitative' datatype='real' />
+      <column name='[Expansion ARR]' role='measure' type='quantitative' datatype='real' />
+      <column name='[Seats]' role='measure' type='quantitative' datatype='integer' />
+      <column name='[Churn Rate]' role='measure' type='quantitative' datatype='real' />
+    </datasource>
+  </datasources>
+</workbook>`;
+
+const HEALTHCARE_CLAIMS_WORKBOOK_XML = `<?xml version='1.0' encoding='utf-8'?>
+<workbook>
+  <datasources>
+    <datasource name='HealthcareClaimsDS'>
+      <column name='[Claim Month]' role='dimension' type='ordinal' datatype='date' />
+      <column name='[Payer]' role='dimension' type='nominal' datatype='string' />
+      <column name='[Service Line]' role='dimension' type='nominal' datatype='string' />
+      <column name='[Diagnosis Group]' role='dimension' type='nominal' datatype='string' />
+      <column name='[Provider Region]' role='dimension' type='nominal' datatype='string' />
+      <column name='[Claim ID]' role='dimension' type='nominal' datatype='string' />
+      <column name='[Allowed Amount]' role='measure' type='quantitative' datatype='real' />
+      <column name='[Paid Amount]' role='measure' type='quantitative' datatype='real' />
+      <column name='[Member Months]' role='measure' type='quantitative' datatype='integer' />
+      <column name='[Denial Rate]' role='measure' type='quantitative' datatype='real' />
+      <column name='[Readmission Rate]' role='measure' type='quantitative' datatype='real' />
+    </datasource>
+  </datasources>
+</workbook>`;
+
+const FINANCE_PLANNING_WORKBOOK_XML = `<?xml version='1.0' encoding='utf-8'?>
+<workbook>
+  <datasources>
+    <datasource name='FinancePlanningDS'>
+      <column name='[Fiscal Period]' role='dimension' type='nominal' datatype='string' />
+      <column name='[Posting Date]' role='dimension' type='ordinal' datatype='date' />
+      <column name='[Entity]' role='dimension' type='nominal' datatype='string' />
+      <column name='[Department]' role='dimension' type='nominal' datatype='string' />
+      <column name='[Actual Amount]' role='measure' type='quantitative' datatype='real' />
+      <column name='[Budget Amount]' role='measure' type='quantitative' datatype='real' />
+      <column name='[Forecast Amount]' role='measure' type='quantitative' datatype='real' />
+      <column name='[Variance Percent]' role='measure' type='quantitative' datatype='real' />
+    </datasource>
+  </datasources>
+</workbook>`;
+
+let manifests: Map<string, TemplateManifest>;
+beforeAll(() => {
+  manifests = loadManifests();
+});
+
+// A few tests need a blocker-held template to be eligible so binder behavior can be
+// isolated from the manifest gate (mirrors portability.invariant.test.ts's helper).
+function withForcedEligible(names: string[]): Map<string, TemplateManifest> {
+  const out = new Map<string, TemplateManifest>();
+  for (const [k, v] of loadManifests()) {
+    out.set(k, names.includes(k) ? { ...v, fast_path_eligible: true } : v);
+  }
+  return out;
+}
+
+describe('portability-lane — schema fixtures summarize to their own alien datasource', () => {
+  it('summarizes the three non-Superstore datasource fixtures', () => {
+    expect(summarizeSchema(SAAS_OPS_WORKBOOK_XML).datasource).toBe('SaaSOpsDS');
+    expect(summarizeSchema(HEALTHCARE_CLAIMS_WORKBOOK_XML).datasource).toBe('HealthcareClaimsDS');
+    expect(summarizeSchema(FINANCE_PLANNING_WORKBOOK_XML).datasource).toBe('FinancePlanningDS');
+  });
+});
+
+describe('portability-lane — non-Superstore bindTemplate field_mapping (W1)', () => {
+  it('binds a healthcare bar end-to-end using the fixture datasource name', async () => {
+    const res = await bindTemplate({
+      ask: 'bar chart of Paid Amount by Payer',
+      workbookXml: HEALTHCARE_CLAIMS_WORKBOOK_XML,
+      manifests,
+    });
+
+    expect(res.status).toBe('bound');
+    if (res.status === 'bound') {
+      expect(res.used_llm).toBe(false);
+      expect(res.args.template_name).toBe('ranking-ordered-bar');
+      expect(res.args.template_parameters.DATASOURCE).toBe('HealthcareClaimsDS');
+      expect(res.args.field_mapping).toEqual({
+        Region: '[HealthcareClaimsDS].[none:Payer:nk]',
+        Sales: '[HealthcareClaimsDS].[sum:Paid Amount:qk]',
+      });
+      expect(JSON.stringify(res.args.field_mapping)).not.toContain('Superstore');
+    }
+  });
+
+  it('field_mapping never contains Superstore for any portability-lane fixture', async () => {
+    const cases = [
+      {
+        ask: 'bar chart of MRR by Account Segment',
+        workbookXml: SAAS_OPS_WORKBOOK_XML,
+        datasource: 'SaaSOpsDS',
+      },
+      {
+        ask: 'bar chart of Paid Amount by Payer',
+        workbookXml: HEALTHCARE_CLAIMS_WORKBOOK_XML,
+        datasource: 'HealthcareClaimsDS',
+      },
+      {
+        ask: 'trend of Actual Amount over time',
+        workbookXml: FINANCE_PLANNING_WORKBOOK_XML,
+        datasource: 'FinancePlanningDS',
+      },
+    ];
+
+    for (const c of cases) {
+      const res = await bindTemplate({ ask: c.ask, workbookXml: c.workbookXml, manifests });
+      expect(res.status, `expected bound for ${c.datasource}`).toBe('bound');
+      if (res.status !== 'bound') continue;
+      expect(res.args.template_parameters.DATASOURCE).toBe(c.datasource);
+      expect(JSON.stringify(res.args.field_mapping)).not.toContain('Superstore');
+    }
+  });
+});
+
+describe('portability-lane — geo semantic-role picks (W2, the Territory-class bind)', () => {
+  // Before W2 both asks returned null: token affinity cannot see that "Territory" is a
+  // state-level field. Tableau's semantic-role tag can — and now does, because the metadata
+  // read path plumbs @_semantic-role into SchemaField.semanticRole.
+  it('Territory tagged [State].[Name] binds the choropleth state slot by semantic role', () => {
+    const s = summarizeSchema(SAAS_OPS_WORKBOOK_XML);
+    const cls = classifyNoLlm('map of MRR by Territory', manifests, s);
+    expect(cls).not.toBeNull();
+    expect(cls!.template).toBe('spatial-choropleth-map');
+    const byId = Object.fromEntries(cls!.bindings.map((b) => [b.slot_id, b.field]));
+    expect(byId.state).toBe('Territory');
+    expect(byId.country).toBe('Country');
+  });
+
+  it('a Country map ask auto-completes the state slot with the semantic-role state field', () => {
+    const s = summarizeSchema(SAAS_OPS_WORKBOOK_XML);
+    const cls = classifyNoLlm('map of MRR by Country', manifests, s);
+    expect(cls).not.toBeNull();
+    expect(cls!.template).toBe('spatial-choropleth-map');
+    const byId = Object.fromEntries(cls!.bindings.map((b) => [b.slot_id, b.field]));
+    expect(byId.country).toBe('Country');
+    expect(byId.state).toBe('Territory');
+  });
+
+  it('the Territory map binds end-to-end (used_llm=false, non-Superstore datasource)', async () => {
+    const res = await bindTemplate({
+      ask: 'map of MRR by Territory',
+      workbookXml: SAAS_OPS_WORKBOOK_XML,
+      manifests,
+    });
+    expect(res.status).toBe('bound');
+    if (res.status === 'bound') {
+      expect(res.used_llm).toBe(false);
+      expect(res.args.template_name).toBe('spatial-choropleth-map');
+      expect(res.args.template_parameters.DATASOURCE).toBe('SaaSOpsDS');
+      expect(JSON.stringify(res.args.field_mapping)).not.toContain('Superstore');
+    }
+  });
+});
+
+describe('portability-lane — histogram bin-width refusal (W3)', () => {
+  it('the real distribution-histogram manifest is NOT fast-path eligible (bin width is dataset-specific)', () => {
+    const m = manifests.get('distribution-histogram');
+    expect(m).toBeDefined();
+    expect(m!.fast_path_eligible).toBe(false);
+    expect(m!.fast_path_blockers).toContain('DATASET_SPECIFIC_FORMULA');
+  });
+
+  it('Call 1: a Denial Rate histogram falls through to propose — never a default-width bind', async () => {
+    const res = await bindTemplate({
+      ask: 'histogram of Denial Rate',
+      workbookXml: HEALTHCARE_CLAIMS_WORKBOOK_XML,
+      manifests,
+    });
+    expect(res.status).toBe('propose');
+  });
+
+  it('Call 2: an explicit Denial Rate histogram proposal escalates with DATASET_SPECIFIC_FORMULA', async () => {
+    const proposal: BindingProposal = {
+      template: 'distribution-histogram',
+      title: 'Distribution of Denial Rate',
+      bindings: [{ slot_id: 'measure', field: 'Denial Rate' }],
+      confidence: 0.9,
+    };
+    const res = await bindTemplate({
+      ask: 'histogram of Denial Rate',
+      workbookXml: HEALTHCARE_CLAIMS_WORKBOOK_XML,
+      manifests,
+      proposal,
+    });
+    expect(res.status).toBe('escalate');
+    if (res.status === 'escalate') {
+      expect(res.blockers.some((b) => b.code === 'DATASET_SPECIFIC_FORMULA')).toBe(true);
+    }
+  });
+
+  it('even forced eligible, a histogram bind never emits a Superstore-derived 500 default width', async () => {
+    // tmcp never ported a2td's deriveHistogramBinWidth adapter, so there is no code path
+    // that could inject the old Superstore-derived 500; the template width stays an
+    // unsubstituted placeholder for a data-aware retune. This locks that absence.
+    const proposal: BindingProposal = {
+      template: 'distribution-histogram',
+      title: 'Distribution of Denial Rate',
+      bindings: [{ slot_id: 'measure', field: 'Denial Rate' }],
+      confidence: 0.9,
+    };
+    const res = await bindTemplate({
+      ask: 'histogram of Denial Rate',
+      workbookXml: HEALTHCARE_CLAIMS_WORKBOOK_XML,
+      manifests: withForcedEligible(['distribution-histogram']),
+      proposal,
+    });
+    if (res.status === 'bound') {
+      expect(JSON.stringify(res.args)).not.toContain('500');
+    }
+  });
+});
+
+describe('portability-lane — under-specified scatter proposes with only bindable slots', () => {
+  it('healthcare scatter with too few fields → propose payload exposes the PROPOSAL_OUTPUT_SCHEMA', async () => {
+    const res = await bindTemplate({
+      ask: 'scatter of Paid Amount vs Allowed Amount',
+      workbookXml: HEALTHCARE_CLAIMS_WORKBOOK_XML,
+      manifests: withForcedEligible(['correlation-scatter-plot-chart']),
+    });
+    expect(res.status).toBe('propose');
+    if (res.status === 'propose') {
+      expect(res.output_schema).toBe(PROPOSAL_OUTPUT_SCHEMA);
+      expect(res.llm_input.fields.some((f) => f.name === 'Paid Amount')).toBe(true);
+      expect(res.llm_input.fields.some((f) => f.name === 'Payer')).toBe(true);
+    }
+  });
+});

--- a/src/desktop/binder/schema-summary.ts
+++ b/src/desktop/binder/schema-summary.ts
@@ -28,6 +28,7 @@ export interface SchemaField {
   role: 'dimension' | 'measure';
   type: string; // "quantitative" | "nominal" | "ordinal" | ...
   datatype: string; // "string" | "real" | "integer" | "date" | "datetime" | ...
+  semanticRole?: string; // Tableau geo semantic role, e.g. "[State].[Name]"
   datasource: string;
   isAggregated: boolean;
   column_ref: string; // straight from listAvailableFields, e.g. "[Superstore].[sum:Sales:qk]"
@@ -63,6 +64,7 @@ export function summarizeSchema(workbookXml: string): SchemaSummary {
       role,
       type: f.type,
       datatype: f.datatype ?? '',
+      semanticRole: f.semanticRole,
       datasource: f.datasource,
       isAggregated: !!f.isAggregated,
       column_ref: f.column_ref,

--- a/src/desktop/commands/workbook/cacheFingerprint.test.ts
+++ b/src/desktop/commands/workbook/cacheFingerprint.test.ts
@@ -93,9 +93,9 @@ describe('cache fingerprint sidecars', () => {
     writeFileSync(file, '<worksheet/>', 'utf-8');
     const logSpy = vi.spyOn(loggerModule, 'log').mockImplementation(() => undefined);
 
-    expect(checkSidecar(file, '1', 'worksheet', resolver({ pid: 1, port: 8765, start_time: 's' }))).toEqual(
-      { ok: true },
-    );
+    expect(
+      checkSidecar(file, '1', 'worksheet', resolver({ pid: 1, port: 8765, start_time: 's' })),
+    ).toEqual({ ok: true });
     expect(logSpy).toHaveBeenCalledWith(
       expect.objectContaining({ message: expect.stringContaining('cache sidecar missing') }),
     );
@@ -106,9 +106,9 @@ describe('cache fingerprint sidecars', () => {
     writeFileSync(file, '<worksheet/>', 'utf-8');
     writeFileSync(sidecarPath(file), 'not json', 'utf-8');
     vi.spyOn(loggerModule, 'log').mockImplementation(() => undefined);
-    expect(checkSidecar(file, '1', 'worksheet', resolver({ pid: 1, port: 8765, start_time: 's' }))).toEqual(
-      { ok: true },
-    );
+    expect(
+      checkSidecar(file, '1', 'worksheet', resolver({ pid: 1, port: 8765, start_time: 's' })),
+    ).toEqual({ ok: true });
   });
 
   it('proceeds when no current fingerprint can be resolved (never blocks blind)', () => {

--- a/src/desktop/commands/workbook/cacheFingerprint.test.ts
+++ b/src/desktop/commands/workbook/cacheFingerprint.test.ts
@@ -1,0 +1,125 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import * as loggerModule from '../../../logging/logger.js';
+import {
+  checkSidecar,
+  type FingerprintResolver,
+  type InstanceFingerprint,
+  sidecarPath,
+  writeSidecar,
+} from './cacheFingerprint.js';
+
+const dirs: string[] = [];
+
+function tempFile(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'tableau-cache-fingerprint-'));
+  dirs.push(dir);
+  return join(dir, 'worksheet.xml');
+}
+
+/** A resolver that returns a fixed fingerprint (or undefined) regardless of session id. */
+function resolver(instance: InstanceFingerprint | undefined): FingerprintResolver {
+  return () => instance;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+describe('cache fingerprint sidecars', () => {
+  it('writes sidecar metadata and accepts the same current instance', () => {
+    const file = tempFile();
+    writeFileSync(file, '<worksheet/>', 'utf-8');
+    const fingerprint = { pid: 1, port: 8765, start_time: '2026-07-15T01:00:00Z' };
+    const resolve = resolver(fingerprint);
+
+    writeSidecar(file, '1', resolve);
+
+    const meta = JSON.parse(readFileSync(sidecarPath(file), 'utf-8')) as Record<string, unknown>;
+    expect(meta).toMatchObject({ session_id: '1', ...fingerprint });
+    expect(checkSidecar(file, '1', 'worksheet', resolve)).toEqual({ ok: true });
+  });
+
+  it('refuses when the sidecar fingerprint differs from the current session', () => {
+    const file = tempFile();
+    writeFileSync(file, '<worksheet/>', 'utf-8');
+    writeFileSync(
+      sidecarPath(file),
+      JSON.stringify({
+        session_id: '1',
+        pid: 1,
+        port: 8765,
+        start_time: 'old',
+        created_at: '2026-07-15T01:00:00Z',
+      }),
+      'utf-8',
+    );
+
+    const result = checkSidecar(
+      file,
+      '2',
+      'worksheet',
+      resolver({ pid: 2, port: 8766, start_time: 'new' }),
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.message).toContain('Refusing to apply worksheet cache file');
+    expect(result.message).toContain('get-worksheet-xml');
+  });
+
+  it('refuses a same-pid cache when Desktop restarted (start_time changed)', () => {
+    const file = tempFile();
+    writeFileSync(file, '<worksheet/>', 'utf-8');
+    writeFileSync(
+      sidecarPath(file),
+      JSON.stringify({ session_id: '1', pid: 1, port: 8765, start_time: 'old', created_at: 'x' }),
+      'utf-8',
+    );
+    const result = checkSidecar(
+      file,
+      '1',
+      'worksheet',
+      resolver({ pid: 1, port: 8765, start_time: 'new' }),
+    );
+    expect(result.ok).toBe(false);
+  });
+
+  it('warns and proceeds when the sidecar is missing (pre-sidecar caches stay valid)', () => {
+    const file = tempFile();
+    writeFileSync(file, '<worksheet/>', 'utf-8');
+    const logSpy = vi.spyOn(loggerModule, 'log').mockImplementation(() => undefined);
+
+    expect(checkSidecar(file, '1', 'worksheet', resolver({ pid: 1, port: 8765, start_time: 's' }))).toEqual(
+      { ok: true },
+    );
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ message: expect.stringContaining('cache sidecar missing') }),
+    );
+  });
+
+  it('warns and proceeds when the sidecar is unreadable JSON', () => {
+    const file = tempFile();
+    writeFileSync(file, '<worksheet/>', 'utf-8');
+    writeFileSync(sidecarPath(file), 'not json', 'utf-8');
+    vi.spyOn(loggerModule, 'log').mockImplementation(() => undefined);
+    expect(checkSidecar(file, '1', 'worksheet', resolver({ pid: 1, port: 8765, start_time: 's' }))).toEqual(
+      { ok: true },
+    );
+  });
+
+  it('proceeds when no current fingerprint can be resolved (never blocks blind)', () => {
+    const file = tempFile();
+    writeFileSync(file, '<worksheet/>', 'utf-8');
+    writeFileSync(
+      sidecarPath(file),
+      JSON.stringify({ session_id: '1', pid: 1, port: 8765, start_time: 'old', created_at: 'x' }),
+      'utf-8',
+    );
+    vi.spyOn(loggerModule, 'log').mockImplementation(() => undefined);
+    expect(checkSidecar(file, 'abc', 'worksheet', resolver(undefined))).toEqual({ ok: true });
+  });
+});

--- a/src/desktop/commands/workbook/cacheFingerprint.ts
+++ b/src/desktop/commands/workbook/cacheFingerprint.ts
@@ -1,0 +1,165 @@
+/**
+ * Cache-file instance fingerprinting — the cross-instance bleed guard (W9).
+ *
+ * Cache file names are deterministic and sessionless (workbook-for-parallel-build.xml,
+ * worksheet-<name>.xml), so with two Desktops running, instance A's cached XML can be
+ * applied to instance B. Cache-writing tools write a `<file>.meta.json` sidecar recording
+ * which Desktop instance produced the cache; apply tools that consume a cache file refuse
+ * a mismatched fingerprint and tell the agent to re-read in the current session. There is
+ * deliberately NO override flag — an agent-passable confirm re-opens the self-confirm
+ * hole; the recovery is always "re-read, then apply". Missing/unreadable sidecars warn and
+ * proceed (pre-sidecar caches stay valid), and a fingerprint that cannot be resolved never
+ * blocks blind.
+ */
+import { existsSync, readFileSync, writeFileSync } from 'fs';
+
+import { log } from '../../../logging/logger.js';
+import { DesktopDiscoverer } from '../../desktopDiscoverer.js';
+import { DesktopInstance } from '../../desktopInstance.js';
+
+export interface InstanceFingerprint {
+  pid: number;
+  port: number;
+  start_time: string;
+}
+
+export type CacheArtifactKind = 'worksheet' | 'workbook' | 'dashboard';
+
+export interface CacheSidecarMeta extends InstanceFingerprint {
+  session_id: string;
+  created_at: string;
+}
+
+export interface CheckSidecarResult {
+  ok: boolean;
+  message?: string;
+}
+
+/** Resolves the live fingerprint for a session id. Injectable so tests need no manifest. */
+export type FingerprintResolver = (sessionId: string) => InstanceFingerprint | undefined;
+
+const READ_TOOL_BY_KIND: Record<CacheArtifactKind, string> = {
+  worksheet: 'get-worksheet-xml',
+  workbook: 'get-workbook-xml',
+  dashboard: 'get-dashboard-xml',
+};
+
+export function sidecarPath(cacheFile: string): string {
+  return `${cacheFile}.meta.json`;
+}
+
+export function fingerprintFromInstance(instance: DesktopInstance): InstanceFingerprint {
+  return { pid: instance.pid, port: instance.port, start_time: instance.start_time };
+}
+
+/**
+ * Default resolver: read the live manifest and match the session pid. Returns undefined
+ * for a non-numeric session (external-API pids are still numeric) or a pid absent from
+ * the manifest — callers then proceed rather than block blind.
+ */
+export function defaultFingerprintResolver(sessionId: string): InstanceFingerprint | undefined {
+  if (!/^\d+$/.test(sessionId)) return undefined;
+  const pid = Number.parseInt(sessionId, 10);
+  const instance = new DesktopDiscoverer().getInstances().get(pid);
+  return instance ? fingerprintFromInstance(instance) : undefined;
+}
+
+export function writeSidecar(
+  cacheFile: string,
+  sessionId: string,
+  resolve: FingerprintResolver = defaultFingerprintResolver,
+): void {
+  const fingerprint = resolve(sessionId);
+  if (!fingerprint) {
+    log({
+      message: 'cache sidecar not written — no instance fingerprint',
+      level: 'warning',
+      logger: 'cacheFingerprint',
+      data: { file: cacheFile, sessionId },
+    });
+    return;
+  }
+
+  const meta: CacheSidecarMeta = {
+    session_id: sessionId,
+    ...fingerprint,
+    created_at: new Date().toISOString(),
+  };
+
+  try {
+    writeFileSync(sidecarPath(cacheFile), JSON.stringify(meta, null, 2), 'utf-8');
+  } catch (error) {
+    log({
+      message: 'cache sidecar write failed',
+      level: 'warning',
+      logger: 'cacheFingerprint',
+      data: { file: cacheFile, error: String(error) },
+    });
+  }
+}
+
+export function checkSidecar(
+  cacheFile: string,
+  sessionId: string,
+  kind: CacheArtifactKind,
+  resolve: FingerprintResolver = defaultFingerprintResolver,
+): CheckSidecarResult {
+  const metaFile = sidecarPath(cacheFile);
+  if (!existsSync(metaFile)) {
+    log({
+      message: 'cache sidecar missing — proceeding (pre-sidecar cache)',
+      level: 'warning',
+      logger: 'cacheFingerprint',
+      data: { file: cacheFile, sidecar: metaFile, sessionId, kind },
+    });
+    return { ok: true };
+  }
+
+  let meta: CacheSidecarMeta;
+  try {
+    meta = JSON.parse(readFileSync(metaFile, 'utf-8')) as CacheSidecarMeta;
+  } catch (error) {
+    log({
+      message: 'cache sidecar unreadable — proceeding',
+      level: 'warning',
+      logger: 'cacheFingerprint',
+      data: { file: cacheFile, sidecar: metaFile, error: String(error) },
+    });
+    return { ok: true };
+  }
+
+  const current = resolve(sessionId);
+  if (!current) {
+    log({
+      message: 'cache sidecar current fingerprint unavailable — proceeding',
+      level: 'warning',
+      logger: 'cacheFingerprint',
+      data: { file: cacheFile, sidecar: metaFile, sessionId, kind },
+    });
+    return { ok: true };
+  }
+
+  if (sameFingerprint(meta, current)) return { ok: true };
+
+  const message =
+    `Refusing to apply ${kind} cache file from a different Tableau Desktop session: ${cacheFile}\n\n` +
+    `Cache file fingerprint: session_id=${meta.session_id}, ${formatFingerprint(meta)}\n` +
+    `Current session fingerprint: session_id=${sessionId}, ${formatFingerprint(current)}\n\n` +
+    `Re-read the ${kind} in the current session with ${READ_TOOL_BY_KIND[kind]}, edit the newly returned cache file, then retry the apply. Cached XML files from the old session may not match the current workbook.`;
+
+  log({
+    message: 'cache fingerprint mismatch',
+    level: 'error',
+    logger: 'cacheFingerprint',
+    data: { file: cacheFile, sidecar: metaFile, sessionId, kind, cached: meta, current },
+  });
+  return { ok: false, message };
+}
+
+function sameFingerprint(a: InstanceFingerprint, b: InstanceFingerprint): boolean {
+  return a.pid === b.pid && a.port === b.port && a.start_time === b.start_time;
+}
+
+function formatFingerprint(fingerprint: InstanceFingerprint): string {
+  return `pid=${fingerprint.pid}, port=${fingerprint.port}, start_time=${fingerprint.start_time}`;
+}

--- a/src/desktop/commands/workbook/getWorksheetXml.test.ts
+++ b/src/desktop/commands/workbook/getWorksheetXml.test.ts
@@ -98,6 +98,50 @@ describe('getWorksheetXml (Agent API transport, default)', () => {
     }
   });
 
+  it('appends a "did you mean" suggestion listing close sheet names on a miss (W6)', async () => {
+    // save-worksheet finds nothing; list-worksheets returns the real names so the
+    // miss message can surface close matches for self-correction.
+    const mockExecutor = {
+      executeCommand: vi.fn(async (params: any) => {
+        if (params.command === 'list-worksheets') {
+          return Ok({
+            command_id: 'cmd-list',
+            status: 'completed',
+            parsedResult: {
+              worksheets: JSON.stringify({
+                count: 3,
+                worksheets: [{ name: 'Sales by Region' }, { name: 'Profit Map' }, { name: 'KPIs' }],
+              }),
+            },
+          });
+        }
+        return Ok({
+          command_id: 'cmd-123',
+          status: 'completed',
+          parsedResult: { worksheetXml: '<empty></empty>' },
+        });
+      }),
+    } as unknown as LocalExecutor;
+
+    const result = await getWorksheetXml({
+      worksheetName: 'Sales',
+      executor: mockExecutor,
+      signal: mockSignal,
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      invariant(result.error.type === 'get-worksheet-xml-error');
+      expect(result.error.error.type).toBe('no-worksheet-found');
+      // "Sales" is a substring of "Sales by Region" → surfaced as a close match.
+      expect(result.error.error.message).toContain('Did you mean');
+      expect(result.error.error.message).toContain('"Sales by Region"');
+      expect(result.error.error.message).toContain('ask the user instead of guessing');
+      // A non-matching sheet is not listed among the close matches.
+      expect(result.error.error.message).not.toContain('"KPIs"');
+    }
+  });
+
   it('should return multiple-worksheets-found error when response contains more than one worksheet', async () => {
     const mockXml = '<workbook><worksheet name="Sheet 1"/><worksheet name="Sheet 2"/></workbook>';
     const mockExecutor = {

--- a/src/desktop/commands/workbook/getWorksheetXml.ts
+++ b/src/desktop/commands/workbook/getWorksheetXml.ts
@@ -8,6 +8,39 @@ import {
   WithExecutorAndAbortSignal,
 } from '../../toolExecutor/toolExecutor.js';
 import { getWorkbookXml } from './getWorkbookXml.js';
+import { listWorksheets } from './listWorksheets.js';
+
+/**
+ * Best-effort "did you mean" suffix for a worksheet-name miss (W6, cluster H). Lists the
+ * live sheet names, surfaces close matches (case-insensitive substring either direction)
+ * first, and tells the agent to ask the user rather than guess when nothing clearly
+ * matches. Never throws; returns '' when the list is unavailable — zero cost on success.
+ */
+async function worksheetNameSuggestions(
+  missName: string,
+  { executor, signal }: WithExecutorAndAbortSignal,
+): Promise<string> {
+  try {
+    const listed = await listWorksheets({ executor, signal });
+    if (listed.isErr()) return '';
+    const names = listed.value.worksheets.filter((n) => !!n);
+    if (names.length === 0) return '';
+
+    const needle = missName.toLowerCase();
+    const close = names.filter((n) => {
+      const hay = n.toLowerCase();
+      return hay.includes(needle) || needle.includes(hay);
+    });
+    const candidates = (close.length > 0 ? close : names).slice(0, 12);
+    const heading = close.length > 0 ? 'Did you mean' : 'Available worksheets';
+    return (
+      ` ${heading}: ${candidates.map((n) => `"${n}"`).join(', ')}.` +
+      ` If it is not obvious which sheet the user meant, ask the user instead of guessing.`
+    );
+  } catch {
+    return '';
+  }
+}
 
 export type GetWorksheetXmlError = (
   | { type: 'no-worksheet-found' }
@@ -55,9 +88,13 @@ async function getWorksheetXmlViaAgentApi({
   const worksheetCount = (worksheetXml.match(/<worksheet/g) || []).length;
 
   if (worksheetCount === 0) {
+    const didYouMean = await worksheetNameSuggestions(worksheetName, { executor, signal });
     return Err({
       type: 'get-worksheet-xml-error',
-      error: { type: 'no-worksheet-found', message: `No worksheet found for ${worksheetName}.` },
+      error: {
+        type: 'no-worksheet-found',
+        message: `No worksheet found for ${worksheetName}.${didYouMean}`,
+      },
     });
   }
 
@@ -92,9 +129,13 @@ async function getWorksheetXmlViaExternalApi({
   }
 
   if (worksheetXml === null) {
+    const didYouMean = await worksheetNameSuggestions(worksheetName, { executor, signal });
     return Err({
       type: 'get-worksheet-xml-error',
-      error: { type: 'no-worksheet-found', message: `No worksheet found for ${worksheetName}.` },
+      error: {
+        type: 'no-worksheet-found',
+        message: `No worksheet found for ${worksheetName}.${didYouMean}`,
+      },
     });
   }
 

--- a/src/desktop/commands/workbook/getWorksheetXml.ts
+++ b/src/desktop/commands/workbook/getWorksheetXml.ts
@@ -35,7 +35,7 @@ async function worksheetNameSuggestions(
     const heading = close.length > 0 ? 'Did you mean' : 'Available worksheets';
     return (
       ` ${heading}: ${candidates.map((n) => `"${n}"`).join(', ')}.` +
-      ` If it is not obvious which sheet the user meant, ask the user instead of guessing.`
+      ' If it is not obvious which sheet the user meant, ask the user instead of guessing.'
     );
   } catch {
     return '';

--- a/src/desktop/commands/workbook/loadWorksheetXml.test.ts
+++ b/src/desktop/commands/workbook/loadWorksheetXml.test.ts
@@ -56,33 +56,51 @@ describe('loadWorksheetXml (Agent API transport, default)', () => {
     );
   });
 
+  // A command-dispatching executor: the post-apply readback (W4) re-reads the sheet via
+  // `save-worksheet`, so tests that assert focus/apply choreography must serve that call.
+  function dispatchingAgentExecutor(
+    readbackXml: string,
+    overrides: Partial<Record<string, unknown>> = {},
+  ): {
+    executor: LocalExecutor;
+    calls: Array<{ namespace: string; command: string; args?: Record<string, unknown> }>;
+    executeCommand: ReturnType<typeof vi.fn>;
+  } {
+    const calls: Array<{ namespace: string; command: string; args?: Record<string, unknown> }> = [];
+    const executeCommand = vi.fn(async (params: any) => {
+      calls.push({ namespace: params.namespace, command: params.command, args: params.args });
+      if (params.command in overrides) return overrides[params.command];
+      if (params.command === 'save-worksheet') {
+        return Ok({
+          command_id: 'cmd-readback',
+          status: 'completed',
+          submitted_at: '',
+          parsedResult: { worksheetXml: readbackXml },
+        });
+      }
+      return Ok({ command_id: 'cmd-ok', status: 'completed', submitted_at: '' });
+    });
+    return { executor: { executeCommand } as unknown as LocalExecutor, calls, executeCommand };
+  }
+
   it('focuses the worksheet after a successful apply', async () => {
-    const mockExecutor = {
-      executeCommand: vi
-        .fn()
-        .mockResolvedValueOnce(Ok({ command_id: 'cmd-123', status: 'completed', submitted_at: '' }))
-        .mockResolvedValueOnce(
-          Ok({ command_id: 'cmd-goto', status: 'completed', submitted_at: '' }),
-        ),
-    } as unknown as LocalExecutor;
+    const { executor, calls } = dispatchingAgentExecutor(validXml);
 
     const result = await loadWorksheetXml({
       worksheetName,
       xml: validXml,
-      executor: mockExecutor,
+      executor,
       signal: mockSignal,
     });
 
     expect(result.isOk()).toBe(true);
-    expect(mockExecutor.executeCommand).toHaveBeenNthCalledWith(
-      2,
-      expect.objectContaining({
-        namespace: 'tabdoc',
-        command: 'goto-sheet',
-        args: { sheet: worksheetName },
-        signal: mockSignal,
-      }),
-    );
+    // Post-apply readback (W4) runs before focus; focus is the final call.
+    expect(calls.some((c) => c.namespace === 'tabui' && c.command === 'save-worksheet')).toBe(true);
+    expect(calls.at(-1)).toMatchObject({
+      namespace: 'tabdoc',
+      command: 'goto-sheet',
+      args: { sheet: worksheetName },
+    });
   });
 
   it('keeps worksheet apply successful when focusing the worksheet fails', async () => {
@@ -90,17 +108,12 @@ describe('loadWorksheetXml (Agent API transport, default)', () => {
       type: 'command-failed' as const,
       error: { code: 'GOTO_FAILED', message: 'could not navigate', recoverable: true },
     };
-    const mockExecutor = {
-      executeCommand: vi
-        .fn()
-        .mockResolvedValueOnce(Ok({ command_id: 'cmd-123', status: 'completed', submitted_at: '' }))
-        .mockResolvedValueOnce(Err(error)),
-    } as unknown as LocalExecutor;
+    const { executor } = dispatchingAgentExecutor(validXml, { 'goto-sheet': Err(error) });
 
     const result = await loadWorksheetXml({
       worksheetName,
       xml: validXml,
-      executor: mockExecutor,
+      executor,
       signal: mockSignal,
     });
 
@@ -116,6 +129,56 @@ describe('loadWorksheetXml (Agent API transport, default)', () => {
         }),
       }),
     );
+  });
+
+  it('fails the apply (readback-failed) when Tableau silently drops an intent-bearing node', async () => {
+    const intended =
+      '<worksheet name="Sheet 1"><table>' +
+      '<panes><pane><mark class="Shape"/>' +
+      '<encodings><lod column="[DS].[none:State:nk]"/></encodings></pane></panes>' +
+      '<rows>[DS].[none:State:nk]</rows></table></worksheet>';
+    // Readback comes back with the <lod> encoding and the rows shelf stripped.
+    const stripped =
+      '<worksheet name="Sheet 1"><table>' +
+      '<panes><pane><mark class="Shape"/><encodings/></pane></panes></table></worksheet>';
+    const { executor } = dispatchingAgentExecutor(stripped);
+
+    const result = await loadWorksheetXml({
+      worksheetName,
+      xml: intended,
+      executor,
+      signal: mockSignal,
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      invariant(result.error.type === 'load-worksheet-xml-error');
+      invariant(result.error.error.type === 'readback-failed');
+      expect(result.error.error.message).toContain('silently dropped');
+      expect(result.error.error.findings.some((f) => f.node === 'lod')).toBe(true);
+    }
+  });
+
+  it('surfaces readback WARNINGS on a successful apply without failing it', async () => {
+    const intended =
+      '<worksheet name="Sheet 1"><table>' +
+      '<view><computed-sort column="[DS].[none:State:nk]" direction="DESC" using="[DS].[sum:Profit:qk]"/></view>' +
+      '<panes><pane><mark class="Bar"/></pane></panes></table></worksheet>';
+    // Sort direction changed on readback → warning-severity, non-fatal.
+    const changed = intended.replace('direction="DESC"', 'direction="ASC"');
+    const { executor } = dispatchingAgentExecutor(changed);
+
+    const result = await loadWorksheetXml({
+      worksheetName,
+      xml: intended,
+      executor,
+      signal: mockSignal,
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.readbackWarnings.some((f) => f.kind === 'sort')).toBe(true);
+    }
   });
 
   it('should return error when XML is invalid', async () => {

--- a/src/desktop/commands/workbook/loadWorksheetXml.ts
+++ b/src/desktop/commands/workbook/loadWorksheetXml.ts
@@ -8,11 +8,17 @@ import {
   ExecuteCommandError,
   WithExecutorAndAbortSignal,
 } from '../../toolExecutor/toolExecutor.js';
+import {
+  formatReadbackVerificationError,
+  type ReadbackFinding,
+  verifyWorksheetReadback,
+} from '../../validation/readback-verify.js';
 import { runValidation } from '../../validation/registry.js';
 import { ValidationIssue } from '../../validation/types.js';
 import { withApplyLock } from './applyMutex.js';
 import { focusAppliedSheetBestEffort } from './focusAppliedSheet.js';
 import { getWorkbookXml } from './getWorkbookXml.js';
+import { getWorksheetXml } from './getWorksheetXml.js';
 import { applyWorkbookText, interpretLoadOutcome } from './loadWorkbookXml.js';
 
 export type LoadWorksheetXmlError =
@@ -21,13 +27,77 @@ export type LoadWorksheetXmlError =
   // The load-worksheet command reported command-level completion, but Tableau
   // rejected the actual document load (surfaced in the response payload, not in
   // `status`). `message` carries Desktop's own error text.
-  | { type: 'load-rejected'; message: string };
+  | { type: 'load-rejected'; message: string }
+  // Apply succeeded but the post-apply readback proved Tableau silently dropped or
+  // changed an intent-bearing node (the silently-dropped-pill killer, W4). `message`
+  // carries the agent-facing fix recipe; `findings` the structured evidence.
+  | { type: 'readback-failed'; findings: ReadbackFinding[]; message: string };
+
+/** Non-fatal readback warnings surfaced on a successful apply (sort drops/changes). */
+export interface LoadWorksheetXmlOk {
+  readbackWarnings: ReadbackFinding[];
+}
 
 type LoadWorksheetXmlResult = Result<
-  void,
+  LoadWorksheetXmlOk,
   | { type: 'execute-command-error'; error: ExecuteCommandError }
   | { type: 'load-worksheet-xml-error'; error: LoadWorksheetXmlError }
 >;
+
+/**
+ * Post-apply readback verification. Re-reads the just-applied worksheet and compares
+ * intent-bearing structures against the authored XML. Never throws and never fails the
+ * apply on a re-read miss: if the worksheet cannot be re-read, verification is skipped
+ * (returns no findings) so telemetry can never mask a real apply.
+ */
+async function verifyReadbackAfterApply(
+  worksheetName: string,
+  intendedXml: string,
+  executor: WithExecutorAndAbortSignal['executor'],
+  signal: WithExecutorAndAbortSignal['signal'],
+): Promise<ReadbackFinding[]> {
+  try {
+    const reread = await getWorksheetXml({ worksheetName, executor, signal });
+    if (reread.isErr()) {
+      log({
+        level: 'warning',
+        message: 'Post-apply worksheet readback verification skipped — could not re-read worksheet',
+        logger: 'worksheetCommands',
+        data: { worksheetName, error: reread.error },
+      });
+      return [];
+    }
+    return verifyWorksheetReadback(intendedXml, reread.value);
+  } catch (error) {
+    log({
+      level: 'warning',
+      message: 'Post-apply worksheet readback verification skipped — re-read threw',
+      logger: 'worksheetCommands',
+      data: { worksheetName, error: error instanceof Error ? error.message : String(error) },
+    });
+    return [];
+  }
+}
+
+/**
+ * Turn readback findings into a load outcome: ERROR-severity findings fail the apply
+ * (the rendered chart does not match intent), WARNING-severity findings ride along on a
+ * successful Ok so the tool can surface them without blocking.
+ */
+function readbackOutcome(findings: ReadbackFinding[]): LoadWorksheetXmlResult {
+  const errors = findings.filter((f) => f.severity === 'error');
+  if (errors.length > 0) {
+    return Err({
+      type: 'load-worksheet-xml-error',
+      error: {
+        type: 'readback-failed',
+        findings,
+        message: formatReadbackVerificationError(findings),
+      },
+    });
+  }
+  return Ok({ readbackWarnings: findings });
+}
 
 export async function loadWorksheetXml({
   worksheetName,
@@ -135,6 +205,13 @@ async function loadWorksheetXmlViaAgentApi({
     },
   });
 
+  // Verify the apply landed durably BEFORE focusing — an ERROR-severity readback means
+  // Tableau silently dropped intent-bearing nodes, so we reject and never navigate to the
+  // broken sheet (W4). WARNING-severity findings ride along on the successful Ok.
+  const findings = await verifyReadbackAfterApply(worksheetName, xml, executor, signal);
+  const outcomeResult = readbackOutcome(findings);
+  if (outcomeResult.isErr()) return outcomeResult;
+
   await focusAppliedSheetBestEffort({
     sheetName: worksheetName,
     appliedVia: 'load-worksheet',
@@ -142,7 +219,7 @@ async function loadWorksheetXmlViaAgentApi({
     signal,
   });
 
-  return Ok.EMPTY;
+  return outcomeResult;
 }
 
 async function loadWorksheetXmlViaExternalApi({
@@ -179,6 +256,10 @@ async function loadWorksheetXmlViaExternalApi({
       data: { worksheetName },
     });
 
+    const findings = await verifyReadbackAfterApply(worksheetName, xml, executor, signal);
+    const outcomeResult = readbackOutcome(findings);
+    if (outcomeResult.isErr()) return outcomeResult;
+
     await focusAppliedSheetBestEffort({
       sheetName: worksheetName,
       appliedVia: 'load-worksheet',
@@ -186,7 +267,7 @@ async function loadWorksheetXmlViaExternalApi({
       signal,
     });
 
-    return Ok.EMPTY;
+    return outcomeResult;
   });
 }
 

--- a/src/desktop/desktopDiscoverer.ts
+++ b/src/desktop/desktopDiscoverer.ts
@@ -12,6 +12,19 @@ const manifestSchema = z.object({
 
 export type DesktopInstanceManifest = z.infer<typeof manifestSchema>;
 
+/**
+ * Agent-actionable recovery text for a stale session (Desktop quit/restarted, or a
+ * cache file produced by a different Desktop instance). Shared by SessionManager's
+ * freshness gate and the cache-fingerprint bleed guard so both speak the same recovery.
+ */
+export function staleSessionRecoveryMessage(sessionId: string | number): string {
+  return (
+    `Session ${sessionId} is stale: that Tableau Desktop process is no longer reachable or was restarted. ` +
+    `Call list-instances and retry with the current session id. ` +
+    `Cached XML files from the old session may not match the current workbook — re-read before applying.`
+  );
+}
+
 export class DesktopDiscoverer {
   private readonly isPidAlive: (pid: number) => boolean;
 

--- a/src/desktop/desktopDiscoverer.ts
+++ b/src/desktop/desktopDiscoverer.ts
@@ -20,8 +20,8 @@ export type DesktopInstanceManifest = z.infer<typeof manifestSchema>;
 export function staleSessionRecoveryMessage(sessionId: string | number): string {
   return (
     `Session ${sessionId} is stale: that Tableau Desktop process is no longer reachable or was restarted. ` +
-    `Call list-instances and retry with the current session id. ` +
-    `Cached XML files from the old session may not match the current workbook — re-read before applying.`
+    'Call list-instances and retry with the current session id. ' +
+    'Cached XML files from the old session may not match the current workbook — re-read before applying.'
   );
 }
 

--- a/src/desktop/metadata/field-builder.test.ts
+++ b/src/desktop/metadata/field-builder.test.ts
@@ -177,4 +177,21 @@ describe('listAvailableFields', () => {
     const fields = listAvailableFields(withParams);
     expect(fields.find((f) => f.datasource === 'Parameters')).toBeUndefined();
   });
+
+  it('should preserve Tableau semantic-role attributes on available fields', () => {
+    const xml = `<?xml version='1.0' encoding='utf-8'?>
+<workbook>
+  <datasources>
+    <datasource name='GeoDS'>
+      <column name='[Territory]' role='dimension' type='nominal' datatype='string' semantic-role='[State].[Name]' />
+      <column name='[MRR]' role='measure' type='quantitative' datatype='real' />
+    </datasource>
+  </datasources>
+</workbook>`;
+    const availableFields = listAvailableFields(xml);
+    const territory = availableFields.find((f) => f.columnName === '[Territory]');
+    expect(territory?.semanticRole).toBe('[State].[Name]');
+    const mrr = availableFields.find((f) => f.columnName === '[MRR]');
+    expect(mrr?.semanticRole).toBeUndefined();
+  });
 });

--- a/src/desktop/metadata/field-builder.ts
+++ b/src/desktop/metadata/field-builder.ts
@@ -372,6 +372,7 @@ export function listAvailableFields(
       let type: string;
       let datatype: string;
       let caption: string | undefined;
+      let semanticRole: string | undefined;
 
       let isAggregated = false;
       let formula: string | undefined;
@@ -381,6 +382,7 @@ export function listAvailableFields(
         type = column['@_type'];
         datatype = column['@_datatype'];
         caption = column['@_caption'];
+        semanticRole = column['@_semantic-role'];
 
         if (column.calculation && column.calculation['@_formula']) {
           formula = column.calculation['@_formula'];
@@ -407,6 +409,7 @@ export function listAvailableFields(
         type = column['@_type'];
         datatype = column['@_datatype'];
         caption = column['@_caption'];
+        semanticRole = column['@_semantic-role'];
       } else {
         datatype = column['@_datatype'];
         caption = undefined;
@@ -448,6 +451,7 @@ export function listAvailableFields(
         role: role,
         datatype: datatype,
         caption: caption,
+        semanticRole: semanticRole,
         isAggregated: isAggregated,
         formula: formula,
         folder: folder,

--- a/src/desktop/metadata/types.ts
+++ b/src/desktop/metadata/types.ts
@@ -36,6 +36,7 @@ export interface FieldReference {
   type: string;
   role: string;
   datatype?: string;
+  semanticRole?: string; // Tableau geo semantic role, e.g. "[State].[Name]"
   caption?: string;
   isAggregated?: boolean;
   formula?: string;

--- a/src/desktop/sessionManager.test.ts
+++ b/src/desktop/sessionManager.test.ts
@@ -1,8 +1,9 @@
 import { existsSync, readFileSync } from 'fs';
 import { homedir } from 'os';
 
-import { DesktopInstanceManifest } from './desktopDiscoverer.js';
-import { SessionManager } from './sessionManager.js';
+import { DesktopDiscoverer, DesktopInstanceManifest } from './desktopDiscoverer.js';
+import { DesktopInstance } from './desktopInstance.js';
+import { SessionManager, SessionStaleError } from './sessionManager.js';
 import { LocalExecutor } from './toolExecutor/localToolExecutor.js';
 
 vi.mock('fs');
@@ -133,6 +134,70 @@ describe('SessionManager', () => {
       const executor2 = await sessionManager.getExecutor(sessionId2);
 
       expect(executor1).not.toBe(executor2);
+    });
+  });
+
+  // W9 — a cached executor can outlive its Desktop process. getExecutor re-verifies the
+  // cached instance against the live manifest before handing it back.
+  describe('stale-session freshness gate', () => {
+    function instance(over: Partial<DesktopInstance> = {}): DesktopInstance {
+      return new DesktopInstance({
+        pid: 12345,
+        port: 8765,
+        secret: 'test-secret-123',
+        start_time: '2024-01-15T10:30:00Z',
+        ...over,
+      });
+    }
+
+    /** A discoverer whose manifest can shift between calls (Desktop restart). */
+    function mkDiscoverer(seq: Array<Map<number, DesktopInstance>>): DesktopDiscoverer {
+      const d = new DesktopDiscoverer();
+      let i = 0;
+      vi.spyOn(d, 'getInstances').mockImplementation(() => seq[Math.min(i++, seq.length - 1)]);
+      return d;
+    }
+
+    it('returns the SAME cached executor when the instance is unchanged', async () => {
+      const live = new Map([[12345, instance()]]);
+      const sm = new SessionManager({ discoverer: mkDiscoverer([live, live, live]) });
+
+      const first = await sm.getExecutor('12345');
+      const second = await sm.getExecutor('12345');
+      expect(second).toBe(first);
+    });
+
+    it('throws SessionStaleError when the cached port shifts (Desktop restarted)', async () => {
+      const before = new Map([[12345, instance({ port: 8765 })]]);
+      const after = new Map([[12345, instance({ port: 9999, start_time: '2024-06-01T00:00:00Z' })]]);
+      const sm = new SessionManager({ discoverer: mkDiscoverer([before, after]) });
+
+      await sm.getExecutor('12345');
+      await expect(sm.getExecutor('12345')).rejects.toBeInstanceOf(SessionStaleError);
+    });
+
+    it('throws SessionStaleError when the pid vanishes from the manifest', async () => {
+      const before = new Map([[12345, instance()]]);
+      const gone = new Map<number, DesktopInstance>();
+      const sm = new SessionManager({ discoverer: mkDiscoverer([before, gone]) });
+
+      await sm.getExecutor('12345');
+      await expect(sm.getExecutor('12345')).rejects.toThrow(/stale/i);
+    });
+
+    it('evicts the stale session so a subsequent call rebuilds it fresh', async () => {
+      const before = new Map([[12345, instance({ port: 8765 })]]);
+      const restarted = new Map([
+        [12345, instance({ port: 9001, start_time: '2024-06-01T00:00:00Z' })],
+      ]);
+      const sm = new SessionManager({ discoverer: mkDiscoverer([before, restarted, restarted]) });
+
+      const original = await sm.getExecutor('12345');
+      await expect(sm.getExecutor('12345')).rejects.toBeInstanceOf(SessionStaleError);
+      // The eviction cleared the cache; the next call builds a NEW executor for the
+      // restarted instance rather than handing back the dead one.
+      const rebuilt = await sm.getExecutor('12345');
+      expect(rebuilt).not.toBe(original);
     });
   });
 });

--- a/src/desktop/sessionManager.test.ts
+++ b/src/desktop/sessionManager.test.ts
@@ -169,7 +169,9 @@ describe('SessionManager', () => {
 
     it('throws SessionStaleError when the cached port shifts (Desktop restarted)', async () => {
       const before = new Map([[12345, instance({ port: 8765 })]]);
-      const after = new Map([[12345, instance({ port: 9999, start_time: '2024-06-01T00:00:00Z' })]]);
+      const after = new Map([
+        [12345, instance({ port: 9999, start_time: '2024-06-01T00:00:00Z' })],
+      ]);
       const sm = new SessionManager({ discoverer: mkDiscoverer([before, after]) });
 
       await sm.getExecutor('12345');

--- a/src/desktop/sessionManager.ts
+++ b/src/desktop/sessionManager.ts
@@ -2,7 +2,7 @@ import { Err, Ok, Result } from 'ts-results-es';
 
 import { getDesktopConfig } from '../config.desktop.js';
 import { log } from '../logging/logger.js';
-import { DesktopDiscoverer } from './desktopDiscoverer.js';
+import { DesktopDiscoverer, staleSessionRecoveryMessage } from './desktopDiscoverer.js';
 import { DesktopInstance } from './desktopInstance.js';
 import { discoverInstances } from './externalApi/discovery.js';
 import { ExternalApiToolExecutor } from './externalApi/externalApiToolExecutor.js';
@@ -16,11 +16,44 @@ export type DesktopConnection = {
   desktopInstance?: DesktopInstance;
 };
 
+/**
+ * Thrown when a cached session's Desktop instance no longer matches the live manifest
+ * (Desktop quit/restarted, so a new process reused — or shifted — the pid/port). The
+ * message is agent-actionable: re-list instances, retry with the current session id,
+ * re-read stale caches (W9).
+ */
+export class SessionStaleError extends Error {
+  constructor(sessionId: string | number) {
+    super(staleSessionRecoveryMessage(sessionId));
+    this.name = 'SessionStaleError';
+  }
+}
+
 export class SessionManager {
   private readonly sessions: Map<string, DesktopConnection> = new Map();
+  private readonly discoverer: DesktopDiscoverer;
+
+  constructor({ discoverer }: { discoverer?: DesktopDiscoverer } = {}) {
+    this.discoverer = discoverer ?? new DesktopDiscoverer();
+  }
+
+  /** The Desktop instance a cached local session is pinned to (for cache fingerprinting). */
+  getDesktopInstance(sessionId: string): DesktopInstance | undefined {
+    return this.sessions.get(sessionId)?.desktopInstance;
+  }
 
   async getExecutor(sessionId: string): Promise<ToolExecutor> {
     let session = this.sessions.get(sessionId);
+
+    // A cached executor can outlive its Desktop process: quit/restart replaces the
+    // manifest entry but the cached DesktopConnection lingers. Before handing the
+    // executor out, verify the cached instance still matches the live manifest — a
+    // cheap manifest read, no HTTP — and evict + throw actionably on mismatch (W9).
+    // Skipped in external-API mode (no cached DesktopInstance to compare against).
+    if (session && session.desktopInstance && !getDesktopConfig().externalApiEnabled) {
+      this.ensureCachedLocalSessionFresh(sessionId, session);
+      session = this.sessions.get(sessionId);
+    }
 
     if (!session) {
       const sessionIdResult = parseSessionId(sessionId);
@@ -42,8 +75,7 @@ export class SessionManager {
         });
         await executor.start();
       } else {
-        const desktopDiscoverer = new DesktopDiscoverer();
-        desktopInstance = desktopDiscoverer.getInstance(pid);
+        desktopInstance = this.discoverer.getInstance(pid);
         executor = new LocalExecutor({
           agentApiBase: `http://127.0.0.1:${desktopInstance.port}/api/v1`,
           authToken: desktopInstance.secret,
@@ -74,6 +106,61 @@ export class SessionManager {
 
     session.lastAccess = Date.now();
     return session.executor;
+  }
+
+  /**
+   * Verify a cached local session's Desktop instance still matches the live manifest.
+   * A restarted Desktop keeps the same pid rarely but almost always shifts port and
+   * always changes start_time, so a port/start_time mismatch (or a pid gone from the
+   * manifest) means the cached executor points at a dead or different process. Evict
+   * and throw SessionStaleError on mismatch. A manifest with no matching pid also
+   * evicts. Never mutates state when the cached instance is still current.
+   */
+  private ensureCachedLocalSessionFresh(sessionId: string, session: DesktopConnection): void {
+    const cached = session.desktopInstance;
+    if (!cached) return;
+
+    const current = this.discoverer.getInstances().get(cached.pid);
+    if (!current || current.port !== cached.port || current.start_time !== cached.start_time) {
+      this.evictStaleSession(sessionId, session, current);
+    }
+  }
+
+  private evictStaleSession(
+    sessionId: string,
+    session: DesktopConnection,
+    current?: DesktopInstance,
+  ): never {
+    try {
+      session.executor.stop();
+    } catch (error) {
+      log({
+        message: 'Failed to stop stale session executor',
+        level: 'warning',
+        logger: 'SessionManager',
+        data: { sessionId, error: String(error) },
+      });
+    }
+    this.sessions.delete(sessionId);
+    log({
+      message: 'Session stale — evicted',
+      level: 'warning',
+      logger: 'SessionManager',
+      data: {
+        sessionId,
+        cached: session.desktopInstance
+          ? {
+              pid: session.desktopInstance.pid,
+              port: session.desktopInstance.port,
+              start_time: session.desktopInstance.start_time,
+            }
+          : null,
+        current: current
+          ? { pid: current.pid, port: current.port, start_time: current.start_time }
+          : null,
+      },
+    });
+    throw new SessionStaleError(sessionId);
   }
 }
 

--- a/src/desktop/sessionManager.ts
+++ b/src/desktop/sessionManager.ts
@@ -31,10 +31,20 @@ export class SessionStaleError extends Error {
 
 export class SessionManager {
   private readonly sessions: Map<string, DesktopConnection> = new Map();
-  private readonly discoverer: DesktopDiscoverer;
+  private injectedDiscoverer?: DesktopDiscoverer;
+  private lazyDiscoverer?: DesktopDiscoverer;
 
   constructor({ discoverer }: { discoverer?: DesktopDiscoverer } = {}) {
-    this.discoverer = discoverer ?? new DesktopDiscoverer();
+    this.injectedDiscoverer = discoverer;
+  }
+
+  /**
+   * The manifest reader, constructed lazily. Constructing it eagerly would consult
+   * discovery machinery even for an explicit-session tool call that never needs it, so
+   * it is built only on first real use (session create or the freshness gate).
+   */
+  private get discoverer(): DesktopDiscoverer {
+    return (this.injectedDiscoverer ??= this.lazyDiscoverer ??= new DesktopDiscoverer());
   }
 
   /** The Desktop instance a cached local session is pinned to (for cache fingerprinting). */

--- a/src/desktop/validation/readback-verify.test.ts
+++ b/src/desktop/validation/readback-verify.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from 'vitest';
+
+import { verifyWorksheetReadback } from './readback-verify.js';
+
+const GEO_FIELD = '[DS].[none:State:nk]';
+const PROFIT_FIELD = '[DS].[sum:Profit:qk]';
+const SALES_FIELD = '[DS].[sum:Sales:qk]';
+
+function worksheet(inner: string): string {
+  return `<worksheet name="Blank Map"><table>${inner}</table></worksheet>`;
+}
+
+function encodedWorksheet(extra = ''): string {
+  return worksheet(`
+    <view>
+      <computed-sort column="${GEO_FIELD}" direction="DESC" using="${PROFIT_FIELD}"/>
+    </view>
+    <panes><pane>
+      <mark class="Shape"/>
+      <encodings>
+        <lod column="${GEO_FIELD}"/>
+        <color column="${PROFIT_FIELD}"/>
+      </encodings>
+    </pane></panes>
+    <filter class="categorical" column="${GEO_FIELD}"/>
+    <rows>${GEO_FIELD}</rows>
+    <cols>${PROFIT_FIELD}</cols>
+    ${extra}
+  `);
+}
+
+describe('verifyWorksheetReadback', () => {
+  it('flags intended lod encodings that Tableau silently strips on readback', () => {
+    const readback = encodedWorksheet().replace(`<lod column="${GEO_FIELD}"/>`, '');
+
+    const findings = verifyWorksheetReadback(encodedWorksheet(), readback);
+
+    expect(findings).toContainEqual({
+      kind: 'encoding',
+      node: 'lod',
+      column: GEO_FIELD,
+      intended: `<lod column="${GEO_FIELD}">`,
+      readback: 'missing',
+      severity: 'error',
+    });
+  });
+
+  it('returns no findings for an identical readback', () => {
+    const xml = encodedWorksheet();
+
+    expect(verifyWorksheetReadback(xml, xml)).toEqual([]);
+  });
+
+  it('flags dropped filters by filter class and column', () => {
+    const readback = encodedWorksheet().replace(
+      `<filter class="categorical" column="${GEO_FIELD}"/>`,
+      '',
+    );
+
+    const findings = verifyWorksheetReadback(encodedWorksheet(), readback);
+
+    expect(findings).toContainEqual({
+      kind: 'filter',
+      node: 'filter',
+      column: GEO_FIELD,
+      intended: `<filter class="categorical" column="${GEO_FIELD}">`,
+      readback: 'missing',
+      severity: 'error',
+    });
+  });
+
+  it('flags changed sorts as warnings', () => {
+    const readback = encodedWorksheet().replace(
+      `direction="DESC" using="${PROFIT_FIELD}"`,
+      `direction="ASC" using="${SALES_FIELD}"`,
+    );
+
+    const findings = verifyWorksheetReadback(encodedWorksheet(), readback);
+
+    expect(findings).toContainEqual({
+      kind: 'sort',
+      node: 'computed-sort',
+      column: GEO_FIELD,
+      intended: `<computed-sort column="${GEO_FIELD}" direction="DESC" using="${PROFIT_FIELD}">`,
+      readback: 'changed',
+      severity: 'warning',
+    });
+  });
+
+  it('flags changed shelf expressions and mark classes as errors', () => {
+    const readback = encodedWorksheet()
+      .replace(`<rows>${GEO_FIELD}</rows>`, `<rows>${SALES_FIELD}</rows>`)
+      .replace(`<mark class="Shape"/>`, `<mark class="Bar"/>`);
+
+    const findings = verifyWorksheetReadback(encodedWorksheet(), readback);
+
+    expect(findings).toEqual(
+      expect.arrayContaining([
+        {
+          kind: 'shelf',
+          node: 'rows',
+          column: GEO_FIELD,
+          intended: GEO_FIELD,
+          readback: 'changed',
+          severity: 'error',
+        },
+        {
+          kind: 'mark',
+          node: 'mark',
+          intended: `<mark class="Shape">`,
+          readback: 'changed',
+          severity: 'error',
+        },
+      ]),
+    );
+  });
+
+  it('tolerates Tableau-added readback noise such as style and formatting nodes', () => {
+    const readback = encodedWorksheet(`
+      <style><style-rule element="worksheet"><format attr="font-size" value="10"/></style-rule></style>
+      <format attr="border-color" value="#ffffff"/>
+    `);
+
+    expect(verifyWorksheetReadback(encodedWorksheet(), readback)).toEqual([]);
+  });
+});
+
+describe('verifyWorksheetReadback — column-instance co-dependency (RT finding RB-03)', () => {
+  const withDeps = (deps: string): string =>
+    `<worksheet name="Map"><table>
+      <view><datasource-dependencies datasource="DS">${deps}</datasource-dependencies></view>
+      <panes><pane><mark class="Shape"/><encodings><lod column="[DS].[none:Location:nk]"/></encodings></pane></panes>
+      <rows>[DS].[avg:Latitude:qk]</rows>
+    </table></worksheet>`;
+  const CI = `<column-instance column="[Location]" derivation="None" name="[none:Location:nk]" pivot="key" type="nominal"/>`;
+
+  it('flags a surviving <lod> tag whose column-instance declaration was dropped', () => {
+    const findings = verifyWorksheetReadback(withDeps(CI), withDeps(''));
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({
+      kind: 'encoding',
+      node: 'column-instance',
+      column: '[none:Location:nk]',
+      readback: 'missing',
+      severity: 'error',
+    });
+  });
+
+  it('passes when the declaration survives with the tag', () => {
+    expect(verifyWorksheetReadback(withDeps(CI), withDeps(CI))).toHaveLength(0);
+  });
+
+  it('does not double-report when the encoding itself is missing (tag finding already covers it)', () => {
+    const readbackNoLod = withDeps(CI)
+      .replace('<encodings><lod column="[DS].[none:Location:nk]"/></encodings>', '<encodings/>')
+      .replace(CI, '');
+    const findings = verifyWorksheetReadback(withDeps(CI), readbackNoLod);
+    expect(findings.filter((f) => f.node === 'column-instance')).toHaveLength(0);
+    expect(findings.filter((f) => f.node === 'lod')).toHaveLength(1);
+  });
+
+  it('does not fire when the intended XML never declared the instance either', () => {
+    expect(verifyWorksheetReadback(withDeps(''), withDeps(''))).toHaveLength(0);
+  });
+});

--- a/src/desktop/validation/readback-verify.test.ts
+++ b/src/desktop/validation/readback-verify.test.ts
@@ -115,6 +115,38 @@ describe('verifyWorksheetReadback', () => {
     );
   });
 
+  it('does not flag an authored Automatic mark that Tableau resolved to a concrete class', () => {
+    const intended = encodedWorksheet().replace(
+      '<mark class="Shape"/>',
+      '<mark class="Automatic"/>',
+    );
+    const readback = encodedWorksheet().replace('<mark class="Shape"/>', '<mark class="Bar"/>');
+
+    const findings = verifyWorksheetReadback(intended, readback);
+
+    expect(findings.some((f) => f.kind === 'mark')).toBe(false);
+  });
+
+  it('still flags an Automatic mark that is entirely absent from the readback (real drop)', () => {
+    const intended = encodedWorksheet().replace(
+      '<mark class="Shape"/>',
+      '<mark class="Automatic"/>',
+    );
+    const readback = encodedWorksheet()
+      .replace('<panes><pane>', '<panes><pane2>')
+      .replace('</pane></panes>', '</pane2></panes>');
+
+    const findings = verifyWorksheetReadback(intended, readback);
+
+    expect(findings).toContainEqual({
+      kind: 'mark',
+      node: 'mark',
+      intended: '<mark class="Automatic">',
+      readback: 'missing',
+      severity: 'error',
+    });
+  });
+
   it('tolerates Tableau-added readback noise such as style and formatting nodes', () => {
     const readback = encodedWorksheet(`
       <style><style-rule element="worksheet"><format attr="font-size" value="10"/></style-rule></style>

--- a/src/desktop/validation/readback-verify.test.ts
+++ b/src/desktop/validation/readback-verify.test.ts
@@ -90,7 +90,7 @@ describe('verifyWorksheetReadback', () => {
   it('flags changed shelf expressions and mark classes as errors', () => {
     const readback = encodedWorksheet()
       .replace(`<rows>${GEO_FIELD}</rows>`, `<rows>${SALES_FIELD}</rows>`)
-      .replace(`<mark class="Shape"/>`, `<mark class="Bar"/>`);
+      .replace('<mark class="Shape"/>', '<mark class="Bar"/>');
 
     const findings = verifyWorksheetReadback(encodedWorksheet(), readback);
 
@@ -107,7 +107,7 @@ describe('verifyWorksheetReadback', () => {
         {
           kind: 'mark',
           node: 'mark',
-          intended: `<mark class="Shape">`,
+          intended: '<mark class="Shape">',
           readback: 'changed',
           severity: 'error',
         },
@@ -132,7 +132,8 @@ describe('verifyWorksheetReadback — column-instance co-dependency (RT finding 
       <panes><pane><mark class="Shape"/><encodings><lod column="[DS].[none:Location:nk]"/></encodings></pane></panes>
       <rows>[DS].[avg:Latitude:qk]</rows>
     </table></worksheet>`;
-  const CI = `<column-instance column="[Location]" derivation="None" name="[none:Location:nk]" pivot="key" type="nominal"/>`;
+  const CI =
+    '<column-instance column="[Location]" derivation="None" name="[none:Location:nk]" pivot="key" type="nominal"/>';
 
   it('flags a surviving <lod> tag whose column-instance declaration was dropped', () => {
     const findings = verifyWorksheetReadback(withDeps(CI), withDeps(''));

--- a/src/desktop/validation/readback-verify.ts
+++ b/src/desktop/validation/readback-verify.ts
@@ -1,0 +1,364 @@
+/**
+ * Post-apply worksheet readback verification.
+ *
+ * Tableau Desktop can accept a worksheet apply and then silently strip nodes it
+ * cannot persist. This verifier compares only the intent-bearing worksheet
+ * structures that must survive for the rendered chart to match the authored
+ * XML, while tolerating readback-only formatting/style noise.
+ */
+import { normalizeArray, parseXML } from '../metadata/parser.js';
+
+export type ReadbackFindingKind = 'encoding' | 'shelf' | 'mark' | 'filter' | 'sort';
+export type ReadbackFindingSeverity = 'error' | 'warning';
+
+export interface ReadbackFinding {
+  kind: ReadbackFindingKind;
+  node: string;
+  column?: string;
+  intended: string;
+  readback: 'missing' | 'changed';
+  severity: ReadbackFindingSeverity;
+}
+
+type XmlRecord = Record<string, any>;
+
+interface EncodingSignature {
+  paneIndex: number;
+  tag: string;
+  column: string;
+}
+
+interface MarkSignature {
+  paneIndex: number;
+  klass: string;
+}
+
+interface FilterSignature {
+  klass: string;
+  column: string;
+}
+
+interface SortSignature {
+  tag: 'shelf-sort-v2' | 'computed-sort';
+  column: string;
+  direction: string;
+  using: string;
+  shelf: string;
+  field: string;
+}
+
+interface WorksheetSignature {
+  encodings: EncodingSignature[];
+  shelves: {
+    rows: string[];
+    cols: string[];
+  };
+  marks: MarkSignature[];
+  filters: FilterSignature[];
+  sorts: SortSignature[];
+  /** column-instance names declared in datasource-dependencies, e.g. "[none:Location:nk]". */
+  declaredInstances: Set<string>;
+}
+
+function isRecord(value: unknown): value is XmlRecord {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function attr(node: XmlRecord, name: string): string {
+  const value = node[`@_${name}`];
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function textValue(value: unknown): string {
+  if (typeof value === 'string') return value.trim();
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value).trim();
+  if (isRecord(value) && typeof value['#text'] === 'string') return value['#text'].trim();
+  return '';
+}
+
+function worksheetRoot(parsed: XmlRecord): XmlRecord | null {
+  const rootWorksheet = normalizeArray(parsed.worksheet).find(isRecord);
+  if (rootWorksheet) return rootWorksheet;
+  const firstWorkbookWorksheet = normalizeArray(parsed.workbook?.worksheets?.worksheet).find(
+    isRecord,
+  );
+  return firstWorkbookWorksheet ?? null;
+}
+
+function directChildren(parent: XmlRecord | undefined, key: string): XmlRecord[] {
+  if (!parent) return [];
+  return normalizeArray(parent[key]).filter(isRecord);
+}
+
+function walkElements(node: unknown, visit: (tag: string, element: XmlRecord) => void): void {
+  if (!isRecord(node)) return;
+  for (const [tag, value] of Object.entries(node)) {
+    if (tag.startsWith('@_') || tag === '#text') continue;
+    for (const child of normalizeArray(value)) {
+      if (!isRecord(child)) continue;
+      visit(tag, child);
+      walkElements(child, visit);
+    }
+  }
+}
+
+function shelfValues(value: unknown): string[] {
+  return normalizeArray(value)
+    .flatMap((item) => textValue(item).split('/'))
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function collectEncodings(worksheet: XmlRecord): EncodingSignature[] {
+  const panes = directChildren(worksheet.table?.panes, 'pane');
+  const out: EncodingSignature[] = [];
+  panes.forEach((pane, paneIndex) => {
+    const encodings = isRecord(pane.encodings) ? pane.encodings : undefined;
+    if (!encodings) return;
+    for (const [tag, value] of Object.entries(encodings)) {
+      if (tag.startsWith('@_') || tag === '#text') continue;
+      for (const encoding of normalizeArray(value).filter(isRecord)) {
+        out.push({ paneIndex, tag, column: attr(encoding, 'column') });
+      }
+    }
+  });
+  return out;
+}
+
+function collectMarks(worksheet: XmlRecord): MarkSignature[] {
+  const panes = directChildren(worksheet.table?.panes, 'pane');
+  return panes.flatMap((pane, paneIndex) => {
+    const mark = isRecord(pane.mark) ? pane.mark : null;
+    const klass = mark ? attr(mark, 'class') : '';
+    return klass ? [{ paneIndex, klass }] : [];
+  });
+}
+
+function collectFilters(worksheet: XmlRecord): FilterSignature[] {
+  const filters: FilterSignature[] = [];
+  walkElements(worksheet, (tag, element) => {
+    if (tag !== 'filter') return;
+    filters.push({ klass: attr(element, 'class'), column: attr(element, 'column') });
+  });
+  return filters;
+}
+
+function collectDeclaredInstances(worksheet: XmlRecord): Set<string> {
+  const declared = new Set<string>();
+  walkElements(worksheet, (tag, element) => {
+    if (tag !== 'column-instance') return;
+    const name = attr(element, 'name');
+    if (name) declared.add(name);
+  });
+  return declared;
+}
+
+/** The bracketed instance segment of an encoding column ref: "[DS].[none:X:nk]" → "[none:X:nk]". */
+function instanceNameFromColumnRef(columnRef: string): string | null {
+  const m = /(\[[^\]]+\])\s*$/.exec(columnRef);
+  return m ? m[1] : null;
+}
+
+function collectSorts(worksheet: XmlRecord): SortSignature[] {
+  const sorts: SortSignature[] = [];
+  walkElements(worksheet, (tag, element) => {
+    if (tag !== 'shelf-sort-v2' && tag !== 'computed-sort') return;
+    sorts.push({
+      tag,
+      column: attr(element, 'column'),
+      direction: attr(element, 'direction'),
+      using: attr(element, 'using'),
+      shelf: attr(element, 'shelf'),
+      field: attr(element, 'field'),
+    });
+  });
+  return sorts;
+}
+
+function signature(xml: string): WorksheetSignature | null {
+  try {
+    const parsed = parseXML(xml) as XmlRecord;
+    const worksheet = worksheetRoot(parsed);
+    if (!worksheet) return null;
+    return {
+      encodings: collectEncodings(worksheet),
+      shelves: {
+        rows: shelfValues(worksheet.table?.rows),
+        cols: shelfValues(worksheet.table?.cols),
+      },
+      marks: collectMarks(worksheet),
+      filters: collectFilters(worksheet),
+      sorts: collectSorts(worksheet),
+      declaredInstances: collectDeclaredInstances(worksheet),
+    };
+  } catch {
+    return null;
+  }
+}
+
+function encodingIntended(sig: EncodingSignature): string {
+  return sig.column ? `<${sig.tag} column="${sig.column}">` : `<${sig.tag}>`;
+}
+
+function filterIntended(sig: FilterSignature): string {
+  const klass = sig.klass ? ` class="${sig.klass}"` : '';
+  const column = sig.column ? ` column="${sig.column}"` : '';
+  return `<filter${klass}${column}>`;
+}
+
+function sortIntended(sig: SortSignature): string {
+  const attrs = [
+    sig.column ? `column="${sig.column}"` : '',
+    sig.direction ? `direction="${sig.direction}"` : '',
+    sig.using ? `using="${sig.using}"` : '',
+    sig.shelf ? `shelf="${sig.shelf}"` : '',
+    sig.field ? `field="${sig.field}"` : '',
+  ]
+    .filter(Boolean)
+    .join(' ');
+  return attrs ? `<${sig.tag} ${attrs}>` : `<${sig.tag}>`;
+}
+
+function sameEncoding(a: EncodingSignature, b: EncodingSignature): boolean {
+  return a.paneIndex === b.paneIndex && a.tag === b.tag && a.column === b.column;
+}
+
+function sameFilter(a: FilterSignature, b: FilterSignature): boolean {
+  return a.klass === b.klass && a.column === b.column;
+}
+
+function sameSort(a: SortSignature, b: SortSignature): boolean {
+  return (
+    a.tag === b.tag &&
+    a.column === b.column &&
+    a.direction === b.direction &&
+    a.using === b.using &&
+    a.shelf === b.shelf &&
+    a.field === b.field
+  );
+}
+
+function sortRelated(a: SortSignature, b: SortSignature): boolean {
+  return a.tag === b.tag && a.column === b.column;
+}
+
+export function verifyWorksheetReadback(
+  intendedXml: string,
+  readbackXml: string,
+): ReadbackFinding[] {
+  const intended = signature(intendedXml);
+  const readback = signature(readbackXml);
+  if (!intended || !readback) return [];
+
+  const findings: ReadbackFinding[] = [];
+
+  for (const enc of intended.encodings) {
+    if (readback.encodings.some((candidate) => sameEncoding(enc, candidate))) continue;
+    const related = readback.encodings.some(
+      (candidate) => candidate.paneIndex === enc.paneIndex && candidate.tag === enc.tag,
+    );
+    findings.push({
+      kind: 'encoding',
+      node: enc.tag,
+      column: enc.column || undefined,
+      intended: encodingIntended(enc),
+      readback: related ? 'changed' : 'missing',
+      severity: 'error',
+    });
+  }
+
+  // An encoding tag can survive while its column-instance declaration is dropped —
+  // the encoding is then inert (LOD encodings and their CIs are co-dependent; see
+  // tactics/viz/marks-and-encodings.md). Require the declaration too. (RT finding RB-03)
+  for (const enc of intended.encodings) {
+    if (!enc.column) continue;
+    const instanceName = instanceNameFromColumnRef(enc.column);
+    if (!instanceName || !intended.declaredInstances.has(instanceName)) continue;
+    if (readback.declaredInstances.has(instanceName)) continue;
+    if (!readback.encodings.some((candidate) => sameEncoding(enc, candidate))) continue; // already reported above
+    findings.push({
+      kind: 'encoding',
+      node: 'column-instance',
+      column: instanceName,
+      intended: `<column-instance name="${instanceName}">`,
+      readback: 'missing',
+      severity: 'error',
+    });
+  }
+
+  for (const shelf of ['rows', 'cols'] as const) {
+    for (const value of intended.shelves[shelf]) {
+      if (readback.shelves[shelf].includes(value)) continue;
+      findings.push({
+        kind: 'shelf',
+        node: shelf,
+        column: value,
+        intended: value,
+        readback: readback.shelves[shelf].length > 0 ? 'changed' : 'missing',
+        severity: 'error',
+      });
+    }
+  }
+
+  for (const mark of intended.marks) {
+    const candidate = readback.marks.find((item) => item.paneIndex === mark.paneIndex);
+    if (candidate?.klass === mark.klass) continue;
+    findings.push({
+      kind: 'mark',
+      node: 'mark',
+      intended: `<mark class="${mark.klass}">`,
+      readback: candidate ? 'changed' : 'missing',
+      severity: 'error',
+    });
+  }
+
+  for (const filter of intended.filters) {
+    if (readback.filters.some((candidate) => sameFilter(filter, candidate))) continue;
+    const related = readback.filters.some((candidate) => candidate.klass === filter.klass);
+    findings.push({
+      kind: 'filter',
+      node: 'filter',
+      column: filter.column || undefined,
+      intended: filterIntended(filter),
+      readback: related ? 'changed' : 'missing',
+      severity: 'error',
+    });
+  }
+
+  for (const sort of intended.sorts) {
+    if (readback.sorts.some((candidate) => sameSort(sort, candidate))) continue;
+    findings.push({
+      kind: 'sort',
+      node: sort.tag,
+      column: sort.column || undefined,
+      intended: sortIntended(sort),
+      readback: readback.sorts.some((candidate) => sortRelated(sort, candidate))
+        ? 'changed'
+        : 'missing',
+      severity: 'warning',
+    });
+  }
+
+  return findings;
+}
+
+export function formatReadbackFinding(finding: ReadbackFinding): string {
+  const column = finding.column ? ` column="${finding.column}"` : '';
+  return `<${finding.node}${column}>`;
+}
+
+export function formatReadbackVerificationError(findings: ReadbackFinding[]): string {
+  const errors = findings.filter((finding) => finding.severity === 'error');
+  if (errors.length === 0) return '';
+  return (
+    `apply succeeded but Tableau silently dropped: ${errors.map(formatReadbackFinding).join(', ')}. ` +
+    'The rendered chart does NOT match the intent — likely an invalid/unsupported node. ' +
+    'Fix the worksheet XML to use Tableau-supported shelf, mark, filter, and encoding nodes, then re-apply.'
+  );
+}
+
+export function formatReadbackVerificationWarnings(findings: ReadbackFinding[]): string {
+  const warnings = findings.filter((finding) => finding.severity === 'warning');
+  if (warnings.length === 0) return '';
+  return `\n\n⚠️ Readback verification warning — Tableau changed or dropped: ${warnings.map(formatReadbackFinding).join(', ')}. Re-check the rendered chart before moving on.`;
+}

--- a/src/desktop/validation/readback-verify.ts
+++ b/src/desktop/validation/readback-verify.ts
@@ -303,6 +303,11 @@ export function verifyWorksheetReadback(
   for (const mark of intended.marks) {
     const candidate = readback.marks.find((item) => item.paneIndex === mark.paneIndex);
     if (candidate?.klass === mark.klass) continue;
+    // An authored `Automatic` mark is resolved by Tableau to a concrete class (Bar,
+    // Circle, …) on readback — that is expected resolution, not a dropped mark. Any
+    // concrete class in the same pane satisfies an intended `Automatic`; only a truly
+    // absent mark (no candidate) is a real drop. (False-positive guard, RB readback.)
+    if (mark.klass.toLowerCase() === 'automatic' && candidate) continue;
     findings.push({
       kind: 'mark',
       node: 'mark',

--- a/src/errors/mcpToolError.ts
+++ b/src/errors/mcpToolError.ts
@@ -330,6 +330,16 @@ export class XmlModificationError extends McpToolError {
   }
 }
 
+/**
+ * Refuse to apply a cache file whose instance fingerprint does not match the current
+ * Desktop session (cross-instance cache bleed, W9). `message` carries the recovery recipe.
+ */
+export class CacheSessionMismatchError extends McpToolError {
+  constructor(message: string) {
+    super({ type: 'cache-session-mismatch', message, statusCode: 409 });
+  }
+}
+
 export class XmlValidationError extends McpToolError {
   constructor(errors: string[]) {
     const errorList = errors.map((e, i) => `${i + 1}. ${e}`).join('\n');

--- a/src/tools/desktop/coordination/batchCreateAndCacheSheets.ts
+++ b/src/tools/desktop/coordination/batchCreateAndCacheSheets.ts
@@ -4,6 +4,7 @@ import { Ok } from 'ts-results-es';
 import { z } from 'zod';
 
 import { DesktopCache } from '../../../desktop/cache.js';
+import { writeSidecar } from '../../../desktop/commands/workbook/cacheFingerprint.js';
 import { getDashboardXml } from '../../../desktop/commands/workbook/getDashboardXml.js';
 import { getWorkbookXml } from '../../../desktop/commands/workbook/getWorkbookXml.js';
 import { getWorksheetXml } from '../../../desktop/commands/workbook/getWorksheetXml.js';
@@ -126,6 +127,9 @@ export const getBatchCreateAndCacheSheetsTool = (
             id: 'for-parallel-build',
           });
           writeFileSync(workbookFile, workbookXml, 'utf-8');
+          // Fingerprint the cache with the producing Desktop instance so a Phase-2 apply
+          // can refuse a cache from a different (or restarted) Desktop session (W9).
+          writeSidecar(workbookFile, resolvedSession);
 
           // Fetch and cache all worksheet working copies.
           const worksheetFiles: Record<string, string> = {};
@@ -144,6 +148,7 @@ export const getBatchCreateAndCacheSheetsTool = (
             const safeWsName = name.replace(/[^a-zA-Z0-9]/g, '_');
             const file = cache.getCacheFilePath({ prefix: 'worksheet', id: safeWsName });
             writeFileSync(file, wsResult.value, 'utf-8');
+            writeSidecar(file, resolvedSession);
             worksheetFiles[name] = file;
           }
 
@@ -159,6 +164,7 @@ export const getBatchCreateAndCacheSheetsTool = (
             const safeDashName = dashboardName.replace(/[^a-zA-Z0-9]/g, '_');
             dashboardFile = cache.getCacheFilePath({ prefix: 'dashboard', id: safeDashName });
             writeFileSync(dashboardFile, dashResult.value, 'utf-8');
+            writeSidecar(dashboardFile, resolvedSession);
           }
 
           const worksheetFileLines = Object.entries(worksheetFiles)

--- a/src/tools/desktop/coordination/buildAndApplyWorksheet.characterization.test.ts
+++ b/src/tools/desktop/coordination/buildAndApplyWorksheet.characterization.test.ts
@@ -82,7 +82,7 @@ function makeExtra(workbookXml = WORKBOOK_WITH_CAPTION): TableauDesktopRequestHa
     { name: 'M2', role: 'measure', datatype: 'real', type: 'quantitative' },
   ]);
   vi.mocked(rewriteFieldReferences).mockReturnValue(WORKSHEET_OUTPUT);
-  vi.mocked(loadWorksheetXml).mockResolvedValue(new Ok(undefined));
+  vi.mocked(loadWorksheetXml).mockResolvedValue(new Ok({ readbackWarnings: [] }));
   return extra;
 }
 
@@ -314,7 +314,7 @@ describe('buildAndApplyWorksheetTool — mapping construction characterization',
     const capturedXml: string[] = [];
     vi.mocked(loadWorksheetXml).mockImplementation(async ({ xml }) => {
       capturedXml.push(xml);
-      return new Ok(undefined);
+      return new Ok({ readbackWarnings: [] });
     });
 
     // Two applies into the same workbook; no fields needed — we only exercise the calc.

--- a/src/tools/desktop/coordination/buildAndApplyWorksheet.test.ts
+++ b/src/tools/desktop/coordination/buildAndApplyWorksheet.test.ts
@@ -61,7 +61,7 @@ function makeExtra(): TableauDesktopRequestHandlerExtra {
     { name: 'Sales', role: 'measure', datatype: 'integer', type: 'quantitative' },
   ]);
   vi.mocked(rewriteFieldReferences).mockReturnValue(TEMPLATE_XML);
-  vi.mocked(loadWorksheetXml).mockResolvedValue(new Ok(undefined));
+  vi.mocked(loadWorksheetXml).mockResolvedValue(new Ok({ readbackWarnings: [] }));
   return extra;
 }
 

--- a/src/tools/desktop/coordination/buildAndApplyWorksheet.ts
+++ b/src/tools/desktop/coordination/buildAndApplyWorksheet.ts
@@ -9,6 +9,7 @@ import {
   formatExplicitBindErrors,
   schemaSummaryFromAvailableFields,
 } from '../../../desktop/binder/explicit-bind.js';
+import { checkSidecar } from '../../../desktop/commands/workbook/cacheFingerprint.js';
 import { loadWorksheetXml } from '../../../desktop/commands/workbook/loadWorksheetXml.js';
 import { listAvailableFields } from '../../../desktop/metadata/index.js';
 import {
@@ -23,6 +24,7 @@ import { getTemplateColumnRequirements } from '../../../desktop/templates/templa
 import { readTemplate } from '../../../desktop/templates/templatePath.js';
 import {
   ArgsValidationError,
+  CacheSessionMismatchError,
   DesktopCommandExecutionError,
   FileNotFoundError,
   WorksheetXmlLoadFailedError,
@@ -128,6 +130,13 @@ export const getBuildAndApplyWorksheetTool = (
           );
           if (gateResult) {
             return new Ok(gateResult);
+          }
+
+          // Cross-instance cache-bleed guard (W9): refuse a cache produced by a different
+          // (or restarted) Desktop session — its XML may not match the current workbook.
+          const workbookSidecar = checkSidecar(workbookFile, resolvedSession, 'workbook');
+          if (!workbookSidecar.ok) {
+            return new CacheSessionMismatchError(workbookSidecar.message!).toErr();
           }
 
           const workbookXml = readFileSync(workbookFile, 'utf-8');

--- a/src/tools/desktop/dashboard/applyDashboard.test.ts
+++ b/src/tools/desktop/dashboard/applyDashboard.test.ts
@@ -3,6 +3,7 @@ import { existsSync, readFileSync } from 'fs';
 import { Err, Ok } from 'ts-results-es';
 import { z } from 'zod';
 
+import * as cacheFingerprintModule from '../../../desktop/commands/workbook/cacheFingerprint.js';
 import * as loadDashboardXmlModule from '../../../desktop/commands/workbook/loadDashboardXml.js';
 import {
   ArgsValidationError,
@@ -71,6 +72,29 @@ describe('applyDashboardTool', () => {
     expect(resultObj.message).toContain('Successfully applied dashboard update');
     expect(existsSync).toHaveBeenCalledWith(mockFilePath);
     expect(readFileSync).toHaveBeenCalledWith(mockFilePath, 'utf-8');
+  });
+
+  it('refuses a file-mode apply when the cache sidecar fingerprint mismatches the session (W9)', async () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue('<dashboard name="Sales Dashboard"></dashboard>');
+    const sidecarSpy = vi.spyOn(cacheFingerprintModule, 'checkSidecar').mockReturnValue({
+      ok: false,
+      message: 'Cache produced by a different Desktop session — re-read in the current session.',
+    });
+    const loadSpy = vi
+      .spyOn(loadDashboardXmlModule, 'loadDashboardXml')
+      .mockResolvedValue(Ok.EMPTY);
+
+    const result = await getToolResult({ mode: 'file', dashboardFile: '/path/to/dashboard.xml' });
+
+    expect(result.isError).toBe(true);
+    invariant(result.content[0].type === 'text');
+    expect(result.content[0].text).toContain('different Desktop session');
+    expect(loadSpy).not.toHaveBeenCalled();
+
+    // vi.clearAllMocks() resets call history but not this spy's implementation, so
+    // restore it explicitly to keep the fail-open default for the other file-mode tests.
+    sidecarSpy.mockRestore();
   });
 
   it('should return error when inline mode is used without dashboardXml', async () => {

--- a/src/tools/desktop/dashboard/applyDashboard.ts
+++ b/src/tools/desktop/dashboard/applyDashboard.ts
@@ -3,6 +3,7 @@ import { existsSync, readFileSync } from 'fs';
 import { Ok } from 'ts-results-es';
 import { z } from 'zod';
 
+import { checkSidecar } from '../../../desktop/commands/workbook/cacheFingerprint.js';
 import { loadDashboardXml } from '../../../desktop/commands/workbook/loadDashboardXml.js';
 import {
   buildApplyOverCapNote,
@@ -12,6 +13,7 @@ import {
 import { resolveSession } from '../../../desktop/sessionResolution.js';
 import {
   ArgsValidationError,
+  CacheSessionMismatchError,
   DashboardXmlLoadFailedError,
   DesktopCommandExecutionError,
   FileReadError,
@@ -103,6 +105,17 @@ export const getApplyDashboardTool = (
             return sessionResult.error.toErr();
           }
           const resolvedSession = sessionResult.value;
+
+          // Cross-instance cache-bleed guard (W9): refuse a cache file produced by a
+          // different (or restarted) Desktop session before applying it — file mode only,
+          // since inline content carries no cache fingerprint.
+          if (mode === 'file' && dashboardFile) {
+            const sidecar = checkSidecar(dashboardFile, resolvedSession, 'dashboard');
+            if (!sidecar.ok) {
+              return new CacheSessionMismatchError(sidecar.message!).toErr();
+            }
+          }
+
           const executor = await extra.getExecutor(resolvedSession);
           const result = await loadDashboardXml({
             dashboardName,

--- a/src/tools/desktop/dashboard/buildAndApplyDashboard.ts
+++ b/src/tools/desktop/dashboard/buildAndApplyDashboard.ts
@@ -3,12 +3,14 @@ import { existsSync } from 'fs';
 import { Ok } from 'ts-results-es';
 import { z } from 'zod';
 
+import { checkSidecar } from '../../../desktop/commands/workbook/cacheFingerprint.js';
 import { getWorkbookXml } from '../../../desktop/commands/workbook/getWorkbookXml.js';
 import { injectViewpoints } from '../../../desktop/commands/workbook/injectViewpoints.js';
 import { loadDashboardXml } from '../../../desktop/commands/workbook/loadDashboardXml.js';
 import { loadWorkbookXml } from '../../../desktop/commands/workbook/loadWorkbookXml.js';
 import { resolveSession } from '../../../desktop/sessionResolution.js';
 import {
+  CacheSessionMismatchError,
   DashboardXmlLoadFailedError,
   DesktopCommandExecutionError,
   WorkbookNotFoundError,
@@ -85,6 +87,18 @@ export const getBuildAndApplyDashboardTool = (
             return sessionResult.error.toErr();
           }
           const resolvedSession = sessionResult.value;
+
+          // Cross-instance cache-bleed guard (W9): refuse caches produced by a different
+          // (or restarted) Desktop session before applying either one.
+          const wbSidecar = checkSidecar(workbookFile, resolvedSession, 'workbook');
+          if (!wbSidecar.ok) {
+            return new CacheSessionMismatchError(wbSidecar.message!).toErr();
+          }
+          const dashSidecar = checkSidecar(dashboardFile, resolvedSession, 'dashboard');
+          if (!dashSidecar.ok) {
+            return new CacheSessionMismatchError(dashSidecar.message!).toErr();
+          }
+
           const executor = await extra.getExecutor(resolvedSession);
 
           // Fetch workbook, inject viewpoints, apply workbook

--- a/src/tools/desktop/dashboard/getDashboardXml.ts
+++ b/src/tools/desktop/dashboard/getDashboardXml.ts
@@ -5,6 +5,7 @@ import { z } from 'zod';
 
 import { formatArtifactSummary } from '../../../desktop/artifactSummary.js';
 import { DesktopCache } from '../../../desktop/cache.js';
+import { writeSidecar } from '../../../desktop/commands/workbook/cacheFingerprint.js';
 import { getDashboardXml } from '../../../desktop/commands/workbook/getDashboardXml.js';
 import {
   buildInlineCapFileMessage,
@@ -100,6 +101,9 @@ export const getGetDashboardXmlTool = (
             prefix: `dashboard-${safeName}`,
           });
           writeFileSync(cacheFile, dashboardXml, 'utf-8');
+          // Stamp the producing session so apply-dashboard can refuse a cache from a
+          // different (or restarted) Desktop instance — cross-instance bleed guard (W9).
+          writeSidecar(cacheFile, resolvedSession);
 
           if (capFired) {
             logInlineXmlCapHit({ tool: 'get-dashboard-xml', bytes, capBytes, file: cacheFile });

--- a/src/tools/desktop/workbook/applyWorkbook.test.ts
+++ b/src/tools/desktop/workbook/applyWorkbook.test.ts
@@ -3,6 +3,7 @@ import { existsSync, readFileSync } from 'fs';
 import { Err, Ok } from 'ts-results-es';
 import { z } from 'zod';
 
+import * as cacheFingerprintModule from '../../../desktop/commands/workbook/cacheFingerprint.js';
 import * as loadWorkbookXmlModule from '../../../desktop/commands/workbook/loadWorkbookXml.js';
 import {
   ArgsValidationError,
@@ -91,6 +92,35 @@ describe('applyWorkbookTool', () => {
 
     expect(existsSync).toHaveBeenCalledWith(mockFilePath);
     expect(readFileSync).toHaveBeenCalledWith(mockFilePath, 'utf-8');
+  });
+
+  it('refuses a file-mode apply when the cache sidecar fingerprint mismatches the session (W9)', async () => {
+    const mockFilePath = '/path/to/workbook.twb';
+
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue('<?xml version="1.0"?><workbook></workbook>');
+    const sidecarSpy = vi.spyOn(cacheFingerprintModule, 'checkSidecar').mockReturnValue({
+      ok: false,
+      message: 'Cache produced by a different Desktop session — re-read in the current session.',
+    });
+    const loadSpy = vi.spyOn(loadWorkbookXmlModule, 'loadWorkbookXml').mockResolvedValue(Ok.EMPTY);
+
+    const result = await getToolResult({
+      session: '12345',
+      mode: 'file',
+      workbookFile: mockFilePath,
+      mockExecutor: vi.fn().mockResolvedValue({}),
+    });
+
+    expect(result.isError).toBe(true);
+    invariant(result.content[0].type === 'text');
+    expect(result.content[0].text).toContain('different Desktop session');
+    // The guard must short-circuit BEFORE the workbook is applied.
+    expect(loadSpy).not.toHaveBeenCalled();
+
+    // vi.clearAllMocks() resets call history but not this spy's implementation, so
+    // restore it explicitly to keep the fail-open default for the other file-mode tests.
+    sidecarSpy.mockRestore();
   });
 
   it('should default to file mode when mode is not specified', async () => {

--- a/src/tools/desktop/workbook/applyWorkbook.ts
+++ b/src/tools/desktop/workbook/applyWorkbook.ts
@@ -3,6 +3,7 @@ import { existsSync, readFileSync } from 'fs';
 import { Ok } from 'ts-results-es';
 import { z } from 'zod';
 
+import { checkSidecar } from '../../../desktop/commands/workbook/cacheFingerprint.js';
 import { loadWorkbookXml } from '../../../desktop/commands/workbook/loadWorkbookXml.js';
 import {
   buildApplyOverCapNote,
@@ -12,6 +13,7 @@ import {
 import { resolveSession } from '../../../desktop/sessionResolution.js';
 import {
   ArgsValidationError,
+  CacheSessionMismatchError,
   DesktopCommandExecutionError,
   FileReadError,
   WorkbookNotFoundError,
@@ -101,6 +103,17 @@ export const getApplyWorkbookTool = (
             return sessionResult.error.toErr();
           }
           const resolvedSession = sessionResult.value;
+
+          // Cross-instance cache-bleed guard (W9): refuse a cache file produced by a
+          // different (or restarted) Desktop session before applying it — file mode only,
+          // since inline content carries no cache fingerprint.
+          if (mode === 'file' && workbookFile) {
+            const sidecar = checkSidecar(workbookFile, resolvedSession, 'workbook');
+            if (!sidecar.ok) {
+              return new CacheSessionMismatchError(sidecar.message!).toErr();
+            }
+          }
+
           const executor = await extra.getExecutor(resolvedSession);
           const result = await loadWorkbookXml({
             xml: workbookXml,

--- a/src/tools/desktop/workbook/getWorkbookXml.ts
+++ b/src/tools/desktop/workbook/getWorkbookXml.ts
@@ -5,6 +5,7 @@ import { z } from 'zod';
 
 import { formatArtifactSummary } from '../../../desktop/artifactSummary.js';
 import { DesktopCache } from '../../../desktop/cache.js';
+import { writeSidecar } from '../../../desktop/commands/workbook/cacheFingerprint.js';
 import { getWorkbookXml } from '../../../desktop/commands/workbook/getWorkbookXml.js';
 import {
   buildInlineCapFileMessage,
@@ -91,6 +92,9 @@ export const getGetWorkbookXmlTool = (
           // Save to cache file (requested file mode, or forced by the cap).
           const cacheFile = new DesktopCache().getCacheFilePath({ prefix: 'workbook' });
           writeFileSync(cacheFile, workbookXml, 'utf-8');
+          // Stamp the producing session so apply-workbook can refuse a cache from a
+          // different (or restarted) Desktop instance — cross-instance bleed guard (W9).
+          writeSidecar(cacheFile, resolvedSession);
 
           if (capFired) {
             logInlineXmlCapHit({ tool: 'get-workbook-xml', bytes, capBytes, file: cacheFile });

--- a/src/tools/desktop/worksheet/applyWorksheet.test.ts
+++ b/src/tools/desktop/worksheet/applyWorksheet.test.ts
@@ -49,7 +49,9 @@ describe('applyWorksheetTool', () => {
 
   it('should successfully apply worksheet XML in inline mode', async () => {
     const mockXml = '<worksheet name="Sheet 1"><table></table></worksheet>';
-    vi.spyOn(loadWorksheetXmlModule, 'loadWorksheetXml').mockResolvedValue(Ok({ readbackWarnings: [] }));
+    vi.spyOn(loadWorksheetXmlModule, 'loadWorksheetXml').mockResolvedValue(
+      Ok({ readbackWarnings: [] }),
+    );
 
     const mockExecutor = vi.fn().mockResolvedValue({});
 
@@ -74,7 +76,9 @@ describe('applyWorksheetTool', () => {
 
     vi.mocked(existsSync).mockReturnValue(true);
     vi.mocked(readFileSync).mockReturnValue(mockXml);
-    vi.spyOn(loadWorksheetXmlModule, 'loadWorksheetXml').mockResolvedValue(Ok({ readbackWarnings: [] }));
+    vi.spyOn(loadWorksheetXmlModule, 'loadWorksheetXml').mockResolvedValue(
+      Ok({ readbackWarnings: [] }),
+    );
 
     const mockExecutor = vi.fn().mockResolvedValue({});
 
@@ -257,7 +261,9 @@ describe('applyWorksheetTool over-cap note', () => {
 
   it('accepts an over-cap inline apply but appends the file-mode note', async () => {
     const overCapXml = '<worksheet name="Sales">' + 'x'.repeat(20000) + '</worksheet>';
-    vi.spyOn(loadWorksheetXmlModule, 'loadWorksheetXml').mockResolvedValue(Ok({ readbackWarnings: [] }));
+    vi.spyOn(loadWorksheetXmlModule, 'loadWorksheetXml').mockResolvedValue(
+      Ok({ readbackWarnings: [] }),
+    );
 
     const result = await getToolResult({
       session: '12345',

--- a/src/tools/desktop/worksheet/applyWorksheet.test.ts
+++ b/src/tools/desktop/worksheet/applyWorksheet.test.ts
@@ -49,7 +49,7 @@ describe('applyWorksheetTool', () => {
 
   it('should successfully apply worksheet XML in inline mode', async () => {
     const mockXml = '<worksheet name="Sheet 1"><table></table></worksheet>';
-    vi.spyOn(loadWorksheetXmlModule, 'loadWorksheetXml').mockResolvedValue(Ok.EMPTY);
+    vi.spyOn(loadWorksheetXmlModule, 'loadWorksheetXml').mockResolvedValue(Ok({ readbackWarnings: [] }));
 
     const mockExecutor = vi.fn().mockResolvedValue({});
 
@@ -74,7 +74,7 @@ describe('applyWorksheetTool', () => {
 
     vi.mocked(existsSync).mockReturnValue(true);
     vi.mocked(readFileSync).mockReturnValue(mockXml);
-    vi.spyOn(loadWorksheetXmlModule, 'loadWorksheetXml').mockResolvedValue(Ok.EMPTY);
+    vi.spyOn(loadWorksheetXmlModule, 'loadWorksheetXml').mockResolvedValue(Ok({ readbackWarnings: [] }));
 
     const mockExecutor = vi.fn().mockResolvedValue({});
 
@@ -226,7 +226,7 @@ describe('applyWorksheetTool', () => {
     const mockXml = '<worksheet name="Sheet 1"><table></table></worksheet>';
     const mockLoadWorksheetXml = vi
       .spyOn(loadWorksheetXmlModule, 'loadWorksheetXml')
-      .mockResolvedValue(Ok.EMPTY);
+      .mockResolvedValue(Ok({ readbackWarnings: [] }));
 
     const mockExecutor = vi.fn().mockResolvedValue({});
     const customSignal = new AbortController().signal;
@@ -257,7 +257,7 @@ describe('applyWorksheetTool over-cap note', () => {
 
   it('accepts an over-cap inline apply but appends the file-mode note', async () => {
     const overCapXml = '<worksheet name="Sales">' + 'x'.repeat(20000) + '</worksheet>';
-    vi.spyOn(loadWorksheetXmlModule, 'loadWorksheetXml').mockResolvedValue(Ok.EMPTY);
+    vi.spyOn(loadWorksheetXmlModule, 'loadWorksheetXml').mockResolvedValue(Ok({ readbackWarnings: [] }));
 
     const result = await getToolResult({
       session: '12345',

--- a/src/tools/desktop/worksheet/applyWorksheet.ts
+++ b/src/tools/desktop/worksheet/applyWorksheet.ts
@@ -9,8 +9,8 @@ import {
   isOverInlineXmlCap,
   xmlByteLength,
 } from '../../../desktop/inlineXmlCap.js';
-import { formatReadbackVerificationWarnings } from '../../../desktop/validation/readback-verify.js';
 import { resolveSession } from '../../../desktop/sessionResolution.js';
+import { formatReadbackVerificationWarnings } from '../../../desktop/validation/readback-verify.js';
 import {
   ArgsValidationError,
   DesktopCommandExecutionError,

--- a/src/tools/desktop/worksheet/applyWorksheet.ts
+++ b/src/tools/desktop/worksheet/applyWorksheet.ts
@@ -3,6 +3,7 @@ import { existsSync, readFileSync } from 'fs';
 import { Ok } from 'ts-results-es';
 import { z } from 'zod';
 
+import { checkSidecar } from '../../../desktop/commands/workbook/cacheFingerprint.js';
 import { loadWorksheetXml } from '../../../desktop/commands/workbook/loadWorksheetXml.js';
 import {
   buildApplyOverCapNote,
@@ -13,6 +14,7 @@ import { resolveSession } from '../../../desktop/sessionResolution.js';
 import { formatReadbackVerificationWarnings } from '../../../desktop/validation/readback-verify.js';
 import {
   ArgsValidationError,
+  CacheSessionMismatchError,
   DesktopCommandExecutionError,
   FileReadError,
   WorksheetNotFoundError,
@@ -103,6 +105,17 @@ export const getApplyWorksheetTool = (
             return sessionResult.error.toErr();
           }
           const resolvedSession = sessionResult.value;
+
+          // Cross-instance cache-bleed guard (W9): refuse a cache file produced by a
+          // different (or restarted) Desktop session before applying it — file mode only,
+          // since inline content carries no cache fingerprint.
+          if (mode === 'file' && worksheetFile) {
+            const sidecar = checkSidecar(worksheetFile, resolvedSession, 'worksheet');
+            if (!sidecar.ok) {
+              return new CacheSessionMismatchError(sidecar.message!).toErr();
+            }
+          }
+
           const executor = await extra.getExecutor(resolvedSession);
           const result = await loadWorksheetXml({
             worksheetName,

--- a/src/tools/desktop/worksheet/applyWorksheet.ts
+++ b/src/tools/desktop/worksheet/applyWorksheet.ts
@@ -9,6 +9,7 @@ import {
   isOverInlineXmlCap,
   xmlByteLength,
 } from '../../../desktop/inlineXmlCap.js';
+import { formatReadbackVerificationWarnings } from '../../../desktop/validation/readback-verify.js';
 import { resolveSession } from '../../../desktop/sessionResolution.js';
 import {
   ArgsValidationError,
@@ -130,8 +131,14 @@ export const getApplyWorksheetTool = (
               ? `\n\n${buildApplyOverCapNote(inlineBytes, capBytes)}`
               : '';
 
+          // Non-fatal post-apply readback warnings (e.g. a sort Tableau reshaped) ride
+          // along so the agent can re-check the rendered chart before moving on (W4).
+          const readbackWarning = result.isOk()
+            ? formatReadbackVerificationWarnings(result.value.readbackWarnings)
+            : '';
+
           return new Ok({
-            message: `Successfully applied worksheet update for "${worksheetName}". The worksheet has been updated.${note}`,
+            message: `Successfully applied worksheet update for "${worksheetName}". The worksheet has been updated.${note}${readbackWarning}`,
           });
         },
       });

--- a/src/tools/desktop/worksheet/getWorksheetXml.ts
+++ b/src/tools/desktop/worksheet/getWorksheetXml.ts
@@ -5,6 +5,7 @@ import { z } from 'zod';
 
 import { formatArtifactSummary } from '../../../desktop/artifactSummary.js';
 import { DesktopCache } from '../../../desktop/cache.js';
+import { writeSidecar } from '../../../desktop/commands/workbook/cacheFingerprint.js';
 import { getWorksheetXml } from '../../../desktop/commands/workbook/getWorksheetXml.js';
 import {
   buildInlineCapFileMessage,
@@ -107,6 +108,9 @@ export const getGetWorksheetXmlTool = (
             prefix: `worksheet-${safeName}`,
           });
           writeFileSync(cacheFile, worksheetXml, 'utf-8');
+          // Stamp the producing session so apply-worksheet can refuse a cache from a
+          // different (or restarted) Desktop instance — cross-instance bleed guard (W9).
+          writeSidecar(cacheFile, resolvedSession);
 
           if (capFired) {
             logInlineXmlCapHit({ tool: 'get-worksheet-xml', bytes, capBytes, file: cacheFile });


### PR DESCRIPTION
Ports the a2td overnight portability + reliability wave (a2td `600beb0..a70575d`, PR tableau/agent-to-tableau-desktop#205, merged) onto `feature/desktop`, on top of the merged #510 (detail→lod) and #511 (classify carrier) base. 9 commits; full desktop suite **4252 passed / 1 skipped / 0 errors**, `tsc --noEmit` clean, lockstep gate 6/6.

## What ported (owed items from the port-debt ledger)

- **W2 semanticRole plumbing** — `listAvailableFields` reads `@_semantic-role` → `SchemaField`, which **activates** the #511 classify.ts geo binder (`GEO_SEMANTIC_ROLE_CONCEPT`/`geoConceptFromSemanticRole`). Territory-class fields bind a map end-to-end. classify.ts itself is **never edited** — byte-identical to the a2td canonical; only a lockstep-hash regen for pre-existing #511 base drift.
- **W4 post-apply readback verification** — `src/desktop/validation/readback-verify.ts` + `loadWorksheetXml` wiring; dropped encodings/shelves/marks/filters fail the apply naming the node. (tmcp has no episode system → logged via structured logger, not an interaction event.)
- **W9 session reliability** — SessionManager freshness gate + `SessionStaleError`; cache-fingerprint sidecars + apply refusal (cross-instance cache-bleed guard).
- **W1 + W3 portability lane** — 3 non-Superstore fixtures (behavioral evidence) + histogram fallback→escalate (`DATASET_SPECIFIC_FORMULA`, no Superstore-derived 500).
- **W6 did-you-mean** — sheet-name-miss assist on a worksheet miss.

## Review fixes (dual review: GPT minion on diffs + Opus code-review on the branch)

- **F1 (2880bfd6)** — the W9 cache-bleed guard was wired only into the coordination/batch paths; the primary get→apply flow was unguarded on both ends. Now `writeSidecar` in the three get-*-xml tools + `checkSidecar` in the three apply-* tools, with mismatch tests.
- **F2 (00effb54)** — W4 exact-match mark compare false-flagged an authored `<mark class="Automatic">` resolved to a concrete class on readback. Now `Automatic` tolerates any concrete class in-pane.

## Notes
- Cut from a fresh `origin/feature/desktop` after fetch; ahead-only, no rebase.
- N/A by design: W2 ask-router mirror (tmcp ask-router is selector-only, geo binder lives only in classify.ts); W4 interaction event (no episode system in tmcp).
- Owed a2td twin fix (F2 Automatic-mark tolerance at a2td `readback-verify.ts:298`) is tracked separately and being handled this session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
