### PR TITLE
port(a2td #213): resolve-field self-heals stale workbook caches

### DIFF
--- a/src/tools/desktop/fields/listAvailableFields.ts
+++ b/src/tools/desktop/fields/listAvailableFields.ts
@@ -1,15 +1,14 @@
 import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
-import { existsSync, readFileSync, writeFileSync } from 'fs';
+import { existsSync, readFileSync } from 'fs';
 import { Ok } from 'ts-results-es';
 import { z } from 'zod';
 
-import { writeSidecar } from '../../../desktop/commands/workbook/cacheFingerprint.js';
-import { getWorkbookXml } from '../../../desktop/commands/workbook/getWorkbookXml.js';
 import { listAvailableFields } from '../../../desktop/metadata/index.js';
 import { resolveSession } from '../../../desktop/sessionResolution.js';
-import { FileNotFoundError, FileReadError, UnknownError } from '../../../errors/mcpToolError.js';
+import { FileNotFoundError, FileReadError } from '../../../errors/mcpToolError.js';
 import { DesktopMcpServer } from '../../../server.desktop.js';
 import { DesktopTool } from '../tool.js';
+import { refreshWorkbookCache } from './refreshWorkbookCache.js';
 
 const paramsSchema = {
   session: z.string().optional().describe('Session ID; refreshes live workbook first.'),
@@ -81,22 +80,19 @@ export const getListAvailableFieldsTool = (
               return sessionResult.error.toErr();
             }
 
-            const resolvedSession = sessionResult.value;
-            const executor = await extra.getExecutor(resolvedSession);
-            const result = await getWorkbookXml({ executor, signal: extra.signal });
-            if (result.isErr()) {
-              return new UnknownError(
-                `Failed to refresh workbook from Tableau before listing fields: ${JSON.stringify(result.error)}. Retry without session to read the cache as-is.`,
-              ).toErr();
+            // Shared refresh seam (W-23447478): resolve-field reuses the identical
+            // re-snapshot + cache/sidecar-rewrite path. list-available-fields fails
+            // hard on a refresh failure (never silently lists stale fields).
+            const refresh = await refreshWorkbookCache({
+              extra,
+              workbookFile,
+              resolvedSession: sessionResult.value,
+              action: 'listing fields',
+            });
+            if (!refresh.ok) {
+              return refresh.error.toErr();
             }
-
-            workbookXml = result.value;
-            try {
-              writeFileSync(workbookFile, workbookXml, 'utf-8');
-              writeSidecar(workbookFile, resolvedSession);
-            } catch (error) {
-              return new FileReadError(error).toErr();
-            }
+            workbookXml = refresh.xml;
           } else {
             try {
               workbookXml = readFileSync(workbookFile, 'utf-8');

--- a/src/tools/desktop/fields/refreshWorkbookCache.ts
+++ b/src/tools/desktop/fields/refreshWorkbookCache.ts
@@ -1,0 +1,93 @@
+import { writeFileSync } from 'fs';
+
+import { writeSidecar } from '../../../desktop/commands/workbook/cacheFingerprint.js';
+import { getWorkbookXml } from '../../../desktop/commands/workbook/getWorkbookXml.js';
+import { FileReadError, McpToolError, UnknownError } from '../../../errors/mcpToolError.js';
+import { getExceptionMessage } from '../../../utils/getExceptionMessage.js';
+import { TableauDesktopRequestHandlerExtra } from '../toolContext.js';
+
+/**
+ * Outcome of a live workbook re-snapshot. `ok` carries the fresh XML; a failure
+ * carries both a raw `reason` (for callers that degrade gracefully and want to
+ * surface why) and a ready-to-return `error` McpToolError (for callers that
+ * fail hard).
+ */
+export type RefreshResult =
+  | { ok: true; xml: string }
+  | { ok: false; reason: string; error: McpToolError };
+
+/**
+ * W-23447478 (P2a concurrency): the retry's "exactly once" is per-invocation, so
+ * two concurrent callers against the same stale cache could each fire their own
+ * live re-snapshot and RACE the cache/sidecar writes (duplicate snapshots,
+ * last-writer-wins contents). This module-scope in-flight map keyed by
+ * `workbookFile` dedups the refresh: a second concurrent caller awaits the SAME
+ * promise instead of issuing another getWorkbookXml. The entry is cleared once
+ * the refresh settles (success OR failure) so a later, non-overlapping call
+ * refreshes again.
+ */
+const inflightWorkbookRefreshes = new Map<string, Promise<RefreshResult>>();
+
+/**
+ * W-23447478: a datasource connected AFTER the workbook cache was written is
+ * invisible to a cache-only read — the P0 "agent doesn't recognize my
+ * datasource" shape. Re-snapshot the live workbook, rewrite the cache file +
+ * sidecar, and return the fresh XML.
+ *
+ * On an EXPLICIT refresh failure (getWorkbookXml returns Err, or the cache/sidecar
+ * write throws) this returns `{ ok: false }` with the reason + a ready McpToolError
+ * — never a silent stale fallback. If the underlying getWorkbookXml/getExecutor
+ * REJECTS (transient executor/Agent-API fault) this rejects too, so callers choose
+ * how to handle it: list-available-fields lets it throw (its unchanged behavior);
+ * resolve-field degrades it gracefully (P1). Concurrent callers for the same
+ * workbookFile share one refresh (P2a). Shared so the refresh mechanics stay
+ * identical across the field tools.
+ */
+export async function refreshWorkbookCache({
+  extra,
+  workbookFile,
+  resolvedSession,
+  action,
+}: {
+  extra: TableauDesktopRequestHandlerExtra;
+  workbookFile: string;
+  resolvedSession: string;
+  action: string;
+}): Promise<RefreshResult> {
+  const inflight = inflightWorkbookRefreshes.get(workbookFile);
+  if (inflight) return inflight;
+
+  const refreshPromise: Promise<RefreshResult> = (async () => {
+    const executor = await extra.getExecutor(resolvedSession);
+    const result = await getWorkbookXml({ executor, signal: extra.signal });
+    if (result.isErr()) {
+      const reason = JSON.stringify(result.error);
+      return {
+        ok: false,
+        reason,
+        error: new UnknownError(
+          `Failed to refresh workbook from Tableau before ${action}: ${reason}. Retry without session to read the cache as-is.`,
+        ),
+      };
+    }
+
+    const xml = result.value;
+    try {
+      writeFileSync(workbookFile, xml, 'utf-8');
+      writeSidecar(workbookFile, resolvedSession);
+    } catch (error) {
+      return { ok: false, reason: getExceptionMessage(error), error: new FileReadError(error) };
+    }
+    return { ok: true, xml };
+  })();
+
+  // Register the in-flight promise BEFORE awaiting so a concurrent caller dedups
+  // onto it; clear it once settled (including rejection) so a rejected refresh
+  // never wedges a permanently-stale entry.
+  inflightWorkbookRefreshes.set(workbookFile, refreshPromise);
+  try {
+    return await refreshPromise;
+  } finally {
+    inflightWorkbookRefreshes.delete(workbookFile);
+  }
+}

--- a/src/tools/desktop/fields/resolveField.test.ts
+++ b/src/tools/desktop/fields/resolveField.test.ts
@@ -1,7 +1,10 @@
 import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
-import { existsSync, readFileSync } from 'fs';
+import { existsSync, readFileSync, writeFileSync } from 'fs';
+import { Err, Ok } from 'ts-results-es';
 import { z } from 'zod';
 
+import * as cacheFingerprintModule from '../../../desktop/commands/workbook/cacheFingerprint.js';
+import * as getWorkbookXmlModule from '../../../desktop/commands/workbook/getWorkbookXml.js';
 import * as metadataModule from '../../../desktop/metadata/index.js';
 import { FileNotFoundError, FileReadError } from '../../../errors/mcpToolError.js';
 import { DesktopMcpServer } from '../../../server.desktop.js';
@@ -10,6 +13,8 @@ import { Provider } from '../../../utils/provider.js';
 import { getMockRequestHandlerExtra } from '../toolContext.mock.js';
 import { getResolveFieldTool } from './resolveField.js';
 
+vi.mock('../../../desktop/commands/workbook/cacheFingerprint.js');
+vi.mock('../../../desktop/commands/workbook/getWorkbookXml.js');
 vi.mock('../../../desktop/metadata/index.js');
 vi.mock('fs');
 
@@ -72,8 +77,11 @@ describe('resolveFieldTool', () => {
       workbookFile: expect.any(Object),
       query: expect.any(Object),
       datasource: expect.any(Object),
+      session: expect.any(Object),
     });
-    expect(tool.annotations).toMatchObject({ readOnlyHint: true });
+    // With session, a not_found triggers a cache/sidecar rewrite (self-heal),
+    // so the tool is no longer strictly read-only (matches list-available-fields).
+    expect(tool.annotations).toMatchObject({ readOnlyHint: false });
   });
 
   it('should return error when workbook file does not exist', async () => {
@@ -159,16 +167,241 @@ describe('resolveFieldTool', () => {
   });
 });
 
+// W-23447478 (P0): resolve-field must self-heal a stale cache — a field that
+// exists only after a mid-session datasource connection. With session, a
+// not_found triggers exactly one live re-snapshot + retry; without session the
+// cache-only behavior is unchanged. Ported by content from a2td #213 to tmcp's
+// error/result conventions (Ok-wrapped { resolution, isError } body; CallToolResult
+// .isError stays false — the not_found signal lives in the JSON body).
+describe('resolve-field refresh-on-not_found (W-23447478)', () => {
+  const SESSION = 'session-1';
+  const STALE_XML =
+    '<workbook><datasources><datasource caption="Old DS" name="federated.old1"/></datasources></workbook>';
+  const LIVE_XML =
+    '<workbook><datasources><datasource caption="Fresh DS" name="federated.fresh1"/></datasources></workbook>';
+
+  const staleNotFound = {
+    kind: 'not_found' as const,
+    query: 'Sales',
+    candidates: [],
+    reason: 'no match for "Sales".',
+  };
+  const liveExact = {
+    kind: 'exact' as const,
+    query: 'Sales',
+    column_ref: '[Fresh DS].[sum:Sales:qk]',
+    datasource: 'Fresh DS',
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(writeFileSync).mockReturnValue(undefined);
+  });
+
+  function extraWithExecutor(): ReturnType<typeof getMockRequestHandlerExtra> {
+    return {
+      ...getMockRequestHandlerExtra(),
+      getExecutor: vi.fn().mockResolvedValue({} as never),
+    };
+  }
+
+  it('with session: not_found triggers exactly one live refresh + retry, finds field only in refreshed XML', async () => {
+    vi.mocked(readFileSync).mockReturnValue(STALE_XML);
+    vi.mocked(getWorkbookXmlModule.getWorkbookXml).mockResolvedValue(Ok(LIVE_XML));
+    vi.mocked(metadataModule.resolveField).mockImplementation((xml) =>
+      xml === LIVE_XML ? liveExact : staleNotFound,
+    );
+    const extra = extraWithExecutor();
+
+    const result = await getResult({
+      workbookFile: WORKBOOK_FILE,
+      query: 'Sales',
+      session: SESSION,
+      extra,
+    });
+
+    expect(getWorkbookXmlModule.getWorkbookXml).toHaveBeenCalledTimes(1);
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+    const body = JSON.parse(result.content[0].text);
+    expect(body.resolution.kind).toBe('exact');
+    expect(body.resolution.column_ref).toContain('Sales');
+    expect(body.isError).toBe(false);
+    // Cache + sidecar rewritten with the refreshed XML / current session.
+    expect(writeFileSync).toHaveBeenCalledWith(WORKBOOK_FILE, LIVE_XML, 'utf-8');
+    expect(cacheFingerprintModule.writeSidecar).toHaveBeenCalledWith(WORKBOOK_FILE, SESSION);
+    // Two resolves: once against the stale cache (miss), once against the refresh (hit).
+    expect(metadataModule.resolveField).toHaveBeenCalledTimes(2);
+  });
+
+  it('without session: cache-only, never refreshes, byte-identical not_found (no note appended)', async () => {
+    vi.mocked(readFileSync).mockReturnValue(STALE_XML);
+    vi.mocked(getWorkbookXmlModule.getWorkbookXml).mockResolvedValue(Ok(LIVE_XML));
+    vi.mocked(metadataModule.resolveField).mockReturnValue(staleNotFound);
+    const extra = extraWithExecutor();
+
+    const result = await getResult({ workbookFile: WORKBOOK_FILE, query: 'Sales', extra });
+
+    expect(extra.getExecutor).not.toHaveBeenCalled();
+    expect(getWorkbookXmlModule.getWorkbookXml).not.toHaveBeenCalled();
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+    const text = result.content[0].text;
+    // Byte-identical to the pre-change body: pure compact JSON, NOTHING concatenated
+    // after it. Round-trip identity proves no note was appended when session is absent.
+    expect(text).toBe(JSON.stringify({ resolution: staleNotFound, isError: true }));
+    expect(JSON.parse(text)).toEqual({ resolution: staleNotFound, isError: true });
+    expect(writeFileSync).not.toHaveBeenCalled();
+    expect(cacheFingerprintModule.writeSidecar).not.toHaveBeenCalled();
+  });
+
+  it('P1a: refresh returns an explicit failure → JSON-shaped not_found + refresh-failed note, no throw, cache untouched', async () => {
+    vi.mocked(readFileSync).mockReturnValue(STALE_XML);
+    vi.mocked(getWorkbookXmlModule.getWorkbookXml).mockResolvedValue(
+      Err({ type: 'command-timed-out', error: 'transient executor fault' }),
+    );
+    vi.mocked(metadataModule.resolveField).mockReturnValue(staleNotFound);
+    const extra = extraWithExecutor();
+
+    const result = await getResult({
+      workbookFile: WORKBOOK_FILE,
+      query: 'Sales',
+      session: SESSION,
+      extra,
+    });
+
+    expect(getWorkbookXmlModule.getWorkbookXml).toHaveBeenCalledTimes(1);
+    // Degrades to a normal result (never a thrown tool_error): CallToolResult.isError
+    // stays false, the not_found signal + note live in the body text.
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+    const text = result.content[0].text;
+    expect(text).toContain('"kind":"not_found"');
+    expect(text).toContain('transient executor fault');
+    expect(text).toContain('list-instances');
+    // The failed refresh must NOT rewrite the cache/sidecar (no partial write).
+    expect(writeFileSync).not.toHaveBeenCalled();
+    expect(cacheFingerprintModule.writeSidecar).not.toHaveBeenCalled();
+  });
+
+  it('P1b: refresh REJECTS (transient executor fault) → degrades, no thrown tool_error escapes', async () => {
+    vi.mocked(readFileSync).mockReturnValue(STALE_XML);
+    vi.mocked(getWorkbookXmlModule.getWorkbookXml).mockRejectedValue(
+      new Error('transient executor fault'),
+    );
+    vi.mocked(metadataModule.resolveField).mockReturnValue(staleNotFound);
+    const extra = extraWithExecutor();
+
+    // Must RESOLVE (not throw): a rejection must degrade, never escape as tool_error.
+    const result = await getResult({
+      workbookFile: WORKBOOK_FILE,
+      query: 'Sales',
+      session: SESSION,
+      extra,
+    });
+
+    expect(getWorkbookXmlModule.getWorkbookXml).toHaveBeenCalledTimes(1);
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+    const text = result.content[0].text;
+    expect(text).toContain('"kind":"not_found"');
+    expect(text).toContain('transient executor fault');
+    expect(text).toContain('list-instances');
+    expect(writeFileSync).not.toHaveBeenCalled();
+    expect(cacheFingerprintModule.writeSidecar).not.toHaveBeenCalled();
+  });
+
+  it('P2a: two concurrent resolves against the same stale cache trigger exactly ONE live refresh', async () => {
+    vi.mocked(readFileSync).mockReturnValue(STALE_XML);
+    vi.mocked(metadataModule.resolveField).mockImplementation((xml) =>
+      xml === LIVE_XML ? liveExact : staleNotFound,
+    );
+    // Defer the refresh so both invocations reach the (shared) in-flight refresh
+    // before either completes — the only way to exercise the concurrent-dedup guard.
+    let release: (() => void) | undefined;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    vi.mocked(getWorkbookXmlModule.getWorkbookXml).mockImplementation(async () => {
+      await gate;
+      return Ok(LIVE_XML);
+    });
+    const extra = extraWithExecutor();
+
+    const tool = getResolveFieldTool(new DesktopMcpServer());
+    const callback = await Provider.from(tool.callback);
+    const p1 = callback(
+      { workbookFile: WORKBOOK_FILE, query: 'Sales', datasource: undefined, session: SESSION },
+      extra,
+    );
+    const p2 = callback(
+      { workbookFile: WORKBOOK_FILE, query: 'Sales', datasource: undefined, session: SESSION },
+      extra,
+    );
+    await Promise.resolve();
+    release!();
+    const [r1, r2] = await Promise.all([p1, p2]);
+
+    // Exactly one live re-snapshot despite two concurrent resolves.
+    expect(getWorkbookXmlModule.getWorkbookXml).toHaveBeenCalledTimes(1);
+    expect(writeFileSync).toHaveBeenCalledTimes(1);
+    expect(r1.isError).toBe(false);
+    expect(r2.isError).toBe(false);
+    invariant(r1.content[0].type === 'text' && r2.content[0].type === 'text');
+    expect(JSON.parse(r1.content[0].text).resolution.kind).toBe('exact');
+    expect(JSON.parse(r2.content[0].text).resolution.kind).toBe('exact');
+  });
+
+  it('still not_found after one refresh: actionable message, refreshes once (no loop), cache rewritten', async () => {
+    const stillNotFound = {
+      kind: 'not_found' as const,
+      query: 'Nonexistent Field',
+      candidates: [],
+      reason: 'no match for "Nonexistent Field".',
+    };
+    vi.mocked(readFileSync).mockReturnValue(STALE_XML);
+    vi.mocked(getWorkbookXmlModule.getWorkbookXml).mockResolvedValue(Ok(LIVE_XML));
+    vi.mocked(metadataModule.resolveField).mockReturnValue(stillNotFound);
+    const extra = extraWithExecutor();
+
+    const result = await getResult({
+      workbookFile: WORKBOOK_FILE,
+      query: 'Nonexistent Field',
+      session: SESSION,
+      extra,
+    });
+
+    expect(getWorkbookXmlModule.getWorkbookXml).toHaveBeenCalledTimes(1);
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+    const text = result.content[0].text;
+    expect(text).toContain('"kind":"not_found"');
+    expect(text).toContain('genuinely does not exist');
+    expect(text).toContain('stop re-reading stale caches');
+    // The refresh DID succeed (field just absent), so the cache is rewritten to LIVE.
+    expect(writeFileSync).toHaveBeenCalledWith(WORKBOOK_FILE, LIVE_XML, 'utf-8');
+    expect(metadataModule.resolveField).toHaveBeenCalledTimes(2);
+  });
+});
+
 async function getResult({
   workbookFile,
   query,
   datasource,
+  session,
+  extra,
 }: {
   workbookFile: string;
   query: string;
   datasource?: string;
+  session?: string;
+  extra?: ReturnType<typeof getMockRequestHandlerExtra>;
 }): Promise<CallToolResult> {
   const tool = getResolveFieldTool(new DesktopMcpServer());
   const callback = await Provider.from(tool.callback);
-  return await callback({ workbookFile, query, datasource }, getMockRequestHandlerExtra());
+  return await callback(
+    { workbookFile, query, datasource, session },
+    extra ?? getMockRequestHandlerExtra(),
+  );
 }

--- a/src/tools/desktop/fields/resolveField.ts
+++ b/src/tools/desktop/fields/resolveField.ts
@@ -3,20 +3,35 @@ import { existsSync, readFileSync } from 'fs';
 import { Ok } from 'ts-results-es';
 import { z } from 'zod';
 
-import { resolveField } from '../../../desktop/metadata/index.js';
+import { type FieldResolution, resolveField } from '../../../desktop/metadata/index.js';
+import { resolveSession } from '../../../desktop/sessionResolution.js';
 import {
   FileNotFoundError,
   FileReadError,
   XmlModificationError,
 } from '../../../errors/mcpToolError.js';
+import { log } from '../../../logging/logger.js';
 import { DesktopMcpServer } from '../../../server.desktop.js';
+import { getExceptionMessage } from '../../../utils/getExceptionMessage.js';
 import { DesktopTool } from '../tool.js';
+import { refreshWorkbookCache } from './refreshWorkbookCache.js';
 
 const paramsSchema = {
   workbookFile: z.string().describe('Workbook cache file.'),
   query: z.string().describe('Field reference.'),
   datasource: z.string().optional().describe('Datasource to resolve ambiguity.'),
+  session: z
+    .string()
+    .optional()
+    .describe('Session ID; on not_found, refreshes live workbook and retries once.'),
 };
+
+interface ResolveFieldResult {
+  resolution: FieldResolution;
+  isError: boolean;
+  /** Optional guidance appended after the resolution JSON (self-heal outcome). */
+  note?: string;
+}
 
 const title = 'Resolve Field Name to column_ref';
 export const getResolveFieldTool = (server: DesktopMcpServer): DesktopTool<typeof paramsSchema> => {
@@ -32,15 +47,20 @@ export const getResolveFieldTool = (server: DesktopMcpServer): DesktopTool<typeo
     paramsSchema,
     annotations: {
       title,
-      readOnlyHint: true,
+      // With session, a not_found triggers a live re-snapshot that rewrites the
+      // workbook cache file + sidecar (same as list-available-fields).
+      readOnlyHint: false,
       destructiveHint: false,
       idempotentHint: true,
       openWorldHint: false,
     },
-    callback: async ({ workbookFile, query, datasource }, extra): Promise<CallToolResult> => {
+    callback: async (
+      { workbookFile, query, datasource, session },
+      extra,
+    ): Promise<CallToolResult> => {
       return await resolveFieldTool.logAndExecute({
         extra,
-        args: { workbookFile, query, datasource },
+        args: { workbookFile, query, datasource, session },
         callback: async () => {
           if (!existsSync(workbookFile)) {
             return new FileNotFoundError(workbookFile).toErr();
@@ -53,7 +73,7 @@ export const getResolveFieldTool = (server: DesktopMcpServer): DesktopTool<typeo
             return new FileReadError(error).toErr();
           }
 
-          let resolution;
+          let resolution: FieldResolution;
           try {
             resolution = resolveField(workbookXml, query, { datasource });
           } catch (error) {
@@ -62,9 +82,82 @@ export const getResolveFieldTool = (server: DesktopMcpServer): DesktopTool<typeo
             ).toErr();
           }
 
+          // W-23447478: a field/datasource connected AFTER the cache was written is
+          // invisible to a cache-only resolve — the P0 "agent doesn't recognize my
+          // datasource" shape. When a session is supplied and nothing matched
+          // (kind:"not_found" — also covers the empty-cache "workbook has no
+          // datasources" / "no fields" variants), re-snapshot the live workbook
+          // ONCE and retry via the shared refreshWorkbookCache helper (identical
+          // path to list-available-fields) so a mid-session datasource connection
+          // self-heals. Retry is bounded to one refresh (no loop).
+          //
+          // P1: a refresh FAILURE here must NOT escape as an MCP tool_error. Whether
+          // the helper returns an explicit failure or the underlying getWorkbookXml
+          // REJECTS, degrade to the ORIGINAL not_found resolution, annotate it with
+          // the reason + next action, and return it as a normal result — so consumers
+          // parsing the resolution JSON keep working and no outcome is dropped.
+          // (list-available-fields deliberately keeps its throw-on-reject behavior —
+          // only THIS retry path degrades.)
+          let refreshed = false;
+          let refreshFailure: string | undefined;
+          if (session && resolution.kind === 'not_found') {
+            try {
+              const sessionResult = resolveSession(session);
+              if (sessionResult.isErr()) {
+                refreshFailure = sessionResult.error.getErrorText();
+              } else {
+                const refresh = await refreshWorkbookCache({
+                  extra,
+                  workbookFile,
+                  resolvedSession: sessionResult.value,
+                  action: 'resolving field',
+                });
+                if (refresh.ok) {
+                  refreshed = true;
+                  workbookXml = refresh.xml;
+                  resolution = resolveField(workbookXml, query, { datasource });
+                } else {
+                  refreshFailure = refresh.reason;
+                }
+              }
+            } catch (error) {
+              refreshFailure = getExceptionMessage(error);
+              log({
+                message: 'resolve-field live refresh failed; degrading to cache not_found',
+                level: 'warning',
+                logger: 'resolveField',
+                data: { workbookFile, sessionId: session, error: refreshFailure },
+              });
+            }
+          }
+
           const isError = resolution.kind === 'ambiguous' || resolution.kind === 'not_found';
-          return new Ok({ resolution, isError });
+
+          let note: string | undefined;
+          if (refreshed && resolution.kind === 'not_found') {
+            note =
+              `Refreshed the workbook live from Tableau and "${query}" still does not resolve. ` +
+              'The field genuinely does not exist in the CURRENT workbook — stop re-reading stale caches. ' +
+              'Call list-available-fields (with session) to see the fields that DO exist, or ask-user to clarify.';
+          } else if (refreshFailure && resolution.kind === 'not_found') {
+            note =
+              `Attempted a live refresh from Tableau to rule out a stale cache, but it failed: ${refreshFailure}\n\n` +
+              `This is NOT proof that "${query}" is absent — the live workbook could not be read. ` +
+              'Check the session with list-instances (Tableau may have disconnected or restarted), then retry; ' +
+              'do not conclude the field is missing from a cache that could not be refreshed.';
+          }
+
+          return new Ok<ResolveFieldResult>({ resolution, isError, note });
         },
+        getSuccessResult: ({ resolution, isError, note }): CallToolResult => ({
+          isError: false,
+          content: [
+            {
+              type: 'text' as const,
+              text: `${JSON.stringify({ resolution, isError })}${note ? `\n\n${note}` : ''}`,
+            },
+          ],
+        }),
       });
     },
   });


### PR DESCRIPTION
Twin of tableau/agent-to-tableau-desktop#213 (the Laulima row-10 P0). Port-fidelity review: **SHIP** (dedup registered-before-await/cleared-in-finally verified; retry provably once; every refresh failure shape degrades to the JSON body + note). Convention divergences documented in-branch: transport isError stays false for not_found (pre-existing tmcp convention), telemetry seam doesn't exist here (dropped with receipts). Guidance lines NOT ported to DESKTOP_INSTRUCTIONS (surface-pinned) — they ship as the on-demand knowledge module in the companion PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)