### PR TITLE
@W-23448424: add update-user tool — two-phase HITL site role update

### DIFF
--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -61,6 +61,7 @@ Slack channel in the Tableau #DataDev workspace.
 | [list-extract-refresh-tasks](tools/tasks/list-extract-refresh-tasks.md)                                               | Admin-only. Retrieves a list of extract refresh tasks for the site ([REST API][list-extract-refresh-tasks])         | All SKUs     |
 | [update-cloud-extract-refresh-task](tools/tasks/update-cloud-extract-refresh-task.md)                                 | Admin-only. Confirm-gated update of an extract refresh task schedule on Tableau Cloud ([REST API][update-cloud-extract-refresh-task]) | All SKUs     |
 | [list-users](tools/users/list-users.md)                                                                               | Admin-only. Retrieves a list of users on the site ([REST API][list-users-api])                                      | All SKUs     |
+| [update-user](tools/users/update-user.md)                                                                             | Admin-only. Confirm-gated update of a user's site role ([REST API][update-user-api])                               | All SKUs     |
 | [query-admin-insights](tools/admin-insights/query-admin-insights.md)                                                 | Admin-only. Dispatches on `kind` to TS Events, Site Content, Job Performance, or stale-content report ([VDS API][vds]) | All SKUs     |
 | [delete-content](tools/content/delete-content.md)                                                                     | Admin-only. Two-phase (preview/confirm) delete of a workbook, data source, or extract refresh task ([REST API][delete-workbook], [REST API][delete-datasource], [REST API][delete-extract-refresh-task]) | All SKUs     |
 
@@ -107,6 +108,8 @@ Slack channel in the Tableau #DataDev workspace.
   https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref_extract_and_encryption.htm#update_cloud_extract_refresh_task
 [list-users-api]:
   https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref_users_and_groups.htm#get_users_on_site
+[update-user-api]:
+  https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref_users_and_groups.htm#update_user
 
 ## Prompt List
 

--- a/docs/docs/tools/users/update-user.md
+++ b/docs/docs/tools/users/update-user.md
@@ -1,0 +1,77 @@
+---
+sidebar_position: 2
+---
+
+# Update User
+
+Updates the site role of a user on the Tableau site. Primary use case: downgrade inactive users to "Unlicensed" to reclaim licenses.
+
+:::warning Admin Only
+This tool is restricted to Tableau site administrators and requires the `ADMIN_TOOLS_ENABLED` environment variable to be enabled.
+:::
+
+## Confirm and audit
+
+This mutation is **two-phase**, gated on a server-generated single-use confirmation token:
+
+1. **Preview** (default — `confirm` omitted or `false`): looks up the user, reports the current
+   and proposed site role, and returns a single-use `confirmationToken`.
+2. **Update** (`confirm: true` + `confirmationToken`): applies the role change. The server
+   verifies and consumes the token first.
+
+The token is server-generated and **bound to the previewed `userId` and `siteRole`**: a token minted
+while previewing role A cannot confirm an update to role B, and a `confirm: true` with no prior
+preview (no valid token) is rejected server-side. Present the change to the user and get explicit
+approval before confirming.
+
+## Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `userId` | string | Yes | The LUID of the user to update. Obtain from `list-users`. |
+| `siteRole` | enum | Yes | The new site role: `Creator`, `Explorer`, `ExplorerCanPublish`, `SiteAdministratorCreator`, `SiteAdministratorExplorer`, `Viewer`, `Unlicensed`. |
+| `confirm` | boolean | No | Set `true` to apply the change (requires `confirmationToken`). |
+| `confirmationToken` | string | No | The single-use token from a prior preview call. |
+
+## Example usage
+
+### Preview (dry run)
+
+```json
+{
+  "userId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+  "siteRole": "Unlicensed"
+}
+```
+
+Response:
+```
+Preview — user 'jsmith' (john.smith@example.com) would be changed from Creator → Unlicensed.
+No change has been made.
+Once approved, call again with confirm: true and confirmationToken: "..."
+```
+
+### Confirm
+
+```json
+{
+  "userId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+  "siteRole": "Unlicensed",
+  "confirm": true,
+  "confirmationToken": "<token from preview>"
+}
+```
+
+Response:
+```
+User 'jsmith' has been successfully updated. New site role: Unlicensed.
+```
+
+## OAuth scopes
+
+- **MCP scope:** `tableau:mcp:users:write`
+- **Tableau API scope:** `tableau:users:update`, `tableau:users:read`
+
+## REST API reference
+
+- [Update User](https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref_users_and_groups.htm#update_user) — `PUT /api/{version}/sites/{siteId}/users/{userId}`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "3.1.4",
+  "version": "3.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "3.1.4",
+      "version": "3.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.7.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "3.1.4",
+  "version": "3.2.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/src/restApiInstance.ts
+++ b/src/restApiInstance.ts
@@ -42,6 +42,7 @@ type JwtScopes =
   | 'tableau:datasources:delete'
   | 'tableau:jobs:read'
   | 'tableau:users:read'
+  | 'tableau:users:update'
   | 'tableau:flows:read'
   | 'tableau:flow_connections:read'
   | 'tableau:flow_runs:read';

--- a/src/sdks/tableau/apis/usersApi.ts
+++ b/src/sdks/tableau/apis/usersApi.ts
@@ -89,5 +89,25 @@ const getUserOnSiteEndpoint = makeEndpoint({
   response: z.object({ user: userSchema }),
 });
 
-const usersApi = makeApi([listUsersEndpoint, getUserOnSiteEndpoint]);
+/**
+ * Update User
+ * PUT /api/api-version/sites/site-id/users/user-id
+ * Modifies information about the specified user (site role, auth setting, etc.).
+ * Tableau Cloud scope: tableau:users:update
+ * @see https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref_users_and_groups.htm#update_user
+ */
+const updateUserEndpoint = makeEndpoint({
+  method: 'put',
+  path: '/sites/:siteId/users/:userId',
+  alias: 'updateUser',
+  description: 'Modifies information about the specified user',
+  parameters: [
+    { name: 'siteId', type: 'Path', schema: z.string() },
+    { name: 'userId', type: 'Path', schema: z.string() },
+    { name: 'body', type: 'Body', schema: z.object({ user: z.object({ siteRole: z.string() }) }) },
+  ],
+  response: z.object({ user: userSchema }),
+});
+
+const usersApi = makeApi([listUsersEndpoint, getUserOnSiteEndpoint, updateUserEndpoint]);
 export const usersApis = [...usersApi] as const satisfies ZodiosEndpointDefinitions;

--- a/src/sdks/tableau/apis/usersApi.ts
+++ b/src/sdks/tableau/apis/usersApi.ts
@@ -106,7 +106,7 @@ const updateUserEndpoint = makeEndpoint({
     { name: 'userId', type: 'Path', schema: z.string() },
     { name: 'body', type: 'Body', schema: z.object({ user: z.object({ siteRole: z.string() }) }) },
   ],
-  response: z.object({ user: userSchema }),
+  response: z.object({ user: userSchema.partial() }),
 });
 
 const usersApi = makeApi([listUsersEndpoint, getUserOnSiteEndpoint, updateUserEndpoint]);

--- a/src/sdks/tableau/methods/usersMethods.test.ts
+++ b/src/sdks/tableau/methods/usersMethods.test.ts
@@ -164,4 +164,32 @@ describe('UsersMethods', () => {
       expect(result.pagination?.totalAvailable).toBe(5);
     });
   });
+
+  describe('updateUser', () => {
+    it('should update user site role and return updated user', async () => {
+      const mockApiClient = {
+        updateUser: vi.fn().mockResolvedValue({
+          user: { id: 'u1', name: 'jsmith', siteRole: 'Unlicensed' },
+        }),
+      };
+
+      const usersMethods = new UsersMethods('http://test', { type: 'Bearer', token: 'test' }, {});
+      // @ts-expect-error - Mocking private property
+      usersMethods._apiClient = mockApiClient;
+
+      const result = await usersMethods.updateUser({
+        siteId: 'site-1',
+        userId: 'u1',
+        siteRole: 'Unlicensed',
+      });
+
+      expect(result).toEqual({ id: 'u1', name: 'jsmith', siteRole: 'Unlicensed' });
+      expect(mockApiClient.updateUser).toHaveBeenCalledWith(
+        { user: { siteRole: 'Unlicensed' } },
+        expect.objectContaining({
+          params: { siteId: 'site-1', userId: 'u1' },
+        }),
+      );
+    });
+  });
 });

--- a/src/sdks/tableau/methods/usersMethods.ts
+++ b/src/sdks/tableau/methods/usersMethods.ts
@@ -110,7 +110,7 @@ export default class UsersMethods extends AuthenticatedMethods<typeof usersApis>
     siteId: string;
     userId: string;
     siteRole: string;
-  }): Promise<User> => {
+  }): Promise<Partial<User>> => {
     const { user } = await this._apiClient.updateUser(
       { user: { siteRole } },
       {

--- a/src/sdks/tableau/methods/usersMethods.ts
+++ b/src/sdks/tableau/methods/usersMethods.ts
@@ -91,4 +91,33 @@ export default class UsersMethods extends AuthenticatedMethods<typeof usersApis>
     });
     return user;
   };
+
+  /**
+   * Updates the site role for the specified user.
+   *
+   * Required scopes (Tableau Cloud): `tableau:users:update`
+   *
+   * @param siteId - The Tableau site ID
+   * @param userId - The user ID
+   * @param siteRole - The new site role to assign
+   * @link https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref_users_and_groups.htm#update_user
+   */
+  updateUser = async ({
+    siteId,
+    userId,
+    siteRole,
+  }: {
+    siteId: string;
+    userId: string;
+    siteRole: string;
+  }): Promise<User> => {
+    const { user } = await this._apiClient.updateUser(
+      { user: { siteRole } },
+      {
+        params: { siteId, userId },
+        ...this.authHeader,
+      },
+    );
+    return user;
+  };
 }

--- a/src/server/oauth/scopes.test.ts
+++ b/src/server/oauth/scopes.test.ts
@@ -70,6 +70,24 @@ describe('scopes', () => {
       expect(scopes).not.toContain('tableau:mcp:jobs:read');
     });
 
+    it('should include tableau:mcp:users:write when adminToolsEnabled is true', async () => {
+      mockGetConfig.mockReturnValue({
+        adminToolsEnabled: true,
+      } as any);
+
+      const scopes = await getSupportedMcpScopes();
+      expect(scopes).toContain('tableau:mcp:users:write');
+    });
+
+    it('should exclude tableau:mcp:users:write when adminToolsEnabled is false', async () => {
+      mockGetConfig.mockReturnValue({
+        adminToolsEnabled: false,
+      } as any);
+
+      const scopes = await getSupportedMcpScopes();
+      expect(scopes).not.toContain('tableau:mcp:users:write');
+    });
+
     it('should exclude tableau:mcp:content:delete when adminToolsEnabled is false', async () => {
       mockGetConfig.mockReturnValue({
         adminToolsEnabled: false,
@@ -213,6 +231,24 @@ describe('scopes', () => {
       expect(scopes).not.toContain('tableau:flows:read');
     });
 
+    it('should include tableau:users:update when adminToolsEnabled is true', async () => {
+      mockGetConfig.mockReturnValue({
+        adminToolsEnabled: true,
+      } as any);
+
+      const scopes = await getSupportedApiScopes();
+      expect(scopes).toContain('tableau:users:update');
+    });
+
+    it('should exclude tableau:users:update when adminToolsEnabled is false', async () => {
+      mockGetConfig.mockReturnValue({
+        adminToolsEnabled: false,
+      } as any);
+
+      const scopes = await getSupportedApiScopes();
+      expect(scopes).not.toContain('tableau:users:update');
+    });
+
     it('should always include other API scopes regardless of adminToolsEnabled', async () => {
       mockGetConfig.mockReturnValue({
         adminToolsEnabled: false,
@@ -258,6 +294,8 @@ describe('scopes', () => {
       expect(scopes).not.toContain('tableau:tasks:write');
       expect(scopes).not.toContain('tableau:jobs:read');
       expect(scopes).not.toContain('tableau:users:read');
+      expect(scopes).not.toContain('tableau:mcp:users:write');
+      expect(scopes).not.toContain('tableau:users:update');
     });
   });
 

--- a/src/server/oauth/scopes.ts
+++ b/src/server/oauth/scopes.ts
@@ -28,7 +28,8 @@ export type McpScope =
   | 'tableau:mcp:tasks:write'
   | 'tableau:mcp:jobs:read'
   | 'tableau:mcp:content:delete'
-  | 'tableau:mcp:users:read';
+  | 'tableau:mcp:users:read'
+  | 'tableau:mcp:users:write';
 
 export type TableauApiScope =
   | 'tableau:content:read'
@@ -52,7 +53,8 @@ export type TableauApiScope =
   | 'tableau:datasource_tags:update'
   | 'tableau:datasources:delete'
   | 'tableau:jobs:read'
-  | 'tableau:users:read';
+  | 'tableau:users:read'
+  | 'tableau:users:update';
 
 /**
  * Default scopes supported by the MCP server
@@ -68,6 +70,7 @@ export const DEFAULT_SCOPES_SUPPORTED: ReadonlyArray<McpScope> = [
   'tableau:mcp:workbook:read',
   'tableau:mcp:content:read',
   'tableau:mcp:content:delete',
+  'tableau:mcp:users:write',
   'tableau:mcp:view:read',
   'tableau:mcp:view:download',
   'tableau:mcp:flow:read',
@@ -155,6 +158,10 @@ const toolScopeMap: Record<
   'list-users': {
     mcp: ['tableau:mcp:users:read'],
     api: new Set(['tableau:users:read']),
+  },
+  'update-user': {
+    mcp: ['tableau:mcp:users:write'],
+    api: new Set(['tableau:users:update', 'tableau:users:read']),
   },
   'list-workbooks': {
     mcp: ['tableau:mcp:workbook:read'],
@@ -346,6 +353,7 @@ async function getEnabledToolNames(): Promise<Set<WebToolName>> {
     enabledTools.delete('confirm-delete-content');
     enabledTools.delete('list-jobs');
     enabledTools.delete('list-users');
+    enabledTools.delete('update-user');
     enabledTools.delete('query-admin-insights');
     enabledTools.delete('delete-content');
   }

--- a/src/tools/web/_lib/evidence.test.ts
+++ b/src/tools/web/_lib/evidence.test.ts
@@ -279,6 +279,37 @@ describe('RegistryEvidence', () => {
       ).resolves.toBe(true);
     });
   });
+
+  describe('binding (payload) isolation', () => {
+    it('a nonce minted with binding A does not verify with binding B', async () => {
+      const evidence = new RegistryEvidence();
+      const target: MutationTarget = { id: 'user-1', kind: 'user' };
+      await evidence.establish(makeCtx({ target, tool: 'update-user', binding: 'user-1:Viewer' }));
+      const nonce = evidence.getEstablishedNonce()!;
+      // Different binding (role swap) → must be rejected.
+      await expect(
+        evidence.verify(
+          makeCtx({
+            target,
+            tool: 'update-user',
+            binding: 'user-1:Unlicensed',
+            confirmationToken: nonce,
+          }),
+        ),
+      ).resolves.toBe(false);
+      // Same binding → accepted.
+      await expect(
+        evidence.verify(
+          makeCtx({
+            target,
+            tool: 'update-user',
+            binding: 'user-1:Viewer',
+            confirmationToken: nonce,
+          }),
+        ),
+      ).resolves.toBe(true);
+    });
+  });
 });
 
 describe('AppApprovalEvidence', () => {

--- a/src/tools/web/_lib/mutationGuard.ts
+++ b/src/tools/web/_lib/mutationGuard.ts
@@ -59,9 +59,6 @@ export interface MutationTarget {
   name?: string;
   project?: string;
   owner?: string;
-  // 'user' is reserved/forward-looking: no user-mutation tool is wired yet. Kept in the union so the
-  // audit schema (auditRecord.ts) stays stable when one is added; removing it now would be a
-  // breaking schema change for downstream audit-log consumers.
   kind: 'datasource' | 'workbook' | 'extract-refresh-task' | 'user';
 }
 
@@ -259,6 +256,8 @@ function targetKindHint(tool: WebToolName): MutationTarget['kind'] {
       return 'datasource';
     case 'update-cloud-extract-refresh-task':
       return 'extract-refresh-task';
+    case 'update-user':
+      return 'user';
     default:
       return 'datasource';
   }

--- a/src/tools/web/toolName.ts
+++ b/src/tools/web/toolName.ts
@@ -33,6 +33,7 @@ export const webToolNames = [
   'revoke-access-token',
   'reset-consent',
   'query-admin-insights',
+  'update-user',
   'delete-content',
   'confirm-delete-content',
 ] as const;
@@ -92,7 +93,7 @@ export const webToolGroups = {
     'confirm-update-cloud-extract-refresh-task',
   ],
   jobs: ['list-jobs'],
-  users: ['list-users'],
+  users: ['list-users', 'update-user'],
   'token-management': ['get-embed-token', 'revoke-access-token', 'reset-consent'],
   'admin-insights': ['query-admin-insights'],
   content: ['delete-content', 'confirm-delete-content'],

--- a/src/tools/web/tools.ts
+++ b/src/tools/web/tools.ts
@@ -25,6 +25,7 @@ import { getQueryDatasourceTool } from './queryDatasource/queryDatasource.js';
 import { getResetConsentTool } from './resetConsent/resetConsent.js';
 import { getRevokeAccessTokenTool } from './revokeAccessToken/revokeAccessToken.js';
 import { getListUsersTool } from './users/listUsers.js';
+import { getUpdateUserTool } from './users/updateUser.js';
 import { getGetCustomViewDataTool } from './views/getCustomViewData.js';
 import { getGetCustomViewImageTool } from './views/getCustomViewImage.js';
 import { getGetViewTool } from './views/getView.js';
@@ -45,6 +46,7 @@ export const webToolFactories = [
   getConfirmUpdateCloudExtractRefreshTaskTool,
   getListJobsTool,
   getListUsersTool,
+  getUpdateUserTool,
   getQueryDatasourceTool,
   getListFlowsTool,
   getGetFlowTool,

--- a/src/tools/web/users/updateUser.test.ts
+++ b/src/tools/web/users/updateUser.test.ts
@@ -1,0 +1,245 @@
+import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { Ok } from 'ts-results-es';
+
+import { WebMcpServer } from '../../../server.web.js';
+import { Provider } from '../../../utils/provider.js';
+import { getMockRequestHandlerExtra } from '../toolContext.mock.js';
+import { mockUser } from './mockUser.js';
+import { getUpdateUserTool } from './updateUser.js';
+
+const mocks = vi.hoisted(() => ({
+  mockQueryUserOnSite: vi.fn(),
+  mockUpdateUser: vi.fn(),
+  mockGuardMutation: vi.fn(),
+}));
+
+vi.mock('../../../restApiInstance.js', () => ({
+  useRestApi: vi.fn().mockImplementation(async ({ callback }) =>
+    callback({
+      usersMethods: {
+        queryUserOnSite: mocks.mockQueryUserOnSite,
+        updateUser: mocks.mockUpdateUser,
+      },
+      siteId: 'test-site-id',
+      userId: 'test-user-id',
+    }),
+  ),
+}));
+
+vi.mock('../../../config.js', () => ({
+  getConfig: vi.fn(() => ({
+    adminToolsEnabled: true,
+    productTelemetryEnabled: false,
+    productTelemetryEndpoint: 'https://test.com',
+    server: 'https://test.tableau.com',
+  })),
+}));
+
+vi.mock('../_lib/mutationGuard.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../_lib/mutationGuard.js')>();
+  return {
+    ...actual,
+    guardMutation: mocks.mockGuardMutation,
+  };
+});
+
+vi.mock('../_lib/evidence.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../_lib/evidence.js')>();
+  return {
+    ...actual,
+    RegistryEvidence: vi.fn().mockImplementation(() => ({
+      establish: vi.fn(),
+      verify: vi.fn().mockResolvedValue(true),
+      describeEvidence: () => ({ kind: 'registry-nonce' }),
+      getEstablishedNonce: () => 'mock-nonce-123',
+    })),
+  };
+});
+
+function mockGuardSuccess(): void {
+  mocks.mockGuardMutation.mockResolvedValue(
+    new Ok({
+      actor: { siteLuid: 'test-site-id', siteName: 'tc25' },
+      target: { id: 'a1b2c3d4-e5f6-4890-abcd-ef1234567890', name: 'jsmith', kind: 'user' },
+      recordOutcome: vi.fn(),
+    }),
+  );
+}
+
+describe('updateUserTool', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGuardSuccess();
+  });
+
+  it('should create a tool instance with correct properties', () => {
+    const updateUserTool = getUpdateUserTool(new WebMcpServer());
+    expect(updateUserTool.name).toBe('update-user');
+    expect(updateUserTool.description).toContain('Updates the site role of a user');
+  });
+
+  describe('preview phase', () => {
+    it('should return preview text with current and proposed role', async () => {
+      mocks.mockQueryUserOnSite.mockResolvedValue({
+        ...mockUser,
+        siteRole: 'Creator',
+        email: 'john.smith@example.com',
+      });
+
+      const result = await getToolResult({
+        userId: 'a1b2c3d4-e5f6-4890-abcd-ef1234567890',
+        siteRole: 'Unlicensed',
+      });
+
+      expect(result.isError).toBeFalsy();
+      expect(result.content[0]).toMatchObject({ type: 'text' });
+      const text = (result.content[0] as { type: string; text: string }).text;
+      expect(text).toContain('Preview');
+      expect(text).toContain('Creator');
+      expect(text).toContain('Unlicensed');
+      expect(text).toContain('jsmith');
+      expect(text).toContain('mock-nonce-123');
+    });
+
+    it('should call guardMutation with preview phase and correct binding', async () => {
+      mocks.mockQueryUserOnSite.mockResolvedValue(mockUser);
+
+      await getToolResult({ userId: 'a1b2c3d4-e5f6-4890-abcd-ef1234567890', siteRole: 'Viewer' });
+
+      expect(mocks.mockGuardMutation).toHaveBeenCalledWith(
+        expect.objectContaining({
+          tool: 'update-user',
+          action: 'update',
+          mode: 'preview-confirm',
+          phase: 'preview',
+          binding: 'a1b2c3d4-e5f6-4890-abcd-ef1234567890:Viewer',
+        }),
+      );
+    });
+  });
+
+  describe('confirm phase', () => {
+    it('should update user and return success message', async () => {
+      mocks.mockUpdateUser.mockResolvedValue({ ...mockUser, siteRole: 'Unlicensed' });
+
+      const result = await getToolResult({
+        userId: 'a1b2c3d4-e5f6-4890-abcd-ef1234567890',
+        siteRole: 'Unlicensed',
+        confirm: true,
+        confirmationToken: 'test-token',
+      });
+
+      expect(result.isError).toBeFalsy();
+      const text = (result.content[0] as { type: string; text: string }).text;
+      expect(text).toContain('successfully updated');
+      expect(text).toContain('Unlicensed');
+      expect(mocks.mockUpdateUser).toHaveBeenCalledWith({
+        siteId: 'test-site-id',
+        userId: 'a1b2c3d4-e5f6-4890-abcd-ef1234567890',
+        siteRole: 'Unlicensed',
+      });
+    });
+
+    it('should call guardMutation with confirm phase', async () => {
+      mocks.mockUpdateUser.mockResolvedValue({ ...mockUser, siteRole: 'Viewer' });
+
+      await getToolResult({
+        userId: 'a1b2c3d4-e5f6-4890-abcd-ef1234567890',
+        siteRole: 'Viewer',
+        confirm: true,
+        confirmationToken: 'test-token',
+      });
+
+      expect(mocks.mockGuardMutation).toHaveBeenCalledWith(
+        expect.objectContaining({
+          tool: 'update-user',
+          action: 'update',
+          mode: 'preview-confirm',
+          phase: 'confirm',
+          binding: 'a1b2c3d4-e5f6-4890-abcd-ef1234567890:Viewer',
+          confirmationToken: 'test-token',
+        }),
+      );
+    });
+
+    it('should record outcome on REST failure', async () => {
+      const recordOutcome = vi.fn();
+      mocks.mockGuardMutation.mockResolvedValue(
+        new Ok({
+          actor: { siteLuid: 'test-site-id', siteName: 'tc25' },
+          target: { id: 'a1b2c3d4-e5f6-4890-abcd-ef1234567890', name: 'jsmith', kind: 'user' },
+          recordOutcome,
+        }),
+      );
+      mocks.mockUpdateUser.mockRejectedValue(new Error('Network timeout'));
+
+      const result = await getToolResult({
+        userId: 'a1b2c3d4-e5f6-4890-abcd-ef1234567890',
+        siteRole: 'Unlicensed',
+        confirm: true,
+        confirmationToken: 'test-token',
+      });
+
+      expect(recordOutcome).toHaveBeenCalledWith({
+        ok: false,
+        failureDetail: 'Network timeout',
+      });
+      expect(result.isError).toBe(true);
+    });
+
+    it('should record success outcome on successful update', async () => {
+      const recordOutcome = vi.fn();
+      mocks.mockGuardMutation.mockResolvedValue(
+        new Ok({
+          actor: { siteLuid: 'test-site-id', siteName: 'tc25' },
+          target: { id: 'a1b2c3d4-e5f6-4890-abcd-ef1234567890', name: 'jsmith', kind: 'user' },
+          recordOutcome,
+        }),
+      );
+      mocks.mockUpdateUser.mockResolvedValue({ ...mockUser, siteRole: 'Unlicensed' });
+
+      await getToolResult({
+        userId: 'a1b2c3d4-e5f6-4890-abcd-ef1234567890',
+        siteRole: 'Unlicensed',
+        confirm: true,
+        confirmationToken: 'test-token',
+      });
+
+      expect(recordOutcome).toHaveBeenCalledWith({ ok: true });
+    });
+  });
+
+  describe('guard rejection', () => {
+    it('should return error when guard rejects (not admin)', async () => {
+      const { AdminOnlyError } = await import('../../../errors/mcpToolError.js');
+      mocks.mockGuardMutation.mockResolvedValue(new AdminOnlyError('Not admin').toErr());
+
+      const result = await getToolResult({
+        userId: 'a1b2c3d4-e5f6-4890-abcd-ef1234567890',
+        siteRole: 'Unlicensed',
+      });
+
+      expect(result.isError).toBe(true);
+    });
+
+    it('should return error when guard rejects (preview not run)', async () => {
+      const { PreviewNotRunError } = await import('../../../errors/mcpToolError.js');
+      mocks.mockGuardMutation.mockResolvedValue(new PreviewNotRunError('Preview not run').toErr());
+
+      const result = await getToolResult({
+        userId: 'a1b2c3d4-e5f6-4890-abcd-ef1234567890',
+        siteRole: 'Unlicensed',
+        confirm: true,
+        confirmationToken: 'bad-token',
+      });
+
+      expect(result.isError).toBe(true);
+    });
+  });
+});
+
+async function getToolResult(args: any): Promise<CallToolResult> {
+  const updateUserTool = getUpdateUserTool(new WebMcpServer());
+  const callback = await Provider.from(updateUserTool.callback);
+  return await callback(args, getMockRequestHandlerExtra());
+}

--- a/src/tools/web/users/updateUser.test.ts
+++ b/src/tools/web/users/updateUser.test.ts
@@ -116,6 +116,34 @@ describe('updateUserTool', () => {
         }),
       );
     });
+
+    it('should NOT call updateUser during preview (safety property)', async () => {
+      mocks.mockQueryUserOnSite.mockResolvedValue(mockUser);
+
+      await getToolResult({
+        userId: 'a1b2c3d4-e5f6-4890-abcd-ef1234567890',
+        siteRole: 'Unlicensed',
+      });
+
+      expect(mocks.mockUpdateUser).not.toHaveBeenCalled();
+    });
+
+    it('should handle missing siteRole/email with fallback text', async () => {
+      mocks.mockQueryUserOnSite.mockResolvedValue({
+        ...mockUser,
+        siteRole: undefined,
+        email: undefined,
+      });
+
+      const result = await getToolResult({
+        userId: 'a1b2c3d4-e5f6-4890-abcd-ef1234567890',
+        siteRole: 'Viewer',
+      });
+
+      const text = (result.content[0] as { type: string; text: string }).text;
+      expect(text).toContain('unknown');
+      expect(text).toContain('no email');
+    });
   });
 
   describe('confirm phase', () => {
@@ -206,6 +234,21 @@ describe('updateUserTool', () => {
       });
 
       expect(recordOutcome).toHaveBeenCalledWith({ ok: true });
+    });
+
+    it('should fall back to args.siteRole when API response omits siteRole', async () => {
+      mocks.mockUpdateUser.mockResolvedValue({ name: 'jsmith' });
+
+      const result = await getToolResult({
+        userId: 'a1b2c3d4-e5f6-4890-abcd-ef1234567890',
+        siteRole: 'Unlicensed',
+        confirm: true,
+        confirmationToken: 'test-token',
+      });
+
+      const text = (result.content[0] as { type: string; text: string }).text;
+      expect(text).toContain('Unlicensed');
+      expect(text).toContain('successfully updated');
     });
   });
 

--- a/src/tools/web/users/updateUser.ts
+++ b/src/tools/web/users/updateUser.ts
@@ -1,0 +1,184 @@
+import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { Ok } from 'ts-results-es';
+import { z } from 'zod';
+
+import { getConfig } from '../../../config.js';
+import { UnknownError } from '../../../errors/mcpToolError.js';
+import { useRestApi } from '../../../restApiInstance.js';
+import { WebMcpServer } from '../../../server.web.js';
+import { RegistryEvidence } from '../_lib/evidence.js';
+import { guardMutation, MutationTarget } from '../_lib/mutationGuard.js';
+import { WebTool } from '../tool.js';
+
+const VALID_SITE_ROLES = [
+  'Creator',
+  'Explorer',
+  'ExplorerCanPublish',
+  'SiteAdministratorCreator',
+  'SiteAdministratorExplorer',
+  'Viewer',
+  'Unlicensed',
+] as const;
+
+const paramsSchema = {
+  userId: z
+    .string()
+    .uuid('userId must be a valid UUID')
+    .describe('The LUID of the user to update. Obtain from list-users.'),
+  siteRole: z
+    .enum(VALID_SITE_ROLES)
+    .describe(
+      'The new site role to assign. Common values: Creator, Explorer, ExplorerCanPublish, ' +
+        'SiteAdministratorCreator, SiteAdministratorExplorer, Viewer, Unlicensed. ' +
+        'Use "Unlicensed" to reclaim a license from an inactive user.',
+    ),
+  confirm: z
+    .boolean()
+    .optional()
+    .describe(
+      'When omitted or false, runs a non-destructive preview: looks up the user and reports ' +
+        'the proposed role change without applying it, returning a single-use confirmation token. ' +
+        'When true, applies the role change — but only if the confirmationToken from a prior ' +
+        'preview of this same userId and siteRole is supplied.',
+    ),
+  confirmationToken: z
+    .string()
+    .optional()
+    .describe(
+      'The single-use confirmation token returned by a prior preview call for this userId and ' +
+        'siteRole. Required when confirm is true; ignored otherwise.',
+    ),
+};
+
+export const getUpdateUserTool = (server: WebMcpServer): WebTool<typeof paramsSchema> => {
+  const config = getConfig();
+
+  const updateUserTool = new WebTool({
+    server,
+    name: 'update-user',
+    disabled: !config.adminToolsEnabled,
+    description: `
+  Updates the site role of a user on the Tableau site. Primary use case: downgrade inactive users to "Unlicensed" to reclaim licenses.
+
+  This tool is restricted to Tableau site administrators and requires the \`ADMIN_TOOLS_ENABLED\` feature flag to be enabled.
+
+  This tool is **two-phase** to protect against accidental role changes:
+
+  1. **Preview (default — \`confirm\` omitted or false):** looks up the user, reports the current and proposed site role, and returns a single-use confirmation token. Nothing is changed.
+  2. **Update (\`confirm: true\`):** applies the role change. Requires the \`confirmationToken\` from a prior preview of this same \`userId\` and \`siteRole\` (the server verifies and consumes it).
+
+  The token is server-generated and bound to the previewed \`userId\` and \`siteRole\`: a token minted while previewing role A cannot confirm an update to role B. Present the change to the user and get explicit approval before confirming.
+
+  **Required human confirmation:** After preview, present the change to the user and get explicit approval before calling again with \`confirm: true\`. Do not auto-confirm.
+
+  **Parameters:**
+  - \`userId\` (required) – The LUID of the user to update. Obtain from \`list-users\`.
+  - \`siteRole\` (required) – The new site role. Valid values: Creator, Explorer, ExplorerCanPublish, SiteAdministratorCreator, SiteAdministratorExplorer, Viewer, Unlicensed.
+  - \`confirm\` (optional) – Set \`true\` to apply the change (requires confirmationToken).
+  - \`confirmationToken\` (optional) – The single-use token from the preview. Required when \`confirm\` is true.
+
+  **Response:** Confirmation message with the user's updated site role.
+
+  Tableau Cloud scope: \`tableau:users:update\`.
+  `,
+    paramsSchema,
+    annotations: {
+      title: 'Update User',
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
+    callback: async (args, extra): Promise<CallToolResult> => {
+      return await updateUserTool.logAndExecute<string>({
+        extra,
+        args,
+        callback: async () => {
+          return await useRestApi({
+            ...extra,
+            jwtScopes: updateUserTool.requiredApiScopes,
+            callback: async (restApi) => {
+              const evidence = new RegistryEvidence();
+              const binding = `${args.userId}:${args.siteRole}`;
+
+              let cachedUser: Awaited<
+                ReturnType<typeof restApi.usersMethods.queryUserOnSite>
+              > | null = null;
+
+              const resolveTarget = async (): Promise<MutationTarget> => {
+                cachedUser = await restApi.usersMethods.queryUserOnSite({
+                  siteId: restApi.siteId,
+                  userId: args.userId,
+                });
+                return {
+                  id: args.userId,
+                  name: cachedUser.name,
+                  kind: 'user',
+                };
+              };
+
+              const guardResult = await guardMutation({
+                restApi,
+                extra,
+                tool: 'update-user',
+                action: 'update',
+                mode: 'preview-confirm',
+                phase: args.confirm ? 'confirm' : 'preview',
+                evidence,
+                resolveTarget,
+                confirmationToken: args.confirmationToken,
+                binding,
+              });
+              if (guardResult.isErr()) {
+                return guardResult.error.toErr();
+              }
+              const { target, recordOutcome } = guardResult.value;
+
+              if (!args.confirm) {
+                const user =
+                  cachedUser ??
+                  (await restApi.usersMethods.queryUserOnSite({
+                    siteId: restApi.siteId,
+                    userId: args.userId,
+                  }));
+                const currentRole = user.siteRole ?? 'unknown';
+                const nonce = evidence.getEstablishedNonce()!;
+                return new Ok(
+                  `Preview — user '${target.name ?? args.userId}' (${user.email ?? 'no email'}) ` +
+                    `would be changed from ${currentRole} → ${args.siteRole}. ` +
+                    'No change has been made. ' +
+                    'NEXT STEP — REQUIRED: present this change to the user and ask them to explicitly ' +
+                    "confirm it. Do NOT apply without the user's approval. " +
+                    `Once approved, call again with confirm: true and confirmationToken: "${nonce}" ` +
+                    '(the server will verify and consume this single-use token before applying the update).',
+                );
+              }
+
+              try {
+                const updatedUser = await restApi.usersMethods.updateUser({
+                  siteId: restApi.siteId,
+                  userId: args.userId,
+                  siteRole: args.siteRole,
+                });
+                recordOutcome({ ok: true });
+                return new Ok(
+                  `User '${target.name ?? args.userId}' has been successfully updated. ` +
+                    `New site role: ${updatedUser.siteRole ?? args.siteRole}.`,
+                );
+              } catch (err) {
+                const message = err instanceof Error ? err.message : String(err);
+                recordOutcome({ ok: false, failureDetail: message });
+                return new UnknownError(
+                  `Failed to update user '${args.userId}': ${message}`,
+                ).toErr();
+              }
+            },
+          });
+        },
+        constrainSuccessResult: (result) => ({ type: 'success', result }),
+      });
+    },
+  });
+
+  return updateUserTool;
+};

--- a/src/tools/web/users/updateUser.ts
+++ b/src/tools/web/users/updateUser.ts
@@ -10,6 +10,8 @@ import { RegistryEvidence } from '../_lib/evidence.js';
 import { guardMutation, MutationTarget } from '../_lib/mutationGuard.js';
 import { WebTool } from '../tool.js';
 
+// ServerAdministrator is server-scoped (not assignable via PUT /sites/.../users/...).
+// SupportUser is internal/support-only and not a valid assignment target for customers.
 const VALID_SITE_ROLES = [
   'Creator',
   'Explorer',
@@ -79,14 +81,14 @@ export const getUpdateUserTool = (server: WebMcpServer): WebTool<typeof paramsSc
 
   **Response:** Confirmation message with the user's updated site role.
 
-  Tableau Cloud scope: \`tableau:users:update\`.
+  Tableau REST API scopes: \`tableau:users:update\`, \`tableau:users:read\`.
   `,
     paramsSchema,
     annotations: {
       title: 'Update User',
       readOnlyHint: false,
       destructiveHint: true,
-      idempotentHint: true,
+      idempotentHint: false,
       openWorldHint: false,
     },
     callback: async (args, extra): Promise<CallToolResult> => {
@@ -135,6 +137,9 @@ export const getUpdateUserTool = (server: WebMcpServer): WebTool<typeof paramsSc
               const { target, recordOutcome } = guardResult.value;
 
               if (!args.confirm) {
+                // In production, guardMutation always calls resolveTarget on success, so
+                // cachedUser is guaranteed set. Fallback retained for unit tests that mock
+                // guardMutation (bypassing resolveTarget).
                 const user =
                   cachedUser ??
                   (await restApi.usersMethods.queryUserOnSite({

--- a/tests/e2e/server.test.ts
+++ b/tests/e2e/server.test.ts
@@ -39,6 +39,7 @@ describe('server', () => {
         'update-cloud-extract-refresh-task',
         'list-jobs',
         'list-users',
+        'update-user',
         'query-admin-insights',
         'delete-content',
       ];
@@ -143,6 +144,7 @@ describe('server', () => {
         'update-cloud-extract-refresh-task',
         'list-jobs',
         'list-users',
+        'update-user',
         'query-admin-insights',
         'delete-content',
       ];

--- a/tests/e2e/users/updateUser.test.ts
+++ b/tests/e2e/users/updateUser.test.ts
@@ -1,0 +1,169 @@
+import { z } from 'zod';
+
+import { getDefaultEnv, resetEnv, setEnv } from '../../testEnv.js';
+import { McpClient } from '../mcpClient.js';
+
+/**
+ * E2E coverage for the admin-only, mutating `update-user` tool.
+ *
+ * The tool is two-phase with a server-authoritative preview→confirm gate: the first call (confirm
+ * omitted/false) reports the current and proposed site role, changes nothing, and returns a
+ * server-generated single-use `confirmationToken` bound to the previewed `userId:siteRole`. The
+ * second call passes `confirm: true` plus that token; the server verifies and consumes it before
+ * applying the role change.
+ *
+ * The mutating leg is gated behind `UPDATE_USER_E2E_ID` — set it to a disposable user LUID once
+ * the endpoint is enabled on your Cloud site.
+ */
+describe('update-user', () => {
+  let client: McpClient;
+  let toolsAvailable = false;
+
+  beforeAll(setEnv);
+  afterAll(resetEnv);
+
+  beforeAll(async () => {
+    client = new McpClient({
+      env: { ...getDefaultEnv(), ADMIN_TOOLS_ENABLED: 'true' },
+    });
+    await client.connect();
+    const tools = await client.listTools();
+    toolsAvailable = tools.includes('update-user');
+    if (!toolsAvailable) {
+      console.warn(
+        'Skipping update-user e2e tests — admin tools not registered. ' +
+          'Ensure ADMIN_TOOLS_ENABLED=true in tests/.env and the caller is a site admin.',
+      );
+    }
+  });
+
+  afterAll(async () => {
+    await client.close();
+  });
+
+  it('should register the tool only when admin tools are enabled', async () => {
+    const defaultClient = new McpClient({ env: getDefaultEnv() });
+    await defaultClient.connect();
+    try {
+      const tools = await defaultClient.listTools();
+      expect(tools.includes('update-user')).toBe(false);
+    } finally {
+      await defaultClient.close();
+    }
+  });
+
+  it('should reject an invalid (non-UUID) userId at schema level', async () => {
+    if (!toolsAvailable) {
+      return;
+    }
+
+    let threw = false;
+    try {
+      await client.callTool('update-user', {
+        schema: z.string(),
+        toolArgs: { userId: 'not-a-valid-uuid', siteRole: 'Unlicensed' },
+      });
+    } catch (e) {
+      threw = true;
+      expect(String(e)).toContain('uuid');
+    }
+    expect(threw).toBe(true);
+  });
+
+  it('should reject an invalid siteRole at schema level', async () => {
+    if (!toolsAvailable) {
+      return;
+    }
+
+    let threw = false;
+    try {
+      await client.callTool('update-user', {
+        schema: z.string(),
+        toolArgs: {
+          userId: 'a1b2c3d4-e5f6-4789-9abc-ef1234567890',
+          siteRole: 'InvalidRole',
+        },
+      });
+    } catch (e) {
+      threw = true;
+      expect(String(e).toLowerCase()).toMatch(/siterole|enum|invalid/);
+    }
+    expect(threw).toBe(true);
+  });
+
+  it('should return a preview with a confirmationToken when confirm is omitted', async () => {
+    if (!toolsAvailable) {
+      return;
+    }
+    const message = await client.callTool('update-user', {
+      schema: z.string(),
+      toolArgs: {
+        userId: 'a1b2c3d4-e5f6-4789-9abc-ef1234567890',
+        siteRole: 'Unlicensed',
+      },
+    });
+    expect(message).toContain('Preview');
+    expect(message).toContain('No change has been made');
+    expect(message).toContain('confirmationToken:');
+  });
+
+  it('should reject a confirmed call with a bogus (never-previewed) confirmationToken', async () => {
+    if (!toolsAvailable) {
+      return;
+    }
+    let threw = false;
+    try {
+      await client.callTool('update-user', {
+        schema: z.string(),
+        toolArgs: {
+          userId: 'a1b2c3d4-e5f6-4789-9abc-ef1234567890',
+          siteRole: 'Unlicensed',
+          confirm: true,
+          confirmationToken: '00000000-0000-4000-8000-000000000000',
+        },
+      });
+    } catch (e) {
+      threw = true;
+      expect(String(e)).toContain('could not verify that a preview ran');
+    }
+    expect(threw).toBe(true);
+  });
+
+  it('should update a disposable user via preview → confirm (opt-in, requires live endpoint)', async () => {
+    if (!toolsAvailable) {
+      return;
+    }
+    const disposableId = process.env.UPDATE_USER_E2E_ID;
+    if (!disposableId) {
+      console.warn(
+        'Skipping mutating assertion — set UPDATE_USER_E2E_ID to a disposable user LUID.',
+      );
+      return;
+    }
+
+    const preview = await client.callTool('update-user', {
+      schema: z.string(),
+      toolArgs: { userId: disposableId, siteRole: 'Unlicensed' },
+    });
+    expect(preview).toContain('Preview');
+    expect(preview).toContain('No change has been made');
+
+    const tokenMatch = preview.match(
+      /confirmationToken:\s*\\?"?([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})/,
+    );
+    expect(tokenMatch).toBeTruthy();
+    const token = tokenMatch![1];
+
+    const message = await client.callTool('update-user', {
+      schema: z.string(),
+      toolArgs: {
+        userId: disposableId,
+        siteRole: 'Unlicensed',
+        confirm: true,
+        confirmationToken: token,
+      },
+    });
+
+    expect(message).toContain('successfully updated');
+  });
+});

--- a/tests/e2e/users/updateUser.test.ts
+++ b/tests/e2e/users/updateUser.test.ts
@@ -12,8 +12,9 @@ import { McpClient } from '../mcpClient.js';
  * second call passes `confirm: true` plus that token; the server verifies and consumes it before
  * applying the role change.
  *
- * The mutating leg is gated behind `UPDATE_USER_E2E_ID` — set it to a disposable user LUID once
- * the endpoint is enabled on your Cloud site.
+ * Preview and bogus-token tests are gated behind `UPDATE_USER_E2E_ID` — set it to a disposable
+ * user LUID on the site. The mutating leg is gated behind a separate `UPDATE_USER_E2E_DESTRUCTIVE_ID`
+ * — set it to a disposable user LUID that you don't mind being downgraded to Unlicensed.
  */
 describe('update-user', () => {
   let client: McpClient;
@@ -99,7 +100,7 @@ describe('update-user', () => {
     const userId = process.env.UPDATE_USER_E2E_ID;
     if (!userId) {
       console.warn(
-        'Skipping preview assertion — set UPDATE_USER_E2E_ID to a real user LUID on the site.',
+        'Skipping preview assertion — set UPDATE_USER_E2E_ID to a disposable user LUID on the site.',
       );
       return;
     }
@@ -120,7 +121,7 @@ describe('update-user', () => {
     const userId = process.env.UPDATE_USER_E2E_ID;
     if (!userId) {
       console.warn(
-        'Skipping bogus-token assertion — set UPDATE_USER_E2E_ID to a real user LUID on the site.',
+        'Skipping bogus-token assertion — set UPDATE_USER_E2E_ID to a disposable user LUID on the site.',
       );
       return;
     }
@@ -146,10 +147,10 @@ describe('update-user', () => {
     if (!toolsAvailable) {
       return;
     }
-    const disposableId = process.env.UPDATE_USER_E2E_ID;
+    const disposableId = process.env.UPDATE_USER_E2E_DESTRUCTIVE_ID;
     if (!disposableId) {
       console.warn(
-        'Skipping mutating assertion — set UPDATE_USER_E2E_ID to a disposable user LUID.',
+        'Skipping mutating assertion — set UPDATE_USER_E2E_DESTRUCTIVE_ID to a disposable user LUID.',
       );
       return;
     }

--- a/tests/e2e/users/updateUser.test.ts
+++ b/tests/e2e/users/updateUser.test.ts
@@ -95,12 +95,17 @@ describe('update-user', () => {
     if (!toolsAvailable) {
       return;
     }
+    // resolveTarget calls queryUserOnSite — needs a real user on the site.
+    const userId = process.env.UPDATE_USER_E2E_ID;
+    if (!userId) {
+      console.warn(
+        'Skipping preview assertion — set UPDATE_USER_E2E_ID to a real user LUID on the site.',
+      );
+      return;
+    }
     const message = await client.callTool('update-user', {
       schema: z.string(),
-      toolArgs: {
-        userId: 'a1b2c3d4-e5f6-4789-9abc-ef1234567890',
-        siteRole: 'Unlicensed',
-      },
+      toolArgs: { userId, siteRole: 'Unlicensed' },
     });
     expect(message).toContain('Preview');
     expect(message).toContain('No change has been made');
@@ -111,12 +116,20 @@ describe('update-user', () => {
     if (!toolsAvailable) {
       return;
     }
+    // resolveTarget calls queryUserOnSite — needs a real user on the site.
+    const userId = process.env.UPDATE_USER_E2E_ID;
+    if (!userId) {
+      console.warn(
+        'Skipping bogus-token assertion — set UPDATE_USER_E2E_ID to a real user LUID on the site.',
+      );
+      return;
+    }
     let threw = false;
     try {
       await client.callTool('update-user', {
         schema: z.string(),
         toolArgs: {
-          userId: 'a1b2c3d4-e5f6-4789-9abc-ef1234567890',
+          userId,
           siteRole: 'Unlicensed',
           confirm: true,
           confirmationToken: '00000000-0000-4000-8000-000000000000',

--- a/tests/oauth/embedded-authz/oauth.test.ts
+++ b/tests/oauth/embedded-authz/oauth.test.ts
@@ -149,10 +149,11 @@ describe('OAuth', () => {
         'tableau:mcp:tasks:write',
         'tableau:mcp:jobs:read',
         'tableau:mcp:users:read',
+        'tableau:mcp:users:write',
         'tableau:mcp:content:delete',
       ]),
     );
-    expect(response.body.scopes_supported).toHaveLength(12);
+    expect(response.body.scopes_supported).toHaveLength(13);
   });
 
   it('should provide a authorization server metadata endpoint for the OAuth 2.1 flow', async () => {
@@ -186,10 +187,11 @@ describe('OAuth', () => {
         'tableau:mcp:tasks:write',
         'tableau:mcp:jobs:read',
         'tableau:mcp:users:read',
+        'tableau:mcp:users:write',
         'tableau:mcp:content:delete',
       ]),
     );
-    expect(response.body.scopes_supported).toHaveLength(12);
+    expect(response.body.scopes_supported).toHaveLength(13);
     expect(response.body.token_endpoint_auth_methods_supported).toEqual([
       'none',
       'client_secret_basic',
@@ -228,10 +230,11 @@ describe('OAuth', () => {
         'tableau:mcp:tasks:write',
         'tableau:mcp:jobs:read',
         'tableau:mcp:users:read',
+        'tableau:mcp:users:write',
         'tableau:mcp:content:delete',
       ]),
     );
-    expect(response.body.scopes_supported).toHaveLength(12);
+    expect(response.body.scopes_supported).toHaveLength(13);
     expect(response.body.token_endpoint_auth_methods_supported).toEqual(['none']);
     expect(response.body.subject_types_supported).toEqual(['public']);
     expect(response.body.client_id_metadata_document_supported).toBe(true);


### PR DESCRIPTION
[Akash's agent]

## Summary

Implements GUS story W-23448424 — adds a new `update-user` MCP tool that wraps `PUT /api/3.24/sites/{siteId}/users/{userId}` to change a user's site role.

- **Two-phase HITL flow** using `RegistryEvidence` (preview → confirm) — the server generates a single-use nonce bound to `userId:siteRole` and verifies it before applying
- **OAuth scope**: `tableau:mcp:users:write` (MCP-level) → `tableau:users:update` + `tableau:users:read` (Tableau API-level)
- **Admin-gated** via `ADMIN_TOOLS_ENABLED` + `assertAdmin`
- **Input validation**: UUID on `userId`, enum-constrained `siteRole` (Creator, Explorer, ExplorerCanPublish, SiteAdministratorCreator, SiteAdministratorExplorer, Viewer, Unlicensed)
- **Primary use case**: downgrade inactive users to "Unlicensed" for license reclamation

## Changes

### New files
- `src/tools/web/users/updateUser.ts` — Tool implementation
- `src/tools/web/users/updateUser.test.ts` — 9 unit tests (properties, preview, confirm, outcome recording, guard rejection)
- `docs/docs/tools/users/update-user.md` — Documentation page

### Modified files
- **SDK layer**: PUT endpoint + `updateUser` method + method test
- **OAuth/scopes**: New MCP + API scopes, admin gate, toolScopeMap entry
- **Type propagation**: `JwtScopes` union in `restApiInstance.ts`
- **Mutation guard**: `targetKindHint` case for `'update-user'`, removed stale forward-looking comment
- **Registration**: `webToolNames`, `webToolGroups`, `webToolFactories`
- **E2E/OAuth tests**: `adminOnlyTools` arrays, scope count 12→13

## Test plan

- [x] `npm run build` — clean
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint` — clean
- [x] `npm test` — 2139 tests pass
- [x] E2E + OAuth embedded tests pass
- [x] Code review agent: no critical/medium findings remaining

---

> **Depends on**: PR #498 (v3.0.0 `guardMutation` + `RegistryEvidence`) — already merged to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)