### PR TITLE
@W-23377934: fix extract-refresh-task delete preview existence check + confirm double-audit

### DIFF
--- a/docs/docs/tools/content/delete-content.md
+++ b/docs/docs/tools/content/delete-content.md
@@ -23,8 +23,10 @@ The tool is **two-phase** to keep the destructive action safe:
 1. **Preview** (default — `confirm` omitted or `false`):
    - For `workbook` / `datasource`: tags the resource with `pending-deletion` (reversible,
      visible in the Tableau UI), reports identity, project, and owner.
-   - For `extract-refresh-task`: mints a single-use `confirmationToken` and reports task
-     metadata.
+   - For `extract-refresh-task`: first verifies the task exists on the site (there is no single-get
+     endpoint, so the task list is checked for a matching id) — an unknown `taskId` returns a
+     not-found error and **no** `confirmationToken` is minted. When the task exists, mints a
+     single-use `confirmationToken` and reports task metadata.
    - Does **not** delete anything.
 
 2. **Confirm** (`confirm: true`):
@@ -67,7 +69,7 @@ cannot be previewed or deleted — the request is rejected before any side effec
 
 ### Extract Refresh Task
 
-- [Get Extract Refresh Task](https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref_extract_and_encryption.htm#get_extract_refresh_task) (preview + confirm verification)
+- [List Extract Refresh Tasks](https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref_jobs_tasks_and_schedules.htm#list_extract_refresh_tasks) (preview + confirm — existence check, since there is no single-get endpoint)
 - [Delete Extract Refresh Task](https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref_extract_and_encryption.htm#delete_extract_refresh_task) (confirm)
 
 ### Common

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "3.1.2",
+      "version": "3.1.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.7.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/src/server/oauth/scopes.ts
+++ b/src/server/oauth/scopes.ts
@@ -311,6 +311,7 @@ const toolScopeMap: Record<
       'tableau:workbook_tags:update',
       'tableau:datasources:delete',
       'tableau:datasource_tags:update',
+      'tableau:tasks:read',
       'tableau:tasks:delete',
       'tableau:users:read',
       ...RESOURCE_ACCESS_CHECKER_REQUIRED_API_SCOPES,

--- a/src/tools/web/_lib/auditRecord.ts
+++ b/src/tools/web/_lib/auditRecord.ts
@@ -44,15 +44,17 @@ export const auditRecordSchema = z.object({
     // Non-sensitive description only — NEVER the raw nonce.
     detail: z.string().optional(),
   }),
-  // Lifecycle of a mutation attempt:
-  //   - 'denied'    — authorization/evidence gate rejected the attempt; nothing mutated.
-  //   - 'allowed'   — the attempt passed the gate. For a preview this is terminal (nothing mutates);
-  //                   for a confirm it records only the AUTHORIZATION decision and is followed by a
-  //                   terminal outcome record once the destructive REST call returns.
-  //   - 'completed' — the confirmed mutation's REST call succeeded.
+  // Lifecycle of a mutation attempt — a preview emits exactly ONE record, and so does a confirm:
+  //   - 'denied'    — authorization/evidence gate rejected the attempt; nothing mutated. The SOLE
+  //                   record for a denied attempt (preview or confirm).
+  //   - 'allowed'   — a PREVIEW passed the gate; terminal for a preview (nothing mutates). A confirm
+  //                   NEVER emits 'allowed' — its authorization is folded into the terminal
+  //                   'completed'/'failed' record below so a confirm logs exactly once.
+  //   - 'completed' — the confirmed mutation's REST call succeeded. The SOLE record for a successful
+  //                   confirm.
   //   - 'failed'    — the confirmed mutation was authorized but its REST call failed; the target is
-  //                   unchanged. Distinguishing this from 'completed' is what an incident responder
-  //                   needs — an 'allowed' record alone cannot tell authorized-but-failed from done.
+  //                   unchanged. The SOLE record for a failed confirm. Distinguishing this from
+  //                   'completed' is what an incident responder needs.
   result: z.enum(['allowed', 'denied', 'completed', 'failed']),
   denyReason: z.string().optional(),
   // Non-sensitive summary of why a 'failed' outcome failed (e.g. the Tableau status/code). Never set

--- a/src/tools/web/_lib/confirmDeleteContent.test.ts
+++ b/src/tools/web/_lib/confirmDeleteContent.test.ts
@@ -18,8 +18,8 @@ vi.mock('../users/resolveOwnerEmail.js', () => ({
 }));
 
 // All mutation-audit records emitted so far, each parsed through the authoritative schema so the
-// assertion fails if the guard ever drops a required field. A confirmed deletion emits two (the
-// allowed authorization decision, then the terminal completed/failed outcome); denied paths emit one.
+// assertion fails if the guard ever drops a required field. A confirmed deletion emits exactly one
+// terminal record (completed or failed); denied paths also emit exactly one.
 function getAuditRecords(): ReturnType<typeof auditRecordSchema.parse>[] {
   const log = logger.log as MockedFunction<typeof logger.log>;
   return log.mock.calls
@@ -223,10 +223,10 @@ describe('confirmDeleteContentTool', () => {
       workbookId: validWorkbookId,
       siteId: 'test-site-id',
     });
-    // A confirmed deletion emits two records: the allowed authorization decision, then the terminal
-    // 'completed' outcome once the REST delete succeeds.
+    // A confirmed deletion emits exactly one record: the terminal 'completed' outcome once the REST
+    // delete succeeds (the confirm's authorization is folded into that terminal record).
     const records = getAuditRecords();
-    expect(records.map((r) => r.result)).toEqual(['allowed', 'completed']);
+    expect(records.map((r) => r.result)).toEqual(['completed']);
     expect(records.every((r) => r.phase === 'confirm')).toBe(true);
     expect(records.every((r) => r.action === 'delete')).toBe(true);
   });
@@ -308,7 +308,7 @@ describe('confirmDeleteContentTool', () => {
       siteId: 'test-site-id',
     });
     const records = getAuditRecords();
-    expect(records.map((r) => r.result)).toEqual(['allowed', 'completed']);
+    expect(records.map((r) => r.result)).toEqual(['completed']);
     expect(records.every((r) => r.phase === 'confirm')).toBe(true);
     expect(records.every((r) => r.action === 'delete')).toBe(true);
   });
@@ -332,7 +332,7 @@ describe('confirmDeleteContentTool', () => {
       taskId: validTaskId,
     });
     const records = getAuditRecords();
-    expect(records.map((r) => r.result)).toEqual(['allowed', 'completed']);
+    expect(records.map((r) => r.result)).toEqual(['completed']);
     expect(records.every((r) => r.phase === 'confirm')).toBe(true);
     expect(records.every((r) => r.action === 'delete')).toBe(true);
   });
@@ -368,10 +368,10 @@ describe('confirmDeleteContentTool', () => {
       tag: testTag,
     });
     expect(result.isError).toBe(true);
-    // An authorized-but-failed deletion records the terminal 'failed' outcome so the audit trail
-    // never claims a deletion that did not happen.
+    // An authorized-but-failed deletion records the terminal 'failed' outcome (the sole audit record
+    // for the confirm) so the audit trail never claims a deletion that did not happen.
     const records = getAuditRecords();
-    expect(records.map((r) => r.result)).toEqual(['allowed', 'failed']);
+    expect(records.map((r) => r.result)).toEqual(['failed']);
     const failed = records.find((r) => r.result === 'failed');
     invariant(failed, 'expected a failed audit record');
     expect(failed.failureDetail).toContain('Resource not found');

--- a/src/tools/web/_lib/deleteContent.test.ts
+++ b/src/tools/web/_lib/deleteContent.test.ts
@@ -51,6 +51,7 @@ const mocks = vi.hoisted(() => ({
   mockQueryDatasource: vi.fn(),
   mockAddTagsToDatasource: vi.fn(),
   mockDeleteDatasource: vi.fn(),
+  mockListExtractRefreshTasks: vi.fn(),
   mockDeleteExtractRefreshTask: vi.fn(),
   mockGraphql: vi.fn(),
   mockQueryUserOnSite: vi.fn(),
@@ -78,6 +79,7 @@ vi.mock('../../../restApiInstance.js', () => ({
         deleteDatasource: mocks.mockDeleteDatasource,
       },
       tasksMethods: {
+        listExtractRefreshTasks: mocks.mockListExtractRefreshTasks,
         deleteExtractRefreshTask: mocks.mockDeleteExtractRefreshTask,
       },
       metadataMethods: {
@@ -130,6 +132,9 @@ describe('deleteContentTool', () => {
     mocks.mockAddTagsToDatasource.mockResolvedValue(undefined);
     mocks.mockDeleteWorkbook.mockResolvedValue(undefined);
     mocks.mockDeleteDatasource.mockResolvedValue(undefined);
+    // Existence check for the extract-refresh-task branch: default to a list that CONTAINS the task
+    // id the task tests exercise, so preview/confirm reach the guard as before.
+    mocks.mockListExtractRefreshTasks.mockResolvedValue([{ id: validTaskId }]);
     mocks.mockDeleteExtractRefreshTask.mockResolvedValue(undefined);
     mocks.mockGraphql.mockResolvedValue({ publishedDatasources: [] });
     mocks.mockIsFeatureEnabled.mockResolvedValue(false);
@@ -353,6 +358,135 @@ describe('deleteContentTool', () => {
       expect(result.isError).toBe(true);
       expect(mocks.mockDeleteExtractRefreshTask).not.toHaveBeenCalled();
     });
+
+    // --- DEFECT 1 (W-23377934): existence check BEFORE minting a nonce ---
+    // The task branch has no single-get endpoint, so it list-and-finds. A taskId absent from the
+    // list must 404 WITHOUT the guard minting a confirmationToken — symmetric with the
+    // workbook/datasource branches whose resolveTarget reads 404 before any evidence is established.
+    // Pre-fix, the branch went straight to guardMutation and returned a preview WITH a token for a
+    // nonexistent task; these tests pin the no-token behavior.
+    describe('DEFECT-1: nonexistent task', () => {
+      it('preview returns not-found and mints NO confirmation token', async () => {
+        // Task is genuinely absent from this site (list does not contain validTaskId).
+        mocks.mockListExtractRefreshTasks.mockResolvedValue([{ id: 'some-other-task-id' }]);
+        const result = await getToolResult({
+          resourceType: 'extract-refresh-task',
+          resourceId: validTaskId,
+        });
+
+        // (a) It is an ERROR result carrying the 404 not-found message.
+        expect(result.isError).toBe(true);
+        invariant(result.content[0].type === 'text');
+        const text = result.content[0].text;
+        expect(text).toContain('not found');
+        expect(text).toContain(validTaskId);
+
+        // (b) NO confirmation token / nonce is minted or returned. The preview success text
+        // ('Preview —' + confirmationToken) must NOT appear.
+        expect(text).not.toContain('Preview —');
+        expect(text).not.toMatch(/confirmationToken/i);
+
+        // (c) No delete call, and — because the branch returns before guardMutation — NO audit
+        // record at all was emitted (in particular no 'allowed' for a minted token).
+        expect(mocks.mockDeleteExtractRefreshTask).not.toHaveBeenCalled();
+        expect(getAuditRecords()).toHaveLength(0);
+      });
+
+      it('preview on an EMPTY task list returns not-found and no token', async () => {
+        mocks.mockListExtractRefreshTasks.mockResolvedValue([]);
+        const result = await getToolResult({
+          resourceType: 'extract-refresh-task',
+          resourceId: validTaskId,
+        });
+        expect(result.isError).toBe(true);
+        invariant(result.content[0].type === 'text');
+        expect(result.content[0].text).toContain('not found');
+        expect(result.content[0].text).not.toMatch(/confirmationToken/i);
+        expect(mocks.mockDeleteExtractRefreshTask).not.toHaveBeenCalled();
+        expect(getAuditRecords()).toHaveLength(0);
+      });
+
+      it('confirm:true on a task absent from the list returns not-found and never deletes', async () => {
+        // A caller who forged/replayed a token against a task that no longer exists is 404'd before
+        // the guard runs, so nothing is deleted.
+        mocks.mockListExtractRefreshTasks.mockResolvedValue([]);
+        const result = await getToolResult({
+          resourceType: 'extract-refresh-task',
+          resourceId: validTaskId,
+          confirm: true,
+          confirmationToken: 'a1b2c3d4-e5f6-4789-9abc-ef1234567890',
+        });
+        expect(result.isError).toBe(true);
+        invariant(result.content[0].type === 'text');
+        expect(result.content[0].text).toContain('not found');
+        expect(mocks.mockDeleteExtractRefreshTask).not.toHaveBeenCalled();
+        expect(getAuditRecords()).toHaveLength(0);
+      });
+    });
+
+    // --- DEFECT 2 (W-23377934): a confirm logs EXACTLY ONE audit record ---
+    // The shared guard no longer emits 'allowed' on a confirm; the terminal recordOutcome emit is the
+    // sole record. Pre-fix a successful confirm logged ['allowed','completed'].
+    describe('DEFECT-2: confirm audit fires exactly once', () => {
+      it('preview still emits a single ALLOWED audit record (no regression)', async () => {
+        const result = await getToolResult({
+          resourceType: 'extract-refresh-task',
+          resourceId: validTaskId,
+        });
+        expect(result.isError).toBe(false);
+        const records = getAuditRecords();
+        expect(records.map((r) => r.result)).toEqual(['allowed']);
+        expect(records[0].phase).toBe('preview');
+      });
+
+      it('a successful confirm delete emits exactly one COMPLETED record (not allowed+completed)', async () => {
+        const previewText = await previewAndGetText({
+          resourceType: 'extract-refresh-task',
+          resourceId: validTaskId,
+        });
+        const token = extractToken(previewText);
+        // Isolate the confirm phase's audit emissions from the preview's 'allowed' record.
+        (logger.log as MockedFunction<typeof logger.log>).mockClear();
+
+        const result = await getToolResult({
+          resourceType: 'extract-refresh-task',
+          resourceId: validTaskId,
+          confirm: true,
+          confirmationToken: token,
+        });
+        expect(result.isError).toBe(false);
+        expect(mocks.mockDeleteExtractRefreshTask).toHaveBeenCalledOnce();
+
+        const records = getAuditRecords();
+        expect(records.map((r) => r.result)).toEqual(['completed']);
+        expect(records[0].phase).toBe('confirm');
+        expect(records[0].action).toBe('delete');
+      });
+
+      it('a failed confirm delete emits exactly one FAILED record (not allowed+failed)', async () => {
+        const previewText = await previewAndGetText({
+          resourceType: 'extract-refresh-task',
+          resourceId: validTaskId,
+        });
+        const token = extractToken(previewText);
+        mocks.mockDeleteExtractRefreshTask.mockRejectedValueOnce(new Error('Resource not found'));
+        (logger.log as MockedFunction<typeof logger.log>).mockClear();
+
+        const result = await getToolResult({
+          resourceType: 'extract-refresh-task',
+          resourceId: validTaskId,
+          confirm: true,
+          confirmationToken: token,
+        });
+        expect(result.isError).toBe(true);
+
+        const records = getAuditRecords();
+        expect(records.map((r) => r.result)).toEqual(['failed']);
+        expect(records[0].phase).toBe('confirm');
+        const failed = records[0];
+        expect(failed.failureDetail).toContain('Resource not found');
+      });
+    });
   });
 
   // --- MCP-Apps flag ON: preview returns LEGACY namespace panel + records approval under legacy ---
@@ -455,5 +589,10 @@ async function previewAndGetText(args: {
   return preview.content[0].text;
 }
 
-// silence unused: getAuditRecords wired up in case future tests want to assert audit rows.
-void getAuditRecords;
+function extractToken(previewText: string): string {
+  const match = previewText.match(
+    /confirmationToken:\s*\\?"([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})/,
+  );
+  invariant(match, `expected confirmationToken in preview: ${previewText}`);
+  return match[1];
+}

--- a/src/tools/web/_lib/deleteContent.ts
+++ b/src/tools/web/_lib/deleteContent.ts
@@ -8,6 +8,7 @@ import {
   DatasourceNotAllowedError,
   McpToolError,
   PreviewNotRunError,
+  UnknownError,
   WorkbookNotAllowedError,
 } from '../../../errors/mcpToolError.js';
 import { getFeatureGate } from '../../../features/init.js';
@@ -480,6 +481,22 @@ async function runExtractRefreshTaskBranch({
   mcpAppsEnabled: boolean;
 }): Promise<Result<DeleteContentResult, McpToolError>> {
   const siteId = restApi.siteId;
+
+  // Confirm existence BEFORE the guard mints a nonce. Unlike the workbook/datasource branches (whose
+  // resolveTarget reads the target via getWorkbook/queryDatasource, so a missing resource 404s before
+  // any evidence is established), the task branch has no single-get endpoint — so list-and-find is the
+  // only existence check available. Run it unconditionally (preview AND confirm) to stay symmetric
+  // with the sibling branches and to keep the guard from minting a confirmationToken for a task that
+  // does not exist on this site.
+  const tasks = await restApi.tasksMethods.listExtractRefreshTasks({ siteId });
+  if (!tasks.some((task) => task.id === taskId)) {
+    return new UnknownError(
+      `Extract refresh task '${taskId}' not found. Deleting an extract refresh task is Tableau ` +
+        "Cloud only — verify you're connected to a Cloud site (not Server) and that the taskId " +
+        'came from list-extract-refresh-tasks.',
+      404,
+    ).toErr();
+  }
 
   const resolveTarget = async (): Promise<MutationTarget> => ({
     id: taskId,

--- a/src/tools/web/_lib/mutationGuard.test.ts
+++ b/src/tools/web/_lib/mutationGuard.test.ts
@@ -167,15 +167,20 @@ describe('guardMutation', () => {
     }
   });
 
-  it('on confirm, allows and emits an ALLOWED audit when evidence.verify is true', async () => {
+  it('on confirm, allows but emits NO record until recordOutcome fires, then a single terminal record', async () => {
     const evidence = makeEvidence({ verify: vi.fn().mockResolvedValue(true) });
     const result = await run({ phase: 'confirm', evidence });
     expect(result.isOk()).toBe(true);
 
+    // A confirm that passes the gate emits nothing on its own — the terminal outcome record is the
+    // sole audit entry for the confirm, so a confirm logs exactly once (not twice).
+    expect(getAuditRecords()).toHaveLength(0);
+
+    result.unwrap().recordOutcome({ ok: true });
     const audits = getAuditRecords();
     expect(audits).toHaveLength(1);
     const record = auditRecordSchema.parse(audits[0]);
-    expect(record.result).toBe('allowed');
+    expect(record.result).toBe('completed');
     expect(record.phase).toBe('confirm');
     expect(record.denyReason).toBeUndefined();
   });
@@ -198,7 +203,7 @@ describe('guardMutation', () => {
 
   // --- confirm-only mode ---
 
-  it('confirm-only mode never establishes or verifies and still emits an ALLOWED audit', async () => {
+  it('confirm-only mode never establishes or verifies and emits a single terminal record via recordOutcome', async () => {
     const evidence = new NoEvidence();
     const establishSpy = vi.spyOn(evidence, 'establish');
     const verifySpy = vi.spyOn(evidence, 'verify');
@@ -216,9 +221,14 @@ describe('guardMutation', () => {
     expect(establishSpy).not.toHaveBeenCalled();
     expect(verifySpy).not.toHaveBeenCalled();
 
+    // A confirm logs exactly once: nothing until the caller reports the outcome.
+    expect(getAuditRecords()).toHaveLength(0);
+    result.unwrap().recordOutcome({ ok: true });
+
     const record = auditRecordSchema.parse(getAuditRecords()[0]);
     expect(record.action).toBe('update');
     expect(record.confirmationEvidence.kind).toBe('none');
+    expect(record.result).toBe('completed');
   });
 
   // --- audit record fidelity ---

--- a/src/tools/web/_lib/mutationGuard.ts
+++ b/src/tools/web/_lib/mutationGuard.ts
@@ -62,11 +62,11 @@ export interface GuardOutcome {
   actor: MutationActor;
   target: MutationTarget;
   /**
-   * Records the TERMINAL outcome of a confirmed mutation's REST call. The guard's own `allowed`
-   * record captures only the authorization decision (it is emitted before the caller runs the
-   * destructive REST call); the caller MUST call this once the REST result is known so the audit
-   * trail reflects outcome, not just intent. No-op on the preview phase (nothing mutates), so callers
-   * can invoke it unconditionally. See finding: "Audit says 'allowed' before the mutation runs".
+   * Records the TERMINAL outcome of a confirmed mutation's REST call. On a confirm the guard emits NO
+   * 'allowed' record (that would double-log the attempt); this terminal 'completed'/'failed' record
+   * is the SOLE audit entry for the confirm, so the caller MUST invoke it once the REST result is
+   * known or the attempt goes unaudited. No-op on the preview phase (nothing mutates, and the preview
+   * already logged its single 'allowed' record), so callers can invoke it unconditionally.
    */
   recordOutcome: (outcome: { ok: true } | { ok: false; failureDetail?: string }) => void;
 }
@@ -200,21 +200,26 @@ export async function guardMutation<TTarget>({
     await evidence.establish(evidenceCtx);
   }
 
-  // (6) Allowed: record the authorization decision and let the tool perform its mutation / build its
-  // response. For a confirm this is NOT the terminal record — the caller reports the REST outcome via
-  // recordOutcome() below so the audit trail distinguishes completed from authorized-but-failed.
-  emitAuditRecord({
-    actor,
-    tool,
-    action,
-    phase,
-    target,
-    confirmationEvidence: evidenceDescriptor,
-    result: 'allowed',
-  });
+  // (6) Allowed: on a PREVIEW, emit the single terminal 'allowed' record — nothing mutates, so the
+  // authorization decision is the whole story. On a CONFIRM this record is deliberately suppressed:
+  // the caller reports the REST outcome via recordOutcome() below, and that terminal
+  // 'completed'/'failed' record is the sole audit entry for the confirm (a confirm logs EXACTLY
+  // once). Emitting 'allowed' here too would double-log every confirmed mutation.
+  if (phase !== 'confirm') {
+    emitAuditRecord({
+      actor,
+      tool,
+      action,
+      phase,
+      target,
+      confirmationEvidence: evidenceDescriptor,
+      result: 'allowed',
+    });
+  }
 
   // Terminal-outcome recorder handed to the caller. Only a confirm phase mutates, so the preview
-  // phase is a deliberate no-op — callers can invoke it unconditionally after their REST call.
+  // phase is a deliberate no-op — callers can invoke it unconditionally after their REST call. On a
+  // confirm this emits the SOLE audit record for the attempt ('completed' or 'failed').
   const recordOutcome = (outcome: { ok: true } | { ok: false; failureDetail?: string }): void => {
     if (phase !== 'confirm') {
       return;

--- a/src/tools/web/extractRefreshTasks/confirmUpdateCloudExtractRefreshTask.test.ts
+++ b/src/tools/web/extractRefreshTasks/confirmUpdateCloudExtractRefreshTask.test.ts
@@ -19,8 +19,8 @@ import { scheduleBinding } from './updateCloudExtractRefreshTask.js';
 vi.mock('../../../logging/logger.js');
 
 // All mutation-audit records emitted so far, each parsed through the authoritative schema so the
-// assertion fails if the guard ever drops a required field. A confirmed update emits two (the
-// allowed authorization decision, then the terminal completed/failed outcome); denied paths emit one.
+// assertion fails if the guard ever drops a required field. A confirmed update emits exactly one
+// terminal record (completed or failed); denied paths also emit exactly one.
 function getAuditRecords(): ReturnType<typeof auditRecordSchema.parse>[] {
   const log = logger.log as MockedFunction<typeof logger.log>;
   return log.mock.calls
@@ -159,10 +159,10 @@ describe('confirmUpdateCloudExtractRefreshTaskTool', () => {
       taskId: validTaskId,
       schedule: validSchedule,
     });
-    // A confirmed update emits two records: the allowed authorization decision, then the terminal
-    // 'completed' outcome once the REST update succeeds (audit reflects outcome, not just intent).
+    // A confirmed update emits exactly one record: the terminal 'completed' outcome once the REST
+    // update succeeds (the confirm's authorization is folded into that terminal record).
     const records = getAuditRecords();
-    expect(records.map((r) => r.result)).toEqual(['allowed', 'completed']);
+    expect(records.map((r) => r.result)).toEqual(['completed']);
     expect(records.every((r) => r.phase === 'confirm')).toBe(true);
     expect(records.every((r) => r.action === 'update')).toBe(true);
     expect(records.every((r) => r.confirmationEvidence.kind === 'registry-nonce')).toBe(true);
@@ -296,9 +296,10 @@ describe('confirmUpdateCloudExtractRefreshTaskTool', () => {
     expect(result.content[0].text).toContain('Tableau Cloud only');
     expect(result.content[0].text).toContain('Tableau 404 [404001]');
     // An authorized-but-failed update records the terminal 'failed' outcome (with the Tableau-api
-    // detail) so the audit trail never claims an update that did not happen.
+    // detail) as the sole confirm record, so the audit trail never claims an update that did not
+    // happen.
     const records = getAuditRecords();
-    expect(records.map((r) => r.result)).toEqual(['allowed', 'failed']);
+    expect(records.map((r) => r.result)).toEqual(['failed']);
     const failed = records.find((r) => r.result === 'failed');
     invariant(failed, 'expected a failed audit record');
     expect(failed.failureDetail).toContain('Tableau 404 [404001]');

--- a/src/tools/web/extractRefreshTasks/updateCloudExtractRefreshTask.test.ts
+++ b/src/tools/web/extractRefreshTasks/updateCloudExtractRefreshTask.test.ts
@@ -495,14 +495,15 @@ describe('updateCloudExtractRefreshTaskTool', () => {
       expect(record.confirmationEvidence.kind).toBe('registry-nonce');
     });
 
-    it('AC-6(b): confirm with a valid preview token applies the update and audits allowed→completed', async () => {
+    it('AC-6(b): confirm with a valid preview token applies the update and audits a single completed', async () => {
       const result = await previewThenConfirm({ taskId: validTaskId, schedule: validSchedule });
       expect(result.isError).toBe(false);
       expect(mocks.mockUpdateCloudExtractRefreshTask).toHaveBeenCalled();
-      // Two phases, three records: preview=allowed, confirm=allowed (intent), confirm=completed (outcome).
+      // A confirm logs exactly once: the preview emitted its own allowed record, and the confirm
+      // emits only the terminal 'completed' outcome.
       const records = getAuditRecords();
       const confirmRecords = records.filter((r) => r.phase === 'confirm');
-      expect(confirmRecords.map((r) => r.result)).toEqual(['allowed', 'completed']);
+      expect(confirmRecords.map((r) => r.result)).toEqual(['completed']);
       expect(confirmRecords.every((r) => r.action === 'update')).toBe(true);
       expect(confirmRecords.every((r) => r.target.id === validTaskId)).toBe(true);
     });
@@ -577,9 +578,9 @@ describe('updateCloudExtractRefreshTaskTool', () => {
     });
 
     // Fix #2: the audit trail must reflect OUTCOME, not just intent. When the confirmed REST call
-    // fails, the terminal record is 'failed' (with detail) — never a bare 'allowed' that would claim
-    // a mutation which never happened.
-    it('AC-6(f): a failed confirmed update audits allowed then failed (not completed)', async () => {
+    // fails, the sole confirm record is 'failed' (with detail) — never a bare 'allowed' that would
+    // claim a mutation which never happened.
+    it('AC-6(f): a failed confirmed update audits a single failed (not completed, not allowed)', async () => {
       mocks.mockUpdateCloudExtractRefreshTask.mockResolvedValue(
         new Err({
           type: 'tableau-api',
@@ -592,7 +593,7 @@ describe('updateCloudExtractRefreshTaskTool', () => {
       const result = await previewThenConfirm({ taskId: validTaskId, schedule: validSchedule });
       expect(result.isError).toBe(true);
       const confirmRecords = getAuditRecords().filter((r) => r.phase === 'confirm');
-      expect(confirmRecords.map((r) => r.result)).toEqual(['allowed', 'failed']);
+      expect(confirmRecords.map((r) => r.result)).toEqual(['failed']);
       const failed = confirmRecords.find((r) => r.result === 'failed');
       invariant(failed, 'expected a failed audit record');
       expect(failed.failureDetail).toContain('Tableau 409');

--- a/tests/e2e/server.test.ts
+++ b/tests/e2e/server.test.ts
@@ -51,6 +51,11 @@ describe('server', () => {
       ];
       // flow tools are gated off by default (FLOW_TOOLS_ENABLED)
       const flowTools: ReadonlyArray<WebToolName> = ['list-flows', 'get-flow'];
+      // insights tools are gated off by default (INSIGHTS_TOOLS_ENABLED)
+      const insightsTools: ReadonlyArray<WebToolName> = [
+        'generate-insight-cards',
+        'resolve-datasource-luid',
+      ];
 
       let expectedToolNames = [...webToolNames];
 
@@ -67,6 +72,11 @@ describe('server', () => {
       // Filter out flow tools if they are not enabled
       if (process.env.FLOW_TOOLS_ENABLED !== 'true') {
         expectedToolNames = expectedToolNames.filter((name) => !flowTools.includes(name));
+      }
+
+      // Filter out insights tools if they are not enabled
+      if (process.env.INSIGHTS_TOOLS_ENABLED !== 'true') {
+        expectedToolNames = expectedToolNames.filter((name) => !insightsTools.includes(name));
       }
 
       // Filter out mcp-apps tools (mcp-apps is disabled by default in features.json)
@@ -145,6 +155,11 @@ describe('server', () => {
       ];
       // flow tools are gated off by default (FLOW_TOOLS_ENABLED)
       const flowTools: ReadonlyArray<WebToolName> = ['list-flows', 'get-flow'];
+      // insights tools are gated off by default (INSIGHTS_TOOLS_ENABLED)
+      const insightsTools: ReadonlyArray<WebToolName> = [
+        'generate-insight-cards',
+        'resolve-datasource-luid',
+      ];
 
       let expectedWebToolNames = [...webToolNames];
 
@@ -165,6 +180,11 @@ describe('server', () => {
       // Filter out flow tools if they are not enabled
       if (process.env.FLOW_TOOLS_ENABLED !== 'true') {
         expectedWebToolNames = expectedWebToolNames.filter((name) => !flowTools.includes(name));
+      }
+
+      // Filter out insights tools if they are not enabled
+      if (process.env.INSIGHTS_TOOLS_ENABLED !== 'true') {
+        expectedWebToolNames = expectedWebToolNames.filter((name) => !insightsTools.includes(name));
       }
 
       // Filter out mcp-apps tools (mcp-apps is disabled by default in features.json)


### PR DESCRIPTION
## Summary

Fixes two defects in the consolidated `delete-content` flow (W-23377934, WAM: Tableau MCP for Admins - Part 1).

### DEFECT 1 — preview mints a confirmation token for a non-existent taskId
`runExtractRefreshTaskBranch`'s `resolveTarget` was a pure echo with no REST read, so a well-formed but non-existent `taskId` passed the UUID-shape check, `guardMutation` minted a `RegistryEvidence` nonce, and the preview returned a live `confirmationToken` for a task that doesn't exist. The workbook/datasource branches don't have this problem — they read the target via `getWorkbook`/`queryDatasource` and 404 before any evidence is established. The task branch never read the target, and there is no single-get task endpoint.

**Fix:** before `guardMutation`, verify the task exists via `listExtractRefreshTasks` (list-and-find, since there is no single-get endpoint). An unknown `taskId` returns a `404` not-found error and **no** `confirmationToken` is minted. Runs unconditionally on both preview and confirm, symmetric with the sibling branches. This read requires `tableau:tasks:read`, added to the `delete-content` scope map (`confirm-delete-content` unchanged — its task branch does no read).

### DEFECT 2 — confirm phase double-logs audit
Audit emission is centralized in `guardMutation`. On a successful confirm, two records fired: the unconditional `emitAuditRecord({result:'allowed'})` **plus** the terminal `recordOutcome` emit (`completed`/`failed`). Because it lives in the shared guard, this double-logged **every** confirmed mutation across all resourceTypes and every preview→confirm tool.

**Fix:** suppress the `'allowed'` record on the confirm phase (`if (phase !== 'confirm')`). A confirm now emits exactly one terminal record (`completed`/`failed`); a preview still emits its single `allowed`; denied paths are unaffected. Audit-lifecycle doc comments updated to the one-record contract.

> Note: this deliberately changes a previously-documented audit contract (a confirm now logs once instead of `allowed`+terminal), per the WI's "logged exactly once". All production confirm call sites invoke `recordOutcome` on both success and failure paths, so no path is left unaudited.

## Tests
6 new pinning unit tests:
- **D1:** preview / confirm on nonexistent task + empty-list → `404`, no token minted, no delete, zero audit records.
- **D2:** successful confirm → exactly one `completed`; failed confirm → exactly one `failed`; preview → single `allowed` (regression guard).

Negative control: reverting each fix makes exactly the pinning tests fail. Full suite passes; targeted delete/guard/oauth suites green. `tsc`, `lint`, `build` all clean. Non-destructive live verify on a Cloud test site: bogus UUID → not-found + no token; real task → token minted, no delete.

## Docs
- `delete-content.md`: documents the extract-refresh-task existence check; corrects the REST-API reference to *List Extract Refresh Tasks* (the previously-cited *Get Extract Refresh Task* endpoint does not exist).

## Version
`3.1.2` → `3.1.3` (next free patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)