### PR TITLE
feat(interaction): ask-user clarification tool + fail-closed ambiguity rewiring (W-23447497)

### DIFF
--- a/src/desktop/routeTable.ts
+++ b/src/desktop/routeTable.ts
@@ -74,12 +74,23 @@ export const DESKTOP_ROUTE_TABLE: readonly DesktopInstructionEntry[] = [
     requiredEvidence: [],
   },
   {
+    kind: 'prose',
+    id: 'ask-user-ambiguity',
+    text: 'If ambiguity changes workbook content, call ask-user with urgency=blocking; stop for answer.',
+  },
+  {
     kind: 'route',
     id: 'edit-in-place',
     trigger: 'current/this/that/existing sheet, chart, view, or dashboard',
     action:
-      'edit in place: resolve the target (exact name, else list-worksheets; ask if ambiguous), then refine-worksheet for top-N/sort edits, else get-worksheet-xml -> edit -> apply-worksheet. Never create a new sheet unless explicitly asked.',
-    toolSequence: ['list-worksheets', 'refine-worksheet', 'get-worksheet-xml', 'apply-worksheet'],
+      'edit in place: resolve the target (exact name, else list-worksheets; ask via ask-user if ambiguous), then refine-worksheet for top-N/sort edits, else get-worksheet-xml -> edit -> apply-worksheet. Never create a new sheet unless explicitly asked.',
+    toolSequence: [
+      'list-worksheets',
+      'ask-user',
+      'refine-worksheet',
+      'get-worksheet-xml',
+      'apply-worksheet',
+    ],
     stopConditions: ['Never create a new sheet unless explicitly asked'],
     requiredEvidence: ['resolved worksheet/dashboard target before applying'],
   },

--- a/src/server.desktop.test.ts
+++ b/src/server.desktop.test.ts
@@ -215,7 +215,7 @@ describe('desktop tools/list per-tool byte accounting', () => {
     ['plan-dashboard-creation', 2040], // do not grow
     ['build-and-apply-dashboard', 2033], // do not grow
     ['validate-proposal', 1601], // do not grow
-    ['dashboard-auto-apply', 1295], // do not grow
+    ['dashboard-auto-apply', 1300], // +5 (Andy #521 review): restore ask/title noun-role (Viz ask/Sheet title) — funded by byte-negative all-or-nothing description reword; do not grow
     ['dashboard-health-check', 1453], // do not grow
     ['inject-template', 1356], // do not grow
     ['build-and-apply-worksheet', 1274], // do not grow

--- a/src/server.desktop.test.ts
+++ b/src/server.desktop.test.ts
@@ -100,7 +100,9 @@ For a dashboard ask with 2-6 vizzes (e.g. "a dashboard with sales by region and 
 
 For a data-value question ("what was revenue in Q3?"), do NOT answer with a number — this server cannot read data values. Say so, then offer the viz that would show it (a plain viz ask via bind-template) instead.
 
-For current/this/that/existing sheet, chart, view, or dashboard, edit in place: resolve the target (exact name, else list-worksheets; ask if ambiguous), then refine-worksheet for top-N/sort edits, else get-worksheet-xml -> edit -> apply-worksheet. Never create a new sheet unless explicitly asked.
+If ambiguity changes workbook content, call ask-user with urgency=blocking; stop for answer.
+
+For current/this/that/existing sheet, chart, view, or dashboard, edit in place: resolve the target (exact name, else list-worksheets; ask via ask-user if ambiguous), then refine-worksheet for top-N/sort edits, else get-worksheet-xml -> edit -> apply-worksheet. Never create a new sheet unless explicitly asked.
 
 Every session-scoped tool call needs the session id from list-instances — except bind-template and dashboard-auto-apply, which auto-resolve the session when exactly one Desktop instance is running.
 
@@ -148,7 +150,7 @@ describe('desktop tools/list serialized surface', () => {
 
     // 46_000 is the ToolSearch auto-deferral cliff on MCP hosts, not a tunable constant — past it
     // the whole desktop surface gets deferred behind ToolSearch. The shelf-tool consolidation has
-    // landed, so this is GREEN: the serialized surface is 45_336 bytes, ~664 under the cliff.
+    // landed, so this is GREEN: the serialized surface is 45_202 bytes, ~798 under the cliff.
     // That headroom is the ENTIRE budget for future tools — trim tools to fit it; NEVER raise the
     // cap to ship a tool (raising it just re-buries the whole surface behind ToolSearch).
     expect(total).toBeLessThanOrEqual(46_000);
@@ -212,9 +214,9 @@ describe('desktop tools/list per-tool byte accounting', () => {
     ['bind-template', 2110], // do not grow
     ['plan-dashboard-creation', 2040], // do not grow
     ['build-and-apply-dashboard', 2033], // do not grow
-    ['validate-proposal', 2014], // do not grow
-    ['dashboard-auto-apply', 1829], // do not grow
-    ['dashboard-health-check', 1821], // do not grow
+    ['validate-proposal', 1601], // do not grow
+    ['dashboard-auto-apply', 1295], // do not grow
+    ['dashboard-health-check', 1453], // do not grow
     ['inject-template', 1356], // do not grow
     ['build-and-apply-worksheet', 1274], // do not grow
   ]);

--- a/src/tools/desktop/binder/bindTemplate.test.ts
+++ b/src/tools/desktop/binder/bindTemplate.test.ts
@@ -180,11 +180,12 @@ describe('bindTemplateTool', () => {
       guidance:
         'Escalated (field-not-found). No worksheet was produced. Blockers: ' +
         '[field-not-found] slot \'val\' No field named "Revenue".. Next: Resolve the field(s) ' +
-        'with the resolve-field tool, then call bind-template again with a corrected proposal.',
+        'with the resolve-field tool, then call bind-template again with a corrected proposal; ' +
+        'otherwise ask the user with ask-user (present the candidates).',
     };
     expect(result.content[0].text).toBe(JSON.stringify(expectedBody));
     expect(result.structuredContent).toEqual({
-      nextAction: { label: 'Resolve the fields first', kind: 'prefill' },
+      nextAction: { label: 'Resolve the fields first; otherwise ask the user', kind: 'prefill' },
     });
     const body = JSON.parse(result.content[0].text);
     expect(body.status).toBe('escalate');

--- a/src/tools/desktop/binder/bindTemplate.ts
+++ b/src/tools/desktop/binder/bindTemplate.ts
@@ -116,7 +116,7 @@ const TIER2_REASONS: ReadonlySet<EscalateReason> = new Set<EscalateReason>([
 
 function nextActionForEscalation(reason: EscalateReason): NextAction {
   if (reason === 'ambiguous-field' || reason === 'field-not-found') {
-    return prefillNextAction('Resolve the fields first');
+    return prefillNextAction('Resolve the fields first; otherwise ask the user');
   }
   if (reason === 'low-confidence') {
     return prefillNextAction('Pick a higher-confidence proposal');
@@ -145,7 +145,7 @@ function renderEscalationGuidance(reason: EscalateReason, blockers: Blocker[]): 
   let next: string;
   if (reason === 'ambiguous-field' || reason === 'field-not-found') {
     next =
-      'Resolve the field(s) with the resolve-field tool, then call bind-template again with a corrected proposal.';
+      'Resolve the field(s) with the resolve-field tool, then call bind-template again with a corrected proposal; otherwise ask the user with ask-user (present the candidates).';
   } else if (reason === 'low-confidence') {
     next =
       'Confidence was below the floor. Re-examine the candidate template(s), pick the best fit, and re-propose with higher confidence.';

--- a/src/tools/desktop/binder/validateProposal.ts
+++ b/src/tools/desktop/binder/validateProposal.ts
@@ -33,21 +33,16 @@ import { proposalSchema } from './proposalSchema.js';
 // manifest.template == filename, and listTemplateManifests() is [...loadManifests().values()]).
 
 const paramsSchema = {
-  session: z.string().optional().describe('Session ID; optional if pinned or unique.'),
-  ask: z.string().describe('Natural-language chart request.'),
+  session: z.string().optional().describe('Session.'),
+  ask: z.string().describe('Ask.'),
   // WATCH-CLASS (required): bind-template makes `proposal` OPTIONAL (Call-1 classify vs
   // Call-2 validate). validate-proposal has one job — validate a filled proposal — so the
   // proposal is REQUIRED. Left optional, an omitted proposal would drive bindTemplate down
   // the Call-1 classify path and silently return a propose payload instead of a validation
   // (fail-open). Requiring it at the schema fails closed. The proposal shape itself is the
   // SHARED proposalSchema (confidence required, title <= 80, derivation closed enum).
-  proposal: proposalSchema.describe('Filled binding proposal to validate.'),
-  minConfidence: z
-    .number()
-    .min(0)
-    .max(1)
-    .optional()
-    .describe('Proposal confidence floor; default 0.6.'),
+  proposal: proposalSchema.describe('Proposal.'),
+  minConfidence: z.number().min(0).max(1).optional().describe('Min confidence.'),
 };
 
 /** Result of a validate-proposal call: a dry-run verdict, never an applied change. */
@@ -85,9 +80,8 @@ export const getValidateProposalTool = (
     name: 'validate-proposal',
     title,
     description: [
-      "Dry-run a filled binding proposal through bind-template's deterministic Call-2 gate WITHOUT creating or applying a worksheet.",
-      'Returns valid:true with would-be inject args, or valid:false with reason/blockers. When valid, call bind-template with the same proposal.',
-      'content_status reports content freshness (bundled snapshot, not a live fetch). Details: expertise://tableau/tactics/workflow/templates.',
+      'Dry-run bind-template gate; no apply.',
+      'Returns inject args/blockers; if valid, call bind-template.',
     ].join(' '),
     paramsSchema,
     annotations: {

--- a/src/tools/desktop/coordination/planDashboardCreation.test.ts
+++ b/src/tools/desktop/coordination/planDashboardCreation.test.ts
@@ -122,6 +122,7 @@ describe('planDashboardCreationTool', () => {
         'Next step: disambiguate each field, then re-call plan-dashboard-creation.',
         '  • Use resolve-field with an explicit datasource.',
         '  • For not_found fields, call list-available-fields to see valid names.',
+        '  • Use ask-user to surface the choice to the user.',
       ].join('\n'),
     );
     expect(result.structuredContent).toEqual({

--- a/src/tools/desktop/coordination/planDashboardCreation.ts
+++ b/src/tools/desktop/coordination/planDashboardCreation.ts
@@ -162,6 +162,7 @@ export const getPlanDashboardCreationTool = (
               'Next step: disambiguate each field, then re-call plan-dashboard-creation.',
               '  • Use resolve-field with an explicit datasource.',
               '  • For not_found fields, call list-available-fields to see valid names.',
+              '  • Use ask-user to surface the choice to the user.',
             );
             return attachNextAction(
               new ArgsValidationError(lines.join('\n')),

--- a/src/tools/desktop/dashboard/dashboardAutoApply.ts
+++ b/src/tools/desktop/dashboard/dashboardAutoApply.ts
@@ -63,8 +63,8 @@ const MIN_ASKS = 2;
 const MAX_ASKS = 6;
 
 const askSchema = z.object({
-  ask: z.string().min(1).describe('Natural-language viz request.'),
-  title: z.string().min(1).max(80).optional().describe('Optional sheet title override.'),
+  ask: z.string().min(1).describe('Viz.'),
+  title: z.string().min(1).max(80).optional().describe('Sheet.'),
 });
 
 const layoutSchema = z.object({
@@ -72,25 +72,16 @@ const layoutSchema = z.object({
     .enum(['auto-grid', 'rows', 'columns'])
     .optional()
     .default('auto-grid')
-    .describe('Dashboard grid layout.'),
-  gridColumns: z.number().optional().describe('Auto-grid column count.'),
+    .describe('Grid.'),
+  gridColumns: z.number().optional().describe('Cols.'),
 });
 
 const paramsSchema = {
-  session: z
-    .string()
-    .optional()
-    .describe('Session ID. Optional only when exactly one Desktop instance is running.'),
-  asks: z
-    .array(askSchema)
-    .min(MIN_ASKS)
-    .max(MAX_ASKS)
-    .describe(
-      `2-${MAX_ASKS} viz asks; every ask must bind deterministically or the whole batch is refused.`,
-    ),
-  dashboardName: z.string().min(1).describe('Name of the dashboard to build and apply.'),
-  title: z.string().optional().describe('Optional dashboard title text.'),
-  layout: layoutSchema.optional().describe('Dashboard layout options.'),
+  session: z.string().optional().describe('Session.'),
+  asks: z.array(askSchema).min(MIN_ASKS).max(MAX_ASKS).describe(`2-${MAX_ASKS} asks.`),
+  dashboardName: z.string().min(1).describe('Name.'),
+  title: z.string().optional().describe('Title.'),
+  layout: layoutSchema.optional().describe('Layout.'),
 };
 
 /** One ask's outcome, tagged with its position and original ask text for diagnostics. */
@@ -188,9 +179,7 @@ export const getDashboardAutoApplyTool = (
     name: 'dashboard-auto-apply',
     title,
     description: [
-      'Bind 2-6 viz asks to templates and APPLY one new/replaced dashboard in one call.',
-      'Every ask must bind deterministically; otherwise NOTHING is applied and each outcome is returned.',
-      'All-or-nothing: duplicate/zone-used titles, user edits, or preflight failures refuse the WHOLE batch. Details: expertise://tableau/tactics/dashboard/zones.',
+      'Build dashboard from 2-6 deterministic asks; no apply on bind, duplicate, edit, or preflight fail.',
     ].join(' '),
     paramsSchema,
     annotations: {

--- a/src/tools/desktop/dashboard/dashboardAutoApply.ts
+++ b/src/tools/desktop/dashboard/dashboardAutoApply.ts
@@ -63,8 +63,8 @@ const MIN_ASKS = 2;
 const MAX_ASKS = 6;
 
 const askSchema = z.object({
-  ask: z.string().min(1).describe('Viz.'),
-  title: z.string().min(1).max(80).optional().describe('Sheet.'),
+  ask: z.string().min(1).describe('Viz ask'),
+  title: z.string().min(1).max(80).optional().describe('Sheet title'),
 });
 
 const layoutSchema = z.object({
@@ -179,7 +179,7 @@ export const getDashboardAutoApplyTool = (
     name: 'dashboard-auto-apply',
     title,
     description: [
-      'Build dashboard from 2-6 deterministic asks; no apply on bind, duplicate, edit, or preflight fail.',
+      'Build dashboard from 2-6 asks; all-or-nothing — bind/dup/edit/preflight fail refuses the batch.',
     ].join(' '),
     paramsSchema,
     annotations: {

--- a/src/tools/desktop/fields/resolveField.ts
+++ b/src/tools/desktop/fields/resolveField.ts
@@ -26,7 +26,7 @@ export const getResolveFieldTool = (server: DesktopMcpServer): DesktopTool<typeo
     title,
     description: [
       'Resolve a free-form field reference to an exact column_ref.',
-      'ALWAYS reports ambiguity; DO NOT GUESS. Re-call with datasource or use list-available-fields.',
+      'ALWAYS reports ambiguity; DO NOT GUESS. Re-call with datasource or list-available-fields; if still ambiguous, ask-user with candidates.',
       'Use before add-field-* when column_ref did not come from list-available-fields.',
     ].join(' '),
     paramsSchema,

--- a/src/tools/desktop/health/dashboardHealthCheck.test.ts
+++ b/src/tools/desktop/health/dashboardHealthCheck.test.ts
@@ -273,7 +273,8 @@ describe('dashboardHealthCheckTool (wiring)', () => {
   it('should create a tool instance with correct properties', () => {
     const tool = getDashboardHealthCheckTool(new DesktopMcpServer());
     expect(tool.name).toBe('dashboard-health-check');
-    expect(tool.description).toContain('READ-ONLY drift detector');
+    expect(tool.description).toContain('Read-only');
+    expect(tool.description).toContain('no repairs');
     expect(tool.paramsSchema).toMatchObject({
       session: expect.any(Object),
       manifest: expect.any(Object),

--- a/src/tools/desktop/health/dashboardHealthCheck.ts
+++ b/src/tools/desktop/health/dashboardHealthCheck.ts
@@ -43,18 +43,18 @@ import { DesktopTool } from '../tool.js';
 // ── Binding manifest (input) ─────────────────────────────────────────────────
 
 const boundSheetSchema = z.object({
-  title: z.string().describe('Worksheet title.'),
-  templateName: z.string().describe('Bound template name.'),
-  fieldMapping: z.record(z.string()).describe('slot -> column_ref.'),
-  schemaHash: z.string().describe('Bind-time schema hash.'),
-  primaryDatasource: z.string().describe('Bind-time datasource.'),
+  title: z.string().describe('Sheet.'),
+  templateName: z.string().describe('Template.'),
+  fieldMapping: z.record(z.string()).describe('Mapping.'),
+  schemaHash: z.string().describe('Schema.'),
+  primaryDatasource: z.string().describe('Source.'),
 });
 
 const bindingRecordSchema = z.object({
-  dashboardName: z.string().describe('Dashboard name.'),
-  sheets: z.array(boundSheetSchema).describe('Bound worksheets.'),
-  workbookHashAtBind: z.string().describe('Bind-time workbook hash.'),
-  recordedAt: z.string().describe('Bind timestamp.'),
+  dashboardName: z.string().describe('Dashboard.'),
+  sheets: z.array(boundSheetSchema).describe('Sheets.'),
+  workbookHashAtBind: z.string().describe('Workbook.'),
+  recordedAt: z.string().describe('Time.'),
 });
 
 export type DashboardBoundSheet = z.infer<typeof boundSheetSchema>;
@@ -381,8 +381,8 @@ export function runDashboardHealthCheck({
 // ── Tool registration ────────────────────────────────────────────────────────
 
 const paramsSchema = {
-  session: z.string().optional().describe('Session ID; optional if pinned or unique.'),
-  manifest: bindingRecordSchema.describe('Binding manifest from a prior bind.'),
+  session: z.string().optional().describe('Session.'),
+  manifest: bindingRecordSchema.describe('Bind record.'),
 };
 
 const title = 'Dashboard Health Check (Flag-Only)';
@@ -394,9 +394,8 @@ export const getDashboardHealthCheckTool = (
     name: 'dashboard-health-check',
     title,
     description: [
-      'READ-ONLY drift detector for a previously-bound dashboard.',
-      'Flags renamed/deleted sheets, changed fields, orphan zones, and datasource changes.',
-      'Flag-only: never repairs. D9 live render breakage is not structure-detectable and is disclosed. Details: expertise://tableau/tactics/workflow/recovery.',
+      'Read-only.',
+      'Flags sheet/field/zone/source drift; no repairs; D9 render undetectable.',
     ].join(' '),
     paramsSchema,
     annotations: {

--- a/src/tools/desktop/interaction/askUser.test.ts
+++ b/src/tools/desktop/interaction/askUser.test.ts
@@ -1,0 +1,86 @@
+import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { z } from 'zod';
+
+import { DesktopMcpServer } from '../../../server.desktop.js';
+import invariant from '../../../utils/invariant.js';
+import { Provider } from '../../../utils/provider.js';
+import { getMockRequestHandlerExtra } from '../toolContext.mock.js';
+import { getAskUserTool } from './askUser.js';
+
+describe('askUserTool', () => {
+  it('should create a tool instance with correct properties', () => {
+    const tool = getAskUserTool(new DesktopMcpServer());
+    expect(tool.name).toBe('ask-user');
+    expect(tool.title).toBe('Ask the User a Clarifying Question');
+    expect(tool.description).toContain('Ask instead of guessing');
+    expect(tool.paramsSchema).toMatchObject({
+      question: expect.any(Object),
+      urgency: expect.any(Object),
+      options: expect.any(Object),
+    });
+    expect(tool.annotations).toMatchObject({
+      title: 'Ask the User a Clarifying Question',
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    });
+  });
+
+  it('defaults to blocking urgency', async () => {
+    const text = await getToolText({ question: 'Which Sales field should I use?' });
+    expect(text).toBe('[BLOCKING] Which Sales field should I use?');
+  });
+
+  it('renders soft urgency', async () => {
+    const text = await getToolText({
+      question: 'Should I use monthly grain?',
+      urgency: 'soft',
+    });
+    expect(text).toBe('[SOFT] Should I use monthly grain?');
+  });
+
+  it('renders options as a numbered list', async () => {
+    const text = await getToolText({
+      question: 'Which field should I use?',
+      options: ['Sales', 'Profit', 'Revenue'],
+    });
+    expect(text).toBe(
+      '[BLOCKING] Which field should I use?\n\nOptions:\n1. Sales\n2. Profit\n3. Revenue',
+    );
+  });
+
+  it('rejects an empty question at the schema layer', async () => {
+    const tool = getAskUserTool(new DesktopMcpServer());
+    const schema = z.object(await Provider.from(tool.paramsSchema));
+
+    expect(schema.safeParse({ question: '' }).success).toBe(false);
+    expect(schema.safeParse({ question: 'Which field?' }).success).toBe(true);
+  });
+});
+
+async function getToolText(args: {
+  question: string;
+  urgency?: 'blocking' | 'soft';
+  options?: string[];
+}): Promise<string> {
+  const result = await getToolResult(args);
+  expect(result.isError).toBe(false);
+  invariant(result.content[0].type === 'text');
+  return result.content[0].text;
+}
+
+async function getToolResult(args: {
+  question: string;
+  urgency?: 'blocking' | 'soft';
+  options?: string[];
+}): Promise<CallToolResult> {
+  const tool = getAskUserTool(new DesktopMcpServer());
+  const schema = z.object(await Provider.from(tool.paramsSchema));
+  const parsed = schema.parse(args);
+  const callback = await Provider.from(tool.callback);
+  return await callback(
+    { question: parsed.question, urgency: parsed.urgency, options: parsed.options },
+    getMockRequestHandlerExtra(),
+  );
+}

--- a/src/tools/desktop/interaction/askUser.ts
+++ b/src/tools/desktop/interaction/askUser.ts
@@ -1,0 +1,72 @@
+import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { Ok } from 'ts-results-es';
+import { z } from 'zod';
+
+import { DesktopMcpServer } from '../../../server.desktop.js';
+import { DesktopTool } from '../tool.js';
+
+const urgencySchema = z.enum(['blocking', 'soft']);
+
+const paramsSchema = {
+  question: z.string().min(1).describe('The clarifying question, written for the end user.'),
+  urgency: urgencySchema
+    .optional()
+    .default('blocking')
+    .describe(
+      'blocking = stop; do not call more authoring tools until the user answers. soft = proceed with a stated default.',
+    ),
+  options: z
+    .array(z.string())
+    .optional()
+    .describe('2-5 concrete choices; rendered as a numbered list.'),
+};
+
+const title = 'Ask the User a Clarifying Question';
+
+export const getAskUserTool = (server: DesktopMcpServer): DesktopTool<typeof paramsSchema> => {
+  const askUserTool = new DesktopTool({
+    server,
+    name: 'ask-user',
+    title,
+    description:
+      'Ask instead of guessing when ambiguity would change workbook content: field/sheet/datasource, aggregation/grain, or target. Blocking: stop and wait before more authoring tools.',
+    paramsSchema,
+    annotations: {
+      title,
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
+    callback: async ({ question, urgency, options }, extra): Promise<CallToolResult> => {
+      return await askUserTool.logAndExecute<string>({
+        extra,
+        args: { question, urgency, options },
+        callback: async () => new Ok(renderAskUser({ question, urgency, options })),
+        getSuccessResult: (text) => ({
+          isError: false,
+          content: [{ type: 'text', text }],
+        }),
+      });
+    },
+  });
+
+  return askUserTool;
+};
+
+function renderAskUser({
+  question,
+  urgency,
+  options,
+}: {
+  question: string;
+  urgency?: z.infer<typeof urgencySchema>;
+  options?: string[];
+}): string {
+  const prefix = `[${(urgency ?? 'blocking').toUpperCase()}]`;
+  const optionsBlock =
+    options && options.length > 0
+      ? `\n\nOptions:\n${options.map((option, index) => `${index + 1}. ${option}`).join('\n')}`
+      : '';
+  return `${prefix} ${question}${optionsBlock}`;
+}

--- a/src/tools/desktop/toolName.ts
+++ b/src/tools/desktop/toolName.ts
@@ -23,6 +23,7 @@ export const desktopToolNames = [
   'lookup-workbook-schema',
   'search-workbook-examples',
   'execute-tableau-command',
+  'ask-user',
   'bind-template',
   'dashboard-auto-apply',
   'dashboard-health-check',

--- a/src/tools/desktop/tools.ts
+++ b/src/tools/desktop/tools.ts
@@ -23,6 +23,7 @@ import { getListFieldsTool } from './fields/listFields.js';
 import { getRemoveFieldTool } from './fields/removeField.js';
 import { getResolveFieldTool } from './fields/resolveField.js';
 import { getDashboardHealthCheckTool } from './health/dashboardHealthCheck.js';
+import { getAskUserTool } from './interaction/askUser.js';
 import { getListKnowledgeResourcesTool } from './knowledge/listKnowledgeResources.js';
 import { getReadKnowledgeResourceTool } from './knowledge/readKnowledgeResource.js';
 import { getLookupWorkbookSchemaTool } from './search/lookupWorkbookSchema.js';
@@ -66,6 +67,7 @@ export const desktopToolFactories = [
   getLookupWorkbookSchemaTool,
   getSearchWorkbookExamplesTool,
   getExecuteTableauCommandTool,
+  getAskUserTool,
   getBindTemplateTool,
   getDashboardAutoApplyTool,
   getDashboardHealthCheckTool,


### PR DESCRIPTION
Ports a2td's clarification-loop work to `feature/desktop`. Single commit, rebased onto the merged #520 so the base collapses to exactly the ask-user delta (the #208 stacked-base lesson — verified `origin/feature/desktop` is an ancestor before opening).

## What
- **New `ask-user` tool** (`src/tools/desktop/interaction/askUser.ts`): `question` + `urgency` (blocking|soft, defaults blocking) + numbered `options`. Pure formatter — `readOnlyHint:true`, `destructiveHint:false`, no `_session`, never touches Desktop. The stop-and-wait guarantee lives in the tool contract (which even a2td's version lacked).
- **Fail-closed ambiguity rewiring** routes already-computed candidates to the human instead of dead-ending in tool loops: `resolve-field` ambiguity, `bind-template` ambiguous/missing-field guidance, `plan-dashboard-creation` blocked response, and DESKTOP_INSTRUCTIONS (edit-in-place "ask via ask-user" + a blocking-clarification prose rule).
- Makes real the recovery path TAS's circuit breaker already referenced by this exact tool name (tab-agent-south !42).

## Surface (the real constraint)
describe-trims on validate-proposal / dashboard-auto-apply / dashboard-health-check paid for the ~1,032-byte tool cost: desktop 45,336 → 45,202, combined-lean 45,976 → **45,843 (157 headroom)**. Caps ratcheted DOWN, demo profile untouched.

## Validation
- Full desktop suite **4,305 green** (297 files), tsc clean, combined-lean surface 7/7.

## Residual
The Studio/Claude host actually **pausing the turn** on a `[BLOCKING]` ask-user is contract text, **not yet proven live** — that's the open verification item (W65 battery). If the host does not pause, the follow-up is a TAS-side gate (stop after ask-user tool result), not more prompt text.

W-23447497.

🤖 Generated with [Claude Code](https://claude.com/claude-code)