### PR TITLE
fix(binder): CLS-003 — temporal completion won't swallow an ask-named dimension without slot capacity

### DIFF
--- a/src/desktop/binder/classify.ts
+++ b/src/desktop/binder/classify.ts
@@ -1131,7 +1131,35 @@ function roleGreedyBind(
   const temporalSlots = m.slots.filter((s) => isActive(s) && s.kind === 'temporal');
   const temporalAutoCompleted = new Map<string, SchemaField>();
 
-  for (const slot of m.slots) {
+  // CLS-003 GUARD: unique-date completion must not paper over an ask-NAMED
+  // non-temporal dimension no remaining slot can consume ("trend of Actual Amount
+  // by Fiscal Period" on a temporal+measure template must escalate, never silently
+  // drop Fiscal Period and chart a date axis the user did not ask for). Capacity =
+  // remaining ACTIVE categorical/geo slots, plus ONE armed optional facet slot —
+  // facetBinding appends at most one spare NAMED categorical after the required
+  // slots bind, so an explicit facet ask ("trend of Sales per Region") still
+  // completes. Runs only in the final bind pass (temporalCompletion present).
+  const hasUnslottedNonTemporalDimension = (
+    remainingSlots: TemplateManifest['slots'],
+  ): boolean => {
+    const unconsumedNonTemporalDims = matched.filter(
+      (f) => !used.has(f) && f.role === 'dimension' && !isTemporal(f),
+    );
+    if (unconsumedNonTemporalDims.length === 0) return false;
+    let capacity = remainingSlots.filter(
+      (s) => isActive(s) && (s.kind === 'categorical' || s.kind === 'geo'),
+    ).length;
+    if (
+      temporalCompletion &&
+      askImpliesFacet(temporalCompletion.maskedAsk) &&
+      m.slots.some((s) => isFacetSlot(s) && !isActive(s))
+    ) {
+      capacity += 1;
+    }
+    return unconsumedNonTemporalDims.length > capacity;
+  };
+
+  for (const [i, slot] of m.slots.entries()) {
     if (!isActive(slot)) continue;
     let chosen: SchemaField | null = null;
     switch (slot.kind) {
@@ -1149,7 +1177,12 @@ function roleGreedyBind(
         // completeTemporalSlot. `temporalCompletion` is passed ONLY by classifyNoLlm's
         // final bind — selectWithinFamily's slot-fit probes omit it, so completion can
         // never make an extra candidate look bindable during tie-breaking.
-        if (!chosen && temporalCompletion && temporalSlots.length === 1) {
+        if (
+          !chosen &&
+          temporalCompletion &&
+          temporalSlots.length === 1 &&
+          !hasUnslottedNonTemporalDimension(m.slots.slice(i + 1))
+        ) {
           const completed = completeTemporalSlot(
             temporalCompletion.maskedAsk,
             matched,

--- a/src/desktop/binder/within-family-disambiguation.test.ts
+++ b/src/desktop/binder/within-family-disambiguation.test.ts
@@ -486,3 +486,74 @@ describe('classifyNoLlm — spatial-intent family guard (W-23447710)', () => {
     ).toBeNull();
   });
 });
+
+// ── CLS-003: TEMPORAL-COMPLETION NAMED-DIMENSION GUARD ────────────────────────
+// Unique-date completion must not paper over an ask-NAMED non-temporal dimension
+// that no remaining slot can consume: "trend of Actual Amount by Fiscal Period"
+// on a temporal+measure template must escalate (null), never silently drop
+// Fiscal Period and chart a date axis the user did not ask for. Capacity counts
+// the remaining ACTIVE categorical/geo slots plus ONE armed optional facet slot
+// (facetBinding appends at most one spare named categorical post-bind).
+describe('classifyNoLlm — temporal completion named-dimension guard (CLS-003)', () => {
+  const tempVal = (): SlotSpec[] => [slot('t', 'temporal'), slot('v', 'quantitative')];
+  const financeSummary: SchemaSummary = {
+    datasource: 'DS',
+    fields: [
+      field('Posting Date', 'dimension', 'ordinal', 'date'),
+      field('Fiscal Period', 'dimension', 'nominal', 'string'),
+      field('Actual Amount', 'measure', 'quantitative', 'real'),
+    ],
+  };
+  const superstoreLoneDate: SchemaSummary = {
+    datasource: 'DS',
+    fields: [
+      field('Order Date', 'dimension', 'ordinal', 'date'),
+      field('Region', 'dimension', 'nominal', 'string'),
+      field('Sales', 'measure', 'quantitative', 'real'),
+    ],
+  };
+  const facetCol = (): SlotSpec => ({
+    ...slot('facet_col', 'categorical'),
+    required: false,
+    role: ['cols'],
+  });
+
+  it('does not complete over an ask-named non-temporal dimension no slot can consume', () => {
+    const m = mapOf(synth('ts', 'time-series', ['trend'], tempVal()));
+    expect(classifyNoLlm('trend of Actual Amount by Fiscal Period', m, financeSummary)).toBeNull();
+  });
+
+  it('still completes when the named dimension has its own remaining categorical slot', () => {
+    const m = mapOf(
+      synth(
+        'ts',
+        'time-series',
+        ['trend'],
+        [slot('t', 'temporal'), slot('cat', 'categorical'), slot('v', 'quantitative')],
+      ),
+    );
+    const res = classifyNoLlm('trend of Sales by Region', m, superstoreLoneDate);
+    expect(res).not.toBeNull();
+    expect(res!.bindings).toEqual([
+      { slot_id: 't', field: 'Order Date' },
+      { slot_id: 'cat', field: 'Region' },
+      { slot_id: 'v', field: 'Sales' },
+    ]);
+  });
+
+  it('still completes on an explicit facet ask — the armed optional facet slot is capacity', () => {
+    const m = mapOf(synth('ts', 'time-series', ['trend'], [...tempVal(), facetCol()]));
+    const res = classifyNoLlm('trend of Sales per Region', m, superstoreLoneDate);
+    expect(res).not.toBeNull();
+    expect(res!.bindings).toEqual([
+      { slot_id: 't', field: 'Order Date' },
+      { slot_id: 'v', field: 'Sales' },
+      { slot_id: 'facet_col', field: 'Region' },
+    ]);
+  });
+
+  it('bare "by <dim>" stays blocked even when a facet slot exists (by is not a facet cue)', () => {
+    const m = mapOf(synth('ts', 'time-series', ['trend'], [...tempVal(), facetCol()]));
+    expect(classifyNoLlm('trend of Sales by Region', m, superstoreLoneDate)).toBeNull();
+  });
+});


### PR DESCRIPTION
"trend of Actual Amount by Fiscal Period" (lone schema date, temporal+measure template) silently dropped Fiscal Period and charted a date axis. The final-bind unique-date completion now fails closed unless remaining categorical/geo slots — or one armed optional facet slot ("per Region") — can consume the ask-named dimension. Probes byte-unchanged (guard needs temporalCompletion).

Facet-aware capacity term added per adversarial review: without it, "trend of Sales per Region" on a facet-carrying template would have regressed.

4 new tests (block / categorical-slot allow / facet allow / bare-"by" block). Suite 4270 passed, tsc clean, lint clean. Lockstep twin: agent-to-tableau-desktop PR (classify.ts synced verbatim + hash regen).

🤖 Generated with [Claude Code](https://claude.com/claude-code)