### PR TITLE
W65 red-team fixes: sidecar stamping, geo concept check, readback honesty (desktop twin of a2td #207)

### DIFF
--- a/src/desktop/binder/binder.ts
+++ b/src/desktop/binder/binder.ts
@@ -19,9 +19,9 @@
 // without the two-call round trip. The MCP tool never passes `llmPropose`.
 
 import {
-  buildLlmInput,
+  buildLlmInput as buildCoreLlmInput,
   classifyNoLlm,
-  type LlmProposeInput,
+  type LlmProposeInput as CoreLlmProposeInput,
   MAX_CLASSIFIABLE_FIELDS,
 } from './classify.js';
 import { escapeXml } from './escape.js';
@@ -37,15 +37,59 @@ import {
 // Re-exported as the binder's public surface. Bare (source-less) re-exports of the
 // locally-imported bindings — a single `export ... from './x.js'` alongside the
 // import above would trip the target's `no-duplicate-imports` (includeExports).
-export { buildLlmInput, classifyNoLlm, MAX_CLASSIFIABLE_FIELDS, summarizeSchema, validateBinding };
-export type {
-  BindingProposal,
-  Blocker,
-  EscalateReason,
-  LlmProposeInput,
-  SchemaField,
-  SchemaSummary,
+export { classifyNoLlm, MAX_CLASSIFIABLE_FIELDS, summarizeSchema, validateBinding };
+export type { BindingProposal, Blocker, EscalateReason, SchemaField, SchemaSummary };
+
+type ProposeField = CoreLlmProposeInput['fields'][number] & { semanticRole?: string };
+type FieldIdentity = Pick<ProposeField, 'name' | 'role' | 'type' | 'datatype'>;
+
+export type LlmProposeInput = Omit<CoreLlmProposeInput, 'fields'> & {
+  fields: ProposeField[];
 };
+
+function fieldIdentityKey(f: FieldIdentity): string {
+  return `${f.name}\0${f.role}\0${f.type}\0${f.datatype}`;
+}
+
+/**
+ * Re-attach each summary field's semanticRole to the core payload by identity
+ * (name/role/type/datatype — the exact tuple the core emits). Two summary
+ * fields colliding on the tuple with DIFFERENT semantic roles are ambiguous:
+ * tag neither rather than guess.
+ *
+ * This wrapper intentionally lives outside hash-gated classify.ts.
+ */
+function enrichSemanticRoles(input: CoreLlmProposeInput, summary: SchemaSummary): LlmProposeInput {
+  const semanticRoleByField = new Map<string, string | undefined>();
+  const ambiguous = new Set<string>();
+
+  for (const f of summary.fields) {
+    const key = fieldIdentityKey(f);
+    if (semanticRoleByField.has(key) && semanticRoleByField.get(key) !== f.semanticRole) {
+      ambiguous.add(key);
+      continue;
+    }
+    semanticRoleByField.set(key, f.semanticRole);
+  }
+
+  return {
+    ...input,
+    fields: input.fields.map((f) => {
+      const key = fieldIdentityKey(f);
+      const semanticRole = ambiguous.has(key) ? undefined : semanticRoleByField.get(key);
+      return semanticRole ? { ...f, semanticRole } : f;
+    }),
+  };
+}
+
+export function buildLlmInput(
+  ask: string,
+  manifests: Map<string, TemplateManifest>,
+  summary: SchemaSummary,
+  opts?: { maxFields?: number },
+): LlmProposeInput {
+  return enrichSemanticRoles(buildCoreLlmInput(ask, manifests, summary, opts), summary);
+}
 
 /** The validated, injector-ready args for `tableau-inject-template`. */
 export interface InjectTemplateArgs {

--- a/src/desktop/binder/field-narrowing.test.ts
+++ b/src/desktop/binder/field-narrowing.test.ts
@@ -11,7 +11,7 @@
 
 import { describe, expect, it } from 'vitest';
 
-import { buildLlmInput } from './classify.js';
+import { buildLlmInput } from './binder.js';
 import type { Family, SlotKind, TemplateManifest } from './manifest-types.js';
 import type { SchemaField, SchemaSummary } from './schema-summary.js';
 
@@ -29,6 +29,7 @@ function field(
   role: 'dimension' | 'measure',
   type: string,
   datatype: string,
+  semanticRole?: string,
 ): SchemaField {
   return {
     name,
@@ -36,6 +37,7 @@ function field(
     role,
     type,
     datatype,
+    ...(semanticRole ? { semanticRole } : {}),
     datasource: 'DS',
     isAggregated: false,
     column_ref: `[DS].[${name}]`,
@@ -189,6 +191,31 @@ describe('binder/buildLlmInput — field narrowing (stage 2B)', () => {
       fields.map((f) => ({ name: f.name, role: f.role, type: f.type, datatype: f.datatype })),
     );
     expect(input.more_available).toBeUndefined();
+  });
+
+  // Red-team GEO-03: the propose model can't respect geo tags it never sees.
+  it('includes semanticRole for geo-tagged fields in the propose payload', () => {
+    const fields = [
+      field('Sales', 'measure', 'quantitative', 'real'),
+      field('Territory', 'dimension', 'nominal', 'string', '[State].[Name]'),
+    ];
+    const summary: SchemaSummary = { datasource: 'DS', fields };
+
+    const input = buildLlmInput('bar of Sales by Territory', barTemplate(), summary);
+
+    expect(input.fields.find((f) => f.name === 'Territory')).toEqual({
+      name: 'Territory',
+      role: 'dimension',
+      type: 'nominal',
+      datatype: 'string',
+      semanticRole: '[State].[Name]',
+    });
+    expect(input.fields.find((f) => f.name === 'Sales')).toEqual({
+      name: 'Sales',
+      role: 'measure',
+      type: 'quantitative',
+      datatype: 'real',
+    });
   });
 
   it('more_available reports the exact withheld count', () => {

--- a/src/desktop/binder/validate.test.ts
+++ b/src/desktop/binder/validate.test.ts
@@ -1,3 +1,5 @@
+import * as fs from 'fs';
+import * as path from 'path';
 import { beforeAll, describe, expect, it } from 'vitest';
 
 import { loadManifests } from './manifest.js';
@@ -13,6 +15,7 @@ function field(p: {
   datatype: string;
   caption?: string;
   isAggregated?: boolean;
+  semanticRole?: string;
   datasource?: string;
 }): SchemaField {
   const bare = p.columnName.replace(/^\[|\]$/g, '');
@@ -24,6 +27,7 @@ function field(p: {
     role: p.role,
     type: p.type,
     datatype: p.datatype,
+    ...(p.semanticRole ? { semanticRole: p.semanticRole } : {}),
     datasource: ds,
     isAggregated: p.isAggregated ?? false,
     column_ref: `[${ds}].[none:${bare}:nk]`,
@@ -202,6 +206,60 @@ describe('binder/validate — gate 3: kind/role compatibility', () => {
       ],
     };
     expect(validateBinding(m, p, SUMMARY).ok).toBe(true);
+  });
+
+  // Gate 3b (red-team GEO-02): geo slots must respect the field's Tableau
+  // semantic-role concept, mirroring pickGeoField on the deterministic path.
+  const geoSummary = (regionSemanticRole?: string): SchemaSummary => ({
+    datasource: 'Superstore',
+    fields: [
+      field({
+        columnName: '[Country]',
+        role: 'dimension',
+        type: 'nominal',
+        datatype: 'string',
+        semanticRole: '[Country].[Name]',
+      }),
+      field({
+        columnName: '[Region]',
+        role: 'dimension',
+        type: 'nominal',
+        datatype: 'string',
+        semanticRole: regionSemanticRole,
+      }),
+      field({ columnName: '[Profit]', role: 'measure', type: 'quantitative', datatype: 'real' }),
+    ],
+  });
+  const geoProposal = (m: TemplateManifest): BindingProposal => ({
+    template: m.template,
+    title: 't',
+    bindings: [
+      { slot_id: 'country', field: 'Country' },
+      { slot_id: 'state', field: 'Region' },
+      { slot_id: 'profit', field: 'Profit' },
+    ],
+  });
+
+  it('fire: a City-tagged dimension cannot bind a state geo slot', () => {
+    const m = manifests.get('spatial-choropleth-map')!;
+    const r = validateBinding(m, geoProposal(m), geoSummary('[City].[Name]'));
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      const blocker = r.blockers.find((b) => b.code === 'kind-mismatch' && b.slot_id === 'state');
+      expect(blocker).toBeDefined();
+      expect(blocker!.detail).toContain('geo concept state');
+      expect(blocker!.detail).toContain('[City].[Name]');
+    }
+  });
+
+  it("no-fire: an untagged dimension keeps today's geo-slot acceptance", () => {
+    const m = manifests.get('spatial-choropleth-map')!;
+    expect(validateBinding(m, geoProposal(m), geoSummary(undefined)).ok).toBe(true);
+  });
+
+  it('no-fire: a matching State-tagged dimension binds the state geo slot', () => {
+    const m = manifests.get('spatial-choropleth-map')!;
+    expect(validateBinding(m, geoProposal(m), geoSummary('[State].[Name]')).ok).toBe(true);
   });
 });
 
@@ -1179,4 +1237,24 @@ describe('binder/validate — XML escaping in the emitted payload (M10 Finding 1
       expect(values).toContain('[Superstore].[none:Region:nk]');
     }
   });
+});
+
+describe('binder/validate — geo mirror parity with lockstep classify.ts (GEO-02 port)', () => {
+  // The geo tables here MIRROR private tables in hash-gated classify.ts (not
+  // exported so lockstep-core bytes stay unchanged) — pin them token-identical
+  // at the source level so classifier table edits can't silently drift the gate.
+  const extractTable = (source: string, constName: string): string => {
+    const match = source.match(new RegExp(`const ${constName}[^=]*= \\{[^}]*\\};`));
+    if (!match) throw new Error(`${constName} not found`);
+    return match[0].replace(new RegExp(`const ${constName}[^=]*=`), '');
+  };
+
+  it.each(['GEO_TOKEN_CONCEPT', 'GEO_SEMANTIC_ROLE_CONCEPT'])(
+    '%s literal matches classify.ts byte-for-byte',
+    (constName) => {
+      const validateSrc = fs.readFileSync(path.join(__dirname, 'validate.ts'), 'utf-8');
+      const classifySrc = fs.readFileSync(path.join(__dirname, 'classify.ts'), 'utf-8');
+      expect(extractTable(validateSrc, constName)).toBe(extractTable(classifySrc, constName));
+    },
+  );
 });

--- a/src/desktop/binder/validate.ts
+++ b/src/desktop/binder/validate.ts
@@ -134,6 +134,71 @@ const TEMPORAL_DATATYPES: ReadonlySet<string> = new Set(['date', 'datetime']);
 // only; MIN/MAX on a plain string dimension remains illegal (unchanged).
 const TEMPORAL_MINMAX_DERIVATIONS: ReadonlySet<string> = new Set(['min', 'max']);
 
+// Geo semantic-role concept check (red-team GEO-02). MIRRORS the private
+// tables in hash-gated src/desktop/binder/classify.ts (geoConceptFromSlotId /
+// GEO_SEMANTIC_ROLE_CONCEPT) — they are intentionally not exported because this
+// port must keep lockstep-core bytes unchanged.
+type GeoConcept = 'country' | 'state' | 'city' | 'zip';
+
+const GEO_TOKEN_CONCEPT: Readonly<Record<string, GeoConcept>> = {
+  country: 'country',
+  nation: 'country',
+  state: 'state',
+  province: 'state',
+  region: 'state',
+  admin: 'state',
+  city: 'city',
+  zip: 'zip',
+  zipcode: 'zip',
+  postal: 'zip',
+};
+
+const GEO_SEMANTIC_ROLE_CONCEPT: Readonly<Record<string, GeoConcept>> = {
+  '[Country].[ISO3166_2]': 'country',
+  '[Country].[Name]': 'country',
+  '[State].[Name]': 'state',
+  '[City].[Name]': 'city',
+  '[ZipCode].[Name]': 'zip',
+};
+
+function geoNameTokens(s: string): string[] {
+  return s
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter(Boolean);
+}
+
+function geoConceptFromSlotId(slotId: string): GeoConcept | null {
+  for (const t of geoNameTokens(slotId)) {
+    const concept = GEO_TOKEN_CONCEPT[t];
+    if (concept) return concept;
+  }
+  return null;
+}
+
+function geoConceptFromSemanticRole(semanticRole?: string): GeoConcept | null {
+  if (!semanticRole) return null;
+  return GEO_SEMANTIC_ROLE_CONCEPT[semanticRole] ?? null;
+}
+
+/**
+ * A geo slot must not bind a field whose Tableau semantic role names a
+ * DIFFERENT geo concept — a [City].[Name]-tagged field can't fill a
+ * state/province slot no matter what its name suggests. Fires only when BOTH
+ * concepts are known; an untagged field or exotic slot keeps today's
+ * dimension-only acceptance.
+ */
+function geoConceptMismatch(
+  slot: SlotSpec,
+  f: SchemaField,
+): { slotConcept: GeoConcept; fieldConcept: GeoConcept } | null {
+  if (slot.kind !== 'geo') return null;
+  const slotConcept = geoConceptFromSlotId(slot.slot_id);
+  const fieldConcept = geoConceptFromSemanticRole(f.semanticRole);
+  if (!slotConcept || !fieldConcept || slotConcept === fieldConcept) return null;
+  return { slotConcept, fieldConcept };
+}
+
 /** Column-instance type suffix (field-resolver.ts:107-112 / field-builder.ts:408-410). */
 function typeSuffixFor(type: string): string {
   if (type === 'quantitative') return 'qk';
@@ -311,6 +376,21 @@ export function validateBinding(
         detail:
           `slot '${slotId}' expects ${slot.kind} but "${fieldQuery}" is ` +
           `role=${f.role}, type=${f.type}, datatype=${f.datatype}`,
+      });
+      continue;
+    }
+
+    // Gate 3b: geo semantic-role concept (red-team GEO-02) — the deterministic
+    // path already enforces this in pickGeoField; the validate leg must too or
+    // a City-tagged field can bind a state slot via Call-2.
+    const geoMismatch = geoConceptMismatch(slot, f);
+    if (geoMismatch) {
+      blockers.push({
+        code: 'kind-mismatch',
+        slot_id: slotId,
+        detail:
+          `slot '${slotId}' expects geo concept ${geoMismatch.slotConcept} but "${fieldQuery}" is tagged ` +
+          `semanticRole=${f.semanticRole} (${geoMismatch.fieldConcept})`,
       });
       continue;
     }

--- a/src/desktop/commands/workbook/loadWorksheetXml.test.ts
+++ b/src/desktop/commands/workbook/loadWorksheetXml.test.ts
@@ -181,6 +181,40 @@ describe('loadWorksheetXml (Agent API transport, default)', () => {
     }
   });
 
+  it('reports skipped readback status and logger when post-apply readback is unavailable', async () => {
+    const error = {
+      type: 'command-failed' as const,
+      error: { code: 'BUSY', message: 'worksheet busy', recoverable: true },
+    };
+    const { executor } = dispatchingAgentExecutor(validXml, { 'save-worksheet': Err(error) });
+
+    const result = await loadWorksheetXml({
+      worksheetName,
+      xml: validXml,
+      executor,
+      signal: mockSignal,
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.readbackWarnings).toEqual([]);
+      expect(result.value.readbackVerification).toMatchObject({
+        ok: true,
+        status: 'skipped',
+      });
+    }
+    expect(loggerModule.log).toHaveBeenCalledWith(
+      expect.objectContaining({
+        level: 'warning',
+        message: expect.stringContaining('readback verification skipped'),
+        data: expect.objectContaining({
+          worksheetName,
+          status: 'skipped',
+        }),
+      }),
+    );
+  });
+
   it('should return error when XML is invalid', async () => {
     const mockExecutor = {} as unknown as LocalExecutor;
 

--- a/src/desktop/commands/workbook/loadWorksheetXml.ts
+++ b/src/desktop/commands/workbook/loadWorksheetXml.ts
@@ -11,6 +11,7 @@ import {
 import {
   formatReadbackVerificationError,
   type ReadbackFinding,
+  type ReadbackVerificationResult,
   verifyWorksheetReadback,
 } from '../../validation/readback-verify.js';
 import { runValidation } from '../../validation/registry.js';
@@ -36,6 +37,11 @@ export type LoadWorksheetXmlError =
 /** Non-fatal readback warnings surfaced on a successful apply (sort drops/changes). */
 export interface LoadWorksheetXmlOk {
   readbackWarnings: ReadbackFinding[];
+  readbackVerification?: ReadbackVerificationResult;
+}
+
+interface PostApplyWorksheetReadbackVerification extends ReadbackVerificationResult {
+  findings: ReadbackFinding[];
 }
 
 type LoadWorksheetXmlResult = Result<
@@ -50,32 +56,52 @@ type LoadWorksheetXmlResult = Result<
  * apply on a re-read miss: if the worksheet cannot be re-read, verification is skipped
  * (returns no findings) so telemetry can never mask a real apply.
  */
-async function verifyReadbackAfterApply(
+function publicReadbackVerificationResult(
+  result: PostApplyWorksheetReadbackVerification,
+): ReadbackVerificationResult {
+  return result.message
+    ? { ok: result.ok, status: result.status, message: result.message }
+    : { ok: result.ok, status: result.status };
+}
+
+async function verifyPostApplyWorksheetReadback(
   worksheetName: string,
   intendedXml: string,
   executor: WithExecutorAndAbortSignal['executor'],
   signal: WithExecutorAndAbortSignal['signal'],
-): Promise<ReadbackFinding[]> {
+): Promise<PostApplyWorksheetReadbackVerification> {
   try {
     const reread = await getWorksheetXml({ worksheetName, executor, signal });
     if (reread.isErr()) {
+      const message =
+        reread.error.type === 'get-worksheet-xml-error'
+          ? reread.error.error.message
+          : 'could not re-read worksheet after apply';
       log({
         level: 'warning',
         message: 'Post-apply worksheet readback verification skipped — could not re-read worksheet',
         logger: 'worksheetCommands',
-        data: { worksheetName, error: reread.error },
+        data: { worksheetName, status: 'skipped', error: reread.error },
       });
-      return [];
+      return { ok: true, status: 'skipped', findings: [], message };
     }
-    return verifyWorksheetReadback(intendedXml, reread.value);
+    const findings = verifyWorksheetReadback(intendedXml, reread.value);
+    if (findings.some((f) => f.severity === 'error')) {
+      return { ok: false, status: 'failed', findings };
+    }
+    if (findings.some((f) => f.severity === 'warning')) {
+      return { ok: true, status: 'warning', findings };
+    }
+    return { ok: true, status: 'passed', findings: [] };
   } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
     log({
       level: 'warning',
       message: 'Post-apply worksheet readback verification skipped — re-read threw',
       logger: 'worksheetCommands',
-      data: { worksheetName, error: error instanceof Error ? error.message : String(error) },
+      data: { worksheetName, status: 'skipped', error: message },
     });
-    return [];
+    return { ok: true, status: 'skipped', findings: [], message };
   }
 }
 
@@ -84,7 +110,10 @@ async function verifyReadbackAfterApply(
  * (the rendered chart does not match intent), WARNING-severity findings ride along on a
  * successful Ok so the tool can surface them without blocking.
  */
-function readbackOutcome(findings: ReadbackFinding[]): LoadWorksheetXmlResult {
+function readbackOutcome(
+  verification: PostApplyWorksheetReadbackVerification,
+): LoadWorksheetXmlResult {
+  const { findings } = verification;
   const errors = findings.filter((f) => f.severity === 'error');
   if (errors.length > 0) {
     return Err({
@@ -96,7 +125,10 @@ function readbackOutcome(findings: ReadbackFinding[]): LoadWorksheetXmlResult {
       },
     });
   }
-  return Ok({ readbackWarnings: findings });
+  return Ok({
+    readbackWarnings: findings,
+    readbackVerification: publicReadbackVerificationResult(verification),
+  });
 }
 
 export async function loadWorksheetXml({
@@ -104,9 +136,11 @@ export async function loadWorksheetXml({
   xml,
   executor,
   signal,
+  readbackVerificationOut,
 }: {
   worksheetName: string;
   xml: string;
+  readbackVerificationOut?: ReadbackVerificationResult[];
 } & WithExecutorAndAbortSignal): Promise<LoadWorksheetXmlResult> {
   xml = xml.trim();
   if (!xml || (!xml.startsWith('<?xml') && !xml.startsWith('<'))) {
@@ -149,8 +183,20 @@ export async function loadWorksheetXml({
   // its command registry, so applying a single sheet re-posts a minimal whole-workbook document.
   // The POST upserts by name: it overwrites the colliding sheet in place and leaves the rest live.
   return getDesktopConfig().externalApiEnabled
-    ? loadWorksheetXmlViaExternalApi({ worksheetName, xml, executor, signal })
-    : loadWorksheetXmlViaAgentApi({ worksheetName, xml, executor, signal });
+    ? loadWorksheetXmlViaExternalApi({
+        worksheetName,
+        xml,
+        executor,
+        signal,
+        readbackVerificationOut,
+      })
+    : loadWorksheetXmlViaAgentApi({
+        worksheetName,
+        xml,
+        executor,
+        signal,
+        readbackVerificationOut,
+      });
 }
 
 async function loadWorksheetXmlViaAgentApi({
@@ -158,9 +204,11 @@ async function loadWorksheetXmlViaAgentApi({
   xml,
   executor,
   signal,
+  readbackVerificationOut,
 }: {
   worksheetName: string;
   xml: string;
+  readbackVerificationOut?: ReadbackVerificationResult[];
 } & WithExecutorAndAbortSignal): Promise<LoadWorksheetXmlResult> {
   const result = await executor.executeCommand({
     namespace: 'tabui',
@@ -208,8 +256,9 @@ async function loadWorksheetXmlViaAgentApi({
   // Verify the apply landed durably BEFORE focusing — an ERROR-severity readback means
   // Tableau silently dropped intent-bearing nodes, so we reject and never navigate to the
   // broken sheet (W4). WARNING-severity findings ride along on the successful Ok.
-  const findings = await verifyReadbackAfterApply(worksheetName, xml, executor, signal);
-  const outcomeResult = readbackOutcome(findings);
+  const verification = await verifyPostApplyWorksheetReadback(worksheetName, xml, executor, signal);
+  readbackVerificationOut?.push(publicReadbackVerificationResult(verification));
+  const outcomeResult = readbackOutcome(verification);
   if (outcomeResult.isErr()) return outcomeResult;
 
   await focusAppliedSheetBestEffort({
@@ -227,9 +276,11 @@ async function loadWorksheetXmlViaExternalApi({
   xml,
   executor,
   signal,
+  readbackVerificationOut,
 }: {
   worksheetName: string;
   xml: string;
+  readbackVerificationOut?: ReadbackVerificationResult[];
 } & WithExecutorAndAbortSignal): Promise<LoadWorksheetXmlResult> {
   return withApplyLock(async () => {
     const workbookResult = await getWorkbookXml({ executor, signal });
@@ -256,8 +307,14 @@ async function loadWorksheetXmlViaExternalApi({
       data: { worksheetName },
     });
 
-    const findings = await verifyReadbackAfterApply(worksheetName, xml, executor, signal);
-    const outcomeResult = readbackOutcome(findings);
+    const verification = await verifyPostApplyWorksheetReadback(
+      worksheetName,
+      xml,
+      executor,
+      signal,
+    );
+    readbackVerificationOut?.push(publicReadbackVerificationResult(verification));
+    const outcomeResult = readbackOutcome(verification);
     if (outcomeResult.isErr()) return outcomeResult;
 
     await focusAppliedSheetBestEffort({

--- a/src/desktop/validation/readback-verify.ts
+++ b/src/desktop/validation/readback-verify.ts
@@ -20,6 +20,14 @@ export interface ReadbackFinding {
   severity: ReadbackFindingSeverity;
 }
 
+export type ReadbackVerificationStatus = 'passed' | 'warning' | 'failed' | 'skipped';
+
+export interface ReadbackVerificationResult {
+  ok: boolean;
+  status: ReadbackVerificationStatus;
+  message?: string;
+}
+
 type XmlRecord = Record<string, any>;
 
 interface EncodingSignature {
@@ -360,6 +368,13 @@ export function formatReadbackVerificationError(findings: ReadbackFinding[]): st
     'The rendered chart does NOT match the intent — likely an invalid/unsupported node. ' +
     'Fix the worksheet XML to use Tableau-supported shelf, mark, filter, and encoding nodes, then re-apply.'
   );
+}
+
+export function formatReadbackVerificationStatus(
+  result: ReadbackVerificationResult | undefined,
+): string {
+  if (result?.status !== 'skipped') return '';
+  return 'Apply succeeded, but could not verify (readback unavailable). Re-read the worksheet before relying on the result.';
 }
 
 export function formatReadbackVerificationWarnings(findings: ReadbackFinding[]): string {

--- a/src/server.desktop.test.ts
+++ b/src/server.desktop.test.ts
@@ -213,7 +213,7 @@ describe('desktop tools/list per-tool byte accounting', () => {
     ['validate-proposal', 2014], // do not grow
     ['dashboard-auto-apply', 1829], // do not grow
     ['dashboard-health-check', 1821], // do not grow
-    ['inject-template', 1382], // do not grow
+    ['inject-template', 1356], // do not grow
     ['build-and-apply-worksheet', 1274], // do not grow
   ]);
 

--- a/src/tools/desktop/cache/noDeadEnd.test.ts
+++ b/src/tools/desktop/cache/noDeadEnd.test.ts
@@ -87,7 +87,13 @@ describe('no-dead-end file workflow for a filesystem-less client', () => {
       "<worksheet name='Sales'><table><rows>[Sales Modified]</rows></table></worksheet>";
     const writeCb = await Provider.from(getWriteCachedXmlTool(new DesktopMcpServer()).callback);
     const writeResult = await writeCb(
-      { filePath: file, xmlContent: modifiedSales, worksheet: 'Sales', dashboard: undefined },
+      {
+        session: 's1',
+        filePath: file,
+        xmlContent: modifiedSales,
+        worksheet: 'Sales',
+        dashboard: undefined,
+      },
       extra(),
     );
     expect(writeResult.isError).toBeFalsy();

--- a/src/tools/desktop/cache/writeCachedXml.test.ts
+++ b/src/tools/desktop/cache/writeCachedXml.test.ts
@@ -8,14 +8,17 @@ import { getMockRequestHandlerExtra } from '../toolContext.mock.js';
 import { getWriteCachedXmlTool } from './writeCachedXml.js';
 
 vi.mock('../../../desktop/cache.js');
+vi.mock('../../../desktop/commands/workbook/cacheFingerprint.js');
 vi.mock('fs');
 
 import { existsSync, readFileSync, writeFileSync } from 'fs';
 
 import { DesktopCache } from '../../../desktop/cache.js';
+import * as cacheFingerprintModule from '../../../desktop/commands/workbook/cacheFingerprint.js';
 
 const CACHE_DIR = resolve('/tmp/test-cache');
 const CACHED_FILE = `${CACHE_DIR}/worksheet-session-1.xml`;
+const SESSION = '12345';
 const VALID_XML = '<worksheet name="Sheet1"><table/></worksheet>';
 const MALFORMED_XML = '<worksheet name="Sheet1"><table></worksheet>';
 
@@ -41,6 +44,7 @@ describe('writeCachedXmlTool', () => {
     expect(tool.name).toBe('write-cached-xml');
     expect(tool.annotations).toMatchObject({ readOnlyHint: false });
     expect(tool.paramsSchema).toMatchObject({
+      session: expect.any(Object),
       filePath: expect.any(Object),
       xmlContent: expect.any(Object),
     });
@@ -59,6 +63,12 @@ describe('writeCachedXmlTool', () => {
     await getResult(CACHED_FILE, VALID_XML);
 
     expect(writeFileSync).toHaveBeenCalledWith(resolve(CACHED_FILE), VALID_XML, 'utf-8');
+  });
+
+  it('writes a fingerprint sidecar after writing the cache file', async () => {
+    await getResult(CACHED_FILE, VALID_XML);
+
+    expect(cacheFingerprintModule.writeSidecar).toHaveBeenCalledWith(resolve(CACHED_FILE), SESSION);
   });
 
   it('should return error for malformed XML without writing', async () => {
@@ -245,7 +255,13 @@ async function getResult(
   const tool = getWriteCachedXmlTool(new DesktopMcpServer());
   const callback = await Provider.from(tool.callback);
   return await callback(
-    { filePath, xmlContent, worksheet: selectors.worksheet, dashboard: selectors.dashboard },
+    {
+      session: SESSION,
+      filePath,
+      xmlContent,
+      worksheet: selectors.worksheet,
+      dashboard: selectors.dashboard,
+    },
     getMockRequestHandlerExtra(),
   );
 }

--- a/src/tools/desktop/cache/writeCachedXml.ts
+++ b/src/tools/desktop/cache/writeCachedXml.ts
@@ -4,6 +4,7 @@ import { resolve } from 'path';
 import { Ok } from 'ts-results-es';
 import { z } from 'zod';
 
+import { writeSidecar } from '../../../desktop/commands/workbook/cacheFingerprint.js';
 import { wellFormedXmlRule } from '../../../desktop/validation/rules/wellFormedXml.js';
 import { parseOuterElement, replaceElement } from '../../../desktop/xmlElement.js';
 import {
@@ -16,15 +17,13 @@ import { DesktopTool } from '../tool.js';
 import { getCacheDir, isWithinCacheDir } from './cachePath.js';
 
 const paramsSchema = {
-  filePath: z.string().describe('Cached working-copy file path to write.'),
+  session: z.string().describe('Session ID.'),
+  filePath: z.string().describe('Cache file path to write.'),
   xmlContent: z
     .string()
-    .describe('Content to write: whole file, or replacement element when a selector is provided.'),
-  worksheet: z
-    .string()
-    .optional()
-    .describe('Optional worksheet splice selector. One selector at a time.'),
-  dashboard: z.string().optional().describe('Optional dashboard splice selector.'),
+    .describe('Content to write; replacement element when a selector is provided.'),
+  worksheet: z.string().optional().describe('Worksheet splice selector. One selector at a time.'),
+  dashboard: z.string().optional().describe('Dashboard splice selector.'),
 };
 
 const toolTitle = 'Save Cached Working Copy';
@@ -36,8 +35,7 @@ export const getWriteCachedXmlTool = (
     name: 'write-cached-xml',
     title: toolTitle,
     description:
-      'Save cached workbook, worksheet, or dashboard content before apply-* tools (mutates cache file). For large files, pass exactly ' +
-      'ONE worksheet or dashboard selector to splice one replacement element.',
+      'Save cached workbook, worksheet, or dashboard content before apply-* tools. For large files, pass ONE selector to splice a replacement element.',
     paramsSchema,
     annotations: {
       title: toolTitle,
@@ -47,12 +45,12 @@ export const getWriteCachedXmlTool = (
       openWorldHint: false,
     },
     callback: async (
-      { filePath, xmlContent, worksheet, dashboard },
+      { session, filePath, xmlContent, worksheet, dashboard },
       extra,
     ): Promise<CallToolResult> => {
       return await tool.logAndExecute({
         extra,
-        args: { filePath, xmlContent, worksheet, dashboard },
+        args: { session, filePath, xmlContent, worksheet, dashboard },
         callback: async () => {
           const absolutePath = resolve(filePath);
           const cacheDir = getCacheDir();
@@ -133,6 +131,7 @@ export const getWriteCachedXmlTool = (
 
           try {
             writeFileSync(absolutePath, contentToWrite, 'utf-8');
+            writeSidecar(absolutePath, session);
             return new Ok({
               filePath,
               bytes: contentToWrite.length,

--- a/src/tools/desktop/coordination/buildAndApplyWorksheet.test.ts
+++ b/src/tools/desktop/coordination/buildAndApplyWorksheet.test.ts
@@ -98,6 +98,23 @@ describe('buildAndApplyWorksheetTool', () => {
     expect(result.content[0].text).toContain('ranking-ordered-bar');
   });
 
+  it('reports skipped readback caveat when apply succeeds without verification', async () => {
+    const extra = makeExtra();
+    vi.mocked(loadWorksheetXml).mockResolvedValue(
+      new Ok({
+        readbackWarnings: [],
+        readbackVerification: { ok: true, status: 'skipped', message: 'worksheet busy' },
+      }),
+    );
+
+    const result = await getResult({ session: SESSION, taskSpec: TASK_SPEC_BASE }, extra);
+
+    expect(result.isError).toBeFalsy();
+    invariant(result.content[0].type === 'text');
+    expect(result.content[0].text).toContain('could not verify (readback unavailable)');
+    expect(result.content[0].text).not.toMatch(/\bverified\b/i);
+  });
+
   it('should return error when workbook file does not exist', async () => {
     const extra = makeExtra();
     vi.mocked(existsSync).mockReturnValue(false);

--- a/src/tools/desktop/coordination/buildAndApplyWorksheet.ts
+++ b/src/tools/desktop/coordination/buildAndApplyWorksheet.ts
@@ -22,6 +22,7 @@ import { rewriteFieldReferences } from '../../../desktop/templates/fieldReferenc
 import { ensureUserNamespace } from '../../../desktop/templates/injectTemplateCore.js';
 import { getTemplateColumnRequirements } from '../../../desktop/templates/templateColumnRequirements.js';
 import { readTemplate } from '../../../desktop/templates/templatePath.js';
+import { formatReadbackVerificationStatus } from '../../../desktop/validation/readback-verify.js';
 import {
   ArgsValidationError,
   CacheSessionMismatchError,
@@ -304,8 +305,12 @@ export const getBuildAndApplyWorksheetTool = (
             }
           }
 
+          const readbackStatusWarning = applyResult.isOk()
+            ? formatReadbackVerificationStatus(applyResult.value.readbackVerification)
+            : '';
+
           return new Ok({
-            message: `Built and applied worksheet "${worksheetName}" using template "${template}" with ${fields.length} fields.`,
+            message: `Built and applied worksheet "${worksheetName}" using template "${template}" with ${fields.length} fields.${readbackStatusWarning ? ` ${readbackStatusWarning}` : ''}`,
             worksheetName,
             template,
             fieldCount: fields.length,

--- a/src/tools/desktop/fields/addField.test.ts
+++ b/src/tools/desktop/fields/addField.test.ts
@@ -2,6 +2,7 @@ import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { existsSync, readFileSync, writeFileSync } from 'fs';
 import { z } from 'zod';
 
+import * as cacheFingerprintModule from '../../../desktop/commands/workbook/cacheFingerprint.js';
 import * as metadataModule from '../../../desktop/metadata/index.js';
 import {
   ArgsValidationError,
@@ -16,6 +17,7 @@ import { getMockRequestHandlerExtra } from '../toolContext.mock.js';
 import { getAddFieldTool } from './addField.js';
 
 vi.mock('../../../desktop/metadata/index.js');
+vi.mock('../../../desktop/commands/workbook/cacheFingerprint.js');
 vi.mock('fs');
 
 type EncodingType = 'color' | 'size' | 'lod' | 'detail' | 'text' | 'tooltip' | 'path' | 'angle';
@@ -27,6 +29,7 @@ const resultSchema = z.object({
 });
 
 const WORKSHEET_FILE = '/cache/worksheet.xml';
+const SESSION = '12345';
 const WORKBOOK_FILE = '/cache/workbook.xml';
 const COLUMN_REF = '[Sample - Superstore].[sum:Profit:qk]';
 const MODIFIED_XML = '<worksheet name="Sheet 1"><table></table></worksheet>';
@@ -41,6 +44,7 @@ describe('addFieldTool', () => {
     expect(tool.name).toBe('add-field');
     expect(tool.description).toContain('Rows, Columns, or an encoding');
     expect(tool.paramsSchema).toMatchObject({
+      session: expect.any(Object),
       worksheetFile: expect.any(Object),
       target: expect.any(Object),
       columnRef: expect.any(Object),
@@ -122,6 +126,17 @@ describe('addFieldTool', () => {
     expect(writeFileSync).toHaveBeenCalledWith(WORKSHEET_FILE, MODIFIED_XML, 'utf-8');
   });
 
+  it('writes a fingerprint sidecar after updating the worksheet cache file', async () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue('<worksheet/>');
+    vi.mocked(metadataModule.addFieldToRows).mockReturnValue(MODIFIED_XML);
+    vi.mocked(writeFileSync).mockReturnValue(undefined);
+
+    await getResult({ worksheetFile: WORKSHEET_FILE, target: 'rows', columnRef: COLUMN_REF });
+
+    expect(cacheFingerprintModule.writeSidecar).toHaveBeenCalledWith(WORKSHEET_FILE, SESSION);
+  });
+
   it('does not use the Tableau command channel after a successful field edit', async () => {
     vi.mocked(existsSync).mockReturnValue(true);
     vi.mocked(readFileSync).mockReturnValue('<worksheet/>');
@@ -133,6 +148,7 @@ describe('addFieldTool', () => {
 
     const result = await callback(
       {
+        session: SESSION,
         worksheetFile: WORKSHEET_FILE,
         target: 'rows',
         columnRef: COLUMN_REF,
@@ -428,7 +444,7 @@ async function getResult({
   const tool = getAddFieldTool(new DesktopMcpServer());
   const callback = await Provider.from(tool.callback);
   return await callback(
-    { worksheetFile, target, columnRef, encodingType, index, workbookFile },
+    { session: SESSION, worksheetFile, target, columnRef, encodingType, index, workbookFile },
     getMockRequestHandlerExtra(),
   );
 }

--- a/src/tools/desktop/fields/addField.ts
+++ b/src/tools/desktop/fields/addField.ts
@@ -3,6 +3,7 @@ import { existsSync, readFileSync, writeFileSync } from 'fs';
 import { Ok } from 'ts-results-es';
 import { z } from 'zod';
 
+import { writeSidecar } from '../../../desktop/commands/workbook/cacheFingerprint.js';
 import {
   addFieldToCols,
   addFieldToEncoding,
@@ -34,6 +35,7 @@ const ENCODING_TYPES = [
 const FIELD_TARGETS = ['rows', 'cols', 'encoding'] as const;
 
 const paramsSchema = {
+  session: z.string().describe('Session ID.'),
   worksheetFile: z.string().describe('Worksheet cache file.'),
   target: z.enum(FIELD_TARGETS).describe('Destination: rows=Rows, cols=Columns, or encoding.'),
   columnRef: z.string().describe('Column reference.'),
@@ -41,8 +43,8 @@ const paramsSchema = {
     .enum(ENCODING_TYPES)
     .optional()
     .describe("Encoding channel ('text'=labels); required iff target=encoding."),
-  index: z.number().optional().describe('Optional 0-based insert position.'),
-  workbookFile: z.string().optional().describe('Optional workbook cache file for caption.'),
+  index: z.number().optional().describe('0-based insert position.'),
+  workbookFile: z.string().optional().describe('Workbook cache file for caption.'),
 };
 
 const title = 'Add Field';
@@ -52,7 +54,7 @@ export const getAddFieldTool = (server: DesktopMcpServer): DesktopTool<typeof pa
     name: 'add-field',
     title,
     description:
-      'Add a field to Rows, Columns, or an encoding (mutates cache; adds missing datasource dependency). Apply with apply-worksheet.',
+      'Add a field to Rows, Columns, or an encoding; mutates cache. Apply with apply-worksheet.',
     paramsSchema,
     annotations: {
       title,
@@ -62,12 +64,12 @@ export const getAddFieldTool = (server: DesktopMcpServer): DesktopTool<typeof pa
       idempotentHint: false,
     },
     callback: async (
-      { worksheetFile, target, columnRef, encodingType, index, workbookFile },
+      { session, worksheetFile, target, columnRef, encodingType, index, workbookFile },
       extra,
     ): Promise<CallToolResult> => {
       return await addFieldTool.logAndExecute({
         extra,
-        args: { worksheetFile, target, columnRef, encodingType, index, workbookFile },
+        args: { session, worksheetFile, target, columnRef, encodingType, index, workbookFile },
         callback: async () => {
           if (!existsSync(worksheetFile)) {
             return new FileNotFoundError(worksheetFile).toErr();
@@ -138,6 +140,7 @@ export const getAddFieldTool = (server: DesktopMcpServer): DesktopTool<typeof pa
 
           try {
             writeFileSync(worksheetFile, modifiedXml, 'utf-8');
+            writeSidecar(worksheetFile, session);
           } catch (error) {
             return new FileReadError(error).toErr();
           }

--- a/src/tools/desktop/fields/removeField.test.ts
+++ b/src/tools/desktop/fields/removeField.test.ts
@@ -2,6 +2,7 @@ import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { existsSync, readFileSync, writeFileSync } from 'fs';
 import { z } from 'zod';
 
+import * as cacheFingerprintModule from '../../../desktop/commands/workbook/cacheFingerprint.js';
 import * as metadataModule from '../../../desktop/metadata/index.js';
 import {
   ArgsValidationError,
@@ -16,6 +17,7 @@ import { getMockRequestHandlerExtra } from '../toolContext.mock.js';
 import { getRemoveFieldTool } from './removeField.js';
 
 vi.mock('../../../desktop/metadata/index.js');
+vi.mock('../../../desktop/commands/workbook/cacheFingerprint.js');
 vi.mock('fs');
 
 type EncodingType = 'color' | 'size' | 'lod' | 'detail' | 'text' | 'tooltip' | 'path' | 'angle';
@@ -27,6 +29,7 @@ const resultSchema = z.object({
 });
 
 const WORKSHEET_FILE = '/cache/worksheet.xml';
+const SESSION = '12345';
 const COLUMN_REF = '[Sample - Superstore].[sum:Profit:qk]';
 const MODIFIED_XML = '<worksheet name="Sheet 1"><table></table></worksheet>';
 
@@ -40,6 +43,7 @@ describe('removeFieldTool', () => {
     expect(tool.name).toBe('remove-field');
     expect(tool.description).toContain('Rows, Columns, or an encoding');
     expect(tool.paramsSchema).toMatchObject({
+      session: expect.any(Object),
       worksheetFile: expect.any(Object),
       target: expect.any(Object),
       columnRef: expect.any(Object),
@@ -122,6 +126,17 @@ describe('removeFieldTool', () => {
     expect(metadataModule.removeFieldFromRows).toHaveBeenCalledWith('<worksheet/>', COLUMN_REF);
   });
 
+  it('writes a fingerprint sidecar after updating the worksheet cache file', async () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue('<worksheet/>');
+    vi.mocked(metadataModule.removeFieldFromRows).mockReturnValue(MODIFIED_XML);
+    vi.mocked(writeFileSync).mockReturnValue(undefined);
+
+    await getResult({ worksheetFile: WORKSHEET_FILE, target: 'rows', columnRef: COLUMN_REF });
+
+    expect(cacheFingerprintModule.writeSidecar).toHaveBeenCalledWith(WORKSHEET_FILE, SESSION);
+  });
+
   it('does not use the Tableau command channel after a successful field edit', async () => {
     vi.mocked(existsSync).mockReturnValue(true);
     vi.mocked(readFileSync).mockReturnValue('<worksheet/>');
@@ -133,6 +148,7 @@ describe('removeFieldTool', () => {
 
     const result = await callback(
       {
+        session: SESSION,
         worksheetFile: WORKSHEET_FILE,
         target: 'rows',
         columnRef: COLUMN_REF,
@@ -320,7 +336,7 @@ async function getResult({
   const tool = getRemoveFieldTool(new DesktopMcpServer());
   const callback = await Provider.from(tool.callback);
   return await callback(
-    { worksheetFile, target, columnRef, encodingType },
+    { session: SESSION, worksheetFile, target, columnRef, encodingType },
     getMockRequestHandlerExtra(),
   );
 }

--- a/src/tools/desktop/fields/removeField.ts
+++ b/src/tools/desktop/fields/removeField.ts
@@ -3,6 +3,7 @@ import { existsSync, readFileSync, writeFileSync } from 'fs';
 import { Ok } from 'ts-results-es';
 import { z } from 'zod';
 
+import { writeSidecar } from '../../../desktop/commands/workbook/cacheFingerprint.js';
 import {
   removeFieldFromCols,
   removeFieldFromEncoding,
@@ -34,15 +35,14 @@ const ENCODING_TYPES = [
 const FIELD_TARGETS = ['rows', 'cols', 'encoding'] as const;
 
 const paramsSchema = {
+  session: z.string().describe('Session ID.'),
   worksheetFile: z.string().describe('Worksheet cache file.'),
-  target: z
-    .enum(FIELD_TARGETS)
-    .describe("Source: 'rows' for Rows, 'cols' for Columns, or 'encoding'."),
+  target: z.enum(FIELD_TARGETS).describe('Source: rows, cols, or encoding.'),
   columnRef: z.string().describe('Column reference to remove.'),
   encodingType: z
     .enum(ENCODING_TYPES)
     .optional()
-    .describe("Encoding channel ('text'=labels); required when target=encoding, else ignored."),
+    .describe("Encoding channel ('text'=labels); required iff target=encoding."),
 };
 
 const title = 'Remove Field';
@@ -52,7 +52,7 @@ export const getRemoveFieldTool = (server: DesktopMcpServer): DesktopTool<typeof
     name: 'remove-field',
     title,
     description:
-      'Remove a field from Rows, Columns, or an encoding on a worksheet locally. Reads from and writes to cache file. Use apply-worksheet to apply changes.',
+      'Remove a field from Rows, Columns, or an encoding; mutates cache. Apply with apply-worksheet.',
     paramsSchema,
     annotations: {
       title,
@@ -62,12 +62,12 @@ export const getRemoveFieldTool = (server: DesktopMcpServer): DesktopTool<typeof
       idempotentHint: false,
     },
     callback: async (
-      { worksheetFile, target, columnRef, encodingType },
+      { session, worksheetFile, target, columnRef, encodingType },
       extra,
     ): Promise<CallToolResult> => {
       return await removeFieldTool.logAndExecute({
         extra,
-        args: { worksheetFile, target, columnRef, encodingType },
+        args: { session, worksheetFile, target, columnRef, encodingType },
         callback: async () => {
           if (!existsSync(worksheetFile)) {
             return new FileNotFoundError(worksheetFile).toErr();
@@ -123,6 +123,7 @@ export const getRemoveFieldTool = (server: DesktopMcpServer): DesktopTool<typeof
 
           try {
             writeFileSync(worksheetFile, modifiedXml, 'utf-8');
+            writeSidecar(worksheetFile, session);
           } catch (error) {
             return new FileReadError(error).toErr();
           }

--- a/src/tools/desktop/template/injectTemplate.characterization.test.ts
+++ b/src/tools/desktop/template/injectTemplate.characterization.test.ts
@@ -18,6 +18,7 @@ import { getInjectTemplateTool } from './injectTemplate.js';
 vi.mock('../../../desktop/templates/injectTemplate.js');
 vi.mock('../../../desktop/templates/fieldReferenceRewriter.js');
 vi.mock('../../../desktop/templates/templatePath.js');
+vi.mock('../../../desktop/commands/workbook/cacheFingerprint.js');
 vi.mock('fs');
 
 import { existsSync, readFileSync, writeFileSync } from 'fs';
@@ -28,6 +29,7 @@ import { listTemplateNames, readTemplate } from '../../../desktop/templates/temp
 import { TableauDesktopRequestHandlerExtra } from '../toolContext.js';
 
 const WORKBOOK_FILE = resolve('/cache/workbook.xml');
+const SESSION = '12345';
 const WORKBOOK_XML = '<?xml version="1.0"?><workbook><worksheets/></workbook>';
 // Template carries {{TITLE}}, a non-DATASOURCE placeholder ({{SUBTITLE}}), a bare
 // {{DATASOURCE}} placeholder, and a field ref — exercising every substitution path.
@@ -42,6 +44,7 @@ const INJECTED_XML =
   '<?xml version="1.0"?><workbook><worksheets><worksheet name="Sheet1"/></worksheets></workbook>';
 
 const BASE_PARAMS = {
+  session: SESSION,
   workbookFile: WORKBOOK_FILE,
   templateName: 'ranking-ordered-bar',
   title: 'Sheet1',

--- a/src/tools/desktop/template/injectTemplate.test.ts
+++ b/src/tools/desktop/template/injectTemplate.test.ts
@@ -1,6 +1,7 @@
 import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { resolve } from 'path';
 
+import * as cacheFingerprintModule from '../../../desktop/commands/workbook/cacheFingerprint.js';
 import { removeSameNamedWorksheet } from '../../../desktop/templates/injectTemplateCore.js';
 import { DesktopMcpServer } from '../../../server.desktop.js';
 import invariant from '../../../utils/invariant.js';
@@ -11,6 +12,7 @@ import { getInjectTemplateTool } from './injectTemplate.js';
 vi.mock('../../../desktop/templates/injectTemplate.js');
 vi.mock('../../../desktop/templates/fieldReferenceRewriter.js');
 vi.mock('../../../desktop/templates/templatePath.js');
+vi.mock('../../../desktop/commands/workbook/cacheFingerprint.js');
 vi.mock('fs');
 
 import { existsSync, readFileSync, writeFileSync } from 'fs';
@@ -21,6 +23,7 @@ import { listTemplateNames, readTemplate } from '../../../desktop/templates/temp
 import { TableauDesktopRequestHandlerExtra } from '../toolContext.js';
 
 const WORKBOOK_FILE = resolve('/cache/workbook.xml');
+const SESSION = '12345';
 const WORKBOOK_XML = '<?xml version="1.0"?><workbook><worksheets/></workbook>';
 const TEMPLATE_XML =
   '<workbook><worksheets><worksheet name="{{TITLE}}"/></worksheets>' +
@@ -29,6 +32,7 @@ const INJECTED_XML =
   '<?xml version="1.0"?><workbook><worksheets><worksheet name="Sheet1"/></worksheets></workbook>';
 
 const BASE_PARAMS = {
+  session: SESSION,
   workbookFile: WORKBOOK_FILE,
   templateName: 'ranking-ordered-bar',
   title: 'Sheet1',
@@ -58,6 +62,7 @@ describe('injectTemplateTool', () => {
     expect(tool.name).toBe('inject-template');
     expect(tool.annotations).toMatchObject({ readOnlyHint: false });
     expect(tool.paramsSchema).toMatchObject({
+      session: expect.any(Object),
       workbookFile: expect.any(Object),
       templateName: expect.any(Object),
       title: expect.any(Object),
@@ -79,6 +84,15 @@ describe('injectTemplateTool', () => {
     await getResult(BASE_PARAMS);
 
     expect(writeFileSync).toHaveBeenCalledWith(resolve(WORKBOOK_FILE), INJECTED_XML, 'utf-8');
+  });
+
+  it('writes a fingerprint sidecar after updating the workbook cache file', async () => {
+    await getResult(BASE_PARAMS);
+
+    expect(cacheFingerprintModule.writeSidecar).toHaveBeenCalledWith(
+      resolve(WORKBOOK_FILE),
+      SESSION,
+    );
   });
 
   it('should return error when workbook file does not exist', async () => {

--- a/src/tools/desktop/template/injectTemplate.ts
+++ b/src/tools/desktop/template/injectTemplate.ts
@@ -10,6 +10,7 @@ import {
   formatExplicitBindErrors,
 } from '../../../desktop/binder/explicit-bind.js';
 import { summarizeSchema } from '../../../desktop/binder/schema-summary.js';
+import { writeSidecar } from '../../../desktop/commands/workbook/cacheFingerprint.js';
 import { buildInjectedWorkbookXml } from '../../../desktop/templates/injectTemplateCore.js';
 import { listTemplateNames, readTemplate } from '../../../desktop/templates/templatePath.js';
 import {
@@ -22,20 +23,18 @@ import { DesktopMcpServer } from '../../../server.desktop.js';
 import { DesktopTool } from '../tool.js';
 
 const paramsSchema = {
-  workbookFile: z.string().describe('Workbook cache file path.'),
+  session: z.string().describe('Session ID.'),
+  workbookFile: z.string().describe('Workbook cache file.'),
   templateName: z.string().describe('Template name.'),
   title: z.string().describe('New sheet name; replaces {{TITLE}}.'),
-  sheetType: z.enum(['worksheet', 'dashboard', 'story']).describe('Type of sheet being injected.'),
-  templateParameters: z
-    .record(z.string())
-    .optional()
-    .describe('Additional placeholder substitutions.'),
+  sheetType: z.enum(['worksheet', 'dashboard', 'story']).describe('Sheet type.'),
+  templateParameters: z.record(z.string()).optional().describe('Placeholder substitutions.'),
   fieldMapping: z.record(z.string()).optional().describe('Template field to column-ref map.'),
   insertPosition: z
     .enum(['end', 'before_sheet', 'after_sheet'])
     .optional()
     .describe('Tab insertion position.'),
-  relativeSheetName: z.string().optional().describe('Anchor sheet for before/after insertion.'),
+  relativeSheetName: z.string().optional().describe('Anchor for before/after insertion.'),
 };
 
 const toolTitle = 'Inject Template';
@@ -47,8 +46,8 @@ export const getInjectTemplateTool = (
     name: 'inject-template',
     title: toolTitle,
     description: [
-      'Inject a worksheet/dashboard/story template into a cached workbook (mutates).',
-      'Names from template list; supports {{TITLE}}. Then apply-workbook.',
+      'Inject a template into a cached workbook (mutates).',
+      'Supports {{TITLE}}. Then apply-workbook.',
     ].join(' '),
     paramsSchema,
     annotations: {
@@ -60,6 +59,7 @@ export const getInjectTemplateTool = (
     },
     callback: async (
       {
+        session,
         workbookFile,
         templateName,
         title,
@@ -74,6 +74,7 @@ export const getInjectTemplateTool = (
       return await tool.logAndExecute({
         extra,
         args: {
+          session,
           workbookFile,
           templateName,
           title,
@@ -103,7 +104,7 @@ export const getInjectTemplateTool = (
 
             // Per-apply calc namespacing identity: the shared core defaults
             // namespacing OFF and never mints its own nonce, so the caller supplies
-            // one. inject-template has no session, so the per-apply identity is the
+            // one. The sidecar uses session for cache fingerprinting; this nonce is
             // target workbook file + apply timestamp; a randomUUID guards against
             // same-millisecond collisions.
             // Manifest enforcement (P0 W-23447710): a caller-supplied mapping for a
@@ -151,6 +152,7 @@ export const getInjectTemplateTool = (
             }
 
             writeFileSync(resolve(workbookFile), result.xml, 'utf-8');
+            writeSidecar(resolve(workbookFile), session);
 
             return new Ok({
               workbookFile,

--- a/src/tools/desktop/worksheet/applyWorksheet.test.ts
+++ b/src/tools/desktop/worksheet/applyWorksheet.test.ts
@@ -24,6 +24,11 @@ describe('applyWorksheetTool', () => {
   const resultSchema = z.object({
     message: z.string(),
   });
+  const skippedReadbackVerification = {
+    ok: true,
+    status: 'skipped' as const,
+    message: 'worksheet busy',
+  };
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -98,6 +103,51 @@ describe('applyWorksheetTool', () => {
 
     expect(existsSync).toHaveBeenCalledWith(mockFilePath);
     expect(readFileSync).toHaveBeenCalledWith(mockFilePath, 'utf-8');
+  });
+
+  it('reports skipped readback honestly for inline worksheet XML apply', async () => {
+    const mockXml = '<worksheet name="Sheet 1"><table></table></worksheet>';
+    vi.spyOn(loadWorksheetXmlModule, 'loadWorksheetXml').mockResolvedValue(
+      Ok({ readbackWarnings: [], readbackVerification: skippedReadbackVerification }),
+    );
+
+    const result = await getToolResult({
+      session: '12345',
+      worksheetName: 'Sheet 1',
+      mode: 'inline',
+      worksheetXml: mockXml,
+      mockExecutor: vi.fn().mockResolvedValue({}),
+    });
+
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+    const message = resultSchema.parse(JSON.parse(result.content[0].text)).message;
+    expect(message).toContain('could not verify (readback unavailable)');
+    expect(message).not.toMatch(/\bverified\b/i);
+  });
+
+  it('reports skipped readback honestly for file-based worksheet apply', async () => {
+    const mockXml = '<worksheet name="Sheet 1"><table></table></worksheet>';
+    const mockFilePath = '/path/to/worksheet.xml';
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue(mockXml);
+    vi.spyOn(loadWorksheetXmlModule, 'loadWorksheetXml').mockResolvedValue(
+      Ok({ readbackWarnings: [], readbackVerification: skippedReadbackVerification }),
+    );
+
+    const result = await getToolResult({
+      session: '12345',
+      worksheetName: 'Sheet 1',
+      mode: 'file',
+      worksheetFile: mockFilePath,
+      mockExecutor: vi.fn().mockResolvedValue({}),
+    });
+
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+    const message = resultSchema.parse(JSON.parse(result.content[0].text)).message;
+    expect(message).toContain('could not verify (readback unavailable)');
+    expect(message).not.toMatch(/\bverified\b/i);
   });
 
   it('should return error when inline mode is used without worksheetXml', async () => {

--- a/src/tools/desktop/worksheet/applyWorksheet.ts
+++ b/src/tools/desktop/worksheet/applyWorksheet.ts
@@ -11,7 +11,10 @@ import {
   xmlByteLength,
 } from '../../../desktop/inlineXmlCap.js';
 import { resolveSession } from '../../../desktop/sessionResolution.js';
-import { formatReadbackVerificationWarnings } from '../../../desktop/validation/readback-verify.js';
+import {
+  formatReadbackVerificationStatus,
+  formatReadbackVerificationWarnings,
+} from '../../../desktop/validation/readback-verify.js';
 import {
   ArgsValidationError,
   CacheSessionMismatchError,
@@ -149,9 +152,13 @@ export const getApplyWorksheetTool = (
           const readbackWarning = result.isOk()
             ? formatReadbackVerificationWarnings(result.value.readbackWarnings)
             : '';
+          const readbackStatus = result.isOk()
+            ? formatReadbackVerificationStatus(result.value.readbackVerification)
+            : '';
+          const updateStatus = readbackStatus || 'The worksheet has been updated.';
 
           return new Ok({
-            message: `Successfully applied worksheet update for "${worksheetName}". The worksheet has been updated.${note}${readbackWarning}`,
+            message: `Successfully applied worksheet update for "${worksheetName}". ${updateStatus}${note}${readbackWarning}`,
           });
         },
       });


### PR DESCRIPTION
Desktop twins of the three a2td #207 red-team fixes, ported per the adjudicated port drafts (quote-checked against this head by independent review legs before apply).

## Commits

1. **SCG-001/002 — sidecar stamping on cache mutators** (`e305ca50`): `write-cached-xml`, `add-field`, `remove-field`, and `inject-template` wrote cache files without fingerprint sidecars; a missing sidecar deliberately fails open at apply, so files written by these tools permanently bypassed the cross-instance cache-bleed guard. Every mutator write now stamps `writeSidecar`, and `session` is required on their schemas. Bonus: `inject-template`'s describe trims land it 26 bytes under its grandfather pin — pin ratcheted 1382 → 1356.

2. **GEO-02/03 — geo concept check on the validate leg** (`f90dda9b`): the LLM-propose path validated geo slots on name affinity alone, so a `[City].[Name]`-tagged field could fill a state slot. Gate 3b now rejects a geo bind whose semantic-role concept contradicts the slot, and `buildLlmInput` carries `semanticRole`. Mirrors the private geo tables from hash-gated `classify.ts` — kept token-identical, pinned by a new source-level parity test. Lockstep-core bytes untouched.

3. **RB-01/SCG-004 — honest skipped-readback responses** (`8ef0d4dd`): a skipped post-apply readback (re-read failed or threw) was indistinguishable from a passed one, so `apply-worksheet`/`build-and-apply-worksheet` claimed verified success they never verified. The verifier now returns `{ok, status, message}` and the response text carries the skip status and reason.

## Validation (per commit)

- Full desktop suite green at each commit (4,256 → 4,262 → 4,267 tests, 0 failures)
- `tsc --noEmit` clean, scoped eslint clean
- `check-lockstep.mjs` 6/6 at each commit
- Surface ratchet suites green; net surface change is a ratchet win (inject-template pin lowered)

Authored by Claude (MattGPT automation) on Matt Filbert's behalf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)