### PR TITLE
port(a2td #215): compose-focus suppression (parallel builds stop stealing focus)

### DIFF
--- a/src/desktop/commands/workbook/loadWorksheetXml.test.ts
+++ b/src/desktop/commands/workbook/loadWorksheetXml.test.ts
@@ -103,6 +103,25 @@ describe('loadWorksheetXml (Agent API transport, default)', () => {
     });
   });
 
+  it('suppresses the post-apply goto-sheet when suppressFocus is set (compose-focus seam)', async () => {
+    // Plan-owned worksheet apply: the final dashboard apply owns focus, so a parallel worksheet
+    // apply must NOT issue its own goto-sheet. The apply + readback still run and still succeed.
+    const { executor, calls } = dispatchingAgentExecutor(validXml);
+
+    const result = await loadWorksheetXml({
+      worksheetName,
+      xml: validXml,
+      executor,
+      signal: mockSignal,
+      suppressFocus: true,
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(calls.some((c) => c.command === 'load-worksheet')).toBe(true);
+    expect(calls.some((c) => c.command === 'save-worksheet')).toBe(true); // readback still runs
+    expect(calls.some((c) => c.command === 'goto-sheet')).toBe(false); // focus suppressed
+  });
+
   it('keeps worksheet apply successful when focusing the worksheet fails', async () => {
     const error = {
       type: 'command-failed' as const,

--- a/src/desktop/commands/workbook/loadWorksheetXml.ts
+++ b/src/desktop/commands/workbook/loadWorksheetXml.ts
@@ -204,10 +204,15 @@ export async function loadWorksheetXml({
   executor,
   signal,
   readbackVerificationOut,
+  suppressFocus = false,
 }: {
   worksheetName: string;
   xml: string;
   readbackVerificationOut?: ReadbackVerificationResult[];
+  // When true, skip the post-apply goto-sheet. Set by build-and-apply-worksheet for
+  // worksheets that belong to a multi-task dashboard plan, so the final dashboard apply
+  // owns focus instead of the last of N parallel worksheet applies (compose-focus seam).
+  suppressFocus?: boolean;
 } & WithExecutorAndAbortSignal): Promise<LoadWorksheetXmlResult> {
   xml = xml.trim();
   if (!xml || (!xml.startsWith('<?xml') && !xml.startsWith('<'))) {
@@ -271,6 +276,7 @@ export async function loadWorksheetXml({
         executor,
         signal,
         readbackVerificationOut,
+        suppressFocus,
       })
     : loadWorksheetXmlViaAgentApi({
         worksheetName: canonicalName,
@@ -278,6 +284,7 @@ export async function loadWorksheetXml({
         executor,
         signal,
         readbackVerificationOut,
+        suppressFocus,
       }));
   if (result.isErr()) {
     return result;
@@ -293,10 +300,12 @@ async function loadWorksheetXmlViaAgentApi({
   executor,
   signal,
   readbackVerificationOut,
+  suppressFocus = false,
 }: {
   worksheetName: string;
   xml: string;
   readbackVerificationOut?: ReadbackVerificationResult[];
+  suppressFocus?: boolean;
 } & WithExecutorAndAbortSignal): Promise<LoadWorksheetXmlResult> {
   const result = await executor.executeCommand({
     namespace: 'tabui',
@@ -356,12 +365,17 @@ async function loadWorksheetXmlViaAgentApi({
   const outcomeResult = readbackOutcome(verification);
   if (outcomeResult.isErr()) return outcomeResult;
 
-  await focusAppliedSheetBestEffort({
-    sheetName: worksheetName,
-    appliedVia: 'load-worksheet',
-    executor,
-    signal,
-  });
+  // Focus the applied sheet UNLESS this apply belongs to a multi-task plan (compose-focus
+  // seam): there the final dashboard apply owns focus, so parallel worksheet applies must
+  // not race to steal it.
+  if (!suppressFocus) {
+    await focusAppliedSheetBestEffort({
+      sheetName: worksheetName,
+      appliedVia: 'load-worksheet',
+      executor,
+      signal,
+    });
+  }
 
   return outcomeResult;
 }
@@ -372,10 +386,12 @@ async function loadWorksheetXmlViaExternalApi({
   executor,
   signal,
   readbackVerificationOut,
+  suppressFocus = false,
 }: {
   worksheetName: string;
   xml: string;
   readbackVerificationOut?: ReadbackVerificationResult[];
+  suppressFocus?: boolean;
 } & WithExecutorAndAbortSignal): Promise<LoadWorksheetXmlResult> {
   return withApplyLock(async () => {
     const workbookResult = await getWorkbookXml({ executor, signal });
@@ -412,12 +428,16 @@ async function loadWorksheetXmlViaExternalApi({
     const outcomeResult = readbackOutcome(verification);
     if (outcomeResult.isErr()) return outcomeResult;
 
-    await focusAppliedSheetBestEffort({
-      sheetName: worksheetName,
-      appliedVia: 'load-worksheet',
-      executor,
-      signal,
-    });
+    // Focus the applied sheet UNLESS this apply belongs to a multi-task plan (compose-focus
+    // seam) — the final dashboard apply owns focus in that case.
+    if (!suppressFocus) {
+      await focusAppliedSheetBestEffort({
+        sheetName: worksheetName,
+        appliedVia: 'load-worksheet',
+        executor,
+        signal,
+      });
+    }
 
     return outcomeResult;
   });

--- a/src/tools/desktop/coordination/buildAndApplyWorksheet.test.ts
+++ b/src/tools/desktop/coordination/buildAndApplyWorksheet.test.ts
@@ -24,6 +24,7 @@ import { rewriteFieldReferences } from '../../../desktop/templates/fieldReferenc
 import { getTemplateColumnRequirements } from '../../../desktop/templates/templateColumnRequirements.js';
 import { readTemplate } from '../../../desktop/templates/templatePath.js';
 import { TableauDesktopRequestHandlerExtra } from '../toolContext.js';
+import { markPlanBuildWorksheets, resetPlanBuildWorksheets } from './planBuildFocus.js';
 
 const SESSION = 'session-1';
 const FLAG = 'ROUTE_ENFORCEMENT';
@@ -189,6 +190,51 @@ describe('buildAndApplyWorksheetTool', () => {
     expect(result.isError).toBe(true);
     invariant(result.content[0].type === 'text');
     expect(result.content[0].text).toContain('<worksheet>');
+  });
+});
+
+// Compose-focus seam (a2td #215 port): build-and-apply-worksheet suppresses its per-sheet
+// focus only for worksheets recorded by a multi-task plan (session+name scoped), so the final
+// dashboard apply owns focus. Standalone applies keep focusing.
+describe('buildAndApplyWorksheetTool — plan-build focus suppression', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetPlanBuildWorksheets();
+  });
+
+  afterEach(() => {
+    resetPlanBuildWorksheets();
+  });
+
+  it('does NOT suppress focus for a standalone apply (no plan recorded)', async () => {
+    const result = await getResult({ session: SESSION, taskSpec: TASK_SPEC_BASE });
+
+    expect(result.isError).toBeFalsy();
+    expect(loadWorksheetXml).toHaveBeenCalledWith(
+      expect.objectContaining({ worksheetName: 'Sheet1', suppressFocus: false }),
+    );
+  });
+
+  it('suppresses focus when the (session, worksheet) was recorded by a plan', async () => {
+    markPlanBuildWorksheets(SESSION, ['Sheet1']);
+
+    const result = await getResult({ session: SESSION, taskSpec: TASK_SPEC_BASE });
+
+    expect(result.isError).toBeFalsy();
+    expect(loadWorksheetXml).toHaveBeenCalledWith(
+      expect.objectContaining({ worksheetName: 'Sheet1', suppressFocus: true }),
+    );
+  });
+
+  it('does NOT suppress focus when the plan was recorded for a DIFFERENT session', async () => {
+    markPlanBuildWorksheets('other-session', ['Sheet1']);
+
+    const result = await getResult({ session: SESSION, taskSpec: TASK_SPEC_BASE });
+
+    expect(result.isError).toBeFalsy();
+    expect(loadWorksheetXml).toHaveBeenCalledWith(
+      expect.objectContaining({ worksheetName: 'Sheet1', suppressFocus: false }),
+    );
   });
 });
 

--- a/src/tools/desktop/coordination/buildAndApplyWorksheet.ts
+++ b/src/tools/desktop/coordination/buildAndApplyWorksheet.ts
@@ -32,6 +32,7 @@ import {
 } from '../../../errors/mcpToolError.js';
 import { DesktopMcpServer } from '../../../server.desktop.js';
 import { DesktopTool } from '../tool.js';
+import { isPlanBuildWorksheet } from './planBuildFocus.js';
 
 function isRouteGateResult(result: unknown): result is RouteGateResult {
   return (
@@ -285,11 +286,18 @@ export const getBuildAndApplyWorksheetTool = (
           // Apply to Tableau
           const executor = await extra.getExecutor(resolvedSession);
           const signal = extra.signal;
+          // Suppress the per-worksheet goto-sheet ONLY when this apply belongs to a multi-task
+          // dashboard plan (recorded by plan-dashboard-creation): there the last of N parallel
+          // worksheet applies would otherwise steal focus, and only the final dashboard apply
+          // should own it. This tool is publicly reachable, so a STANDALONE hand-crafted taskSpec
+          // (no plan recorded for this session/name) still focuses its sheet as before.
+          const suppressFocus = isPlanBuildWorksheet(resolvedSession, worksheetName);
           const applyResult = await loadWorksheetXml({
             worksheetName,
             xml: worksheetXml,
             executor,
             signal,
+            suppressFocus,
           });
 
           if (applyResult.isErr()) {

--- a/src/tools/desktop/coordination/planBuildFocus.test.ts
+++ b/src/tools/desktop/coordination/planBuildFocus.test.ts
@@ -1,0 +1,46 @@
+import {
+  isPlanBuildWorksheet,
+  markPlanBuildWorksheets,
+  resetPlanBuildWorksheets,
+} from './planBuildFocus.js';
+
+afterEach(() => resetPlanBuildWorksheets());
+
+// Compose-focus seam (a2td #215 port): focus-suppression is scoped to multi-task plans.
+describe('plan-build focus ownership (internal seam)', () => {
+  it('standalone worksheet (no plan recorded) is NOT focus-suppressed', () => {
+    expect(isPlanBuildWorksheet('session-1', 'Sales by State')).toBe(false);
+  });
+
+  it('a worksheet recorded by a plan IS focus-suppressed; others / other sessions are not', () => {
+    markPlanBuildWorksheets('session-1', ['Revenue Bar', 'Revenue KPI']);
+
+    expect(isPlanBuildWorksheet('session-1', 'Revenue Bar')).toBe(true);
+    expect(isPlanBuildWorksheet('session-1', '  Revenue KPI  ')).toBe(true); // trimmed match
+    expect(isPlanBuildWorksheet('session-1', 'Not In Plan')).toBe(false);
+    expect(isPlanBuildWorksheet('other-session', 'Revenue Bar')).toBe(false); // session-scoped
+  });
+
+  it('trims recorded names so a padded plan name still matches an unpadded apply', () => {
+    markPlanBuildWorksheets('session-1', ['  Padded Sheet  ']);
+    expect(isPlanBuildWorksheet('session-1', 'Padded Sheet')).toBe(true);
+  });
+
+  it('reset clears all recorded ownership', () => {
+    markPlanBuildWorksheets('session-1', ['Revenue Bar']);
+    resetPlanBuildWorksheets();
+    expect(isPlanBuildWorksheet('session-1', 'Revenue Bar')).toBe(false);
+  });
+
+  // Disclosed residual (a2td #215): a later plan for the same session OVERWRITES the set.
+  // Names dropped from the new plan stop being suppressed; there is no per-apply eviction, so
+  // names that stay in the new plan remain suppressed until re-plan/restart.
+  it('re-planning a session overwrites the previous set (drops stale names, keeps re-listed ones)', () => {
+    markPlanBuildWorksheets('session-1', ['Old Only', 'Shared']);
+    markPlanBuildWorksheets('session-1', ['Shared', 'New Only']);
+
+    expect(isPlanBuildWorksheet('session-1', 'Old Only')).toBe(false); // dropped by re-plan
+    expect(isPlanBuildWorksheet('session-1', 'Shared')).toBe(true); // still in the new plan
+    expect(isPlanBuildWorksheet('session-1', 'New Only')).toBe(true); // added by re-plan
+  });
+});

--- a/src/tools/desktop/coordination/planBuildFocus.ts
+++ b/src/tools/desktop/coordination/planBuildFocus.ts
@@ -1,0 +1,42 @@
+// ── Multi-task-plan focus ownership (internal seam, NOT a tool-surface field) ──
+//
+// A dashboard-creation plan builds N worksheets + 1 dashboard. Phase 2 tells the
+// client to spawn those worksheet applies in PARALLEL (see plan-dashboard-creation),
+// and every build-and-apply-worksheet apply otherwise issues its own goto-sheet
+// (focusAppliedSheetBestEffort). With parallel applies the LAST completer would steal
+// focus nondeterministically onto a worksheet — the live blank-"Sheet 1" symptom —
+// when only the FINAL dashboard apply should own focus.
+//
+// The plan tool records the worksheet names it owns, keyed by session; build-and-apply-
+// worksheet suppresses focus ONLY for a worksheet that belongs to such a plan. A
+// standalone hand-crafted taskSpec (no plan recorded for that session/name) focuses as
+// before.
+//
+// This is deliberately an internal module seam rather than a taskSpec schema field: the
+// desktop tool surface is already near the ToolSearch auto-deferral cliff and both
+// plan-dashboard-creation and build-and-apply-worksheet are grandfathered at their
+// current byte sizes (see server.desktop.test.ts byte budget), so a public input field
+// is not acceptable.
+//
+// Residual (disclosed, mirrors a2td #215): entries are process-global and session-keyed,
+// and are only ever replaced by a later plan for the same session (markPlanBuildWorksheets
+// overwrites) or cleared on process restart — there is no per-apply eviction. So after a
+// plan, a genuinely standalone build-and-apply-worksheet that reuses a planned name in the
+// SAME session stays focus-suppressed until the session re-plans (which overwrites the set)
+// or the process restarts. Re-planning with a different worksheet set drops the stale names.
+const PLAN_BUILD_WORKSHEETS = new Map<string, Set<string>>();
+
+/** Record the worksheet names a multi-task dashboard plan owns for a session. */
+export function markPlanBuildWorksheets(sessionId: string, worksheetNames: string[]): void {
+  PLAN_BUILD_WORKSHEETS.set(sessionId, new Set(worksheetNames.map((n) => n.trim())));
+}
+
+/** True when a worksheet apply belongs to a recorded multi-task plan (→ suppress focus). */
+export function isPlanBuildWorksheet(sessionId: string, worksheetName: string): boolean {
+  return PLAN_BUILD_WORKSHEETS.get(sessionId)?.has(worksheetName.trim()) ?? false;
+}
+
+/** Test-only: clear all recorded plan-build focus ownership. */
+export function resetPlanBuildWorksheets(): void {
+  PLAN_BUILD_WORKSHEETS.clear();
+}

--- a/src/tools/desktop/coordination/planDashboardCreation.test.ts
+++ b/src/tools/desktop/coordination/planDashboardCreation.test.ts
@@ -18,6 +18,7 @@ import { getWorkbookXml } from '../../../desktop/commands/workbook/getWorkbookXm
 import { FieldResolution, resolveField } from '../../../desktop/metadata/index.js';
 import { getTemplatesDir } from '../../../desktop/templates/templatePath.js';
 import { TableauDesktopRequestHandlerExtra } from '../toolContext.js';
+import { isPlanBuildWorksheet, resetPlanBuildWorksheets } from './planBuildFocus.js';
 
 const SESSION = 'session-1';
 
@@ -231,6 +232,74 @@ describe('planDashboardCreationTool', () => {
     expect(result.isError).toBeFalsy();
     invariant(result.content[0].type === 'text');
     expect(result.content[0].text).not.toContain('PARALLELIZE');
+  });
+});
+
+// Compose-focus seam (a2td #215 port): the plan tool records every planned worksheet name for
+// its session so build-and-apply-worksheet can suppress per-sheet focus (final dashboard apply
+// owns it). Names outside the plan, and other sessions, stay standalone (unrecorded).
+describe('planDashboardCreationTool — records plan worksheets for focus suppression', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetPlanBuildWorksheets();
+  });
+
+  afterEach(() => {
+    resetPlanBuildWorksheets();
+  });
+
+  it('registers every planned worksheet name (and leaves standalone names / other sessions unrecorded)', async () => {
+    vi.mocked(resolveField).mockReturnValue(makeExactResolution('Sales'));
+
+    const result = await getResult({
+      session: 'plan-session',
+      dashboardName: 'Exec Dashboard',
+      worksheets: [
+        { name: 'Sales by Region', type: 'chart', fields: ['Sales'] },
+        { name: 'Profit KPI', type: 'kpi', fields: ['Sales'] },
+      ],
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(isPlanBuildWorksheet('plan-session', 'Sales by Region')).toBe(true);
+    expect(isPlanBuildWorksheet('plan-session', 'Profit KPI')).toBe(true);
+    // A name that was not part of the plan, and a different session, stay standalone.
+    expect(isPlanBuildWorksheet('plan-session', 'Some Other Sheet')).toBe(false);
+    expect(isPlanBuildWorksheet('different-session', 'Sales by Region')).toBe(false);
+  });
+
+  it('does not record any worksheet when planning is BLOCKED on an ambiguous field', async () => {
+    vi.mocked(resolveField).mockReturnValue({
+      kind: 'ambiguous',
+      query: 'Sales',
+      candidates: [
+        {
+          column_ref: '[DS1].[sum:Sales:qk]',
+          datasource: 'DS1',
+          column_name: 'Sales',
+          role: 'measure',
+          is_aggregated: false,
+        },
+        {
+          column_ref: '[DS2].[sum:Sales:qk]',
+          datasource: 'DS2',
+          column_name: 'Sales',
+          role: 'measure',
+          is_aggregated: false,
+        },
+      ],
+    });
+
+    const result = await getResult({
+      session: 'plan-session',
+      dashboardName: 'Blocked Dashboard',
+      worksheets: [{ name: 'Sales by Region', type: 'chart', fields: ['Sales'] }],
+    });
+
+    expect(result.isError).toBe(true);
+    // Planning bailed before building tasks, so nothing is recorded — a later standalone apply
+    // of this name must still focus.
+    expect(isPlanBuildWorksheet('plan-session', 'Sales by Region')).toBe(false);
   });
 });
 

--- a/src/tools/desktop/coordination/planDashboardCreation.ts
+++ b/src/tools/desktop/coordination/planDashboardCreation.ts
@@ -11,6 +11,7 @@ import { ArgsValidationError, DesktopCommandExecutionError } from '../../../erro
 import { DesktopMcpServer } from '../../../server.desktop.js';
 import { attachNextAction, prefillNextAction } from '../structuredContent.js';
 import { DesktopTool } from '../tool.js';
+import { markPlanBuildWorksheets } from './planBuildFocus.js';
 
 const paramsSchema = {
   session: z.string().optional().describe('Session ID; optional if pinned or unique.'),
@@ -194,6 +195,16 @@ export const getPlanDashboardCreationTool = (
               workbookFile,
             };
           });
+
+          // Record that these worksheets belong to a multi-task plan whose FINAL dashboard
+          // apply owns focus, so each (parallel) build-and-apply-worksheet suppresses its own
+          // goto-sheet. Standalone callers of build-and-apply-worksheet are not recorded here
+          // and keep focusing as before. Recorded regardless of canParallelize: sequential
+          // plans also want the dashboard to own the final focus.
+          markPlanBuildWorksheets(
+            resolvedSession,
+            worksheetTasks.map((t) => t.worksheetName),
+          );
 
           const safeDashName = dashboardName.replace(/[^a-zA-Z0-9]/g, '_');
           const dashboardFile = cache.getCacheFilePath({ prefix: 'dashboard', id: safeDashName });


### PR DESCRIPTION
Completes the focus-follows story in tmcp: #522 shipped the canonical-name gate; this ports a2td #215's remaining half — the parallel-focus race (the live blank-Sheet-1 'kept going back' symptom). Gap was CONFIRMED in this repo (plan tool instructs parallel subagent builds at >=5 sheets; both API paths focused unconditionally). Port-fidelity review: SHIP (independently re-validated, 87 targeted tests + tsc clean; full sweep 2341 green). Disclosed residual mirrors a2td: plan marks evict on re-plan/restart only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)