### PR TITLE
fix(desktop): canonical-name gate — goto-sheet can never focus a stale 'Sheet 1' (focus-follows harden)

### DIFF
--- a/src/desktop/commands/workbook/loadDashboardXml.test.ts
+++ b/src/desktop/commands/workbook/loadDashboardXml.test.ts
@@ -104,6 +104,150 @@ describe('loadDashboardXml (Agent API transport, default)', () => {
     );
   });
 
+  it('rejects before apply when dashboard_name does not match the XML dashboard name', async () => {
+    // Canonical-name gate: the XML root name is the identity Tableau applies. A caller name
+    // that disagrees must fail BEFORE apply so goto-sheet can never target a stale/default sheet.
+    const executeCommand = vi
+      .fn()
+      .mockResolvedValue(Ok({ command_id: 'cmd-123', status: 'completed', submitted_at: '' }));
+    const mockExecutor = { executeCommand } as unknown as LocalExecutor;
+
+    const result = await loadDashboardXml({
+      dashboardName: 'Different Dashboard',
+      xml: validXml, // name="Sales Dashboard"
+      executor: mockExecutor,
+      signal: mockSignal,
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      invariant(result.error.type === 'load-dashboard-xml-error');
+      invariant(result.error.error.type === 'name-mismatch');
+      // Recovery-oriented (P2a): both names verbatim + a FIX line telling the LLM exactly how to
+      // recover (align dashboard_name to the XML name, or edit the <dashboard name> attribute).
+      expect(result.error.error.message).toBe(
+        'dashboard_name "Different Dashboard" does not match the <dashboard name> in the XML ' +
+          '("Sales Dashboard"). FIX: Retry with dashboard_name set to the XML\'s name "Sales Dashboard" — ' +
+          'or update the <dashboard name> attribute in the XML to "Different Dashboard" if the caller ' +
+          'name is intended.',
+      );
+    }
+    // No apply and no navigation happened.
+    expect(executeCommand).not.toHaveBeenCalled();
+  });
+
+  it('rejects a <workbook>-wrapped payload before apply with a single-fragment recovery error', async () => {
+    // P1: a whole-workbook document has no top-level <dashboard> identity to gate on. It passes
+    // upstream validation (well-formed) and reaches the resolver, so instead of the misleading
+    // `does not match XML dashboard name ""`, the gate must reject with an actionable, non-empty
+    // recovery hint. It must NOT be "selected" or applied — the fragment-only contract is enforced
+    // downstream by buildMinimalDashboardDoc, so accepting a workbook here would only fail later.
+    const executeCommand = vi
+      .fn()
+      .mockResolvedValue(Ok({ command_id: 'cmd-123', status: 'completed', submitted_at: '' }));
+    const mockExecutor = { executeCommand } as unknown as LocalExecutor;
+    const workbookShaped =
+      "<?xml version='1.0'?><workbook><dashboards>" +
+      '<dashboard name="Sales Dashboard"><zones></zones></dashboard></dashboards>' +
+      '<windows><window class="dashboard" name="Sales Dashboard"/></windows></workbook>';
+
+    const result = await loadDashboardXml({
+      dashboardName: 'Sales Dashboard',
+      xml: workbookShaped,
+      executor: mockExecutor,
+      signal: mockSignal,
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      invariant(result.error.type === 'load-dashboard-xml-error');
+      invariant(result.error.error.type === 'name-mismatch');
+      expect(result.error.error.message).toContain('single <dashboard name="..."> fragment');
+      expect(result.error.error.message).toContain('whole <workbook> document');
+      expect(result.error.error.message).toContain('apply-workbook');
+      // The old, misleading empty-name mismatch must be gone.
+      expect(result.error.error.message).not.toContain('name ""');
+    }
+    // Never applied and never navigated.
+    expect(executeCommand).not.toHaveBeenCalled();
+  });
+
+  it('passes the gate when the caller arg is NFD and the XML name is NFC (visually identical)', async () => {
+    // P2b: "Café" spelled with a precomposed é (NFC) in the XML vs a decomposed e + combining
+    // acute (NFD) in the caller arg are visually identical and must not false-mismatch. The
+    // canonical name threaded to load + goto-sheet is the name exactly as authored in the XML.
+    const nfcName = 'Caf\u00e9'; // é as a single precomposed code point (NFC)
+    const nfdName = 'Cafe\u0301'; // e + U+0301 combining acute accent (NFD)
+    expect(nfcName).not.toBe(nfdName); // different code points…
+    expect(nfcName.normalize('NFC')).toBe(nfdName.normalize('NFC')); // …but NFC-equal
+    const nfcXml = `<dashboard name="${nfcName}"><zones></zones></dashboard>`;
+    const executeCommand = vi
+      .fn()
+      .mockResolvedValueOnce(Ok({ command_id: 'cmd-123', status: 'completed', submitted_at: '' }))
+      .mockResolvedValueOnce(Ok({ command_id: 'cmd-goto', status: 'completed', submitted_at: '' }));
+    const mockExecutor = { executeCommand } as unknown as LocalExecutor;
+
+    const result = await loadDashboardXml({
+      dashboardName: nfdName,
+      xml: nfcXml,
+      executor: mockExecutor,
+      signal: mockSignal,
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(executeCommand).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        namespace: 'tabui',
+        command: 'load-dashboard',
+        args: { dashboardName: nfcName, dashboardXml: nfcXml },
+      }),
+    );
+    expect(executeCommand).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        namespace: 'tabdoc',
+        command: 'goto-sheet',
+        args: { sheet: nfcName },
+      }),
+    );
+  });
+
+  it('focuses the canonical XML dashboard name (not the raw caller arg) after a matched apply', async () => {
+    const executeCommand = vi
+      .fn()
+      .mockResolvedValueOnce(Ok({ command_id: 'cmd-123', status: 'completed', submitted_at: '' }))
+      .mockResolvedValueOnce(Ok({ command_id: 'cmd-goto', status: 'completed', submitted_at: '' }));
+    const mockExecutor = { executeCommand } as unknown as LocalExecutor;
+
+    const result = await loadDashboardXml({
+      dashboardName: '  Sales Dashboard  ', // matches "Sales Dashboard" after trim
+      xml: validXml,
+      executor: mockExecutor,
+      signal: mockSignal,
+    });
+
+    expect(result.isOk()).toBe(true);
+    // The load command and the final goto-sheet both use the canonical, trimmed name.
+    expect(mockExecutor.executeCommand).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        namespace: 'tabui',
+        command: 'load-dashboard',
+        args: { dashboardName: 'Sales Dashboard', dashboardXml: validXml },
+      }),
+    );
+    expect(mockExecutor.executeCommand).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        namespace: 'tabdoc',
+        command: 'goto-sheet',
+        args: { sheet: 'Sales Dashboard' },
+        signal: mockSignal,
+      }),
+    );
+  });
+
   it('should return invalid-xml error when xml is empty', async () => {
     const mockExecutor = { executeCommand: vi.fn() } as unknown as LocalExecutor;
 

--- a/src/desktop/commands/workbook/loadDashboardXml.ts
+++ b/src/desktop/commands/workbook/loadDashboardXml.ts
@@ -4,6 +4,8 @@ import { getDesktopConfig } from '../../../config.desktop.js';
 import { log } from '../../../logging/logger.js';
 import { sanitizeValue } from '../../../logging/sanitize.js';
 import { buildMinimalDashboardDoc } from '../../metadata/dashboards.js';
+import { normalizeArray, parseXML } from '../../metadata/parser.js';
+import type { ParsedDashboard } from '../../metadata/types.js';
 import {
   ExecuteCommandError,
   WithExecutorAndAbortSignal,
@@ -19,6 +21,11 @@ import { applyWorkbookText, interpretLoadOutcome } from './loadWorkbookXml.js';
 export type LoadDashboardXmlError =
   | { type: 'invalid-xml' }
   | { type: 'validation-failed'; issues: Array<ValidationIssue> }
+  // The caller's dashboard_name disagrees with the `<dashboard name>` in the authored XML, or the
+  // payload carries no top-level `<dashboard>` fragment to gate on (e.g. a whole `<workbook>`
+  // document). Caught BEFORE apply so the post-apply goto-sheet can never target a stale/default
+  // sheet, and so the agent gets an actionable message instead of a misleading empty-name mismatch.
+  | { type: 'name-mismatch'; message: string }
   // The load-dashboard command reported command-level completion, but Tableau
   // rejected the actual document load (surfaced in the response payload, not in
   // `status`). `message` carries Desktop's own error text.
@@ -39,6 +46,64 @@ type LoadDashboardHelperResult = Result<
   | { type: 'execute-command-error'; error: ExecuteCommandError }
   | { type: 'load-dashboard-xml-error'; error: LoadDashboardXmlError }
 >;
+
+/**
+ * Canonical-name gate. The `<dashboard name>` in the authored XML is the identity Tableau
+ * applies, so require the caller's `dashboardName` to agree with it before we touch Desktop.
+ * Names are compared after trim and Unicode NFC normalization (case-sensitive) so visually
+ * identical NFD/NFC spellings do not false-mismatch. Returns the validated canonical name — the
+ * name exactly as authored in the XML (trimmed), which is what Tableau stores when it applies the
+ * raw XML — for the load and the post-apply goto-sheet, so focus can never target a stale/default
+ * sheet (e.g. "Sheet 1"), and so buildMinimalDashboardDoc's own name check still matches.
+ *
+ * Only a single top-level `<dashboard>` fragment is a legal payload here (the same fragment
+ * get-dashboard-xml returns and buildMinimalDashboardDoc requires). A `<workbook>`-wrapped document
+ * has no top-level identity to gate on, so it is rejected before apply with a recovery hint rather
+ * than failing as a misleading mismatch against an empty XML name.
+ */
+function resolveCanonicalDashboardName(
+  dashboardName: string,
+  xml: string,
+): Result<string, Extract<LoadDashboardXmlError, { type: 'name-mismatch' }>> {
+  const callerName = dashboardName.trim();
+  let xmlName = '';
+  let isWorkbookDocument = false;
+  try {
+    const parsed = parseXML(xml);
+    const dashboard = normalizeArray(parsed.dashboard as ParsedDashboard | undefined)[0];
+    xmlName = dashboard?.['@_name']?.trim() ?? '';
+    isWorkbookDocument = !xmlName && Boolean(parsed.workbook);
+  } catch {
+    xmlName = '';
+  }
+
+  if (!xmlName) {
+    // No top-level <dashboard> identity to gate on — reject with an actionable recovery message
+    // instead of a misleading mismatch against an empty XML name.
+    return Err({
+      type: 'name-mismatch',
+      message: isWorkbookDocument
+        ? 'apply-dashboard expects a single <dashboard name="..."> fragment, but the XML is a whole ' +
+          `<workbook> document. FIX: Extract just the <dashboard name="${callerName}"> element and retry ` +
+          'with that fragment as dashboardXml — or apply the whole document with apply-workbook.'
+        : 'apply-dashboard could not find a top-level <dashboard name="..."> element in the XML. ' +
+          `FIX: Provide a single <dashboard name="${callerName}"> fragment (as returned by get-dashboard-xml) ` +
+          'as dashboardXml.',
+    });
+  }
+
+  if (xmlName.normalize('NFC') !== callerName.normalize('NFC')) {
+    return Err({
+      type: 'name-mismatch',
+      message:
+        `dashboard_name "${dashboardName}" does not match the <dashboard name> in the XML ("${xmlName}"). ` +
+        `FIX: Retry with dashboard_name set to the XML's name "${xmlName}" — or update the <dashboard name> ` +
+        `attribute in the XML to "${dashboardName}" if the caller name is intended.`,
+    });
+  }
+
+  return Ok(xmlName);
+}
 
 export async function loadDashboardXml({
   dashboardName,
@@ -86,12 +151,27 @@ export async function loadDashboardXml({
     });
   }
 
+  // Canonical-name gate (focus hardening): require the caller's dashboard_name to agree with
+  // the XML root name before apply, then thread the validated canonical name through the load
+  // and goto-sheet so navigation can never land on a stale/default sheet.
+  const canonicalNameResult = resolveCanonicalDashboardName(dashboardName, xml);
+  if (canonicalNameResult.isErr()) {
+    log({
+      level: 'error',
+      message: 'dashboard_name does not match the XML dashboard name — not sent to Tableau',
+      logger: 'dashboardCommands',
+      data: { dashboardName, message: canonicalNameResult.error.message },
+    });
+    return Err({ type: 'load-dashboard-xml-error', error: canonicalNameResult.error });
+  }
+  const canonicalName = canonicalNameResult.value;
+
   // External Client API ("Athena V0") exposes no per-sheet route — tabui:load-dashboard is not in
   // its command registry, so applying a single dashboard re-posts a minimal whole-workbook document.
   // The POST upserts by name: it overwrites the colliding dashboard in place and leaves the rest live.
   const result = await (getDesktopConfig().externalApiEnabled
-    ? loadDashboardXmlViaExternalApi({ dashboardName, xml, executor, signal })
-    : loadDashboardXmlViaAgentApi({ dashboardName, xml, executor, signal }));
+    ? loadDashboardXmlViaExternalApi({ dashboardName: canonicalName, xml, executor, signal })
+    : loadDashboardXmlViaAgentApi({ dashboardName: canonicalName, xml, executor, signal }));
   if (result.isErr()) {
     return result;
   }

--- a/src/desktop/commands/workbook/loadWorksheetXml.test.ts
+++ b/src/desktop/commands/workbook/loadWorksheetXml.test.ts
@@ -131,6 +131,120 @@ describe('loadWorksheetXml (Agent API transport, default)', () => {
     );
   });
 
+  it('rejects before apply when worksheet_name does not match the XML worksheet name', async () => {
+    // Canonical-name gate: the XML root name is the identity Tableau applies. A caller name
+    // that disagrees must fail BEFORE apply so goto-sheet can never target a stale/default sheet.
+    const { executor, calls } = dispatchingAgentExecutor(validXml);
+
+    const result = await loadWorksheetXml({
+      worksheetName: 'Different Sheet',
+      xml: validXml, // name="Sheet 1"
+      executor,
+      signal: mockSignal,
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      invariant(result.error.type === 'load-worksheet-xml-error');
+      invariant(result.error.error.type === 'name-mismatch');
+      // Recovery-oriented (P2a): both names verbatim + a FIX line telling the LLM exactly how to
+      // recover (align worksheet_name to the XML name, or edit the <worksheet name> attribute).
+      expect(result.error.error.message).toBe(
+        'worksheet_name "Different Sheet" does not match the <worksheet name> in the XML ("Sheet 1"). ' +
+          'FIX: Retry with worksheet_name set to the XML\'s name "Sheet 1" — or update the <worksheet name> ' +
+          'attribute in the XML to "Different Sheet" if the caller name is intended.',
+      );
+    }
+    // No apply and no navigation happened.
+    expect(calls.some((c) => c.command === 'load-worksheet')).toBe(false);
+    expect(calls.some((c) => c.command === 'goto-sheet')).toBe(false);
+  });
+
+  it('rejects a <workbook>-wrapped payload before apply with a single-fragment recovery error', async () => {
+    // P1: a whole-workbook document has no top-level <worksheet> identity to gate on. It passes
+    // upstream validation (well-formed) and reaches the resolver, so instead of the misleading
+    // `does not match XML worksheet name ""`, the gate must reject with an actionable, non-empty
+    // recovery hint. It must NOT be "selected" or applied — the fragment-only contract is enforced
+    // downstream by buildMinimalSheetDoc, so accepting a workbook here would only fail later.
+    const { executor, calls } = dispatchingAgentExecutor(validXml);
+    const workbookShaped =
+      "<?xml version='1.0'?><workbook><worksheets>" +
+      '<worksheet name="Sheet 1"><table></table></worksheet></worksheets>' +
+      '<windows><window class="worksheet" name="Sheet 1"/></windows></workbook>';
+
+    const result = await loadWorksheetXml({
+      worksheetName: 'Sheet 1',
+      xml: workbookShaped,
+      executor,
+      signal: mockSignal,
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      invariant(result.error.type === 'load-worksheet-xml-error');
+      invariant(result.error.error.type === 'name-mismatch');
+      expect(result.error.error.message).toContain('single <worksheet name="..."> fragment');
+      expect(result.error.error.message).toContain('whole <workbook> document');
+      expect(result.error.error.message).toContain('apply-workbook');
+      // The old, misleading empty-name mismatch must be gone.
+      expect(result.error.error.message).not.toContain('name ""');
+    }
+    // Never applied and never navigated.
+    expect(calls.some((c) => c.command === 'load-worksheet')).toBe(false);
+    expect(calls.some((c) => c.command === 'goto-sheet')).toBe(false);
+  });
+
+  it('passes the gate when the caller arg is NFD and the XML name is NFC (visually identical)', async () => {
+    // P2b: "Café" spelled with a precomposed é (NFC) in the XML vs a decomposed e + combining
+    // acute (NFD) in the caller arg are visually identical and must not false-mismatch. The
+    // canonical name threaded to load + goto-sheet is the name exactly as authored in the XML.
+    const nfcName = 'Caf\u00e9'; // é as a single precomposed code point (NFC)
+    const nfdName = 'Cafe\u0301'; // e + U+0301 combining acute accent (NFD)
+    expect(nfcName).not.toBe(nfdName); // different code points…
+    expect(nfcName.normalize('NFC')).toBe(nfdName.normalize('NFC')); // …but NFC-equal
+    const nfcXml = `<worksheet name="${nfcName}"><table></table></worksheet>`;
+    const { executor, calls } = dispatchingAgentExecutor(nfcXml);
+
+    const result = await loadWorksheetXml({
+      worksheetName: nfdName,
+      xml: nfcXml,
+      executor,
+      signal: mockSignal,
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(calls.find((c) => c.command === 'load-worksheet')?.args).toMatchObject({
+      worksheetName: nfcName,
+    });
+    expect(calls.at(-1)).toMatchObject({
+      namespace: 'tabdoc',
+      command: 'goto-sheet',
+      args: { sheet: nfcName },
+    });
+  });
+
+  it('focuses the canonical XML worksheet name (not the raw caller arg) after a matched apply', async () => {
+    const { executor, calls } = dispatchingAgentExecutor(validXml);
+
+    const result = await loadWorksheetXml({
+      worksheetName: '  Sheet 1  ', // matches "Sheet 1" after trim
+      xml: validXml,
+      executor,
+      signal: mockSignal,
+    });
+
+    expect(result.isOk()).toBe(true);
+    // The load command and the final goto-sheet both use the canonical, trimmed name.
+    expect(calls.find((c) => c.command === 'load-worksheet')?.args).toMatchObject({
+      worksheetName: 'Sheet 1',
+    });
+    expect(calls.at(-1)).toMatchObject({
+      namespace: 'tabdoc',
+      command: 'goto-sheet',
+      args: { sheet: 'Sheet 1' },
+    });
+  });
+
   it('fails the apply (readback-failed) when Tableau silently drops an intent-bearing node', async () => {
     const intended =
       '<worksheet name="Sheet 1"><table>' +

--- a/src/desktop/commands/workbook/loadWorksheetXml.ts
+++ b/src/desktop/commands/workbook/loadWorksheetXml.ts
@@ -3,7 +3,9 @@ import { Err, Ok, Result } from 'ts-results-es';
 import { getDesktopConfig } from '../../../config.desktop.js';
 import { log } from '../../../logging/logger.js';
 import { sanitizeValue } from '../../../logging/sanitize.js';
+import { normalizeArray, parseXML } from '../../metadata/parser.js';
 import { buildMinimalSheetDoc } from '../../metadata/sheets.js';
+import type { ParsedWorksheet } from '../../metadata/types.js';
 import {
   ExecuteCommandError,
   WithExecutorAndAbortSignal,
@@ -26,6 +28,11 @@ import { applyWorkbookText, interpretLoadOutcome } from './loadWorkbookXml.js';
 export type LoadWorksheetXmlError =
   | { type: 'invalid-xml' }
   | { type: 'validation-failed'; issues: Array<ValidationIssue> }
+  // The caller's worksheet_name disagrees with the `<worksheet name>` in the authored XML, or the
+  // payload carries no top-level `<worksheet>` fragment to gate on (e.g. a whole `<workbook>`
+  // document). Caught BEFORE apply so the post-apply goto-sheet can never target a stale/default
+  // sheet, and so the agent gets an actionable message instead of a misleading empty-name mismatch.
+  | { type: 'name-mismatch'; message: string }
   // The load-worksheet command reported command-level completion, but Tableau
   // rejected the actual document load (surfaced in the response payload, not in
   // `status`). `message` carries Desktop's own error text.
@@ -133,6 +140,64 @@ function readbackOutcome(
   });
 }
 
+/**
+ * Canonical-name gate. The `<worksheet name>` in the authored XML is the identity Tableau
+ * applies, so require the caller's `worksheetName` to agree with it before we touch Desktop.
+ * Names are compared after trim and Unicode NFC normalization (case-sensitive) so visually
+ * identical NFD/NFC spellings do not false-mismatch. Returns the validated canonical name — the
+ * name exactly as authored in the XML (trimmed), which is what Tableau stores when it applies the
+ * raw XML — for the load, the readback, and the post-apply goto-sheet, so focus can never target a
+ * stale/default sheet (e.g. "Sheet 1"), and so buildMinimalSheetDoc's own name check still matches.
+ *
+ * Only a single top-level `<worksheet>` fragment is a legal payload here (the same fragment
+ * get-worksheet-xml returns and buildMinimalSheetDoc requires). A `<workbook>`-wrapped document has
+ * no top-level identity to gate on, so it is rejected before apply with a recovery hint rather than
+ * failing as a misleading mismatch against an empty XML name.
+ */
+function resolveCanonicalWorksheetName(
+  worksheetName: string,
+  xml: string,
+): Result<string, Extract<LoadWorksheetXmlError, { type: 'name-mismatch' }>> {
+  const callerName = worksheetName.trim();
+  let xmlName = '';
+  let isWorkbookDocument = false;
+  try {
+    const parsed = parseXML(xml);
+    const worksheet = normalizeArray(parsed.worksheet as ParsedWorksheet | undefined)[0];
+    xmlName = worksheet?.['@_name']?.trim() ?? '';
+    isWorkbookDocument = !xmlName && Boolean(parsed.workbook);
+  } catch {
+    xmlName = '';
+  }
+
+  if (!xmlName) {
+    // No top-level <worksheet> identity to gate on — reject with an actionable recovery message
+    // instead of a misleading mismatch against an empty XML name.
+    return Err({
+      type: 'name-mismatch',
+      message: isWorkbookDocument
+        ? 'apply-worksheet expects a single <worksheet name="..."> fragment, but the XML is a whole ' +
+          `<workbook> document. FIX: Extract just the <worksheet name="${callerName}"> element and retry ` +
+          'with that fragment as worksheetXml — or apply the whole document with apply-workbook.'
+        : 'apply-worksheet could not find a top-level <worksheet name="..."> element in the XML. ' +
+          `FIX: Provide a single <worksheet name="${callerName}"> fragment (as returned by get-worksheet-xml) ` +
+          'as worksheetXml.',
+    });
+  }
+
+  if (xmlName.normalize('NFC') !== callerName.normalize('NFC')) {
+    return Err({
+      type: 'name-mismatch',
+      message:
+        `worksheet_name "${worksheetName}" does not match the <worksheet name> in the XML ("${xmlName}"). ` +
+        `FIX: Retry with worksheet_name set to the XML's name "${xmlName}" — or update the <worksheet name> ` +
+        `attribute in the XML to "${worksheetName}" if the caller name is intended.`,
+    });
+  }
+
+  return Ok(xmlName);
+}
+
 export async function loadWorksheetXml({
   worksheetName,
   xml,
@@ -181,19 +246,34 @@ export async function loadWorksheetXml({
     });
   }
 
+  // Canonical-name gate (focus hardening): require the caller's worksheet_name to agree with
+  // the XML root name before apply, then thread the validated canonical name through the load,
+  // readback, and goto-sheet so navigation can never land on a stale/default sheet.
+  const canonicalNameResult = resolveCanonicalWorksheetName(worksheetName, xml);
+  if (canonicalNameResult.isErr()) {
+    log({
+      level: 'error',
+      message: 'worksheet_name does not match the XML worksheet name — not sent to Tableau',
+      logger: 'worksheetCommands',
+      data: { worksheetName, message: canonicalNameResult.error.message },
+    });
+    return Err({ type: 'load-worksheet-xml-error', error: canonicalNameResult.error });
+  }
+  const canonicalName = canonicalNameResult.value;
+
   // External Client API ("Athena V0") exposes no per-sheet route — tabui:load-worksheet is not in
   // its command registry, so applying a single sheet re-posts a minimal whole-workbook document.
   // The POST upserts by name: it overwrites the colliding sheet in place and leaves the rest live.
   const result = await (getDesktopConfig().externalApiEnabled
     ? loadWorksheetXmlViaExternalApi({
-        worksheetName,
+        worksheetName: canonicalName,
         xml,
         executor,
         signal,
         readbackVerificationOut,
       })
     : loadWorksheetXmlViaAgentApi({
-        worksheetName,
+        worksheetName: canonicalName,
         xml,
         executor,
         signal,


### PR DESCRIPTION
## What

Hardens the focus-follows port (`22659242` lineage) against the blank-Sheet-1 regression Matt hit live 2026-07-16 during the exec-demo rehearsal.

- `resolveCanonicalWorksheetName`/`resolveCanonicalDashboardName`: parse the fragment's real name attr (XML parser, entity-decoded), require it to equal the caller's arg (trimmed, NFC-normalized, case-sensitive), **fail before any Tableau command** on mismatch with a recovery-oriented `FIX:` message.
- Workbook-wrapped / no-fragment payloads now rejected pre-apply with a clear 'single fragment required' message (previously they'd hard-fail deeper at `buildMinimalSheetDoc` — fragment-only contract predates this change, verified).
- The validated canonical name threads into load, readback, and `focusAppliedSheet` on BOTH Agent-API and external-API paths — goto-sheet can never navigate to a name that wasn't just applied.

## Review

Adversarially reviewed (GPT) → FIX-FIRST → all findings addressed: P1 workbook-shaped payload refuted-with-evidence + hardened anyway; P2 recovery text; P2 NFC normalization (compare-only; as-authored name returned so Tableau identity is preserved).

## Validation

- 46 targeted tests (4 new, red-proofed before implementation)
- Full desktop sweep: **169 files, 2325 passed | 1 skipped**
- `tsc --noEmit` + eslint clean

## Twin

a2td twin (canonical-name gate + compose-focus suppression + 3-chart regression eval) lands separately on `claude/w66-focus-harden`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)