### PR TITLE
port(a2td #216): promised-sort loss fails the receipt

### DIFF
--- a/src/desktop/validation/promise-check.test.ts
+++ b/src/desktop/validation/promise-check.test.ts
@@ -5,9 +5,22 @@ import {
   formatWorkbookPromiseCheck,
   formatWorksheetPromiseCheck,
 } from './promise-check.js';
+import type { ReadbackFinding } from './readback-verify.js';
 import type { ValidationIssue } from './types.js';
 
 const warning = (): ValidationIssue => ({ ruleId: 'x', severity: 'warning', message: 'w' });
+
+const SORT_COLUMN = '[DS].[none:State:nk]';
+
+/** A readback sort finding for a submitted <computed-sort> (the promised sort). */
+const computedSortFinding = (readback: 'missing' | 'changed'): ReadbackFinding => ({
+  kind: 'sort',
+  node: 'computed-sort',
+  column: SORT_COLUMN,
+  intended: `<computed-sort column="${SORT_COLUMN}" direction="DESC">`,
+  readback,
+  severity: 'warning',
+});
 
 describe('promise check receipt (W-23447506)', () => {
   it('formats clean readback as verified', () => {
@@ -57,5 +70,68 @@ describe('promise check receipt (W-23447506)', () => {
   it('formats dashboard applies as honestly unverified', () => {
     const text = formatDashboardPromiseCheck([]);
     expect(text).toContain('full dashboard intent NOT re-verified');
+  });
+});
+
+describe('promise check — promised-sort honesty (W66 item 4)', () => {
+  // (a) submitted-with-sort + readback-lost-sort → receipt NOT "verified".
+  it('dropped promised computed-sort → failed, never verified', () => {
+    const text = formatWorksheetPromiseCheck({
+      validationWarnings: [],
+      readback: { ok: true, status: 'warning' },
+      readbackFindings: [computedSortFinding('missing')],
+    });
+    expect(text).not.toContain('HOST VERIFICATION — verified');
+    expect(text).toContain('HOST VERIFICATION — failed');
+    expect(text).toContain('promised sort NOT verified');
+    expect(text).toContain('Do not claim the change is confirmed');
+  });
+
+  it('changed promised computed-sort → failed, never verified', () => {
+    const text = formatWorksheetPromiseCheck({
+      validationWarnings: [],
+      readback: { ok: true, status: 'warning' },
+      readbackFindings: [computedSortFinding('changed')],
+    });
+    expect(text).toContain('HOST VERIFICATION — failed');
+    expect(text).not.toContain('HOST VERIFICATION — verified');
+  });
+
+  // (b) submitted-without-a-promised-sort + sort drift → unchanged (verified).
+  it('incidental shelf-sort drift (no promised computed-sort) stays verified', () => {
+    const drift: ReadbackFinding = {
+      kind: 'sort',
+      node: 'shelf-sort-v2',
+      column: SORT_COLUMN,
+      intended: `<shelf-sort-v2 column="${SORT_COLUMN}">`,
+      readback: 'changed',
+      severity: 'warning',
+    };
+    const text = formatWorksheetPromiseCheck({
+      validationWarnings: [],
+      readback: { ok: true, status: 'warning' },
+      readbackFindings: [drift],
+    });
+    expect(text).toContain('HOST VERIFICATION — verified');
+    expect(text).not.toContain('promised sort NOT verified');
+  });
+
+  it('no sort findings at all → unchanged warning→verified behavior', () => {
+    const text = formatWorksheetPromiseCheck({
+      validationWarnings: [],
+      readback: { ok: true, status: 'warning' },
+      readbackFindings: [],
+    });
+    expect(text).toContain('HOST VERIFICATION — verified');
+  });
+
+  // (c) sort intact → verified as today.
+  it('clean readback with intact sort → verified', () => {
+    const text = formatWorksheetPromiseCheck({
+      validationWarnings: [],
+      readback: { ok: true, status: 'passed' },
+      readbackFindings: [],
+    });
+    expect(text).toContain('HOST VERIFICATION — verified');
   });
 });

--- a/src/desktop/validation/promise-check.ts
+++ b/src/desktop/validation/promise-check.ts
@@ -11,7 +11,7 @@
  *
  * Ported from agent-to-tableau-desktop.
  */
-import type { ReadbackVerificationResult } from './readback-verify.js';
+import type { ReadbackFinding, ReadbackVerificationResult } from './readback-verify.js';
 import type { ValidationIssue } from './types.js';
 
 export type PromiseOutcome = 'verified' | 'unverified' | 'failed';
@@ -19,6 +19,27 @@ export type PromiseOutcome = 'verified' | 'unverified' | 'failed';
 export interface WorksheetReceiptInput {
   validationWarnings: ValidationIssue[];
   readback: ReadbackVerificationResult | undefined;
+  /**
+   * Readback findings for this apply (same list the warnings above render from).
+   * Used to detect a PROMISED sort — a `<computed-sort>` present in the SUBMITTED
+   * XML — that Tableau dropped or changed on readback. That is a claim failure
+   * ("sorted descending" is exactly what was asked), NOT the incidental sort
+   * drift the readback verifier otherwise treats as a warning, so it must not
+   * ride out as "verified". (W66 item 4)
+   */
+  readbackFindings?: ReadbackFinding[];
+}
+
+/**
+ * True when a readback finding proves a submitted `<computed-sort>` did not
+ * survive intact. `verifyWorksheetReadback` only emits a sort finding for a sort
+ * that was in the SUBMITTED XML, and stamps `node` with the sort tag — so a
+ * `computed-sort` sort finding is definitionally "the promise had a computed-sort
+ * and readback lost/changed it". A `shelf-sort-v2` (incidental) finding does not
+ * qualify, and a submission with no sort produces no finding at all.
+ */
+function promisedSortNotVerified(findings: ReadbackFinding[] | undefined): boolean {
+  return (findings ?? []).some((f) => f.kind === 'sort' && f.node === 'computed-sort');
 }
 
 function formatPreflight(validationWarnings: ValidationIssue[]): string {
@@ -49,6 +70,16 @@ export function formatWorksheetPromiseCheck(input: WorksheetReceiptInput): strin
       outcome = 'unverified';
       parts.push('readback unavailable');
       break;
+  }
+  // A `<computed-sort>` in the submitted XML is an explicit sort promise ("sorted
+  // descending"). If readback shows it dropped/changed, the sort claim FAILED and
+  // must never be labeled verified on the warning-status path (readback sort
+  // discrepancies are warnings, and warnings otherwise map to verified). Incidental
+  // drift — a submission with no `<computed-sort>`, or a non-promise shelf sort —
+  // yields no qualifying finding and is left unchanged. (W66 item 4)
+  if (outcome === 'verified' && promisedSortNotVerified(input.readbackFindings)) {
+    outcome = 'failed';
+    parts.push('promised sort NOT verified (computed-sort dropped/changed on readback)');
   }
   const guard =
     outcome === 'verified'

--- a/src/tools/desktop/coordination/buildAndApplyWorksheet.ts
+++ b/src/tools/desktop/coordination/buildAndApplyWorksheet.ts
@@ -311,6 +311,7 @@ export const getBuildAndApplyWorksheetTool = (
             ? formatWorksheetPromiseCheck({
                 validationWarnings: applyResult.value.validationWarnings ?? [],
                 readback: applyResult.value.readbackVerification,
+                readbackFindings: applyResult.value.readbackWarnings,
               })
             : '';
 

--- a/src/tools/desktop/worksheet/applyWorksheet.ts
+++ b/src/tools/desktop/worksheet/applyWorksheet.ts
@@ -157,6 +157,7 @@ export const getApplyWorksheetTool = (
             ? formatWorksheetPromiseCheck({
                 validationWarnings: result.value.validationWarnings ?? [],
                 readback: result.value.readbackVerification,
+                readbackFindings: result.value.readbackWarnings,
               })
             : '';
 


### PR DESCRIPTION
Twin of tableau/agent-to-tableau-desktop#216. Port-fidelity review: SHIP (re-validated; error-severity findings take the Err path so the success receipt can never mislabel them). **Deliberately unported:** the receipt-honoring guidance rule — `DESKTOP_INSTRUCTIONS` is surface-counted and even a trimmed version overflows the 46,000-byte combined-lean cliff by ~244B (measured: 45,848/46,000 current). Needs a surface trim or an on-demand knowledge-module decision — the mechanical honesty ships regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)