### PR TITLE
port(a2td #214): refine sort-insert on unsorted simple bars

### DIFF
--- a/src/desktop/refine/refineWorksheet.test.ts
+++ b/src/desktop/refine/refineWorksheet.test.ts
@@ -1,3 +1,6 @@
+import { ensureUserNamespace } from '../templates/injectTemplateCore.js';
+import { runValidation } from '../validation/registry.js';
+import { parseXml } from '../validation/rules/parseXml.js';
 import {
   confirmSortDirectionApplied,
   confirmTopNApplied,
@@ -302,8 +305,20 @@ describe('planSortDirection', () => {
     expect(r.reason).toMatch(/ASC.*DESC/);
   });
 
-  it('refuses when no computed-sort is present', () => {
-    const xml = BASE.replace(/<computed-sort[^>]*\/>/, '');
+  it('refuses when no computed-sort is present on a shape richer than a simple bar', () => {
+    // This assertion previously used BASE-minus-sort (a single-dim/single-measure bar) to
+    // prove the historic "refuse when unsorted" limitation. That exact shape is now the
+    // ADD-a-sort case (covered below), so it can no longer refuse. The no-sort refusal is
+    // still correct — and still exercised here — for any shape richer than the simple bar
+    // (two categorical dimensions), where we never guess a sort.
+    const xml = withDeps(
+      REGION_COL +
+        "<column datatype='string' name='[Category]' role='dimension' type='nominal' />" +
+        SALES_COL +
+        REGION_CI +
+        "<column-instance column='[Category]' derivation='None' name='[none:Category:nk]' pivot='key' type='nominal' />" +
+        SALES_CI,
+    ).replace(/<computed-sort[^>]*\/>/, '');
     const r = planSortDirection(xml, { direction: 'ASC' });
     expect(r.ok).toBe(false);
     if (r.ok) return;
@@ -330,6 +345,193 @@ describe('planSortDirection', () => {
     expect(r.ok).toBe(false);
     if (r.ok) return;
     expect(r.reason).toMatch(/nested/i);
+  });
+});
+
+describe('planSortDirection — INSERT a sort on an unsorted simple bar', () => {
+  // The unsorted single-dim/single-measure bar: BASE with its <computed-sort> removed —
+  // the exact shape magnitude-simple-bar.xml ships, minus the sort node.
+  const UNSORTED = BASE.replace(/<computed-sort[^>]*\/>/, '');
+
+  it('inserts a safe self-closing computed-sort (desc) with template placement/attributes', () => {
+    const r = planSortDirection(UNSORTED, { direction: 'DESC' });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.column).toBe('[Superstore].[none:Region:nk]');
+    expect(r.direction).toBe('DESC');
+
+    // Mirrors magnitude-simple-bar.xml:24 exactly (column = dim CI, using = measure CI).
+    expect(r.xml).toContain(
+      "<computed-sort column='[Superstore].[none:Region:nk]' direction='DESC' using='[Superstore].[sum:Sales:qk]' />",
+    );
+    // Exactly one sort node (no accidental duplicate) and the XML still parses.
+    expect([...r.xml.matchAll(/<computed-sort\b/g)]).toHaveLength(1);
+    expect(parseXml(r.xml)?.documentElement).toBeTruthy();
+
+    // Placed after the dependencies anchor and before <aggregation> (template ordering).
+    const sortIdx = r.xml.indexOf('<computed-sort');
+    expect(sortIdx).toBeGreaterThan(r.xml.indexOf('</datasource-dependencies>'));
+    expect(sortIdx).toBeLessThan(r.xml.indexOf('<aggregation'));
+  });
+
+  it('honors the requested direction on insert (ASC)', () => {
+    const r = planSortDirection(UNSORTED, { direction: 'ASC' });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.xml).toContain(
+      "<computed-sort column='[Superstore].[none:Region:nk]' direction='ASC' using='[Superstore].[sum:Sales:qk]' />",
+    );
+  });
+
+  it('round-trip: the inserted node passes the SAME preflight validation the apply path runs', () => {
+    const r = planSortDirection(UNSORTED, { direction: 'DESC' });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    // Mirror refineWorksheet.ts: ensureUserNamespace(patched) → runValidation(_, 'worksheet').
+    const result = runValidation(ensureUserNamespace(r.xml), 'worksheet');
+    expect(result.valid).toBe(true);
+    expect(result.issues.filter((i) => i.severity === 'error')).toEqual([]);
+    // Specifically NOT the crashing nested form.
+    expect(result.issues.some((i) => i.ruleId === 'computed-sort-crash')).toBe(false);
+    // And the inserted sort is confirmable by the same readback check the tool uses.
+    expect(confirmSortDirectionApplied(r.xml, r.column, 'DESC')).toBe(true);
+  });
+});
+
+describe('planSortDirection — INSERT refusals (richer shapes keep the no-sort refusal)', () => {
+  const stripSort = (xml: string): string => xml.replace(/<computed-sort[^>]*\/>/, '');
+
+  it('refuses to insert when a second measure makes the ranking key ambiguous', () => {
+    const xml = stripSort(
+      withDeps(
+        REGION_COL +
+          SALES_COL +
+          "<column datatype='real' name='[Profit]' role='measure' type='quantitative' />" +
+          REGION_CI +
+          SALES_CI +
+          "<column-instance column='[Profit]' derivation='Sum' name='[sum:Profit:qk]' pivot='key' type='quantitative' />",
+      ),
+    );
+    const r = planSortDirection(xml, { direction: 'DESC' });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.reason).toMatch(/no <computed-sort>/i);
+  });
+
+  it('refuses to insert when the sheet uses a calculated field', () => {
+    const xml = stripSort(
+      withDeps(
+        REGION_COL +
+          SALES_COL +
+          REGION_CI +
+          "<column-instance column='[Calculation_1]' derivation='User' name='[usr:Calculation_1:qk]' pivot='key' type='quantitative' />",
+      ),
+    );
+    const r = planSortDirection(xml, { direction: 'DESC' });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.reason).toMatch(/no <computed-sort>/i);
+  });
+
+  it('refuses to insert when a table calc is present', () => {
+    // Still one dim + one measure CI (derivation Sum), but the measure carries a
+    // <table-calc> child → out of the simple-bar envelope; the guard keeps the refusal.
+    const xml = stripSort(BASE).replace(
+      SALES_CI,
+      "<column-instance column='[Sales]' derivation='Sum' name='[sum:Sales:qk]' pivot='key' type='quantitative'><table-calc ordering-type='Rows' /></column-instance>",
+    );
+    const r = planSortDirection(xml, { direction: 'DESC' });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.reason).toMatch(/no <computed-sort>/i);
+  });
+
+  it('refuses to insert on a dual-axis / multi-pane sheet', () => {
+    const xml = stripSort(BASE).replace(
+      '</panes>',
+      "  <pane><view><breakdown value='auto' /></view><mark class='Line' /></pane>\n    </panes>",
+    );
+    const r = planSortDirection(xml, { direction: 'DESC' });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.reason).toMatch(/no <computed-sort>/i);
+  });
+
+  it('refuses to insert when the dimension is not bound to a shelf (sort would dangle)', () => {
+    // 1 dim + 1 measure, but the dimension pill is not on rows/cols → the computed-sort
+    // would couple to a pill that isn't placed; keep the refusal rather than guess.
+    const xml = stripSort(BASE).replace('<rows>[Superstore].[none:Region:nk]</rows>', '<rows />');
+    const r = planSortDirection(xml, { direction: 'DESC' });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.reason).toMatch(/no <computed-sort>/i);
+  });
+
+  it('refuses to insert when the same dimension is bound to BOTH shelves (P1c)', () => {
+    // rows AND cols both carry the dimension CI, so this is not the verified simple-bar
+    // shape (dim on exactly one shelf, measure on the other). The old `includes` check
+    // over the concatenated shelves would pass; the per-shelf binding must refuse.
+    const xml = stripSort(BASE).replace(
+      '<cols>[Superstore].[sum:Sales:qk]</cols>',
+      '<cols>[Superstore].[none:Region:nk] / [Superstore].[sum:Sales:qk]</cols>',
+    );
+    const r = planSortDirection(xml, { direction: 'DESC' });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.reason).toMatch(/no <computed-sort>/i);
+  });
+
+  it('refuses to insert when more than one datasource-dependencies block is present (P1b)', () => {
+    // A second dependency block (column metadata only) leaves the primary Region/Sales
+    // CIs unambiguous, but insertion would land between the two blocks — refuse unless
+    // there is EXACTLY one dependency block.
+    const xml = stripSort(BASE).replace(
+      '</datasource-dependencies>',
+      "</datasource-dependencies>\n      <datasource-dependencies datasource='Superstore'>" +
+        "<column datatype='string' name='[Segment]' role='dimension' type='nominal' /></datasource-dependencies>",
+    );
+    const r = planSortDirection(xml, { direction: 'DESC' });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.reason).toMatch(/no <computed-sort>/i);
+  });
+
+  it('refuses to insert when the datasource name carries XML-special characters (P1a)', () => {
+    // A datasource whose name contains an apostrophe/ampersand would be interpolated raw
+    // into single-quoted attributes → malformed XML. The shelves here reference the same
+    // name (double-quoted, apostrophe-safe source) so shelf-binding passes and the ONLY
+    // reason to refuse is the unescaped special char in the built column/using values.
+    const xml = stripSort(BASE)
+      .replace(
+        "<datasource-dependencies datasource='Superstore'>",
+        '<datasource-dependencies datasource="Bob\'s &amp; Sons">',
+      )
+      .replaceAll('[Superstore].', "[Bob's &amp; Sons].");
+    const r = planSortDirection(xml, { direction: 'DESC' });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.reason).toMatch(/no <computed-sort>/i);
+  });
+
+  it("refuses to insert when the only 'dimension' is the Measure Names pseudo-field (P2)", () => {
+    // Measure Names ([:Measure Names], nominal/None) matches the dimension pattern but is
+    // an internal pseudo-CI, not a real categorical dimension — exclude it so the sheet
+    // has no dimension to order and the insert refuses.
+    const xml = stripSort(
+      withDeps(
+        "<column datatype='string' name='[:Measure Names]' role='dimension' type='nominal' />" +
+          SALES_COL +
+          "<column-instance column='[:Measure Names]' derivation='None' name='[none:Measure Names:nk]' pivot='key' type='nominal' />" +
+          SALES_CI,
+      ),
+    ).replace(
+      '<rows>[Superstore].[none:Region:nk]</rows>',
+      '<rows>[Superstore].[none:Measure Names:nk]</rows>',
+    );
+    const r = planSortDirection(xml, { direction: 'DESC' });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.reason).toMatch(/no <computed-sort>/i);
   });
 });
 

--- a/src/desktop/refine/refineWorksheet.ts
+++ b/src/desktop/refine/refineWorksheet.ts
@@ -12,12 +12,17 @@
  *     unambiguous categorical dimension CI, keyed by its single measure CI, then
  *     create/extend <slices>.
  *   - sort_direction: flip `direction` on an existing single self-closing <computed-sort>.
- *     The nested <sort class="computed-sort"> form crashes Desktop and is refused.
+ *     The nested <sort class="computed-sort"> form crashes Desktop and is refused. When
+ *     NO sort node exists yet, INSERT a safe self-closing <computed-sort> — but only under
+ *     the confirmed simple-bar shape (exactly one categorical dimension + one measure, both
+ *     on a shelf, single pane): the exact shape magnitude-simple-bar.xml ships (its sort
+ *     node at :24). Any richer shape keeps the no-sort refusal.
  *
  * Refusal, not repair: anything outside this tiny envelope (ambiguous dims/measures, n
- * outside 1..50, sets/params/rollups/calcs, an existing Top-N, a nested/absent/multiple
- * computed-sort) returns `{ ok: false, reason }` so the caller can hand back to the
- * standard authoring path instead of entering whole-workbook XML surgery.
+ * outside 1..50, sets/params/rollups/calcs, an existing Top-N, a nested/multiple
+ * computed-sort, or an absent computed-sort on a shape richer than a simple bar) returns
+ * `{ ok: false, reason }` so the caller can hand back to the standard authoring path
+ * instead of entering whole-workbook XML surgery.
  *
  * Repo-agnostic by construction: this module imports only third-party XML libraries
  * (@xmldom/xmldom, xpath) — no tableau-mcp modules — so it is a byte-adoption candidate
@@ -138,14 +143,24 @@ function datasourceName(xml: string): string {
   return ds ? (ds[1] ?? ds[2] ?? '') : '';
 }
 
+/**
+ * Internal pseudo-fields (Measure Names / Measure Values and any `[:...]` internal
+ * column) match the nominal/quantitative derivation patterns but are NOT real dims or
+ * measures — never treat them as the sheet's single dimension/measure.
+ */
+function isPseudoFieldCi(ci: ColumnInstance): boolean {
+  return /^\[:/.test(ci.column) || ci.column === '[Multiple Values]';
+}
+
 /** A plain categorical dimension CI: nominal + None derivation (e.g. [none:Region:nk]). */
 function isDimensionCi(ci: ColumnInstance): boolean {
-  return ci.type === 'nominal' && ci.derivation === 'None';
+  return !isPseudoFieldCi(ci) && ci.type === 'nominal' && ci.derivation === 'None';
 }
 
 /** A measure CI: quantitative with a canonical aggregation derivation (e.g. [sum:Sales:qk]). */
 function isMeasureCi(ci: ColumnInstance): boolean {
   return (
+    !isPseudoFieldCi(ci) &&
     ci.type === 'quantitative' &&
     Object.prototype.hasOwnProperty.call(AGG_DERIVATIONS, ci.derivation)
   );
@@ -295,10 +310,81 @@ export function planTopN(
   return { ok: true, xml: out, filterColumn };
 }
 
+/** The text of a single shelf (`rows`/`cols`) — where placed (bound) pills appear DS-qualified. */
+function shelfText(xml: string, shelf: 'rows' | 'cols'): string {
+  return xml.match(new RegExp(`<${shelf}\\b[^>]*>([\\s\\S]*?)</${shelf}>`))?.[1] ?? '';
+}
+
+/** True if a value carries any XML-special char that would break a single-quoted attribute. */
+function hasXmlSpecialChars(value: string): boolean {
+  return /['"<>&]/.test(value);
+}
+
 /**
- * Plan a direction flip on the worksheet's single self-closing <computed-sort>. Refuses if
- * absent, if more than one is present, if the direction is invalid, or if the sort uses the
- * nested <sort class="computed-sort"> crash form. Pure.
+ * Plan the INSERTION of a safe self-closing <computed-sort> on an UNSORTED sheet, but
+ * ONLY when the sheet is the confirmed simple-bar shape magnitude-simple-bar.xml ships:
+ * exactly one categorical dimension + one measure (and no other CIs), both bound to a
+ * shelf, a single pane, and none of the out-of-envelope constructs (calc/set/param/
+ * table-calc). Attributes/placement mirror that template's sort node (:24):
+ *   <computed-sort column='[ds].[dimCI]' direction='…' using='[ds].[measureCI]' />
+ * placed right after </datasource-dependencies>. The node is the self-closing form the
+ * lossy-apply detector explicitly recommends (it round-trips as <computed-sort>, never a
+ * dropped <shelf-sort-v2>), so it cannot trip shelf-sort-v2 loss. Returns a SortPlan when
+ * the shape is safe, else null so the caller keeps the standard no-sort refusal — we never
+ * guess a sort for a richer shape.
+ */
+function planSortInsertion(xml: string, direction: SortDirection): SortPlan | null {
+  const cis = parseColumnInstances(xml);
+  // Out-of-envelope constructs (calc/set/param) or a table calc → do not guess.
+  if (unsupportedConstruct(xml, cis) !== null) return null;
+  if (/<table-calc\b/.test(xml)) return null;
+  // Dual-axis / layered marks show up as multiple panes; the simple bar has exactly one.
+  if ((xml.match(/<pane\b/g) ?? []).length !== 1) return null;
+  // Exactly ONE dependency block, or the insertion anchor (its </…>) is ambiguous and the
+  // node could land between blocks. The simple bar has a single dependency block.
+  if ((xml.match(/<datasource-dependencies\b/g) ?? []).length !== 1) return null;
+  // Exactly the template's two CIs: one categorical dimension + one measure, nothing else.
+  if (cis.length !== 2) return null;
+  const dims = cis.filter(isDimensionCi);
+  const measures = cis.filter(isMeasureCi);
+  if (dims.length !== 1 || measures.length !== 1) return null;
+
+  const ds = datasourceName(xml);
+  if (!ds) return null;
+  if (!/<\/datasource-dependencies>/.test(xml)) return null;
+
+  const column = `[${ds}].${dims[0].name}`;
+  const using = `[${ds}].${measures[0].name}`;
+  // The attribute values are string-built into single-quoted attributes; a datasource name
+  // or CI carrying a quote/angle-bracket/ampersand would emit malformed XML. Refuse rather
+  // than guess an escaping — refusal falls back to the always-safe standard path.
+  if (hasXmlSpecialChars(column) || hasXmlSpecialChars(using)) return null;
+  // The simple bar binds the dimension to exactly one shelf and the measure to the other.
+  // A dimension present on BOTH shelves (or the two sharing a shelf) is not that shape —
+  // check each shelf separately rather than the concatenation (manifest hazard
+  // "computed-sort-pill-coupling": the dimension is what we order, the measure is the key).
+  const rows = shelfText(xml, 'rows');
+  const cols = shelfText(xml, 'cols');
+  const dimOnRows = rows.includes(column);
+  const dimOnCols = cols.includes(column);
+  const measOnRows = rows.includes(using);
+  const measOnCols = cols.includes(using);
+  const boundLikeSimpleBar =
+    (dimOnRows && !dimOnCols && measOnCols && !measOnRows) ||
+    (dimOnCols && !dimOnRows && measOnRows && !measOnCols);
+  if (!boundLikeSimpleBar) return null;
+
+  const node = `<computed-sort column='${column}' direction='${direction}' using='${using}' />`;
+  const out = xml.replace(/<\/datasource-dependencies>/, (m) => `${m}\n      ${node}`);
+  return { ok: true, xml: out, column, direction };
+}
+
+/**
+ * Plan a direction change on the worksheet's single self-closing <computed-sort>: flip an
+ * existing one, or INSERT one on an unsorted simple bar (see planSortInsertion). Refuses if
+ * more than one sort is present, if the direction is invalid, if the sort uses the nested
+ * <sort class="computed-sort"> crash form, or if the sheet is unsorted AND richer than a
+ * simple bar. Pure.
  */
 export function planSortDirection(
   xml: string,
@@ -323,7 +409,13 @@ export function planSortDirection(
   }
 
   const selfClosing = [...xml.matchAll(/<computed-sort\b[^>]*\/>/g)];
-  if (selfClosing.length === 0) return refuse('no <computed-sort> present to change direction on.');
+  if (selfClosing.length === 0) {
+    // No sort yet: ADD one iff the sheet is the safe simple-bar shape; otherwise keep the
+    // historic refusal so a richer shape falls back to the standard build path.
+    const inserted = planSortInsertion(xml, direction);
+    if (inserted) return inserted;
+    return refuse('no <computed-sort> present to change direction on.');
+  }
   if (selfClosing.length > 1) {
     return refuse('more than one <computed-sort> present; the target sort is ambiguous.');
   }


### PR DESCRIPTION
Twin of tableau/agent-to-tableau-desktop#214 (review-gated there; port-fidelity reviewed here — content clean, validation re-run by orchestrator after the reviewer's env mistake: 54 targeted + 2342 full-sweep green, tsc clean, combined-lean 46K cliff held). Pseudo-field exclusion is shared and reaches planTopN (parity). Known divergence, by design: insert REFUSES XML-special-char names (a2td parity) while tmcp's planTopN escapes — refusal is always-safe here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)