### PR TITLE
Port a2td #209 GUS dogfood wave → feature/desktop (W-23447478/507/473/506)

### DIFF
--- a/resources/desktop/knowledge/tactics/viz/worksheets.md
+++ b/resources/desktop/knowledge/tactics/viz/worksheets.md
@@ -321,7 +321,7 @@ The old `get_connected_datasources` had a known limitation — it only exposed d
 - **Worksheet-level `table-calculations` section** — put table-calc config in column-instance children
 - **Sort nodes inside column definitions** in datasource-dependencies — use view-level sort
 - **`shelf-sort-deltas`** at the table level
-- **Top N filters** (`function="filter"` groupfilter) — use table calc filter instead (INDEX() on Rows + quantitative range filter). See `workbook-calcs` module for the full per-partition Top N pattern.
+- **Top N filters authored as a FLAT `function="filter"` groupfilter** — stripped. Two working forms exist: the confirmed NESTED recipe (`function="end"` → `order` → `level-members` + matching `<slices>` entry — see `tactics/viz/filters.md`, Top N section), or a table calc filter (INDEX() on Rows + quantitative range filter; see `workbook-calcs` for the per-partition pattern). Preflight rule `malformed-top-n-filter` blocks the flat shape.
 
 ### Table calculation config (Compute Using)
 

--- a/src/desktop/binder/route-spec.test.ts
+++ b/src/desktop/binder/route-spec.test.ts
@@ -177,6 +177,31 @@ describe('classifyAskRoute — refine detection is EDIT-CONTEXT gated', () => {
     ).toBe(false);
     expect(d.shape).not.toBe('refine-top-n');
   });
+
+  // fix/repair and "current/this/that (work)sheet" wording must carry sheet EDIT context so
+  // the ask is routed as an in-place refine, never as a new-viz build. These invariants pin
+  // the hasEditContext behavior (verified return: refine-encoding / free) without over-fitting.
+  it.each(['fix current sheet', 'repair that worksheet', 'show this worksheet as a line'])(
+    '"%s" carries sheet edit context without becoming a new viz',
+    (ask) => {
+      const d = classifyAskRoute(ask, manifests);
+      // It resolves to a REFINE shape (edit of an existing sheet) ...
+      expect(REFINE_SHAPES.has(d.shape), `${d.shape} should be a refine shape`).toBe(true);
+      // ... never a bind-first new-viz build.
+      expect(d.route).not.toBe('bind-first');
+      expect(d.shape).not.toBe('bind-first-template');
+    },
+  );
+
+  it('does not classify data-source repair wording as a sheet edit', () => {
+    const d = classifyAskRoute('fix the data source', manifests);
+    // The NON_SHEET_FIX_RE guard keeps "fix the data source" out of the edit-context path:
+    // it stays unmatched (NOT a refine shape), unlike the "fix current sheet" case above.
+    expect(d.shape).toBe('unmatched');
+    expect(d.route).toBe('free');
+    expect(REFINE_SHAPES.has(d.shape)).toBe(false);
+    expect(d.shape).not.toBe('refine-encoding');
+  });
 });
 
 describe('classifyAskRoute — fail-open free', () => {

--- a/src/desktop/binder/route-spec.ts
+++ b/src/desktop/binder/route-spec.ts
@@ -128,12 +128,21 @@ const NEW_VIZ_RE =
  */
 const EDIT_ANAPHORA_RE =
   /\b(?:this|that|the|current|existing)\s+(?:(?:bar|line|column|pie|scatter|area|stacked)\s+)?(?:chart|graph|plot|viz|visuali[sz]ation|view|dashboard)\b/i;
+// "current/this/that sheet" is an edit signal too. Deliberately not bare
+// "existing worksheets", which appears in do-not-replace-new-viz wording.
+const CURRENT_SHEET_RE = /\b(?:current|this|that)\s+(?:work)?sheet\b/i;
 const EDIT_INSTRUCTION_RE =
-  /\b(?:change|modify|update|convert|swap|re-?colou?r|re-?sort|adjust|tweak|instead)\b|\b(?:make|show|render|turn|set)\s+(?:it|that|this|them|these|those)\b/i;
+  /\b(?:fix|repair|change|modify|update|convert|swap|re-?colou?r|re-?sort|adjust|tweak|instead)\b|\b(?:make|show|render|turn|set)\s+(?:it|that|this|them|these|those)\b/i;
+const NON_SHEET_FIX_RE = /\b(?:fix|repair)\s+(?:the\s+)?(?:data\s+source|datasource|connection)\b/i;
 
 /** True when the ask carries an EDIT signal (anaphora to an existing viz OR a modify instruction). */
 function hasEditContext(text: string): boolean {
-  return EDIT_ANAPHORA_RE.test(text) || EDIT_INSTRUCTION_RE.test(text);
+  if (NON_SHEET_FIX_RE.test(text) && !EDIT_ANAPHORA_RE.test(text) && !CURRENT_SHEET_RE.test(text)) {
+    return false;
+  }
+  return (
+    EDIT_ANAPHORA_RE.test(text) || CURRENT_SHEET_RE.test(text) || EDIT_INSTRUCTION_RE.test(text)
+  );
 }
 
 /**

--- a/src/desktop/commands/workbook/applyFailureClassifier.test.ts
+++ b/src/desktop/commands/workbook/applyFailureClassifier.test.ts
@@ -1,0 +1,93 @@
+import { classifyApplyFailure, formatApplyFailureForAgent } from './applyFailureClassifier.js';
+
+describe('classifyApplyFailure', () => {
+  it('classifies XML grammar rejections (Qualified Name Parse Error / not well-formed)', () => {
+    const parseError = classifyApplyFailure({
+      context: 'workbook',
+      serverError:
+        'The load was not able to complete successfully. Qualified Name Parse Error --- ' +
+        'Invalid input: mismatched brackets --- Input: [Sample - Superstore].[[Sub-Category]]',
+    });
+    expect(parseError.failure_class).toBe('xml-grammar');
+    expect(parseError.confidence).toBe(0.82);
+    expect(parseError.evidence.length).toBeGreaterThan(0);
+    expect(parseError.evidence.join(' ')).toContain('Qualified Name Parse Error');
+    expect(parseError.guidance).toContain('structurally rejected');
+
+    const notWellFormed = classifyApplyFailure({
+      context: 'worksheet',
+      serverError: 'The worksheet XML is not well-formed near line 4.',
+    });
+    expect(notWellFormed.failure_class).toBe('xml-grammar');
+    expect(notWellFormed.evidence.length).toBeGreaterThan(0);
+  });
+
+  it('classifies unresolved field/calc references as field-binding', () => {
+    const c = classifyApplyFailure({
+      context: 'worksheet',
+      serverError: 'Unknown field [Sales Amount] referenced on the Rows shelf.',
+    });
+    expect(c.failure_class).toBe('field-binding');
+    expect(c.confidence).toBe(0.78);
+    expect(c.guidance).toContain('schema lookup');
+  });
+
+  it('classifies a missing target worksheet as worksheet-not-found', () => {
+    const c = classifyApplyFailure({
+      context: 'worksheet',
+      serverError: "worksheet 'Regional Sales' not found",
+    });
+    expect(c.failure_class).toBe('worksheet-not-found');
+    expect(c.confidence).toBe(0.9);
+    expect(c.guidance).toContain('does not exist');
+  });
+
+  it('classifies a rejected Agent API verb as command-rejected', () => {
+    const c = classifyApplyFailure({
+      context: 'workbook',
+      serverError: "unknown verb 'frobnicate' — the Agent API rejected the command",
+    });
+    expect(c.failure_class).toBe('command-rejected');
+    expect(c.confidence).toBe(0.85);
+    expect(c.guidance).toContain('command name');
+  });
+
+  it('falls back to unknown with low confidence on a generic wrapper', () => {
+    const c = classifyApplyFailure({
+      context: 'workbook',
+      serverError: 'Internal error - an unexpected error occurred',
+    });
+    expect(c.failure_class).toBe('unknown');
+    expect(c.confidence).toBe(0.2);
+    // The honest fallback must forbid blind retrying and force evidence-gathering.
+    expect(c.guidance).toContain('blind-retry');
+    expect(c.evidence.join(' ')).toContain('an unexpected error occurred');
+  });
+
+  it('detects an undeclared auto-calc reference in the payload as field-binding', () => {
+    const c = classifyApplyFailure({
+      context: 'worksheet',
+      // References Calculation_123456 but never declares it as a <column>.
+      xmlSnippet:
+        '<worksheet name="Sheet 1"><table><rows>[Parameters].[Calculation_123456]</rows></table></worksheet>',
+    });
+    expect(c.failure_class).toBe('field-binding');
+    expect(c.confidence).toBe(0.6);
+    expect(c.evidence.join(' ')).toContain('Calculation_123456');
+  });
+});
+
+describe('formatApplyFailureForAgent', () => {
+  it('renders an actionable "Apply failed: ... FIX:" message', () => {
+    const message = formatApplyFailureForAgent({
+      context: 'workbook',
+      serverError:
+        'The load was not able to complete successfully. Qualified Name Parse Error --- ' +
+        'Invalid input: mismatched brackets',
+    });
+    expect(message).toContain('Apply failed:');
+    expect(message).toContain('FIX:');
+    expect(message).toContain('Qualified Name Parse Error');
+    expect(message.startsWith('{')).toBe(false);
+  });
+});

--- a/src/desktop/commands/workbook/applyFailureClassifier.ts
+++ b/src/desktop/commands/workbook/applyFailureClassifier.ts
@@ -1,0 +1,239 @@
+export type ApplyFailureContext = 'workbook' | 'worksheet' | 'dashboard';
+
+export type ApplyFailureClass =
+  | 'xml-grammar'
+  | 'field-binding'
+  | 'dashboard-composition'
+  | 'command-rejected'
+  | 'worksheet-not-found'
+  | 'timeout-or-transport'
+  | 'unknown';
+
+export interface ApplyFailureClassification {
+  failure_class: ApplyFailureClass;
+  confidence: number;
+  evidence: string[];
+  guidance: string;
+}
+
+export interface ClassifyApplyFailureInput {
+  serverError?: unknown;
+  applyResponse?: unknown;
+  xmlSnippet?: string;
+  context: ApplyFailureContext;
+}
+
+const GUIDANCE: Record<ApplyFailureClass, string> = {
+  'xml-grammar':
+    'The document was structurally rejected at load. Do not regenerate the workbook. Re-read the current known-good content, diff it against your payload, and apply the smallest XML patch that fixes the structural delta before re-applying.',
+  'field-binding':
+    'A field, calc, set, parameter, or placeholder reference did not resolve. Do a schema lookup first, bind to the exact field name already in the workbook, and declare any calc/set before referencing it.',
+  'dashboard-composition':
+    'The dashboard linkage was rejected. Verify every zone references a real worksheet included in the workbook, avoid guessed ids/window pairings, and patch the specific dashboard zone instead of rebuilding unrelated sheets.',
+  'command-rejected':
+    'The Agent API rejected the command or verb. Check the command name and required params; do not retry the same command unchanged.',
+  'worksheet-not-found':
+    'The target worksheet does not exist. List the live worksheets, verify the actual sheet name, then target or rename the real sheet before applying. Do not regenerate the workbook.',
+  'timeout-or-transport':
+    'Transport failed before Tableau could evaluate the payload. Confirm Tableau Desktop and the Agent API are reachable, then re-issue the same payload once instead of rewriting the XML.',
+  unknown:
+    'Only a generic wrapper survived. Do not blind-retry. First gather evidence: inspect the command result/logs, re-read the current known-good content, structural-diff it against your payload, then retry with a minimal patch.',
+};
+
+interface Rule {
+  failure_class: ApplyFailureClass;
+  confidence: number;
+  patterns: RegExp[];
+}
+
+const RULES: Rule[] = [
+  {
+    failure_class: 'command-rejected',
+    confidence: 0.85,
+    patterns: [
+      /unknown verb/i,
+      /unknown command/i,
+      /unrecognized command/i,
+      /unsupported command/i,
+      /no such command/i,
+      /verb\s+["']?[\w-]+["']?\s+(?:is\s+)?(?:unknown|invalid|not recognized)/i,
+    ],
+  },
+  {
+    failure_class: 'worksheet-not-found',
+    confidence: 0.9,
+    patterns: [/worksheet\s+["'][^"']+["']\s+(?:was\s+)?not\s+found/i, /\bsheet not found\b/i],
+  },
+  {
+    failure_class: 'field-binding',
+    confidence: 0.78,
+    patterns: [
+      /undeclared-(?:calc|set|aggregate-ok)-reference/i,
+      /unsubstituted-template-token/i,
+      /parameter-field-on-shelf/i,
+      /never declared as a <column>/i,
+      /does not have a valid data source/i,
+      /no valid data source/i,
+      /unknown field/i,
+      /no such field/i,
+      /field\s+["'[][^"'\]]+["'\]]?\s+(?:not found|does not exist|is unknown|cannot be found)/i,
+      /column\s+["'[][^"'\]]+["'\]]?\s+(?:not found|does not exist)/i,
+      /unresolved\s+(?:field|reference|calc|caption)/i,
+    ],
+  },
+  {
+    failure_class: 'dashboard-composition',
+    confidence: 0.72,
+    patterns: [
+      /dashboard-zones-reference-included-worksheets/i,
+      /dashboard\s+["'][^"']+["']\s+references worksheet/i,
+      /\bzone\b[^\n]*\b(?:referenc|missing|not found|invalid)/i,
+      /invalid\s+uuid|uuid[^\n]*(?:invalid|not found|mismatch|unknown)/i,
+      /missing (?:second )?(?:panel|zone|window)/i,
+    ],
+  },
+  {
+    failure_class: 'xml-grammar',
+    confidence: 0.82,
+    patterns: [
+      /qualified name parse error/i,
+      /well-formed-xml/i,
+      /xml (?:is not well-formed|parsing error)/i,
+      /not well[- ]?formed/i,
+      /\bmalformed\b/i,
+      /unexpected (?:element|token|end|close|eof|close tag)/i,
+      /mismatched (?:tag|brackets)/i,
+      /premature end/i,
+      /invalid attribute/i,
+      /expected\s+<\/?[\w:-]+>/i,
+    ],
+  },
+  {
+    failure_class: 'xml-grammar',
+    confidence: 0.5,
+    patterns: [
+      /load-underlying-metadata[\s\S]*?(?:load was not able to complete|not able to complete successfully|could not be completed)/i,
+      /(?:load was not able to complete|not able to complete successfully)[\s\S]*?internal error - an unexpected error/i,
+      /errors occurred while trying to load the workbook/i,
+    ],
+  },
+  {
+    failure_class: 'timeout-or-transport',
+    confidence: 0.65,
+    patterns: [/timed out/i, /\btimeout\b/i, /null response/i, /no response/i],
+  },
+];
+
+function toText(value: unknown): string {
+  if (value == null) return '';
+  if (typeof value === 'string') return value;
+  if (Array.isArray(value)) return value.map(toText).join('\n');
+  if (typeof value === 'object') {
+    try {
+      return JSON.stringify(value);
+    } catch {
+      return '';
+    }
+  }
+  if (typeof value === 'number' || typeof value === 'boolean' || typeof value === 'bigint') {
+    return String(value);
+  }
+  return '';
+}
+
+const MAX_EVIDENCE_LEN = 240;
+
+function collectEvidence(text: string, patterns: RegExp[]): string[] {
+  const found = new Set<string>();
+  for (const pattern of patterns) {
+    const match = pattern.exec(text);
+    if (!match) continue;
+    const index = match.index;
+    const lineStart = text.lastIndexOf('\n', index) + 1;
+    let lineEnd = text.indexOf('\n', index);
+    if (lineEnd === -1) lineEnd = text.length;
+    const line = text.slice(lineStart, lineEnd).trim();
+    let span = line.length <= MAX_EVIDENCE_LEN ? line : match[0].replace(/\s+/g, ' ').trim();
+    if (span.length > MAX_EVIDENCE_LEN) span = span.slice(-MAX_EVIDENCE_LEN).trim();
+    if (span) found.add(span);
+  }
+  return [...found];
+}
+
+const AUTO_CALC_REF = /Calculation_\d{6,}/g;
+
+function findUndeclaredAutoCalc(xml: string): string | null {
+  const referenced = new Set<string>();
+  for (const match of String(xml ?? '').matchAll(AUTO_CALC_REF)) referenced.add(match[0]);
+  for (const calc of referenced) {
+    const declaration = new RegExp(
+      `<column\\b[^>]*\\bname=(['"])\\[[^\\]]*${calc}[^\\]]*\\]\\1`,
+      'i',
+    );
+    if (!declaration.test(xml)) return calc;
+  }
+  return null;
+}
+
+const GENERIC_WRAPPER = [
+  /failed to apply workbook xml/i,
+  /failed to (?:apply|update|load) worksheet/i,
+  /(?:workbook|worksheet|dashboard) could not be loaded/i,
+  /worksheet contains errors/i,
+  /dashboard contains errors/i,
+  /make sure tableau desktop is running/i,
+  /internal error/i,
+  /an unexpected error occurred/i,
+];
+
+function round2(n: number): number {
+  return Math.round(n * 100) / 100;
+}
+
+export function classifyApplyFailure(input: ClassifyApplyFailureInput): ApplyFailureClassification {
+  const text = [toText(input.serverError), toText(input.applyResponse)].filter(Boolean).join('\n');
+
+  for (const rule of RULES) {
+    const evidence = collectEvidence(text, rule.patterns);
+    if (evidence.length === 0) continue;
+    const confidence =
+      rule.failure_class === 'dashboard-composition' && input.context === 'dashboard'
+        ? Math.min(0.85, rule.confidence + 0.1)
+        : rule.confidence;
+    return {
+      failure_class: rule.failure_class,
+      confidence: round2(confidence),
+      evidence: evidence.slice(0, 6),
+      guidance: GUIDANCE[rule.failure_class],
+    };
+  }
+
+  if (input.xmlSnippet) {
+    const calc = findUndeclaredAutoCalc(input.xmlSnippet);
+    if (calc) {
+      return {
+        failure_class: 'field-binding',
+        confidence: 0.6,
+        evidence: [`undeclared auto-calc reference in payload: ${calc} (no <column> declaration)`],
+        guidance: GUIDANCE['field-binding'],
+      };
+    }
+  }
+
+  const generic = collectEvidence(text, GENERIC_WRAPPER);
+  const evidence =
+    generic.length > 0
+      ? generic.slice(0, 3)
+      : text.trim()
+        ? [text.trim().split(/\r?\n/)[0].slice(0, MAX_EVIDENCE_LEN)]
+        : ['no error text preserved'];
+  return { failure_class: 'unknown', confidence: 0.2, evidence, guidance: GUIDANCE.unknown };
+}
+
+export function formatApplyFailureForAgent(input: ClassifyApplyFailureInput): string {
+  const classification = classifyApplyFailure(input);
+  const evidence = classification.evidence.length
+    ? `\nEvidence: ${classification.evidence.join(' | ')}`
+    : '';
+  return `Apply failed: ${classification.failure_class} (confidence ${classification.confidence}).${evidence}\n\nFIX: ${classification.guidance}`;
+}

--- a/src/desktop/commands/workbook/loadDashboardXml.ts
+++ b/src/desktop/commands/workbook/loadDashboardXml.ts
@@ -23,7 +23,17 @@ export type LoadDashboardXmlError =
   // `status`). `message` carries Desktop's own error text.
   | { type: 'load-rejected'; message: string };
 
+export interface LoadDashboardXmlOk {
+  validationWarnings: ValidationIssue[];
+}
+
 type LoadDashboardXmlResult = Result<
+  LoadDashboardXmlOk,
+  | { type: 'execute-command-error'; error: ExecuteCommandError }
+  | { type: 'load-dashboard-xml-error'; error: LoadDashboardXmlError }
+>;
+
+type LoadDashboardHelperResult = Result<
   void,
   | { type: 'execute-command-error'; error: ExecuteCommandError }
   | { type: 'load-dashboard-xml-error'; error: LoadDashboardXmlError }
@@ -78,9 +88,15 @@ export async function loadDashboardXml({
   // External Client API ("Athena V0") exposes no per-sheet route — tabui:load-dashboard is not in
   // its command registry, so applying a single dashboard re-posts a minimal whole-workbook document.
   // The POST upserts by name: it overwrites the colliding dashboard in place and leaves the rest live.
-  return getDesktopConfig().externalApiEnabled
+  const result = await (getDesktopConfig().externalApiEnabled
     ? loadDashboardXmlViaExternalApi({ dashboardName, xml, executor, signal })
-    : loadDashboardXmlViaAgentApi({ dashboardName, xml, executor, signal });
+    : loadDashboardXmlViaAgentApi({ dashboardName, xml, executor, signal }));
+  if (result.isErr()) {
+    return result;
+  }
+  // Preflight warnings ride along so apply responses can compute the host
+  // verification receipt (W-23447506) without re-running validation.
+  return Ok({ validationWarnings: validation.issues });
 }
 
 async function loadDashboardXmlViaAgentApi({
@@ -91,7 +107,7 @@ async function loadDashboardXmlViaAgentApi({
 }: {
   dashboardName: string;
   xml: string;
-} & WithExecutorAndAbortSignal): Promise<LoadDashboardXmlResult> {
+} & WithExecutorAndAbortSignal): Promise<LoadDashboardHelperResult> {
   const result = await executor.executeCommand({
     namespace: 'tabui',
     command: 'load-dashboard',
@@ -153,7 +169,7 @@ async function loadDashboardXmlViaExternalApi({
 }: {
   dashboardName: string;
   xml: string;
-} & WithExecutorAndAbortSignal): Promise<LoadDashboardXmlResult> {
+} & WithExecutorAndAbortSignal): Promise<LoadDashboardHelperResult> {
   return withApplyLock(async () => {
     const workbookResult = await getWorkbookXml({ executor, signal });
     if (workbookResult.isErr()) {

--- a/src/desktop/commands/workbook/loadDashboardXml.ts
+++ b/src/desktop/commands/workbook/loadDashboardXml.ts
@@ -10,6 +10,7 @@ import {
 } from '../../toolExecutor/toolExecutor.js';
 import { runValidation } from '../../validation/registry.js';
 import { ValidationIssue } from '../../validation/types.js';
+import { formatApplyFailureForAgent } from './applyFailureClassifier.js';
 import { withApplyLock } from './applyMutex.js';
 import { focusAppliedSheetBestEffort } from './focusAppliedSheet.js';
 import { getWorkbookXml } from './getWorkbookXml.js';
@@ -137,7 +138,14 @@ async function loadDashboardXmlViaAgentApi({
 
     return Err({
       type: 'load-dashboard-xml-error',
-      error: { type: 'load-rejected', message: outcome.message },
+      error: {
+        type: 'load-rejected',
+        message: formatApplyFailureForAgent({
+          context: 'dashboard',
+          serverError: outcome.message,
+          xmlSnippet: xml,
+        }),
+      },
     });
   }
 

--- a/src/desktop/commands/workbook/loadWorkbookXml.ts
+++ b/src/desktop/commands/workbook/loadWorkbookXml.ts
@@ -14,6 +14,7 @@ import {
 } from '../../toolExecutor/toolExecutor.js';
 import { runValidation } from '../../validation/registry.js';
 import { ValidationIssue } from '../../validation/types.js';
+import { formatApplyFailureForAgent } from './applyFailureClassifier.js';
 import { withApplyLock } from './applyMutex.js';
 import { getWorkbookXml } from './getWorkbookXml.js';
 
@@ -283,7 +284,14 @@ async function loadUnderlyingMetadataByFilepath({
 
     return Err({
       type: 'load-workbook-xml-error',
-      error: { type: 'load-rejected', message: outcome.message },
+      error: {
+        type: 'load-rejected',
+        message: formatApplyFailureForAgent({
+          context: 'workbook',
+          serverError: outcome.message,
+          xmlSnippet: xml,
+        }),
+      },
     });
   }
 
@@ -341,7 +349,14 @@ async function loadUnderlyingMetadataByText({
 
     return Err({
       type: 'load-workbook-xml-error',
-      error: { type: 'load-rejected', message: outcome.message },
+      error: {
+        type: 'load-rejected',
+        message: formatApplyFailureForAgent({
+          context: 'workbook',
+          serverError: outcome.message,
+          xmlSnippet: xml,
+        }),
+      },
     });
   }
 

--- a/src/desktop/commands/workbook/loadWorkbookXml.ts
+++ b/src/desktop/commands/workbook/loadWorkbookXml.ts
@@ -128,8 +128,12 @@ function firstString(...values: unknown[]): string | undefined {
   return undefined;
 }
 
+export interface LoadWorkbookXmlOk {
+  validationWarnings: ValidationIssue[];
+}
+
 type LoadWorkbookXmlResult = Result<
-  void,
+  LoadWorkbookXmlOk,
   | { type: 'execute-command-error'; error: ExecuteCommandError }
   | { type: 'load-workbook-xml-error'; error: LoadWorkbookXmlError }
 >;
@@ -183,10 +187,16 @@ export async function loadWorkbookXml({
     if (result.isErr()) {
       return Err({ type: 'execute-command-error', error: result.error });
     }
-    return Ok.EMPTY;
+    return Ok({ validationWarnings: validation.issues });
   }
 
-  return loadUnderlyingMetadataByFilepath({ xml, executor, signal, filePath });
+  const result = await loadUnderlyingMetadataByFilepath({ xml, executor, signal, filePath });
+  if (result.isErr()) {
+    return result;
+  }
+  // Preflight warnings ride along so apply responses can compute the host
+  // verification receipt (W-23447506) without re-running validation.
+  return Ok({ validationWarnings: validation.issues });
 }
 
 async function loadUnderlyingMetadataByFilepath({

--- a/src/desktop/commands/workbook/loadWorksheetXml.test.ts
+++ b/src/desktop/commands/workbook/loadWorksheetXml.test.ts
@@ -362,7 +362,13 @@ describe('loadWorksheetXml (Agent API transport, default)', () => {
     if (result.isErr()) {
       invariant(result.error.type === 'load-worksheet-xml-error');
       invariant(result.error.error.type === 'load-rejected');
+      // The load-rejected message is now the classifier's actionable format, not the
+      // raw Desktop error: it prefixes the classification and appends a FIX recipe while
+      // still preserving Desktop's original text as evidence.
+      expect(result.error.error.message).toContain('Apply failed:');
       expect(result.error.error.message).toContain('Qualified Name Parse Error');
+      expect(result.error.error.message).toContain('FIX:');
+      expect(result.error.error.message).not.toBe(deskError);
     }
   });
 

--- a/src/desktop/commands/workbook/loadWorksheetXml.ts
+++ b/src/desktop/commands/workbook/loadWorksheetXml.ts
@@ -38,6 +38,7 @@ export type LoadWorksheetXmlError =
 export interface LoadWorksheetXmlOk {
   readbackWarnings: ReadbackFinding[];
   readbackVerification?: ReadbackVerificationResult;
+  validationWarnings?: ValidationIssue[];
 }
 
 interface PostApplyWorksheetReadbackVerification extends ReadbackVerificationResult {
@@ -182,7 +183,7 @@ export async function loadWorksheetXml({
   // External Client API ("Athena V0") exposes no per-sheet route — tabui:load-worksheet is not in
   // its command registry, so applying a single sheet re-posts a minimal whole-workbook document.
   // The POST upserts by name: it overwrites the colliding sheet in place and leaves the rest live.
-  return getDesktopConfig().externalApiEnabled
+  const result = await (getDesktopConfig().externalApiEnabled
     ? loadWorksheetXmlViaExternalApi({
         worksheetName,
         xml,
@@ -196,7 +197,13 @@ export async function loadWorksheetXml({
         executor,
         signal,
         readbackVerificationOut,
-      });
+      }));
+  if (result.isErr()) {
+    return result;
+  }
+  // Preflight warnings ride along so apply responses can compute the host
+  // verification receipt (W-23447506) without re-running validation.
+  return Ok({ ...result.value, validationWarnings: validation.issues });
 }
 
 async function loadWorksheetXmlViaAgentApi({

--- a/src/desktop/commands/workbook/loadWorksheetXml.ts
+++ b/src/desktop/commands/workbook/loadWorksheetXml.ts
@@ -16,6 +16,7 @@ import {
 } from '../../validation/readback-verify.js';
 import { runValidation } from '../../validation/registry.js';
 import { ValidationIssue } from '../../validation/types.js';
+import { formatApplyFailureForAgent } from './applyFailureClassifier.js';
 import { withApplyLock } from './applyMutex.js';
 import { focusAppliedSheetBestEffort } from './focusAppliedSheet.js';
 import { getWorkbookXml } from './getWorkbookXml.js';
@@ -246,7 +247,14 @@ async function loadWorksheetXmlViaAgentApi({
 
     return Err({
       type: 'load-worksheet-xml-error',
-      error: { type: 'load-rejected', message: outcome.message },
+      error: {
+        type: 'load-rejected',
+        message: formatApplyFailureForAgent({
+          context: 'worksheet',
+          serverError: outcome.message,
+          xmlSnippet: xml,
+        }),
+      },
     });
   }
 

--- a/src/desktop/routeTable.test.ts
+++ b/src/desktop/routeTable.test.ts
@@ -29,9 +29,9 @@ describe('DESKTOP_ROUTE_TABLE', () => {
     expect(new Set(ids).size).toBe(ids.length);
   });
 
-  it('contains the plain-chart, dashboard, and data-value deflection routes', () => {
+  it('contains the required desktop routes', () => {
     expect(routes.map((route) => route.id)).toEqual(
-      expect.arrayContaining(['plain-chart', 'dashboard', 'data-value-question']),
+      expect.arrayContaining(['plain-chart', 'dashboard', 'data-value-question', 'edit-in-place']),
     );
   });
 

--- a/src/desktop/routeTable.ts
+++ b/src/desktop/routeTable.ts
@@ -74,6 +74,16 @@ export const DESKTOP_ROUTE_TABLE: readonly DesktopInstructionEntry[] = [
     requiredEvidence: [],
   },
   {
+    kind: 'route',
+    id: 'edit-in-place',
+    trigger: 'current/this/that/existing sheet, chart, view, or dashboard',
+    action:
+      'edit in place: resolve the target (exact name, else list-worksheets; ask if ambiguous), then refine-worksheet for top-N/sort edits, else get-worksheet-xml -> edit -> apply-worksheet. Never create a new sheet unless explicitly asked.',
+    toolSequence: ['list-worksheets', 'refine-worksheet', 'get-worksheet-xml', 'apply-worksheet'],
+    stopConditions: ['Never create a new sheet unless explicitly asked'],
+    requiredEvidence: ['resolved worksheet/dashboard target before applying'],
+  },
+  {
     kind: 'prose',
     id: SESSION_RESOLUTION_ID,
     text: 'Every session-scoped tool call needs the session id from list-instances — except bind-template and dashboard-auto-apply, which auto-resolve the session when exactly one Desktop instance is running.',

--- a/src/desktop/validation/promise-check.test.ts
+++ b/src/desktop/validation/promise-check.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  formatDashboardPromiseCheck,
+  formatWorkbookPromiseCheck,
+  formatWorksheetPromiseCheck,
+} from './promise-check.js';
+import type { ValidationIssue } from './types.js';
+
+const warning = (): ValidationIssue => ({ ruleId: 'x', severity: 'warning', message: 'w' });
+
+describe('promise check receipt (W-23447506)', () => {
+  it('formats clean readback as verified', () => {
+    const text = formatWorksheetPromiseCheck({
+      validationWarnings: [],
+      readback: { ok: true, status: 'passed' },
+    });
+    expect(text).toContain('HOST VERIFICATION — verified');
+    expect(text).toContain('readback clean');
+    expect(text).toContain('do not report unlisted issues');
+  });
+
+  it('formats skipped readback as unverified', () => {
+    const text = formatWorksheetPromiseCheck({
+      validationWarnings: [],
+      readback: { ok: true, status: 'skipped' },
+    });
+    expect(text).toContain('HOST VERIFICATION — unverified');
+    expect(text).toContain('readback unavailable');
+    expect(text).toContain('Do not claim the change is confirmed');
+  });
+
+  it('formats missing readback as unverified', () => {
+    const text = formatWorksheetPromiseCheck({
+      validationWarnings: [warning()],
+      readback: undefined,
+    });
+    expect(text).toContain('unverified');
+    expect(text).toContain('preflight 1 warning(s)');
+  });
+
+  it('formats failed readback as failed', () => {
+    const text = formatWorksheetPromiseCheck({
+      validationWarnings: [],
+      readback: { ok: false, status: 'failed' },
+    });
+    expect(text).toContain('HOST VERIFICATION — failed');
+    expect(text).toContain('readback FAILED');
+  });
+
+  it('formats workbook applies as honestly unverified', () => {
+    const text = formatWorkbookPromiseCheck([]);
+    expect(text).toContain('HOST VERIFICATION — unverified');
+    expect(text).toContain('full workbook intent NOT re-verified');
+  });
+
+  it('formats dashboard applies as honestly unverified', () => {
+    const text = formatDashboardPromiseCheck([]);
+    expect(text).toContain('full dashboard intent NOT re-verified');
+  });
+});

--- a/src/desktop/validation/promise-check.ts
+++ b/src/desktop/validation/promise-check.ts
@@ -1,0 +1,81 @@
+/**
+ * Promise check (W-23447506): a HOST-COMPUTED verification receipt appended to
+ * apply-style responses, so the agent's narration is anchored to evidence the
+ * server actually has — instead of the model inventing problems ("workbook
+ * wiring issue") or confidence ("verified!") that nothing measured.
+ *
+ * Schema-decay rule: the model fills NOTHING here. Every field derives from
+ * validation issues and readback verification already computed on the apply
+ * path. Dashboard/whole-workbook intent is honestly labeled unverified — only
+ * worksheet readback proves structural survival.
+ *
+ * Ported from agent-to-tableau-desktop.
+ */
+import type { ReadbackVerificationResult } from './readback-verify.js';
+import type { ValidationIssue } from './types.js';
+
+export type PromiseOutcome = 'verified' | 'unverified' | 'failed';
+
+export interface WorksheetReceiptInput {
+  validationWarnings: ValidationIssue[];
+  readback: ReadbackVerificationResult | undefined;
+}
+
+function formatPreflight(validationWarnings: ValidationIssue[]): string {
+  return validationWarnings.length === 0
+    ? 'preflight clean'
+    : `preflight ${validationWarnings.length} warning(s)`;
+}
+
+/** One compact line: outcome + the checks that back it + the claim guard. */
+export function formatWorksheetPromiseCheck(input: WorksheetReceiptInput): string {
+  const parts: string[] = [formatPreflight(input.validationWarnings), 'apply completed'];
+  let outcome: PromiseOutcome;
+  switch (input.readback?.status) {
+    case 'passed':
+      outcome = 'verified';
+      parts.push('readback clean');
+      break;
+    case 'warning':
+      outcome = 'verified';
+      parts.push('readback warnings (listed above)');
+      break;
+    case 'failed':
+      outcome = 'failed';
+      parts.push('readback FAILED (nodes dropped)');
+      break;
+    case 'skipped':
+    default:
+      outcome = 'unverified';
+      parts.push('readback unavailable');
+      break;
+  }
+  const guard =
+    outcome === 'verified'
+      ? ' No host evidence of any workbook problem beyond the findings listed above — do not report unlisted issues.'
+      : ' Do not claim the change is confirmed; report only the evidence above.';
+  return `\n\nHOST VERIFICATION — ${outcome}: ${parts.join(' · ')}.${guard}`;
+}
+
+/**
+ * Whole-workbook applies have NO structural readback today — say so instead of
+ * letting success text imply full verification.
+ */
+export function formatWorkbookPromiseCheck(validationWarnings: ValidationIssue[]): string {
+  const parts = [
+    formatPreflight(validationWarnings),
+    'apply completed',
+    'full workbook intent NOT re-verified',
+  ];
+  return `\n\nHOST VERIFICATION — unverified: ${parts.join(' · ')}. Treat sheet-level state as unconfirmed until read back; do not report problems without host evidence.`;
+}
+
+/** Dashboard applies likewise have no structural readback — honest by construction. */
+export function formatDashboardPromiseCheck(validationWarnings: ValidationIssue[]): string {
+  const parts = [
+    formatPreflight(validationWarnings),
+    'apply completed',
+    'full dashboard intent NOT re-verified',
+  ];
+  return `\n\nHOST VERIFICATION — unverified: ${parts.join(' · ')}. Treat dashboard state as unconfirmed until read back; do not report problems without host evidence.`;
+}

--- a/src/desktop/validation/rules/malformedTopNFilter.test.ts
+++ b/src/desktop/validation/rules/malformedTopNFilter.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+
+import { runValidation } from '../registry.js';
+import { malformedSetGroupfilterRule } from './malformedSetGroupfilter.js';
+import { malformedTopNFilterRule } from './malformedTopNFilter.js';
+
+function worksheetWith(filter: string): string {
+  return `<worksheet name="S"><table><view>${filter}</view></table></worksheet>`;
+}
+
+function workbookWith(filter: string): string {
+  return `<workbook><worksheets>${worksheetWith(filter)}</worksheets></workbook>`;
+}
+
+const FLAT_TOP_N = `<filter class="categorical" column="[DS].[none:Customer:nk]">
+  <groupfilter count="20" count-type="count" direction="top" expression="sum" field="[Sales]" function="filter"/>
+</filter>`;
+
+const NESTED_CONFIRMED = `<filter class="categorical" column="[DS].[none:Customer:nk]">
+  <groupfilter function="end" end="top" count="20" units="records">
+    <groupfilter function="order" direction="DESC" expression="SUM([Sales])">
+      <groupfilter function="level-members" level="[none:Customer:nk]"/>
+    </groupfilter>
+  </groupfilter>
+</filter>`;
+
+const EXPRESSION_PREDICATE = `<filter class="categorical" column="[DS].[none:Region:nk]">
+  <groupfilter function="filter" expression="SUM([Sales]) &gt; 1000">
+    <groupfilter function="level-members" level="[none:Region:nk]"/>
+  </groupfilter>
+</filter>`;
+
+const FLAT_SET_GROUPFILTER = `<workbook><datasources><datasource name="Sample - Superstore">
+  <group caption="Top N Set" field="[Sub-Category]" name="[Set_TopN]" name-style="unqualified">
+    <groupfilter count="[Parameters].[Parameter 1]" count-type="count" direction="top" expression="sum" field="[Profit]" function="filter"/>
+  </group>
+</datasource></datasources></workbook>`;
+
+describe('malformed-top-n-filter rule', () => {
+  it("errors on the flat function='filter' Top-N filter shape", () => {
+    const issues = malformedTopNFilterRule.validate(worksheetWith(FLAT_TOP_N));
+
+    expect(issues).toHaveLength(1);
+    expect(issues[0].severity).toBe('error');
+    expect(issues[0].message).toContain('[DS].[none:Customer:nk]');
+    expect(issues[0].suggestion).toContain('function="end"');
+  });
+
+  it("stays silent on the confirmed nested function='end' recipe", () => {
+    expect(malformedTopNFilterRule.validate(worksheetWith(NESTED_CONFIRMED))).toHaveLength(0);
+  });
+
+  it("stays silent on a non-Top-N expression predicate using function='filter'", () => {
+    expect(malformedTopNFilterRule.validate(worksheetWith(EXPRESSION_PREDICATE))).toHaveLength(0);
+  });
+
+  it('does not overlap with malformed-set-groupfilter on set definitions', () => {
+    expect(malformedTopNFilterRule.validate(FLAT_SET_GROUPFILTER)).toHaveLength(0);
+    expect(malformedSetGroupfilterRule.validate(FLAT_SET_GROUPFILTER)).toHaveLength(1);
+  });
+
+  it('blocks worksheet validation when registered', () => {
+    const result = runValidation(worksheetWith(FLAT_TOP_N), 'worksheet');
+
+    expect(result.valid).toBe(false);
+    expect(result.issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          ruleId: 'malformed-top-n-filter',
+          severity: 'error',
+        }),
+      ]),
+    );
+  });
+
+  it('blocks workbook validation when registered', () => {
+    const result = runValidation(workbookWith(FLAT_TOP_N), 'workbook');
+
+    expect(result.valid).toBe(false);
+    expect(result.issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          ruleId: 'malformed-top-n-filter',
+          severity: 'error',
+        }),
+      ]),
+    );
+  });
+});

--- a/src/desktop/validation/rules/malformedTopNFilter.ts
+++ b/src/desktop/validation/rules/malformedTopNFilter.ts
@@ -1,0 +1,53 @@
+/**
+ * Validation rule: malformed-top-n-filter
+ *
+ * W-23447507: a Top-N filter authored as a flat <groupfilter function="filter">
+ * with count/direction attributes is silently stripped by Tableau on apply. The
+ * confirmed working form is the nested function="end" -> order -> level-members
+ * recipe, plus a matching <slices> entry.
+ *
+ * Ported from agent-to-tableau-desktop.
+ */
+import * as xpath from 'xpath';
+
+import type { ValidationIssue, ValidationRule } from '../types.js';
+import { parseXml } from './parseXml.js';
+
+const TOP_N_FILTER_XPATH =
+  "//filter[not(ancestor::group) and groupfilter[@function='filter' and " +
+  '(@count or @count-type or @field) and ' +
+  "(translate(@direction, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz')='top' or " +
+  "translate(@direction, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz')='bottom')]]";
+
+export const malformedTopNFilterRule: ValidationRule = {
+  id: 'malformed-top-n-filter',
+  description:
+    "Errors when a Top-N filter uses the flat <groupfilter function='filter'> shape that Tableau silently strips. " +
+    "Use the nested function='end' recipe instead.",
+  contexts: ['workbook', 'worksheet'],
+
+  validate(xml: string): ValidationIssue[] {
+    const doc = parseXml(xml);
+    if (!doc) return [];
+
+    const filters = xpath.select(TOP_N_FILTER_XPATH, doc as unknown as Node) as Element[];
+
+    return filters.map((filter): ValidationIssue => {
+      const column = filter.getAttribute('column') ?? '(unknown column)';
+      return {
+        ruleId: 'malformed-top-n-filter',
+        severity: 'error',
+        message:
+          `Top-N filter on "${column}" uses the flat <groupfilter function="filter"> shape. ` +
+          'Tableau silently strips this filter on apply, so the viz shows unfiltered data while apply reports success.',
+        xpath:
+          "//filter[not(ancestor::group)]/groupfilter[@function='filter'][@direction='top' or @direction='bottom']",
+        suggestion:
+          'Author Top-N with the confirmed nested recipe: ' +
+          '<groupfilter function="end" end="top" count="N"> wrapping ' +
+          '<groupfilter function="order" direction="DESC" expression="SUM([Measure])"> wrapping ' +
+          '<groupfilter function="level-members" level="[none:Field:nk]"/>, plus a matching <slices><column> entry.',
+      };
+    });
+  },
+};

--- a/src/desktop/validation/rules/rules.ts
+++ b/src/desktop/validation/rules/rules.ts
@@ -16,6 +16,7 @@ import { hardcodedDateFilterRule } from './hardcodedDateFilter.js';
 import { invalidColumnInstancePivotRule } from './invalidColumnInstancePivot.js';
 import { invalidDerivationStringRule } from './invalidDerivationString.js';
 import { malformedSetGroupfilterRule } from './malformedSetGroupfilter.js';
+import { malformedTopNFilterRule } from './malformedTopNFilter.js';
 import { mixedAggregationCalcRule } from './mixedAggregationCalc.js';
 import { parameterFieldOnShelfRule } from './parameterFieldOnShelf.js';
 import { placeholderDatasourceRefRule } from './placeholderDatasourceRef.js';
@@ -50,6 +51,7 @@ export const validationRules = [
   duplicateEmptyParameterRule,
   setCountMalformedParameterRule,
   malformedSetGroupfilterRule,
+  malformedTopNFilterRule,
   calcNameFieldCollisionRule,
   mixedAggregationCalcRule,
   aggregateCalcDerivationRule,

--- a/src/errors/mcpToolError.ts
+++ b/src/errors/mcpToolError.ts
@@ -5,10 +5,22 @@ import { fromError } from 'zod-validation-error/v3';
 import type { GetDashboardXmlError } from '../desktop/commands/workbook/getDashboardXml.js';
 import type { GetWorksheetXmlError } from '../desktop/commands/workbook/getWorksheetXml.js';
 import type { LoadDashboardXmlError } from '../desktop/commands/workbook/loadDashboardXml.js';
-import { LoadWorkbookXmlError } from '../desktop/commands/workbook/loadWorkbookXml.js';
+import type { LoadWorkbookXmlError } from '../desktop/commands/workbook/loadWorkbookXml.js';
 import type { LoadWorksheetXmlError } from '../desktop/commands/workbook/loadWorksheetXml.js';
 import { ExecuteCommandError } from '../desktop/toolExecutor/toolExecutor.js';
 import { getExceptionMessage } from '../utils/getExceptionMessage.js';
+
+// The load-*-xml error union carries Desktop's own rejection text on its message-bearing
+// variants (load-rejected / readback-failed), already formatted for the agent by
+// applyFailureClassifier. Surface that text directly instead of JSON.stringify-wrapping it;
+// fall back to JSON only for the structural variants that carry no message string.
+function xmlLoadErrorMessage(
+  error: LoadWorkbookXmlError | LoadWorksheetXmlError | LoadDashboardXmlError,
+): string {
+  return 'message' in error && typeof error.message === 'string'
+    ? error.message
+    : JSON.stringify(error);
+}
 
 export class McpToolError extends Error {
   readonly type: string;
@@ -258,7 +270,7 @@ export class WorkbookXmlLoadFailedError extends McpToolError {
   constructor(error: LoadWorkbookXmlError) {
     super({
       type: 'load-workbook-xml-error',
-      message: JSON.stringify(error),
+      message: xmlLoadErrorMessage(error),
       statusCode: 500,
     });
   }
@@ -268,7 +280,7 @@ export class WorksheetXmlLoadFailedError extends McpToolError {
   constructor(error: LoadWorksheetXmlError) {
     super({
       type: 'load-worksheet-xml-error',
-      message: JSON.stringify(error),
+      message: xmlLoadErrorMessage(error),
       statusCode: 500,
     });
   }
@@ -298,7 +310,7 @@ export class DashboardXmlLoadFailedError extends McpToolError {
   constructor(error: LoadDashboardXmlError) {
     super({
       type: 'load-dashboard-xml-error',
-      message: JSON.stringify(error),
+      message: xmlLoadErrorMessage(error),
       statusCode: 500,
     });
   }

--- a/src/server.desktop.test.ts
+++ b/src/server.desktop.test.ts
@@ -100,6 +100,8 @@ For a dashboard ask with 2-6 vizzes (e.g. "a dashboard with sales by region and 
 
 For a data-value question ("what was revenue in Q3?"), do NOT answer with a number — this server cannot read data values. Say so, then offer the viz that would show it (a plain viz ask via bind-template) instead.
 
+For current/this/that/existing sheet, chart, view, or dashboard, edit in place: resolve the target (exact name, else list-worksheets; ask if ambiguous), then refine-worksheet for top-N/sort edits, else get-worksheet-xml -> edit -> apply-worksheet. Never create a new sheet unless explicitly asked.
+
 Every session-scoped tool call needs the session id from list-instances — except bind-template and dashboard-auto-apply, which auto-resolve the session when exactly one Desktop instance is running.
 
 If an apply is rejected by preflight validation, fix the workbook content per the FIX lines in the error and re-apply. Prefer file mode for large workbooks.`,
@@ -146,7 +148,7 @@ describe('desktop tools/list serialized surface', () => {
 
     // 46_000 is the ToolSearch auto-deferral cliff on MCP hosts, not a tunable constant — past it
     // the whole desktop surface gets deferred behind ToolSearch. The shelf-tool consolidation has
-    // landed, so this is GREEN: the serialized surface is 44_015 bytes, ~1_985 under the cliff.
+    // landed, so this is GREEN: the serialized surface is 45_336 bytes, ~664 under the cliff.
     // That headroom is the ENTIRE budget for future tools — trim tools to fit it; NEVER raise the
     // cap to ship a tool (raising it just re-buries the whole surface behind ToolSearch).
     expect(total).toBeLessThanOrEqual(46_000);

--- a/src/tools/desktop/cache/noDeadEnd.test.ts
+++ b/src/tools/desktop/cache/noDeadEnd.test.ts
@@ -53,7 +53,7 @@ describe('no-dead-end file workflow for a filesystem-less client', () => {
 
   it('supports get(capped) -> slice-read -> targeted write -> apply(file) with only server tools', async () => {
     vi.spyOn(getWorkbookXmlCmd, 'getWorkbookXml').mockResolvedValue(Ok(WORKBOOK));
-    const loadSpy = vi.spyOn(loadWorkbookXmlCmd, 'loadWorkbookXml').mockResolvedValue(Ok.EMPTY);
+    const loadSpy = vi.spyOn(loadWorkbookXmlCmd, 'loadWorkbookXml').mockResolvedValue(Ok({ validationWarnings: [] }));
 
     // 1) GET: inline requested, but the cap forces file mode. Agent gets a path + summary,
     //    NOT the 20KB workbook.

--- a/src/tools/desktop/cache/noDeadEnd.test.ts
+++ b/src/tools/desktop/cache/noDeadEnd.test.ts
@@ -53,7 +53,9 @@ describe('no-dead-end file workflow for a filesystem-less client', () => {
 
   it('supports get(capped) -> slice-read -> targeted write -> apply(file) with only server tools', async () => {
     vi.spyOn(getWorkbookXmlCmd, 'getWorkbookXml').mockResolvedValue(Ok(WORKBOOK));
-    const loadSpy = vi.spyOn(loadWorkbookXmlCmd, 'loadWorkbookXml').mockResolvedValue(Ok({ validationWarnings: [] }));
+    const loadSpy = vi
+      .spyOn(loadWorkbookXmlCmd, 'loadWorkbookXml')
+      .mockResolvedValue(Ok({ validationWarnings: [] }));
 
     // 1) GET: inline requested, but the cap forces file mode. Agent gets a path + summary,
     //    NOT the 20KB workbook.

--- a/src/tools/desktop/coordination/batchCreateAndCacheSheets.test.ts
+++ b/src/tools/desktop/coordination/batchCreateAndCacheSheets.test.ts
@@ -39,7 +39,7 @@ function makeExtra(): TableauDesktopRequestHandlerExtra {
   vi.mocked(getWorkbookXml).mockResolvedValue(new Ok(WORKBOOK_XML));
   vi.mocked(addSheet).mockReturnValue(WORKBOOK_XML);
   vi.mocked(addDashboard).mockReturnValue(WORKBOOK_XML);
-  vi.mocked(loadWorkbookXml).mockResolvedValue(new Ok(undefined));
+  vi.mocked(loadWorkbookXml).mockResolvedValue(new Ok({ validationWarnings: [] }));
   vi.mocked(getWorksheetXml).mockResolvedValue(new Ok(WORKSHEET_XML));
   vi.mocked(getDashboardXml).mockResolvedValue(new Ok(DASHBOARD_XML));
   vi.mocked(writeFileSync).mockImplementation(() => {});
@@ -75,6 +75,8 @@ describe('batchCreateAndCacheSheetsTool', () => {
     expect(result.content[0].text).toContain('Sheet2');
     expect(result.content[0].text).toContain('My Dashboard');
     expect(result.content[0].text).toContain('Ready for Phase 2');
+    expect(result.content[0].text).toContain('HOST VERIFICATION — unverified');
+    expect(result.content[0].text).toContain('full workbook intent NOT re-verified');
   });
 
   it('should call addSheet for each worksheet name', async () => {

--- a/src/tools/desktop/coordination/batchCreateAndCacheSheets.ts
+++ b/src/tools/desktop/coordination/batchCreateAndCacheSheets.ts
@@ -15,6 +15,7 @@ import {
   type RouteGateResult,
 } from '../../../desktop/route/route-gate.js';
 import { resolveSession } from '../../../desktop/sessionResolution.js';
+import { formatWorkbookPromiseCheck } from '../../../desktop/validation/promise-check.js';
 import {
   DesktopCommandExecutionError,
   WorkbookXmlLoadFailedError,
@@ -179,6 +180,12 @@ export const getBatchCreateAndCacheSheetsTool = (
             msg += `\n\nWarnings:\n${worksheetWarnings.map((w) => `  • ${w}`).join('\n')}`;
           }
           msg += '\n\nReady for Phase 2 parallel execution.';
+          // Host verification receipt (W-23447506): this whole-workbook apply has
+          // no structural readback, so say so honestly instead of implying full
+          // re-verification happened.
+          msg += applyResult.isOk()
+            ? formatWorkbookPromiseCheck(applyResult.value.validationWarnings)
+            : '';
 
           return new Ok({
             message: msg,

--- a/src/tools/desktop/coordination/buildAndApplyWorksheet.test.ts
+++ b/src/tools/desktop/coordination/buildAndApplyWorksheet.test.ts
@@ -96,6 +96,7 @@ describe('buildAndApplyWorksheetTool', () => {
     invariant(result.content[0].type === 'text');
     expect(result.content[0].text).toContain('Sheet1');
     expect(result.content[0].text).toContain('ranking-ordered-bar');
+    expect(result.content[0].text).toContain('HOST VERIFICATION');
   });
 
   it('reports skipped readback caveat when apply succeeds without verification', async () => {
@@ -111,7 +112,8 @@ describe('buildAndApplyWorksheetTool', () => {
 
     expect(result.isError).toBeFalsy();
     invariant(result.content[0].type === 'text');
-    expect(result.content[0].text).toContain('could not verify (readback unavailable)');
+    expect(result.content[0].text).toContain('HOST VERIFICATION — unverified');
+    expect(result.content[0].text).toContain('readback unavailable');
     expect(result.content[0].text).not.toMatch(/\bverified\b/i);
   });
 

--- a/src/tools/desktop/coordination/buildAndApplyWorksheet.ts
+++ b/src/tools/desktop/coordination/buildAndApplyWorksheet.ts
@@ -22,7 +22,7 @@ import { rewriteFieldReferences } from '../../../desktop/templates/fieldReferenc
 import { ensureUserNamespace } from '../../../desktop/templates/injectTemplateCore.js';
 import { getTemplateColumnRequirements } from '../../../desktop/templates/templateColumnRequirements.js';
 import { readTemplate } from '../../../desktop/templates/templatePath.js';
-import { formatReadbackVerificationStatus } from '../../../desktop/validation/readback-verify.js';
+import { formatWorksheetPromiseCheck } from '../../../desktop/validation/promise-check.js';
 import {
   ArgsValidationError,
   CacheSessionMismatchError,
@@ -305,12 +305,17 @@ export const getBuildAndApplyWorksheetTool = (
             }
           }
 
-          const readbackStatusWarning = applyResult.isOk()
-            ? formatReadbackVerificationStatus(applyResult.value.readbackVerification)
+          // Host verification receipt (W-23447506) — subsumes the old readback
+          // status sentence: one host-truth line derived from preflight + readback.
+          const receipt = applyResult.isOk()
+            ? formatWorksheetPromiseCheck({
+                validationWarnings: applyResult.value.validationWarnings ?? [],
+                readback: applyResult.value.readbackVerification,
+              })
             : '';
 
           return new Ok({
-            message: `Built and applied worksheet "${worksheetName}" using template "${template}" with ${fields.length} fields.${readbackStatusWarning ? ` ${readbackStatusWarning}` : ''}`,
+            message: `Built and applied worksheet "${worksheetName}" using template "${template}" with ${fields.length} fields.${receipt}`,
             worksheetName,
             template,
             fieldCount: fields.length,

--- a/src/tools/desktop/dashboard/applyDashboard.test.ts
+++ b/src/tools/desktop/dashboard/applyDashboard.test.ts
@@ -43,7 +43,9 @@ describe('applyDashboardTool', () => {
 
   it('should successfully apply dashboard XML in inline mode', async () => {
     const mockXml = '<dashboard name="Sales Dashboard"><zones></zones></dashboard>';
-    vi.spyOn(loadDashboardXmlModule, 'loadDashboardXml').mockResolvedValue(Ok.EMPTY);
+    vi.spyOn(loadDashboardXmlModule, 'loadDashboardXml').mockResolvedValue(
+      Ok({ validationWarnings: [] }),
+    );
 
     const result = await getToolResult({
       mode: 'inline',
@@ -54,6 +56,8 @@ describe('applyDashboardTool', () => {
     invariant(result.content[0].type === 'text');
     const resultObj = resultSchema.parse(JSON.parse(result.content[0].text));
     expect(resultObj.message).toContain('Successfully applied dashboard update');
+    expect(resultObj.message).toContain('HOST VERIFICATION — unverified');
+    expect(resultObj.message).toContain('full dashboard intent NOT re-verified');
   });
 
   it('should successfully apply dashboard XML in file mode', async () => {
@@ -62,7 +66,9 @@ describe('applyDashboardTool', () => {
 
     vi.mocked(existsSync).mockReturnValue(true);
     vi.mocked(readFileSync).mockReturnValue(mockXml);
-    vi.spyOn(loadDashboardXmlModule, 'loadDashboardXml').mockResolvedValue(Ok.EMPTY);
+    vi.spyOn(loadDashboardXmlModule, 'loadDashboardXml').mockResolvedValue(
+      Ok({ validationWarnings: [] }),
+    );
 
     const result = await getToolResult({ mode: 'file', dashboardFile: mockFilePath });
 
@@ -83,7 +89,7 @@ describe('applyDashboardTool', () => {
     });
     const loadSpy = vi
       .spyOn(loadDashboardXmlModule, 'loadDashboardXml')
-      .mockResolvedValue(Ok.EMPTY);
+      .mockResolvedValue(Ok({ validationWarnings: [] }));
 
     const result = await getToolResult({ mode: 'file', dashboardFile: '/path/to/dashboard.xml' });
 
@@ -161,7 +167,9 @@ describe('applyDashboardTool', () => {
   it('accepts an over-cap inline apply but appends the file-mode note', async () => {
     const overCapXml =
       '<dashboard name="Sales Dashboard"><zones>' + 'x'.repeat(20000) + '</zones></dashboard>';
-    vi.spyOn(loadDashboardXmlModule, 'loadDashboardXml').mockResolvedValue(Ok.EMPTY);
+    vi.spyOn(loadDashboardXmlModule, 'loadDashboardXml').mockResolvedValue(
+      Ok({ validationWarnings: [] }),
+    );
 
     const result = await getToolResult({ mode: 'inline', dashboardXml: overCapXml });
 
@@ -177,7 +185,7 @@ describe('applyDashboardTool', () => {
     const mockXml = '<dashboard name="Sales Dashboard"><zones></zones></dashboard>';
     const mockLoad = vi
       .spyOn(loadDashboardXmlModule, 'loadDashboardXml')
-      .mockResolvedValue(Ok.EMPTY);
+      .mockResolvedValue(Ok({ validationWarnings: [] }));
     const customSignal = new AbortController().signal;
 
     await getToolResult({ mode: 'inline', dashboardXml: mockXml, customSignal });

--- a/src/tools/desktop/dashboard/applyDashboard.ts
+++ b/src/tools/desktop/dashboard/applyDashboard.ts
@@ -11,6 +11,7 @@ import {
   xmlByteLength,
 } from '../../../desktop/inlineXmlCap.js';
 import { resolveSession } from '../../../desktop/sessionResolution.js';
+import { formatDashboardPromiseCheck } from '../../../desktop/validation/promise-check.js';
 import {
   ArgsValidationError,
   CacheSessionMismatchError,
@@ -144,8 +145,15 @@ export const getApplyDashboardTool = (
               ? `\n\n${buildApplyOverCapNote(inlineBytes, capBytes)}`
               : '';
 
+          // Host verification receipt (W-23447506): dashboard applies have no
+          // structural readback, so say so honestly instead of implying full
+          // re-verification happened.
+          const receipt = result.isOk()
+            ? formatDashboardPromiseCheck(result.value.validationWarnings)
+            : '';
+
           return new Ok({
-            message: `Successfully applied dashboard update for "${dashboardName}". The dashboard has been updated.${note}`,
+            message: `Successfully applied dashboard update for "${dashboardName}". The dashboard has been updated.${note}${receipt}`,
           });
         },
       });

--- a/src/tools/desktop/dashboard/applyDashboardWithViewpoints.test.ts
+++ b/src/tools/desktop/dashboard/applyDashboardWithViewpoints.test.ts
@@ -33,8 +33,12 @@ describe('applyDashboardWithViewpointsTool', () => {
     vi.mocked(readFileSync).mockReturnValue(mockDashboardXml);
     vi.spyOn(getWorkbookXmlModule, 'getWorkbookXml').mockResolvedValue(Ok(mockWorkbookXml));
     vi.spyOn(injectViewpointsModule, 'injectViewpoints').mockReturnValue(mockWorkbookXml);
-    vi.spyOn(loadWorkbookXmlModule, 'loadWorkbookXml').mockResolvedValue(Ok({ validationWarnings: [] }));
-    vi.spyOn(loadDashboardXmlModule, 'loadDashboardXml').mockResolvedValue(Ok({ validationWarnings: [] }));
+    vi.spyOn(loadWorkbookXmlModule, 'loadWorkbookXml').mockResolvedValue(
+      Ok({ validationWarnings: [] }),
+    );
+    vi.spyOn(loadDashboardXmlModule, 'loadDashboardXml').mockResolvedValue(
+      Ok({ validationWarnings: [] }),
+    );
   });
 
   it('should create a tool instance with correct properties', () => {

--- a/src/tools/desktop/dashboard/applyDashboardWithViewpoints.test.ts
+++ b/src/tools/desktop/dashboard/applyDashboardWithViewpoints.test.ts
@@ -33,8 +33,8 @@ describe('applyDashboardWithViewpointsTool', () => {
     vi.mocked(readFileSync).mockReturnValue(mockDashboardXml);
     vi.spyOn(getWorkbookXmlModule, 'getWorkbookXml').mockResolvedValue(Ok(mockWorkbookXml));
     vi.spyOn(injectViewpointsModule, 'injectViewpoints').mockReturnValue(mockWorkbookXml);
-    vi.spyOn(loadWorkbookXmlModule, 'loadWorkbookXml').mockResolvedValue(Ok.EMPTY);
-    vi.spyOn(loadDashboardXmlModule, 'loadDashboardXml').mockResolvedValue(Ok.EMPTY);
+    vi.spyOn(loadWorkbookXmlModule, 'loadWorkbookXml').mockResolvedValue(Ok({ validationWarnings: [] }));
+    vi.spyOn(loadDashboardXmlModule, 'loadDashboardXml').mockResolvedValue(Ok({ validationWarnings: [] }));
   });
 
   it('should create a tool instance with correct properties', () => {

--- a/src/tools/desktop/dashboard/buildAndApplyDashboard.test.ts
+++ b/src/tools/desktop/dashboard/buildAndApplyDashboard.test.ts
@@ -43,8 +43,12 @@ describe('buildAndApplyDashboardTool', () => {
     vi.mocked(existsSync).mockReturnValue(true);
     vi.spyOn(getWorkbookXmlModule, 'getWorkbookXml').mockResolvedValue(Ok(mockWorkbookXml));
     vi.spyOn(injectViewpointsModule, 'injectViewpoints').mockReturnValue(mockWorkbookXml);
-    vi.spyOn(loadWorkbookXmlModule, 'loadWorkbookXml').mockResolvedValue(Ok({ validationWarnings: [] }));
-    vi.spyOn(loadDashboardXmlModule, 'loadDashboardXml').mockResolvedValue(Ok({ validationWarnings: [] }));
+    vi.spyOn(loadWorkbookXmlModule, 'loadWorkbookXml').mockResolvedValue(
+      Ok({ validationWarnings: [] }),
+    );
+    vi.spyOn(loadDashboardXmlModule, 'loadDashboardXml').mockResolvedValue(
+      Ok({ validationWarnings: [] }),
+    );
   });
 
   it('should create a tool instance with correct properties', () => {

--- a/src/tools/desktop/dashboard/buildAndApplyDashboard.test.ts
+++ b/src/tools/desktop/dashboard/buildAndApplyDashboard.test.ts
@@ -43,8 +43,8 @@ describe('buildAndApplyDashboardTool', () => {
     vi.mocked(existsSync).mockReturnValue(true);
     vi.spyOn(getWorkbookXmlModule, 'getWorkbookXml').mockResolvedValue(Ok(mockWorkbookXml));
     vi.spyOn(injectViewpointsModule, 'injectViewpoints').mockReturnValue(mockWorkbookXml);
-    vi.spyOn(loadWorkbookXmlModule, 'loadWorkbookXml').mockResolvedValue(Ok.EMPTY);
-    vi.spyOn(loadDashboardXmlModule, 'loadDashboardXml').mockResolvedValue(Ok.EMPTY);
+    vi.spyOn(loadWorkbookXmlModule, 'loadWorkbookXml').mockResolvedValue(Ok({ validationWarnings: [] }));
+    vi.spyOn(loadDashboardXmlModule, 'loadDashboardXml').mockResolvedValue(Ok({ validationWarnings: [] }));
   });
 
   it('should create a tool instance with correct properties', () => {
@@ -78,7 +78,7 @@ describe('buildAndApplyDashboardTool', () => {
   it('should call loadDashboardXml with built XML containing zone elements', async () => {
     const mockLoad = vi
       .spyOn(loadDashboardXmlModule, 'loadDashboardXml')
-      .mockResolvedValue(Ok.EMPTY);
+      .mockResolvedValue(Ok({ validationWarnings: [] }));
 
     await getToolResult({ layoutSpec: defaultLayoutSpec, worksheetNames: ['Chart 1'] });
 
@@ -93,7 +93,7 @@ describe('buildAndApplyDashboardTool', () => {
   it('should include a title text zone when title is provided', async () => {
     const mockLoad = vi
       .spyOn(loadDashboardXmlModule, 'loadDashboardXml')
-      .mockResolvedValue(Ok.EMPTY);
+      .mockResolvedValue(Ok({ validationWarnings: [] }));
 
     await getToolResult({
       title: 'My Dashboard',

--- a/src/tools/desktop/fields/listAvailableFields.test.ts
+++ b/src/tools/desktop/fields/listAvailableFields.test.ts
@@ -1,7 +1,10 @@
 import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
-import { existsSync, readFileSync } from 'fs';
+import { existsSync, readFileSync, writeFileSync } from 'fs';
+import { Err, Ok } from 'ts-results-es';
 import { z } from 'zod';
 
+import * as cacheFingerprintModule from '../../../desktop/commands/workbook/cacheFingerprint.js';
+import * as getWorkbookXmlModule from '../../../desktop/commands/workbook/getWorkbookXml.js';
 import * as metadataModule from '../../../desktop/metadata/index.js';
 import { FileNotFoundError, FileReadError } from '../../../errors/mcpToolError.js';
 import { DesktopMcpServer } from '../../../server.desktop.js';
@@ -10,6 +13,8 @@ import { Provider } from '../../../utils/provider.js';
 import { getMockRequestHandlerExtra } from '../toolContext.mock.js';
 import { getListAvailableFieldsTool } from './listAvailableFields.js';
 
+vi.mock('../../../desktop/commands/workbook/cacheFingerprint.js');
+vi.mock('../../../desktop/commands/workbook/getWorkbookXml.js');
 vi.mock('../../../desktop/metadata/index.js');
 vi.mock('fs');
 
@@ -45,6 +50,26 @@ const mockFields = [
   },
 ];
 
+const mockLiveFields = [
+  {
+    datasource: 'Fresh DS',
+    columnName: '[Sales]',
+    columnInstanceName: '[sum:Sales:qk]',
+    derivation: 'Sum',
+    type: 'quantitative',
+    role: 'measure',
+    datatype: 'real',
+    caption: 'Sales',
+    isAggregated: false,
+    column_ref: '[Fresh DS].[sum:Sales:qk]',
+  },
+];
+
+const WORKBOOK_FILE = '/workbook.xml';
+const SESSION = '12345';
+const STALE_XML = '<workbook><datasource name="stale"/></workbook>';
+const LIVE_XML = '<workbook><datasource name="live"/></workbook>';
+
 describe('listAvailableFieldsTool', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -54,10 +79,13 @@ describe('listAvailableFieldsTool', () => {
     const tool = getListAvailableFieldsTool(new DesktopMcpServer());
     expect(tool.name).toBe('list-available-fields');
     expect(tool.description).toContain('List ALL fields available in workbook datasources');
-    expect(tool.paramsSchema).toMatchObject({ workbookFile: expect.any(Object) });
+    expect(tool.paramsSchema).toMatchObject({
+      session: expect.any(Object),
+      workbookFile: expect.any(Object),
+    });
     expect(tool.annotations).toMatchObject({
       title: 'List All Available Fields in Workbook Datasources',
-      readOnlyHint: true,
+      readOnlyHint: false,
     });
   });
 
@@ -103,6 +131,77 @@ describe('listAvailableFieldsTool', () => {
     expect(body.fields).toHaveLength(2);
   });
 
+  it('with session re-snapshots live workbook, rewrites cache and sidecar, and lists new fields', async () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue(STALE_XML);
+    vi.mocked(writeFileSync).mockReturnValue(undefined);
+    vi.mocked(getWorkbookXmlModule.getWorkbookXml).mockResolvedValue(Ok(LIVE_XML));
+    vi.mocked(metadataModule.listAvailableFields).mockReturnValue(mockLiveFields as any);
+    const mockExecutor = {} as any;
+    const extra = {
+      ...getMockRequestHandlerExtra(),
+      getExecutor: vi.fn().mockResolvedValue(mockExecutor),
+    };
+
+    const result = await getResult({ session: SESSION, workbookFile: WORKBOOK_FILE, extra });
+
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+    const body = resultSchema.parse(JSON.parse(result.content[0].text));
+    expect(body.message).toContain('Sales');
+    expect(extra.getExecutor).toHaveBeenCalledWith(SESSION);
+    expect(getWorkbookXmlModule.getWorkbookXml).toHaveBeenCalledWith({
+      executor: mockExecutor,
+      signal: extra.signal,
+    });
+    expect(writeFileSync).toHaveBeenCalledWith(WORKBOOK_FILE, LIVE_XML, 'utf-8');
+    expect(cacheFingerprintModule.writeSidecar).toHaveBeenCalledWith(WORKBOOK_FILE, SESSION);
+    expect(metadataModule.listAvailableFields).toHaveBeenCalledWith(LIVE_XML);
+  });
+
+  it('without session preserves cache-only behavior', async () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue(STALE_XML);
+    vi.mocked(getWorkbookXmlModule.getWorkbookXml).mockResolvedValue(Ok(LIVE_XML));
+    vi.mocked(metadataModule.listAvailableFields).mockReturnValue(mockFields as any);
+    const extra = getMockRequestHandlerExtra();
+
+    const result = await getResult({ workbookFile: WORKBOOK_FILE, extra });
+
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+    const body = resultSchema.parse(JSON.parse(result.content[0].text));
+    expect(body.message).toContain('Profit');
+    expect(extra.getExecutor).not.toHaveBeenCalled();
+    expect(getWorkbookXmlModule.getWorkbookXml).not.toHaveBeenCalled();
+    expect(writeFileSync).not.toHaveBeenCalled();
+    expect(cacheFingerprintModule.writeSidecar).not.toHaveBeenCalled();
+    expect(metadataModule.listAvailableFields).toHaveBeenCalledWith(STALE_XML);
+  });
+
+  it('refresh failure is an explicit error and never silently lists stale fields', async () => {
+    const error = { type: 'command-timed-out' as const, error: 'no session' };
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue(STALE_XML);
+    vi.mocked(getWorkbookXmlModule.getWorkbookXml).mockResolvedValue(Err(error));
+    const extra = {
+      ...getMockRequestHandlerExtra(),
+      getExecutor: vi.fn().mockResolvedValue({} as any),
+    };
+
+    const result = await getResult({ session: SESSION, workbookFile: WORKBOOK_FILE, extra });
+
+    expect(result.isError).toBe(true);
+    invariant(result.content[0].type === 'text');
+    expect(result.content[0].text).toContain(
+      'Failed to refresh workbook from Tableau before listing fields',
+    );
+    expect(result.content[0].text).toContain('no session');
+    expect(readFileSync).not.toHaveBeenCalled();
+    expect(writeFileSync).not.toHaveBeenCalled();
+    expect(metadataModule.listAvailableFields).not.toHaveBeenCalled();
+  });
+
   it('should return empty message when no fields are found', async () => {
     vi.mocked(existsSync).mockReturnValue(true);
     vi.mocked(readFileSync).mockReturnValue('<workbook/>');
@@ -118,8 +217,16 @@ describe('listAvailableFieldsTool', () => {
   });
 });
 
-async function getResult({ workbookFile }: { workbookFile: string }): Promise<CallToolResult> {
+async function getResult({
+  workbookFile,
+  session,
+  extra,
+}: {
+  workbookFile: string;
+  session?: string;
+  extra?: ReturnType<typeof getMockRequestHandlerExtra>;
+}): Promise<CallToolResult> {
   const tool = getListAvailableFieldsTool(new DesktopMcpServer());
   const callback = await Provider.from(tool.callback);
-  return await callback({ workbookFile }, getMockRequestHandlerExtra());
+  return await callback({ session, workbookFile }, extra ?? getMockRequestHandlerExtra());
 }

--- a/src/tools/desktop/fields/listAvailableFields.ts
+++ b/src/tools/desktop/fields/listAvailableFields.ts
@@ -1,14 +1,18 @@
 import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
-import { existsSync, readFileSync } from 'fs';
+import { existsSync, readFileSync, writeFileSync } from 'fs';
 import { Ok } from 'ts-results-es';
 import { z } from 'zod';
 
+import { writeSidecar } from '../../../desktop/commands/workbook/cacheFingerprint.js';
+import { getWorkbookXml } from '../../../desktop/commands/workbook/getWorkbookXml.js';
 import { listAvailableFields } from '../../../desktop/metadata/index.js';
-import { FileNotFoundError, FileReadError } from '../../../errors/mcpToolError.js';
+import { resolveSession } from '../../../desktop/sessionResolution.js';
+import { FileNotFoundError, FileReadError, UnknownError } from '../../../errors/mcpToolError.js';
 import { DesktopMcpServer } from '../../../server.desktop.js';
 import { DesktopTool } from '../tool.js';
 
 const paramsSchema = {
+  session: z.string().optional().describe('Session ID; refreshes live workbook first.'),
   workbookFile: z.string().describe('Workbook cache file, not worksheet.'),
 };
 
@@ -51,30 +55,54 @@ export const getListAvailableFieldsTool = (
     description: [
       'List ALL fields available in workbook datasources.',
       'Returns exact column_ref inputs for field tools. Call before adding fields to Rows, Columns, or encodings.',
-      'Reads the workbook cache file, NOT a worksheet file.',
+      'Reads cache; session refreshes live workbook first. NOT a worksheet file.',
     ].join(' '),
     paramsSchema,
     annotations: {
       title,
-      readOnlyHint: true,
+      readOnlyHint: false, // With session, rewrites the workbook cache file + sidecar
       destructiveHint: false,
       idempotentHint: true,
       openWorldHint: false,
     },
-    callback: async ({ workbookFile }, extra): Promise<CallToolResult> => {
+    callback: async ({ session, workbookFile }, extra): Promise<CallToolResult> => {
       return await listAvailableFieldsTool.logAndExecute({
         extra,
-        args: { workbookFile },
+        args: { session, workbookFile },
         callback: async () => {
           if (!existsSync(workbookFile)) {
             return new FileNotFoundError(workbookFile).toErr();
           }
 
           let workbookXml: string;
-          try {
-            workbookXml = readFileSync(workbookFile, 'utf-8');
-          } catch (error) {
-            return new FileReadError(error).toErr();
+          if (session) {
+            const sessionResult = resolveSession(session);
+            if (sessionResult.isErr()) {
+              return sessionResult.error.toErr();
+            }
+
+            const resolvedSession = sessionResult.value;
+            const executor = await extra.getExecutor(resolvedSession);
+            const result = await getWorkbookXml({ executor, signal: extra.signal });
+            if (result.isErr()) {
+              return new UnknownError(
+                `Failed to refresh workbook from Tableau before listing fields: ${JSON.stringify(result.error)}. Retry without session to read the cache as-is.`,
+              ).toErr();
+            }
+
+            workbookXml = result.value;
+            try {
+              writeFileSync(workbookFile, workbookXml, 'utf-8');
+              writeSidecar(workbookFile, resolvedSession);
+            } catch (error) {
+              return new FileReadError(error).toErr();
+            }
+          } else {
+            try {
+              workbookXml = readFileSync(workbookFile, 'utf-8');
+            } catch (error) {
+              return new FileReadError(error).toErr();
+            }
           }
 
           const fields = listAvailableFields(workbookXml);

--- a/src/tools/desktop/workbook/applyWorkbook.test.ts
+++ b/src/tools/desktop/workbook/applyWorkbook.test.ts
@@ -49,7 +49,9 @@ describe('applyWorkbookTool', () => {
 
   it('should successfully apply workbook XML in inline mode', async () => {
     const mockXml = '<?xml version="1.0"?><workbook></workbook>';
-    vi.spyOn(loadWorkbookXmlModule, 'loadWorkbookXml').mockResolvedValue(Ok.EMPTY);
+    vi.spyOn(loadWorkbookXmlModule, 'loadWorkbookXml').mockResolvedValue(
+      Ok({ validationWarnings: [] }),
+    );
 
     const mockExecutor = vi.fn().mockResolvedValue({});
 
@@ -65,6 +67,8 @@ describe('applyWorkbookTool', () => {
 
     const resultObj = resultSchema.parse(JSON.parse(result.content[0].text));
     expect(resultObj.message).toContain('Successfully applied workbook update');
+    expect(resultObj.message).toContain('HOST VERIFICATION — unverified');
+    expect(resultObj.message).toContain('full workbook intent NOT re-verified');
   });
 
   it('should successfully apply workbook XML in file mode', async () => {
@@ -73,7 +77,9 @@ describe('applyWorkbookTool', () => {
 
     vi.mocked(existsSync).mockReturnValue(true);
     vi.mocked(readFileSync).mockReturnValue(mockXml);
-    vi.spyOn(loadWorkbookXmlModule, 'loadWorkbookXml').mockResolvedValue(Ok.EMPTY);
+    vi.spyOn(loadWorkbookXmlModule, 'loadWorkbookXml').mockResolvedValue(
+      Ok({ validationWarnings: [] }),
+    );
 
     const mockExecutor = vi.fn().mockResolvedValue({});
 
@@ -103,7 +109,9 @@ describe('applyWorkbookTool', () => {
       ok: false,
       message: 'Cache produced by a different Desktop session — re-read in the current session.',
     });
-    const loadSpy = vi.spyOn(loadWorkbookXmlModule, 'loadWorkbookXml').mockResolvedValue(Ok.EMPTY);
+    const loadSpy = vi
+      .spyOn(loadWorkbookXmlModule, 'loadWorkbookXml')
+      .mockResolvedValue(Ok({ validationWarnings: [] }));
 
     const result = await getToolResult({
       session: '12345',
@@ -129,7 +137,9 @@ describe('applyWorkbookTool', () => {
 
     vi.mocked(existsSync).mockReturnValue(true);
     vi.mocked(readFileSync).mockReturnValue(mockXml);
-    vi.spyOn(loadWorkbookXmlModule, 'loadWorkbookXml').mockResolvedValue(Ok.EMPTY);
+    vi.spyOn(loadWorkbookXmlModule, 'loadWorkbookXml').mockResolvedValue(
+      Ok({ validationWarnings: [] }),
+    );
 
     const mockExecutor = vi.fn().mockResolvedValue({});
 
@@ -296,7 +306,9 @@ describe('applyWorkbookTool', () => {
 
   it('accepts an over-cap inline apply but appends the file-mode note', async () => {
     const overCapXml = '<workbook>' + 'x'.repeat(20000) + '</workbook>';
-    vi.spyOn(loadWorkbookXmlModule, 'loadWorkbookXml').mockResolvedValue(Ok.EMPTY);
+    vi.spyOn(loadWorkbookXmlModule, 'loadWorkbookXml').mockResolvedValue(
+      Ok({ validationWarnings: [] }),
+    );
 
     const result = await getToolResult({
       session: '12345',
@@ -317,7 +329,9 @@ describe('applyWorkbookTool', () => {
 
   it('does not append the note for an under-cap inline apply', async () => {
     const smallXml = '<?xml version="1.0"?><workbook></workbook>';
-    vi.spyOn(loadWorkbookXmlModule, 'loadWorkbookXml').mockResolvedValue(Ok.EMPTY);
+    vi.spyOn(loadWorkbookXmlModule, 'loadWorkbookXml').mockResolvedValue(
+      Ok({ validationWarnings: [] }),
+    );
 
     const result = await getToolResult({
       session: '12345',
@@ -335,7 +349,7 @@ describe('applyWorkbookTool', () => {
     const mockXml = '<?xml version="1.0"?><workbook></workbook>';
     const mockLoadWorkbookXml = vi
       .spyOn(loadWorkbookXmlModule, 'loadWorkbookXml')
-      .mockResolvedValue(Ok.EMPTY);
+      .mockResolvedValue(Ok({ validationWarnings: [] }));
 
     const mockExecutor = vi.fn().mockResolvedValue({});
     const customSignal = new AbortController().signal;

--- a/src/tools/desktop/workbook/applyWorkbook.test.ts
+++ b/src/tools/desktop/workbook/applyWorkbook.test.ts
@@ -274,10 +274,14 @@ describe('applyWorkbookTool', () => {
     expect(result.content[0].text).toBe(new WorkbookXmlLoadFailedError(error.error).message);
   });
 
-  it('reports failure (not success) when Desktop rejected the load', async () => {
+  it('reports actionable failure text when Desktop rejected the load', async () => {
     // Bug 1 (P0): apply must not lie. When loadWorkbookXml surfaces Desktop's actual
     // load rejection, the tool must return isError with that error text — never the
-    // canned "Successfully applied" message.
+    // canned "Successfully applied" message. This tool-level test exercises the
+    // McpToolError message passthrough (xmlLoadErrorMessage): the command layer's
+    // load-rejected message is surfaced verbatim, no longer JSON.stringify-wrapped.
+    // (The classifier is NOT exercised here — the mock injects at the loadWorkbookXml
+    // boundary, so the message it carries is what the tool must present unwrapped.)
     const mockXml = '<?xml version="1.0"?><workbook></workbook>';
     const deskError =
       'The load was not able to complete successfully. Qualified Name Parse Error --- ' +
@@ -302,6 +306,8 @@ describe('applyWorkbookTool', () => {
     invariant(result.content[0].type === 'text');
     expect(result.content[0].text).not.toContain('Successfully applied');
     expect(result.content[0].text).toContain('Qualified Name Parse Error');
+    // Presentation change: the message is surfaced as-is, not JSON.stringify-wrapped.
+    expect(result.content[0].text).not.toMatch(/^\{/);
   });
 
   it('accepts an over-cap inline apply but appends the file-mode note', async () => {

--- a/src/tools/desktop/workbook/applyWorkbook.ts
+++ b/src/tools/desktop/workbook/applyWorkbook.ts
@@ -11,6 +11,7 @@ import {
   xmlByteLength,
 } from '../../../desktop/inlineXmlCap.js';
 import { resolveSession } from '../../../desktop/sessionResolution.js';
+import { formatWorkbookPromiseCheck } from '../../../desktop/validation/promise-check.js';
 import {
   ArgsValidationError,
   CacheSessionMismatchError,
@@ -143,8 +144,15 @@ export const getApplyWorkbookTool = (
               ? `\n\n${buildApplyOverCapNote(inlineBytes, capBytes)}`
               : '';
 
+          // Host verification receipt (W-23447506): whole-workbook applies have
+          // no structural readback, so say so honestly instead of implying
+          // full re-verification happened.
+          const receipt = result.isOk()
+            ? formatWorkbookPromiseCheck(result.value.validationWarnings)
+            : '';
+
           return new Ok({
-            message: `Successfully applied workbook update. The workbook has been updated.${note}`,
+            message: `Successfully applied workbook update. The workbook has been updated.${note}${receipt}`,
           });
         },
       });

--- a/src/tools/desktop/worksheet/applyWorksheet.test.ts
+++ b/src/tools/desktop/worksheet/applyWorksheet.test.ts
@@ -73,6 +73,7 @@ describe('applyWorksheetTool', () => {
 
     const resultObj = resultSchema.parse(JSON.parse(result.content[0].text));
     expect(resultObj.message).toContain('Successfully applied worksheet update');
+    expect(resultObj.message).toContain('HOST VERIFICATION');
   });
 
   it('should successfully apply worksheet XML in file mode', async () => {
@@ -100,6 +101,7 @@ describe('applyWorksheetTool', () => {
 
     const resultObj = resultSchema.parse(JSON.parse(result.content[0].text));
     expect(resultObj.message).toContain('Successfully applied worksheet update');
+    expect(resultObj.message).toContain('HOST VERIFICATION');
 
     expect(existsSync).toHaveBeenCalledWith(mockFilePath);
     expect(readFileSync).toHaveBeenCalledWith(mockFilePath, 'utf-8');
@@ -122,7 +124,8 @@ describe('applyWorksheetTool', () => {
     expect(result.isError).toBe(false);
     invariant(result.content[0].type === 'text');
     const message = resultSchema.parse(JSON.parse(result.content[0].text)).message;
-    expect(message).toContain('could not verify (readback unavailable)');
+    expect(message).toContain('HOST VERIFICATION — unverified');
+    expect(message).toContain('readback unavailable');
     expect(message).not.toMatch(/\bverified\b/i);
   });
 
@@ -146,7 +149,8 @@ describe('applyWorksheetTool', () => {
     expect(result.isError).toBe(false);
     invariant(result.content[0].type === 'text');
     const message = resultSchema.parse(JSON.parse(result.content[0].text)).message;
-    expect(message).toContain('could not verify (readback unavailable)');
+    expect(message).toContain('HOST VERIFICATION — unverified');
+    expect(message).toContain('readback unavailable');
     expect(message).not.toMatch(/\bverified\b/i);
   });
 

--- a/src/tools/desktop/worksheet/applyWorksheet.ts
+++ b/src/tools/desktop/worksheet/applyWorksheet.ts
@@ -11,10 +11,8 @@ import {
   xmlByteLength,
 } from '../../../desktop/inlineXmlCap.js';
 import { resolveSession } from '../../../desktop/sessionResolution.js';
-import {
-  formatReadbackVerificationStatus,
-  formatReadbackVerificationWarnings,
-} from '../../../desktop/validation/readback-verify.js';
+import { formatWorksheetPromiseCheck } from '../../../desktop/validation/promise-check.js';
+import { formatReadbackVerificationWarnings } from '../../../desktop/validation/readback-verify.js';
 import {
   ArgsValidationError,
   CacheSessionMismatchError,
@@ -152,13 +150,18 @@ export const getApplyWorksheetTool = (
           const readbackWarning = result.isOk()
             ? formatReadbackVerificationWarnings(result.value.readbackWarnings)
             : '';
-          const readbackStatus = result.isOk()
-            ? formatReadbackVerificationStatus(result.value.readbackVerification)
+          // Host verification receipt (W-23447506) — subsumes the old readback
+          // status sentence: one host-truth line, derived from preflight +
+          // readback, never model-filled.
+          const receipt = result.isOk()
+            ? formatWorksheetPromiseCheck({
+                validationWarnings: result.value.validationWarnings ?? [],
+                readback: result.value.readbackVerification,
+              })
             : '';
-          const updateStatus = readbackStatus || 'The worksheet has been updated.';
 
           return new Ok({
-            message: `Successfully applied worksheet update for "${worksheetName}". ${updateStatus}${note}${readbackWarning}`,
+            message: `Successfully applied worksheet update for "${worksheetName}". The worksheet has been updated.${note}${readbackWarning}${receipt}`,
           });
         },
       });

--- a/src/tools/desktop/worksheet/deleteWorksheet.test.ts
+++ b/src/tools/desktop/worksheet/deleteWorksheet.test.ts
@@ -232,7 +232,9 @@ describe('deleteWorksheetTool', () => {
       extraWindows: ["<window class='dashboard' name='Dash One'><viewpoints/></window>"],
     });
     vi.spyOn(getWorkbookXmlModule, 'getWorkbookXml').mockResolvedValue(Ok(fixture));
-    const loadSpy = vi.spyOn(loadWorkbookXmlModule, 'loadWorkbookXml').mockResolvedValue(Ok({ validationWarnings: [] }));
+    const loadSpy = vi
+      .spyOn(loadWorkbookXmlModule, 'loadWorkbookXml')
+      .mockResolvedValue(Ok({ validationWarnings: [] }));
 
     const result = await getToolResult({ worksheetName: 'Beta' });
 
@@ -286,7 +288,9 @@ describe('deleteWorksheetTool', () => {
 
   it('proceeds without the events gate on transports without event support', async () => {
     vi.spyOn(getWorkbookXmlModule, 'getWorkbookXml').mockResolvedValue(Ok(buildWorkbook()));
-    const loadSpy = vi.spyOn(loadWorkbookXmlModule, 'loadWorkbookXml').mockResolvedValue(Ok({ validationWarnings: [] }));
+    const loadSpy = vi
+      .spyOn(loadWorkbookXmlModule, 'loadWorkbookXml')
+      .mockResolvedValue(Ok({ validationWarnings: [] }));
     const getEvents = vi.fn().mockResolvedValue(Err('events unsupported on this transport'));
 
     const result = await getToolResult({ worksheetName: 'Beta', getEvents });

--- a/src/tools/desktop/worksheet/deleteWorksheet.test.ts
+++ b/src/tools/desktop/worksheet/deleteWorksheet.test.ts
@@ -232,7 +232,7 @@ describe('deleteWorksheetTool', () => {
       extraWindows: ["<window class='dashboard' name='Dash One'><viewpoints/></window>"],
     });
     vi.spyOn(getWorkbookXmlModule, 'getWorkbookXml').mockResolvedValue(Ok(fixture));
-    const loadSpy = vi.spyOn(loadWorkbookXmlModule, 'loadWorkbookXml').mockResolvedValue(Ok.EMPTY);
+    const loadSpy = vi.spyOn(loadWorkbookXmlModule, 'loadWorkbookXml').mockResolvedValue(Ok({ validationWarnings: [] }));
 
     const result = await getToolResult({ worksheetName: 'Beta' });
 
@@ -286,7 +286,7 @@ describe('deleteWorksheetTool', () => {
 
   it('proceeds without the events gate on transports without event support', async () => {
     vi.spyOn(getWorkbookXmlModule, 'getWorkbookXml').mockResolvedValue(Ok(buildWorkbook()));
-    const loadSpy = vi.spyOn(loadWorkbookXmlModule, 'loadWorkbookXml').mockResolvedValue(Ok.EMPTY);
+    const loadSpy = vi.spyOn(loadWorkbookXmlModule, 'loadWorkbookXml').mockResolvedValue(Ok({ validationWarnings: [] }));
     const getEvents = vi.fn().mockResolvedValue(Err('events unsupported on this transport'));
 
     const result = await getToolResult({ worksheetName: 'Beta', getEvents });


### PR DESCRIPTION
Ports the four GUS dogfood items from a2td #209 (merged to a2td main today) to `feature/desktop`, mapped onto tmcp's layering rather than copied. One commit per item.

## What's in it

- **W-23447507** (`a3e5b57a`) — `malformed-top-n-filter` validation rule (flat `<groupfilter function="filter">` Top-N is silently stripped by Tableau; the rule blocks it preflight in workbook+worksheet contexts) + the worksheets.md knowledge correction teaching the nested `function="end"` recipe. a2td's `droppedFilters` tracking deliberately NOT ported — tmcp's readback-verify already fails dropped filters at error severity (stricter). Overlap with `malformed-set-groupfilter` pinned impossible by test.
- **W-23447478** (`e694c3a3`) — `list-available-fields` gains optional `session`: live workbook re-snapshot (same executor path as `get-workbook-xml`), cache rewrite + fingerprint sidecar before listing; explicit error on refresh failure, never a silent stale listing. `readOnlyHint` flips to false (the tool now writes the cache when refreshing). Surface delta +108 bytes.
- **W-23447506** (`e66d961e`) — host-computed `HOST VERIFICATION` receipt on apply responses: worksheet applies derive verified/unverified/failed from preflight warnings + readback (subsumes the old skipped-readback sentence); workbook/dashboard/batch applies honestly state intent is NOT structurally re-verified. Command layer returns preflight warnings with the load result. a2td's lossy-scan clause dropped — tmcp has no lossy-node detector, and claiming a scan that never ran defeats the seam's purpose.
- **W-23447473 p1** (`26c4492e`) — apply-failure classifier beside `interpretLoadOutcome`: every `load-rejected` message is now actionable `Apply failed: <class> ... FIX: ...` text; `McpToolError` XML-load subclasses pass string messages through instead of `JSON.stringify` (also un-JSONs W4's readback-failed fix recipes).
- **W-23447473 p2** (`18f196c6`) — edit-in-place routing: `CURRENT_SHEET_RE` + fix/repair edit verbs in route-spec (with a `NON_SHEET_FIX_RE` guard so "fix the data source" doesn't classify as a sheet edit), and an `edit-in-place` route in `DESKTOP_ROUTE_TABLE` so generated instructions carry the never-create-a-new-sheet rule.

## Evidence

Full suite **4,300 passed / 1 skipped (296 files)**; tsc clean; eslint clean on all touched files; surface pins green.

## Surface budget — heads-up

The 44,015 comment in `server.desktop.test.ts` was stale. Measured after this PR: desktop total **45,336**, combined-lean **45,976** — **24 bytes under the 46,000 cliff**. The edit-in-place instruction prose was already tightened to fit; the next instruction/tool-description growth on this line must trim something, not raise the cap.

## Residuals

- `ExecuteCommandError` dispatch failures/timeouts keep their existing JSON funnel (classifier only runs on `load-rejected`); a2td's datasource-collapse/ECONN patterns not wired (no such verifiers in tmcp).
- Receipt behavior on live Desktop not yet re-verified (unit/behavioral coverage only) — rides the next live-verify lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)