### PR TITLE
Add optional datasource id_type to insight bundle request schema

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "3.5.1",
+  "version": "3.5.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "3.5.1",
+      "version": "3.5.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.7.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "3.5.3",
+  "version": "3.5.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "3.5.1",
+  "version": "3.5.3",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/src/sdks/tableau/types/pulse.ts
+++ b/src/sdks/tableau/types/pulse.ts
@@ -361,7 +361,9 @@ export const pulseBundleRequestSchema = z.object({
         definition: z.object({
           datasource: z.object({
             id: z.string(),
-            id_type: z.enum(['DATASOURCE_ID_TYPE_PUBLISHED', 'DATASOURCE_ID_TYPE_WORKBOOK_DATASOURCE']).optional(),
+            id_type: z
+              .enum(['DATASOURCE_ID_TYPE_PUBLISHED', 'DATASOURCE_ID_TYPE_WORKBOOK_DATASOURCE'])
+              .optional(),
           }),
           basic_specification: pulseBasicSpecificationSchema,
           is_running_total: z.boolean(),

--- a/src/sdks/tableau/types/pulse.ts
+++ b/src/sdks/tableau/types/pulse.ts
@@ -361,6 +361,7 @@ export const pulseBundleRequestSchema = z.object({
         definition: z.object({
           datasource: z.object({
             id: z.string(),
+            id_type: z.enum(['DATASOURCE_ID_TYPE_PUBLISHED', 'DATASOURCE_ID_TYPE_WORKBOOK_DATASOURCE']).optional(),
           }),
           basic_specification: pulseBasicSpecificationSchema,
           is_running_total: z.boolean(),

--- a/src/sdks/tableau/types/pulse.ts
+++ b/src/sdks/tableau/types/pulse.ts
@@ -361,9 +361,7 @@ export const pulseBundleRequestSchema = z.object({
         definition: z.object({
           datasource: z.object({
             id: z.string(),
-            id_type: z
-              .enum(['DATASOURCE_ID_TYPE_PUBLISHED', 'DATASOURCE_ID_TYPE_WORKBOOK_DATASOURCE'])
-              .optional(),
+            id_type: z.enum(['DATASOURCE_ID_TYPE_WORKBOOK_DATASOURCE']).optional(),
           }),
           basic_specification: pulseBasicSpecificationSchema,
           is_running_total: z.boolean(),

--- a/src/tools/web/pulse/generateMetricValueInsightBundle/generatePulseMetricValueInsightBundleTool.ts
+++ b/src/tools/web/pulse/generateMetricValueInsightBundle/generatePulseMetricValueInsightBundleTool.ts
@@ -32,6 +32,9 @@ Generate an insight bundle for the current aggregated value for Pulse Metric usi
     - time_zone: 'UTC'
     - language: 'LANGUAGE_EN_US'
     - locale: 'LOCALE_EN_US'
+    - The \`datasource\` field under \`metric.definition\` requires an \`id\` (datasource LUID) and accepts an optional \`id_type\`:
+      - Omit \`id_type\` or use \`'DATASOURCE_ID_TYPE_PUBLISHED'\` for standard published datasources (default behavior).
+      - Use \`'DATASOURCE_ID_TYPE_WORKBOOK_DATASOURCE'\` when the metric is based on an embedded workbook datasource rather than a published datasource.
 - \`bundleType\` (optional): The type of bundle to generate.  The default is 'ban'.
   - 'ban' - Return a basic insight bundle with the current aggregated value for the Pulse Metric, period over period change, and the highest ranked insight for each filterable dimension of the metric.
   - 'springboard' - Return a springboard insight bundle with the current value, period over period change, and the highest ranked insight for the metric.

--- a/src/tools/web/pulse/generateMetricValueInsightBundle/generatePulseMetricValueInsightBundleTool.ts
+++ b/src/tools/web/pulse/generateMetricValueInsightBundle/generatePulseMetricValueInsightBundleTool.ts
@@ -33,7 +33,7 @@ Generate an insight bundle for the current aggregated value for Pulse Metric usi
     - language: 'LANGUAGE_EN_US'
     - locale: 'LOCALE_EN_US'
     - The \`datasource\` field under \`metric.definition\` requires an \`id\` (datasource LUID) and accepts an optional \`id_type\`:
-      - Omit \`id_type\` or use \`'DATASOURCE_ID_TYPE_PUBLISHED'\` for standard published datasources (default behavior).
+      - Omit \`id_type\` for standard published datasources (default behavior).
       - Use \`'DATASOURCE_ID_TYPE_WORKBOOK_DATASOURCE'\` when the metric is based on an embedded workbook datasource rather than a published datasource.
 - \`bundleType\` (optional): The type of bundle to generate.  The default is 'ban'.
   - 'ban' - Return a basic insight bundle with the current aggregated value for the Pulse Metric, period over period change, and the highest ranked insight for each filterable dimension of the metric.


### PR DESCRIPTION
Allows MCP to indicate whether a metric is based on a published datasource or a workbook-embedded datasource, enabling the Insights service to route workbook datasource requests to HBI.

**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of
the pull request._

# Pull Request Template

<!-- Thank you for your contribution! Please fill out the following template to help us review your pull
request! -->

## Description

<!-- Please include a summary of the change. -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## How Has This Been Tested?

<!-- Please describe the tests that you performed to verify your changes. -->

## Related Issues

<!-- List any related issues, pull requests, or discussions. -->

## Checklist

- [ ] I have updated the version in the package.json file by using `npm run version`. For example,
      use `npm run version:patch` for a patch version bump.
- [ ] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have documented any breaking changes in the PR description. For example, renaming a config
      environment variable or changing its default value.

## Contributor Agreement

By submitting this pull request, I confirm that:

- [ ] I have read the [CONTRIBUTING guidelines](../../CONTRIBUTING.md) for this project and followed
      its Contribution Checklist.
