### PR TITLE
@W-23125362: complete mutation-tool safety layer — audit target enrichment + centralized HITL text + durability contract

### DIFF
--- a/docs/docs/tools/content/delete-content.md
+++ b/docs/docs/tools/content/delete-content.md
@@ -114,6 +114,21 @@ Example: `"stale-pending-deletion"`
 **For `resourceType="extract-refresh-task"` only.** The single-use token returned by a prior
 preview call. Required when `confirm` is `true`; ignored otherwise.
 
+## Audit records and durability
+
+Every mutation attempt — allowed, denied, completed, or failed — emits a single authoritative,
+structured-JSON audit record (actor, tool, action, phase, target identity, evidence kind, result) on
+a dedicated `audit` logger. That logger bypasses the `LOG_LEVEL` severity filter, so an operator
+cannot suppress security-audit records by raising `LOG_LEVEL`. For an extract-refresh-task target,
+the record's `name`/`project`/`owner` derive best-effort from the task's underlying data source or
+workbook (the task itself has no such fields); if that lookup fails the record still carries the task
+id.
+
+**Durability is the deployment's responsibility.** The server only emits these records to its log
+stream (stderr/stdout/file). To retain them, operators must ship that audit-logger stream to a
+durable, ideally immutable, log store (SIEM, log archive, etc.). There is no built-in durable audit
+sink in this server.
+
 ## Side effects
 
 - **Preview (workbook/datasource)** adds the pending-deletion tag. Reversible.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "3.1.3",
+      "version": "3.1.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.7.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/src/tools/web/_lib/auditRecord.ts
+++ b/src/tools/web/_lib/auditRecord.ts
@@ -15,6 +15,12 @@ import { z } from 'zod';
  * SECURITY: `confirmationEvidence.detail` is a non-sensitive description of the evidence (e.g. the
  * tag label, or that a registry nonce matched) — it MUST NEVER carry the raw single-use nonce, which
  * would let a reader of the audit log forge a confirmation.
+ *
+ * DURABILITY CONTRACT (AC-5): these records are emitted as structured JSON on the dedicated `audit`
+ * logger (see AUDIT_LOGGER), which bypasses the LOG_LEVEL severity filter so they can't be suppressed
+ * by raising LOG_LEVEL. DURABILITY is the DEPLOYMENT's responsibility: the server writes the records
+ * to its log stream (stderr/stdout/file); operators MUST ship that audit stream to their
+ * durable/immutable log store for retention. There is no built-in durable sink in this server.
  */
 export const auditRecordSchema = z.object({
   schemaVersion: z.literal(2),

--- a/src/tools/web/_lib/confirmDeleteContent.test.ts
+++ b/src/tools/web/_lib/confirmDeleteContent.test.ts
@@ -46,6 +46,7 @@ const mocks = vi.hoisted(() => ({
   mockDeleteDatasource: vi.fn(),
   mockQueryDatasource: vi.fn(),
   mockDeleteExtractRefreshTask: vi.fn(),
+  mockListExtractRefreshTasks: vi.fn(),
   mockQueryUserOnSite: vi.fn(),
   mockAssertAdmin: vi.fn(),
   mockIsFeatureEnabled: vi.fn(),
@@ -72,6 +73,7 @@ vi.mock('../../../restApiInstance.js', () => ({
       },
       tasksMethods: {
         deleteExtractRefreshTask: mocks.mockDeleteExtractRefreshTask,
+        listExtractRefreshTasks: mocks.mockListExtractRefreshTasks,
       },
       usersMethods: {
         queryUserOnSite: mocks.mockQueryUserOnSite,
@@ -177,6 +179,11 @@ describe('confirmDeleteContentTool', () => {
     mocks.mockDeleteExtractRefreshTask.mockResolvedValue(undefined);
     mocks.mockAddTagsToWorkbook.mockResolvedValue(undefined);
     mocks.mockAddTagsToDatasource.mockResolvedValue(undefined);
+    // Default: the task list resolves the task to its underlying datasource so the audit target is
+    // enriched (AC-3). Individual tests override to exercise the id-only fallback.
+    mocks.mockListExtractRefreshTasks.mockResolvedValue([
+      { id: validTaskId, datasource: { id: validDatasourceId } },
+    ]);
   });
 
   it('is a model-invisible app-only tool gated on adminToolsEnabled && mcp-apps', () => {
@@ -335,6 +342,11 @@ describe('confirmDeleteContentTool', () => {
     expect(records.map((r) => r.result)).toEqual(['completed']);
     expect(records.every((r) => r.phase === 'confirm')).toBe(true);
     expect(records.every((r) => r.action === 'delete')).toBe(true);
+    // AC-3 / Gap-B: the task audit target is enriched with the underlying datasource identity
+    // (name/project from queryDatasource, owner from resolveOwnerEmail — both mocked above).
+    expect(records[0].target.name).toBe('Test Datasource');
+    expect(records[0].target.project).toBe('Test Project');
+    expect(records[0].target.owner).toBe('owner@test.com');
   });
 
   // --- Cross-namespace isolation: an update approval must not unlock a delete ---

--- a/src/tools/web/_lib/confirmDeleteContent.ts
+++ b/src/tools/web/_lib/confirmDeleteContent.ts
@@ -12,6 +12,7 @@ import { WebTool } from '../tool.js';
 import { resolveOwnerEmail } from '../users/resolveOwnerEmail.js';
 import { AllEvidence, AppApprovalEvidence, TagEvidence } from './evidence.js';
 import { guardMutation, MutationTarget } from './mutationGuard.js';
+import { resolveExtractRefreshTaskTarget } from './resolveExtractRefreshTaskTarget.js';
 
 const resourceTypeSchema = z.enum(['workbook', 'datasource', 'extract-refresh-task']);
 
@@ -202,10 +203,18 @@ allowed time window. If the check fails the deletion is rejected and the user mu
                 }
 
                 case 'extract-refresh-task': {
-                  const resolveTarget = async (): Promise<MutationTarget> => ({
-                    id: resourceId,
-                    kind: 'extract-refresh-task',
-                  });
+                  // Enrich the audit target with the underlying content's name/project/owner (AC-3)
+                  // via the shared best-effort helper. No task list is pre-fetched on this confirm
+                  // path, so the helper lists tasks once, finds this id, then does ONE content lookup
+                  // + ONE owner lookup. A resolve failure degrades to an id-only target and never
+                  // blocks the deletion.
+                  const resolveTarget = async (): Promise<MutationTarget> =>
+                    resolveExtractRefreshTaskTarget({
+                      restApi,
+                      siteId,
+                      taskId: resourceId,
+                      logger: 'confirm-delete-content',
+                    });
 
                   const guardResult = await guardMutation({
                     restApi,

--- a/src/tools/web/_lib/deleteContent.test.ts
+++ b/src/tools/web/_lib/deleteContent.test.ts
@@ -338,6 +338,50 @@ describe('deleteContentTool', () => {
       });
     });
 
+    // AC-3 / Gap-B: the audit record's target is enriched with the underlying content's
+    // name/project/owner, derived from the task's datasource (the task list carries only the id).
+    it('enriches the preview audit target with the underlying datasource name/project/owner', async () => {
+      mocks.mockListExtractRefreshTasks.mockResolvedValue([
+        { id: validTaskId, datasource: { id: mockDatasource.id } },
+      ]);
+      const result = await getToolResult({
+        resourceType: 'extract-refresh-task',
+        resourceId: validTaskId,
+      });
+      expect(result.isError).toBe(false);
+      const record = getAuditRecords()[0];
+      expect(record.target.id).toBe(validTaskId);
+      expect(record.target.kind).toBe('extract-refresh-task');
+      expect(record.target.name).toBe(mockDatasource.name);
+      expect(record.target.project).toBe('Samples');
+      expect(record.target.owner).toBe('owner@example.com');
+    });
+
+    it('enriched confirm audit target carries the underlying content identity', async () => {
+      mocks.mockListExtractRefreshTasks.mockResolvedValue([
+        { id: validTaskId, datasource: { id: mockDatasource.id } },
+      ]);
+      const previewText = await previewAndGetText({
+        resourceType: 'extract-refresh-task',
+        resourceId: validTaskId,
+      });
+      const token = extractToken(previewText);
+      (logger.log as MockedFunction<typeof logger.log>).mockClear();
+
+      const result = await getToolResult({
+        resourceType: 'extract-refresh-task',
+        resourceId: validTaskId,
+        confirm: true,
+        confirmationToken: token,
+      });
+      expect(result.isError).toBe(false);
+      const records = getAuditRecords();
+      expect(records.map((r) => r.result)).toEqual(['completed']);
+      expect(records[0].target.name).toBe(mockDatasource.name);
+      expect(records[0].target.project).toBe('Samples');
+      expect(records[0].target.owner).toBe('owner@example.com');
+    });
+
     it('rejects a non-UUID resourceId with a clear error', async () => {
       const result = await getToolResult({
         resourceType: 'extract-refresh-task',

--- a/src/tools/web/_lib/deleteContent.ts
+++ b/src/tools/web/_lib/deleteContent.ts
@@ -34,7 +34,13 @@ import {
   RegistryEvidence,
   TagEvidence,
 } from './evidence.js';
+import {
+  renderConfirmClosedMessage,
+  renderTagDeleteNextStep,
+  renderTokenConfirmNextStep,
+} from './hitlText.js';
 import { guardMutation, MutationTarget } from './mutationGuard.js';
+import { resolveExtractRefreshTaskTarget } from './resolveExtractRefreshTaskTarget.js';
 
 export type DeleteWorkbookConfirmPanel = {
   kind: 'delete-workbook-confirm';
@@ -183,10 +189,12 @@ permanent.
             callback: async (restApi) => {
               if (confirm && mcpAppsEnabled) {
                 return new PreviewNotRunError(
-                  `Mutation blocked: deleting a ${resourceType} requires a human ` +
-                    'confirmation in the approval panel. Run delete-content in preview (omit ' +
-                    'confirm) to open the panel; the deletion is performed only when a person ' +
-                    "clicks Delete. The assistant cannot confirm on the user's behalf.",
+                  renderConfirmClosedMessage({
+                    actionPhrase: `deleting a ${resourceType}`,
+                    panelName: 'the approval panel',
+                    previewTool: 'delete-content',
+                    appliedClause: 'the deletion is performed only when a person clicks Delete',
+                  }),
                 ).toErr();
               }
               switch (resourceType) {
@@ -333,10 +341,10 @@ async function runWorkbookBranch({
   return new Ok<DeleteContentResult>(
     `Preview — workbook '${target.name}' (id ${workbookId}) in '${projectName}', ${ownerText}. ` +
       `It has been tagged '${pendingTag}' (reversible). ` +
-      'NEXT STEP — REQUIRED: show this workbook (name, project, owner) to the user and ask them ' +
-      'to explicitly confirm deleting it. Do NOT delete without the user’s approval. ' +
-      'Once approved, call again with confirm: true (the server will verify this ' +
-      `'${pendingTag}' tag before deleting). ` +
+      renderTagDeleteNextStep({
+        subject: 'show this workbook (name, project, owner)',
+        pendingTag,
+      }) +
       `Deleted workbooks are recoverable from the Tableau recycle bin (${RECYCLE_BIN_DOC_URL}) ` +
       'for a limited time.',
   );
@@ -455,11 +463,10 @@ async function runDatasourceBranch({
     `Preview — data source '${target.name}' (id ${datasourceId}) in '${projectName}', ${ownerText}. ` +
       `${dependencyWarning} ` +
       `It has been tagged '${pendingTag}' (reversible). ` +
-      'NEXT STEP — REQUIRED: show this data source (name, project, owner) and its dependent ' +
-      'content to the user and ask them to explicitly confirm deleting it. Do NOT delete ' +
-      'without the user’s approval. ' +
-      'Once approved, call again with confirm: true (the server will verify this ' +
-      `'${pendingTag}' tag before deleting). ` +
+      renderTagDeleteNextStep({
+        subject: 'show this data source (name, project, owner) and its dependent content',
+        pendingTag,
+      }) +
       'On Tableau Cloud deleted data sources are recoverable from the recycle bin ' +
       `(${RECYCLE_BIN_DOC_URL}) for a limited time; on Tableau Server deletion is permanent.`,
   );
@@ -498,10 +505,19 @@ async function runExtractRefreshTaskBranch({
     ).toErr();
   }
 
-  const resolveTarget = async (): Promise<MutationTarget> => ({
-    id: taskId,
-    kind: 'extract-refresh-task',
-  });
+  // Enrich the audit target with the underlying content's name/project/owner (AC-3). The already-
+  // fetched `tasks` list carries only the underlying content id, so this pays ONE content lookup +
+  // ONE owner lookup on the preview/confirm path — the same cost the workbook/datasource branches
+  // already pay. The shared helper is best-effort: a lookup failure degrades to an id-only target and
+  // never fails the mutation. Feed it the already-fetched `tasks` to avoid re-listing.
+  const resolveTarget = async (): Promise<MutationTarget> =>
+    resolveExtractRefreshTaskTarget({
+      restApi,
+      siteId,
+      taskId,
+      logger: 'delete-content',
+      tasks,
+    });
 
   const registryEvidence = new RegistryEvidence();
 
@@ -559,10 +575,12 @@ async function runExtractRefreshTaskBranch({
   return new Ok<DeleteContentResult>(
     `Preview — extract refresh task '${taskId}' would be permanently deleted (the underlying data ` +
       'source or workbook is unaffected, but it will no longer be refreshed on this schedule). ' +
-      'NEXT STEP — REQUIRED: present this task to the user and ask them to explicitly confirm ' +
-      'deleting it. Do NOT delete without the user’s approval. ' +
-      `Once approved, call again with confirm: true and confirmationToken: "${nonce}" ` +
-      '(the server will verify and consume this single-use token before deleting).',
+      renderTokenConfirmNextStep({
+        subject: 'present this task',
+        approvalClause: 'confirm deleting it. Do NOT delete',
+        nonce,
+        tail: ' before deleting).',
+      }),
   );
 }
 

--- a/src/tools/web/_lib/hitlText.ts
+++ b/src/tools/web/_lib/hitlText.ts
@@ -1,0 +1,122 @@
+/**
+ * Single-sourced tool-side human-in-the-loop (HITL) / gate wording for the mutation tools
+ * (AC-4, W-23125362).
+ *
+ * The PROMPT surface centralizes its HITL text in src/prompts/_lib/confirm.ts. The TOOL surface — the
+ * preview "NEXT STEP" instructions, the flag-ON "confirm is closed" block, and the guard's
+ * PreviewNotRunError recovery text — was previously hand-rolled at each call site and drifted. These
+ * renderers collect that wording in one place so the language stays consistent and can be hardened
+ * once.
+ *
+ * PLACEMENT: this lives under src/tools/web/_lib (not src/prompts/_lib) on purpose. The guard
+ * (mutationGuard.ts) that consumes some of this text is itself under src/tools/web/_lib; importing
+ * from src/prompts/_lib would introduce a tools→prompts cross-layer import that does not otherwise
+ * exist in the tools tree. A tools-side module keeps the dependency direction clean.
+ *
+ * The strings are BEHAVIOR-PRESERVING extractions — semantically identical to the prior inline text,
+ * just single-sourced.
+ */
+
+/**
+ * Preview "NEXT STEP" text for a TAG-gated delete (workbook / datasource). The caller supplies the
+ * `subject` clause (what to show the user) and the pending-deletion `tag` the confirm re-verifies.
+ */
+export function renderTagDeleteNextStep({
+  subject,
+  pendingTag,
+}: {
+  /** Imperative clause naming what to present, e.g. "show this workbook (name, project, owner)". */
+  subject: string;
+  /** The pending-deletion tag label the confirm phase verifies. */
+  pendingTag: string;
+}): string {
+  return (
+    `NEXT STEP — REQUIRED: ${subject} to the user and ask them to explicitly confirm ` +
+    'deleting it. Do NOT delete without the user’s approval. ' +
+    'Once approved, call again with confirm: true (the server will verify this ' +
+    `'${pendingTag}' tag before deleting). `
+  );
+}
+
+/**
+ * Preview "NEXT STEP" text for a TOKEN-gated mutation (extract-refresh-task delete, cloud
+ * extract-refresh schedule update). Parameterized because the delete and update variants differ in
+ * subject, the confirm-verb clause, and the trailing gate description.
+ */
+export function renderTokenConfirmNextStep({
+  subject,
+  approvalClause,
+  nonce,
+  tail,
+}: {
+  /** Imperative clause naming what to present, e.g. "present this task" / "present this change". */
+  subject: string;
+  /** The confirm-verb clause, e.g. "confirm deleting it. Do NOT delete" / "confirm it. Do NOT apply". */
+  approvalClause: string;
+  /** The single-use confirmation token to echo into the instruction. */
+  nonce: string | undefined;
+  /** Trailing gate clause, starting right after "single-use token", e.g. " before deleting)." */
+  tail: string;
+}): string {
+  return (
+    `NEXT STEP — REQUIRED: ${subject} to the user and ask them to explicitly ` +
+    `${approvalClause} without the user’s approval. ` +
+    `Once approved, call again with confirm: true and confirmationToken: "${nonce}" ` +
+    `(the server will verify and consume this single-use token${tail}`
+  );
+}
+
+/**
+ * The flag-ON "model-driven confirm is CLOSED" message returned as a PreviewNotRunError body when the
+ * `mcp-apps` feature is enabled and an agent tries to self-confirm. Parameterized for the delete vs
+ * update surfaces.
+ */
+export function renderConfirmClosedMessage({
+  actionPhrase,
+  panelName,
+  previewTool,
+  appliedClause,
+}: {
+  /** What is being gated, e.g. "deleting a workbook" / "changing an extract refresh schedule". */
+  actionPhrase: string;
+  /** The panel to open, e.g. "the approval panel" / "the update-... approval panel". */
+  panelName: string;
+  /** The model-visible preview tool the user re-runs to open the panel. */
+  previewTool: string;
+  /** How/when the mutation is actually applied, e.g. "the deletion is performed only when a person clicks Delete". */
+  appliedClause: string;
+}): string {
+  return (
+    `Mutation blocked: ${actionPhrase} requires a human confirmation in ${panelName}. ` +
+    `Run ${previewTool} in preview (omit confirm) to open the panel; ${appliedClause}. ` +
+    "The assistant cannot confirm on the user's behalf."
+  );
+}
+
+/**
+ * The guard's PreviewNotRunError body when a confirm cannot verify that a preview ran. When
+ * `previewTool` is set (an app-only confirm tool) the recovery points at re-previewing and approving
+ * in the panel; otherwise (a model-visible preview-confirm tool) it points at re-running with confirm
+ * omitted.
+ */
+export function renderPreviewNotRunMessage({
+  tool,
+  previewTool,
+  targetKind,
+  targetId,
+}: {
+  tool: string;
+  previewTool?: string;
+  targetKind: string;
+  targetId: string;
+}): string {
+  const recovery = previewTool
+    ? `Re-run ${previewTool} to preview again, then approve in the confirmation panel.`
+    : `Run ${tool} with confirm omitted (or false) first to preview, then call again with ` +
+      'confirm: true.';
+  return (
+    `Mutation blocked: ${tool} could not verify that a preview ran for ${targetKind} ` +
+    `${targetId}. ${recovery} This gate verifies server-side state and cannot be bypassed by ` +
+    'computing a token.'
+  );
+}

--- a/src/tools/web/_lib/mutationGuard.ts
+++ b/src/tools/web/_lib/mutationGuard.ts
@@ -12,6 +12,13 @@
  *      forged confirmations exactly as #414's tag gate does.
  *   4. Emits a single authoritative AuditRecord (allowed OR denied) to the durable log sink.
  *
+ * DURABILITY CONTRACT (AC-5, honest note): the authoritative audit records emitted below are
+ * structured JSON written to the dedicated `audit` logger, which bypasses the LOG_LEVEL severity
+ * filter (see AUDIT_LOGGER) so an operator cannot suppress them by raising LOG_LEVEL. DURABILITY
+ * itself is the DEPLOYMENT's responsibility: this server emits the records to its log stream
+ * (stderr/stdout/file); operators MUST ship that audit stream to their durable/immutable log store
+ * (SIEM, log archive, etc.) for retention. There is no built-in durable sink here.
+ *
  * AC-5 — RESIDUAL GAP (code-enforced human approval): the MCP SDK shipped with this server
  * (@modelcontextprotocol/sdk >=1.26, currently 1.29) DOES expose an elicitation primitive
  * (server.elicitInput(...)), but it is not wired in here and host/client support for it is uneven —
@@ -36,6 +43,7 @@ import { TableauWebRequestHandlerExtra } from '../toolContext.js';
 import { WebToolName } from '../toolName.js';
 import { AuditRecord, auditRecordSchema } from './auditRecord.js';
 import { EvidenceContext, EvidenceStrategy } from './evidence.js';
+import { renderPreviewNotRunMessage } from './hitlText.js';
 
 /** Identity of the principal attempting the mutation, captured for the audit record. */
 export interface MutationActor {
@@ -183,14 +191,14 @@ export async function guardMutation<TTarget>({
       // approving in the rendered panel — it is model-invisible and takes no `confirm` arg, so the
       // "run with confirm omitted" recovery does not apply to it. A model-visible preview-confirm
       // tool (no previewTool) previews and confirms under the SAME name, so it recovers in place.
-      const recovery = previewTool
-        ? `Re-run ${previewTool} to preview again, then approve in the confirmation panel.`
-        : `Run ${tool} with confirm omitted (or false) first to preview, then call again with ` +
-          'confirm: true.';
+      // Wording single-sourced in hitlText.ts (renderPreviewNotRunMessage).
       return new PreviewNotRunError(
-        `Mutation blocked: ${tool} could not verify that a preview ran for ${target.kind} ` +
-          `${target.id}. ${recovery} This gate verifies server-side state and cannot be bypassed by ` +
-          'computing a token.',
+        renderPreviewNotRunMessage({
+          tool,
+          previewTool,
+          targetKind: target.kind,
+          targetId: target.id,
+        }),
       ).toErr();
     }
   }

--- a/src/tools/web/_lib/resolveExtractRefreshTaskTarget.test.ts
+++ b/src/tools/web/_lib/resolveExtractRefreshTaskTarget.test.ts
@@ -1,0 +1,161 @@
+import { RestApi } from '../../../sdks/tableau/restApi.js';
+import { ExtractRefreshTask } from '../../../sdks/tableau/types/extractRefreshTask.js';
+import { resolveExtractRefreshTaskTarget } from './resolveExtractRefreshTaskTarget.js';
+
+// Auto-mock the logger so the best-effort warning on a resolve failure is captured, not written to
+// stderr.
+vi.mock('../../../logging/logger.js');
+
+const siteId = 'test-site-id';
+const taskId = 'a1b2c3d4-e5f6-4789-9abc-ef1234567890';
+
+const mocks = vi.hoisted(() => ({
+  mockListExtractRefreshTasks: vi.fn(),
+  mockQueryDatasource: vi.fn(),
+  mockGetWorkbook: vi.fn(),
+  mockQueryUserOnSite: vi.fn(),
+}));
+
+function makeRestApi(): RestApi {
+  return {
+    siteId,
+    tasksMethods: { listExtractRefreshTasks: mocks.mockListExtractRefreshTasks },
+    datasourcesMethods: { queryDatasource: mocks.mockQueryDatasource },
+    workbooksMethods: { getWorkbook: mocks.mockGetWorkbook },
+    usersMethods: { queryUserOnSite: mocks.mockQueryUserOnSite },
+  } as unknown as RestApi;
+}
+
+describe('resolveExtractRefreshTaskTarget', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.mockQueryUserOnSite.mockResolvedValue({
+      id: 'owner-1',
+      name: 'Owner One',
+      email: 'owner@example.com',
+    });
+  });
+
+  it('derives name/project/owner from the underlying DATASOURCE', async () => {
+    const tasks: ExtractRefreshTask[] = [{ id: taskId, datasource: { id: 'ds-1' } }];
+    mocks.mockQueryDatasource.mockResolvedValue({
+      id: 'ds-1',
+      name: 'Sales Extract',
+      project: { name: 'Finance' },
+      owner: { id: 'owner-1' },
+    });
+    const target = await resolveExtractRefreshTaskTarget({
+      restApi: makeRestApi(),
+      siteId,
+      taskId,
+      tasks,
+    });
+    expect(target).toEqual({
+      id: taskId,
+      name: 'Sales Extract',
+      project: 'Finance',
+      owner: 'owner@example.com',
+      kind: 'extract-refresh-task',
+    });
+    // The already-fetched task list was reused — no re-list.
+    expect(mocks.mockListExtractRefreshTasks).not.toHaveBeenCalled();
+  });
+
+  it('derives name/project/owner from the underlying WORKBOOK when there is no datasource', async () => {
+    const tasks: ExtractRefreshTask[] = [{ id: taskId, workbook: { id: 'wb-1' } }];
+    mocks.mockGetWorkbook.mockResolvedValue({
+      id: 'wb-1',
+      name: 'Exec Dashboard',
+      project: { name: 'Leadership' },
+      owner: { id: 'owner-1' },
+    });
+    const target = await resolveExtractRefreshTaskTarget({
+      restApi: makeRestApi(),
+      siteId,
+      taskId,
+      tasks,
+    });
+    expect(target).toEqual({
+      id: taskId,
+      name: 'Exec Dashboard',
+      project: 'Leadership',
+      owner: 'owner@example.com',
+      kind: 'extract-refresh-task',
+    });
+  });
+
+  it('lists tasks itself when none are pre-fetched', async () => {
+    mocks.mockListExtractRefreshTasks.mockResolvedValue([
+      { id: taskId, datasource: { id: 'ds-1' } },
+    ]);
+    mocks.mockQueryDatasource.mockResolvedValue({
+      id: 'ds-1',
+      name: 'Sales Extract',
+      project: { name: 'Finance' },
+      owner: { id: 'owner-1' },
+    });
+    const target = await resolveExtractRefreshTaskTarget({
+      restApi: makeRestApi(),
+      siteId,
+      taskId,
+    });
+    expect(mocks.mockListExtractRefreshTasks).toHaveBeenCalledOnce();
+    expect(target.name).toBe('Sales Extract');
+  });
+
+  it('degrades to id-only when the task has no datasource/workbook reference', async () => {
+    const tasks: ExtractRefreshTask[] = [{ id: taskId }];
+    const target = await resolveExtractRefreshTaskTarget({
+      restApi: makeRestApi(),
+      siteId,
+      taskId,
+      tasks,
+    });
+    expect(target).toEqual({ id: taskId, kind: 'extract-refresh-task' });
+    expect(mocks.mockQueryDatasource).not.toHaveBeenCalled();
+  });
+
+  it('degrades to id-only when the task id is not in the list', async () => {
+    const tasks: ExtractRefreshTask[] = [{ id: 'some-other-id', datasource: { id: 'ds-9' } }];
+    const target = await resolveExtractRefreshTaskTarget({
+      restApi: makeRestApi(),
+      siteId,
+      taskId,
+      tasks,
+    });
+    expect(target).toEqual({ id: taskId, kind: 'extract-refresh-task' });
+  });
+
+  it('degrades to id-only (never throws) when the content lookup fails', async () => {
+    const tasks: ExtractRefreshTask[] = [{ id: taskId, datasource: { id: 'ds-1' } }];
+    mocks.mockQueryDatasource.mockRejectedValue(new Error('403 querying datasource'));
+    const target = await resolveExtractRefreshTaskTarget({
+      restApi: makeRestApi(),
+      siteId,
+      taskId,
+      tasks,
+    });
+    expect(target).toEqual({ id: taskId, kind: 'extract-refresh-task' });
+  });
+
+  it('leaves owner undefined when the owner lookup returns nothing (best-effort)', async () => {
+    const tasks: ExtractRefreshTask[] = [{ id: taskId, datasource: { id: 'ds-1' } }];
+    mocks.mockQueryDatasource.mockResolvedValue({
+      id: 'ds-1',
+      name: 'Sales Extract',
+      project: { name: 'Finance' },
+      owner: { id: 'owner-1' },
+    });
+    // resolveOwnerEmail returns null when the user query fails; it never throws.
+    mocks.mockQueryUserOnSite.mockRejectedValue(new Error('user not found'));
+    const target = await resolveExtractRefreshTaskTarget({
+      restApi: makeRestApi(),
+      siteId,
+      taskId,
+      tasks,
+    });
+    expect(target.name).toBe('Sales Extract');
+    expect(target.project).toBe('Finance');
+    expect(target.owner).toBeUndefined();
+  });
+});

--- a/src/tools/web/_lib/resolveExtractRefreshTaskTarget.ts
+++ b/src/tools/web/_lib/resolveExtractRefreshTaskTarget.ts
@@ -1,0 +1,96 @@
+import { log } from '../../../logging/logger.js';
+import { RestApi } from '../../../sdks/tableau/restApi.js';
+import { ExtractRefreshTask } from '../../../sdks/tableau/types/extractRefreshTask.js';
+import { getExceptionMessage } from '../../../utils/getExceptionMessage.js';
+import { resolveOwnerEmail } from '../users/resolveOwnerEmail.js';
+import { MutationTarget } from './mutationGuard.js';
+
+/**
+ * Best-effort resolution of an extract-refresh task's audit-target identity (AC-3, W-23125362).
+ *
+ * IDENTITY MAPPING (lead decision): an extract-refresh task has no natural name/project/owner of its
+ * own. The Tableau REST list entry carries ONLY `{ id, schedule?, datasource?: {id}, workbook?: {id} }`
+ * (see src/sdks/tableau/types/extractRefreshTask.ts) and there is NO single-task GET endpoint — so a
+ * task's identity DERIVES from its underlying content:
+ *   - `target.name`    = the underlying datasource/workbook name
+ *   - `target.project` = its project name
+ *   - `target.owner`   = its owner email/name (via resolveOwnerEmail, best-effort)
+ * If the task has no datasource/workbook reference, or the content lookup fails, the field is left
+ * undefined (documented best-effort). This function NEVER throws: every lookup is wrapped so a resolve
+ * failure degrades to an id-only target and can never block or fail the guarded mutation/audit.
+ *
+ * COST: the task list yields only the underlying content ID, so enriching name/project/owner requires
+ * ONE content lookup (queryDatasource | getWorkbook) plus ONE owner lookup (queryUserOnSite) —
+ * mirroring the cost the workbook/datasource delete branches already pay. Callers that ALREADY hold
+ * the task list (the delete-content task branch runs it as its existence check) pass it via `tasks` to
+ * avoid a re-list; the confirm/update paths omit it and this helper lists once itself.
+ *
+ * This is single-sourced across all four extract-refresh-task mutation paths (delete-content task
+ * branch, update-cloud-extract-refresh-task, confirm-delete-content, confirm-update-cloud-extract-refresh-task)
+ * so the identity mapping lives in exactly one place.
+ */
+export async function resolveExtractRefreshTaskTarget({
+  restApi,
+  siteId,
+  taskId,
+  logger = 'resolve-extract-refresh-task-target',
+  tasks,
+}: {
+  restApi: RestApi;
+  siteId: string;
+  taskId: string;
+  logger?: string;
+  /** Pre-fetched task list, if the caller already has it (avoids a re-list). */
+  tasks?: ReadonlyArray<ExtractRefreshTask>;
+}): Promise<MutationTarget> {
+  const idOnly: MutationTarget = { id: taskId, kind: 'extract-refresh-task' };
+
+  try {
+    const taskList = tasks ?? (await restApi.tasksMethods.listExtractRefreshTasks({ siteId }));
+    const task = taskList.find((t) => t.id === taskId);
+    if (!task) {
+      return idOnly;
+    }
+
+    if (task.datasource?.id) {
+      const datasource = await restApi.datasourcesMethods.queryDatasource({
+        datasourceId: task.datasource.id,
+        siteId,
+      });
+      const owner = await resolveOwnerEmail(restApi, siteId, datasource.owner?.id, logger);
+      return {
+        id: taskId,
+        name: datasource.name,
+        project: datasource.project?.name,
+        owner: owner ?? undefined,
+        kind: 'extract-refresh-task',
+      };
+    }
+
+    if (task.workbook?.id) {
+      const workbook = await restApi.workbooksMethods.getWorkbook({
+        workbookId: task.workbook.id,
+        siteId,
+      });
+      const owner = await resolveOwnerEmail(restApi, siteId, workbook.owner?.id, logger);
+      return {
+        id: taskId,
+        name: workbook.name,
+        project: workbook.project?.name,
+        owner: owner ?? undefined,
+        kind: 'extract-refresh-task',
+      };
+    }
+
+    return idOnly;
+  } catch (error) {
+    // Best-effort: a resolve failure must never block or fail the mutation/audit — degrade to id-only.
+    log({
+      message: `${logger}: failed to resolve underlying content for extract refresh task ${taskId}`,
+      level: 'warning',
+      logger,
+      data: getExceptionMessage(error),
+    });
+    return idOnly;
+  }
+}

--- a/src/tools/web/extractRefreshTasks/confirmUpdateCloudExtractRefreshTask.test.ts
+++ b/src/tools/web/extractRefreshTasks/confirmUpdateCloudExtractRefreshTask.test.ts
@@ -57,6 +57,8 @@ const updatedTask: ExtractRefreshTask = {
 
 const mocks = vi.hoisted(() => ({
   mockUpdateCloudExtractRefreshTask: vi.fn(),
+  mockListExtractRefreshTasks: vi.fn(),
+  mockQueryDatasource: vi.fn(),
   mockQueryUserOnSite: vi.fn(),
   mockAssertAdmin: vi.fn(),
   mockIsFeatureEnabled: vi.fn(),
@@ -71,6 +73,10 @@ vi.mock('../../../restApiInstance.js', () => ({
     callback({
       tasksMethods: {
         updateCloudExtractRefreshTask: mocks.mockUpdateCloudExtractRefreshTask,
+        listExtractRefreshTasks: mocks.mockListExtractRefreshTasks,
+      },
+      datasourcesMethods: {
+        queryDatasource: mocks.mockQueryDatasource,
       },
       usersMethods: {
         queryUserOnSite: mocks.mockQueryUserOnSite,
@@ -116,8 +122,24 @@ describe('confirmUpdateCloudExtractRefreshTaskTool', () => {
     vi.clearAllMocks();
     delete process.env.MUTATION_PREVIEW_TTL_MINUTES;
     mocks.mockAssertAdmin.mockResolvedValue(new Ok(true));
-    mocks.mockQueryUserOnSite.mockResolvedValue({ siteRole: 'SiteAdministratorCreator' });
+    mocks.mockQueryUserOnSite.mockResolvedValue({
+      id: 'owner-1',
+      name: 'Owner One',
+      email: 'owner@example.com',
+      siteRole: 'SiteAdministratorCreator',
+    });
     mocks.mockUpdateCloudExtractRefreshTask.mockResolvedValue(new Ok(updatedTask));
+    // Default: the task list resolves this task to its underlying datasource so the audit target is
+    // enriched (AC-3).
+    mocks.mockListExtractRefreshTasks.mockResolvedValue([
+      { id: validTaskId, datasource: { id: 'ds-1' } },
+    ]);
+    mocks.mockQueryDatasource.mockResolvedValue({
+      id: 'ds-1',
+      name: 'Sales Extract',
+      project: { name: 'Finance' },
+      owner: { id: 'owner-1' },
+    });
     mocks.mockIsFeatureEnabled.mockResolvedValue(true);
   });
 
@@ -166,6 +188,10 @@ describe('confirmUpdateCloudExtractRefreshTaskTool', () => {
     expect(records.every((r) => r.phase === 'confirm')).toBe(true);
     expect(records.every((r) => r.action === 'update')).toBe(true);
     expect(records.every((r) => r.confirmationEvidence.kind === 'registry-nonce')).toBe(true);
+    // AC-3 / Gap-B: the audit target is enriched from the task's underlying datasource.
+    expect(records[0].target.name).toBe('Sales Extract');
+    expect(records[0].target.project).toBe('Finance');
+    expect(records[0].target.owner).toBe('owner@example.com');
   });
 
   // --- Missing approval → PreviewNotRunError, no update ---

--- a/src/tools/web/extractRefreshTasks/confirmUpdateCloudExtractRefreshTask.ts
+++ b/src/tools/web/extractRefreshTasks/confirmUpdateCloudExtractRefreshTask.ts
@@ -11,6 +11,7 @@ import { WebMcpServer } from '../../../server.web.js';
 import { Provider } from '../../../utils/provider.js';
 import { AppApprovalEvidence } from '../_lib/evidence.js';
 import { guardMutation, MutationTarget } from '../_lib/mutationGuard.js';
+import { resolveExtractRefreshTaskTarget } from '../_lib/resolveExtractRefreshTaskTarget.js';
 import { WebTool } from '../tool.js';
 import { scheduleBinding } from './updateCloudExtractRefreshTask.js';
 
@@ -85,11 +86,17 @@ schedule values.
             jwtScopes: confirmUpdateCloudExtractRefreshTaskTool.requiredApiScopes,
             callback: async (restApi) => {
               // The task carries no durable taggable state; the human gesture in the iframe is the
-              // proof. name/project may be undefined for a task — that's fine, the audit schema allows it.
-              const resolveTarget = async (): Promise<MutationTarget> => ({
-                id: args.taskId,
-                kind: 'extract-refresh-task',
-              });
+              // proof. Enrich the audit target with the underlying content's name/project/owner
+              // (AC-3) via the shared best-effort helper: it lists tasks once, finds this id, then
+              // does ONE content lookup + ONE owner lookup. A resolve failure degrades to an id-only
+              // target and never blocks the update.
+              const resolveTarget = async (): Promise<MutationTarget> =>
+                resolveExtractRefreshTaskTarget({
+                  restApi,
+                  siteId: restApi.siteId,
+                  taskId: args.taskId,
+                  logger: 'confirm-update-cloud-extract-refresh-task',
+                });
 
               // Require a fresh, single-use in-iframe human approval recorded by the preview — bound to
               // the exact schedule that was previewed/approved. `binding` is folded into the approval

--- a/src/tools/web/extractRefreshTasks/updateCloudExtractRefreshTask.test.ts
+++ b/src/tools/web/extractRefreshTasks/updateCloudExtractRefreshTask.test.ts
@@ -55,6 +55,8 @@ function extractConfirmationToken(text: string): string {
 
 const mocks = vi.hoisted(() => ({
   mockUpdateCloudExtractRefreshTask: vi.fn(),
+  mockListExtractRefreshTasks: vi.fn(),
+  mockQueryDatasource: vi.fn(),
   mockQueryUserOnSite: vi.fn(),
   mockAssertAdmin: vi.fn(),
   mockIsFeatureEnabled: vi.fn(),
@@ -69,6 +71,10 @@ vi.mock('../../../restApiInstance.js', () => ({
     callback({
       tasksMethods: {
         updateCloudExtractRefreshTask: mocks.mockUpdateCloudExtractRefreshTask,
+        listExtractRefreshTasks: mocks.mockListExtractRefreshTasks,
+      },
+      datasourcesMethods: {
+        queryDatasource: mocks.mockQueryDatasource,
       },
       usersMethods: {
         queryUserOnSite: mocks.mockQueryUserOnSite,
@@ -120,8 +126,25 @@ describe('updateCloudExtractRefreshTaskTool', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.mockAssertAdmin.mockResolvedValue(new Ok(true));
-    mocks.mockQueryUserOnSite.mockResolvedValue({ siteRole: 'SiteAdministratorCreator' });
+    mocks.mockQueryUserOnSite.mockResolvedValue({
+      id: 'owner-1',
+      name: 'Owner One',
+      email: 'owner@example.com',
+      siteRole: 'SiteAdministratorCreator',
+    });
     mocks.mockUpdateCloudExtractRefreshTask.mockResolvedValue(new Ok(updatedTask));
+    // Default: the task list resolves this task to its underlying datasource so the audit target is
+    // enriched (AC-3). Tests that don't care about enrichment are unaffected (best-effort, id always
+    // present).
+    mocks.mockListExtractRefreshTasks.mockResolvedValue([
+      { id: validTaskId, datasource: { id: 'ds-1' } },
+    ]);
+    mocks.mockQueryDatasource.mockResolvedValue({
+      id: 'ds-1',
+      name: 'Sales Extract',
+      project: { name: 'Finance' },
+      owner: { id: 'owner-1' },
+    });
     // Default: mcp-apps flag OFF → today's exact confirm-only behavior.
     mocks.mockIsFeatureEnabled.mockResolvedValue(false);
   });
@@ -506,6 +529,10 @@ describe('updateCloudExtractRefreshTaskTool', () => {
       expect(confirmRecords.map((r) => r.result)).toEqual(['completed']);
       expect(confirmRecords.every((r) => r.action === 'update')).toBe(true);
       expect(confirmRecords.every((r) => r.target.id === validTaskId)).toBe(true);
+      // AC-3 / Gap-B: the audit target is enriched from the task's underlying datasource.
+      expect(confirmRecords.every((r) => r.target.name === 'Sales Extract')).toBe(true);
+      expect(confirmRecords.every((r) => r.target.project === 'Finance')).toBe(true);
+      expect(confirmRecords.every((r) => r.target.owner === 'owner@example.com')).toBe(true);
     });
 
     // Fix #1: the confirm is bound to the exact schedule that was previewed. A token minted for

--- a/src/tools/web/extractRefreshTasks/updateCloudExtractRefreshTask.ts
+++ b/src/tools/web/extractRefreshTasks/updateCloudExtractRefreshTask.ts
@@ -19,7 +19,9 @@ import {
   getMutationPreviewTtlMs,
   RegistryEvidence,
 } from '../_lib/evidence.js';
+import { renderConfirmClosedMessage, renderTokenConfirmNextStep } from '../_lib/hitlText.js';
 import { guardMutation, MutationTarget } from '../_lib/mutationGuard.js';
+import { resolveExtractRefreshTaskTarget } from '../_lib/resolveExtractRefreshTaskTarget.js';
 import { AppToolResult, WebTool } from '../tool.js';
 
 /**
@@ -188,11 +190,14 @@ export const getUpdateCloudExtractRefreshTaskTool = async (
               // keeps the original nonce-gated confirm:true path intact.
               if (args.confirm && mcpAppsEnabled) {
                 return new PreviewNotRunError(
-                  'Mutation blocked: changing an extract refresh schedule requires a human ' +
-                    'confirmation in the update-cloud-extract-refresh-task approval panel. Run ' +
-                    'update-cloud-extract-refresh-task in preview (omit confirm) to open the panel; the ' +
-                    'change is applied by confirm-update-cloud-extract-refresh-task only when a person ' +
-                    "clicks Apply. The assistant cannot confirm on the user's behalf.",
+                  renderConfirmClosedMessage({
+                    actionPhrase: 'changing an extract refresh schedule',
+                    panelName: 'the update-cloud-extract-refresh-task approval panel',
+                    previewTool: 'update-cloud-extract-refresh-task',
+                    appliedClause:
+                      'the change is applied by confirm-update-cloud-extract-refresh-task only when ' +
+                      'a person clicks Apply',
+                  }),
                 ).toErr();
               }
 
@@ -202,10 +207,17 @@ export const getUpdateCloudExtractRefreshTaskTool = async (
               // schedule (see scheduleBinding), so a token minted while previewing schedule A cannot
               // confirm an update to schedule B, and a confirm with no prior preview is rejected
               // server-side. The guard audits both the preview and the confirmed update.
-              const resolveTarget = async (): Promise<MutationTarget> => ({
-                id: args.taskId,
-                kind: 'extract-refresh-task',
-              });
+              // Enrich the audit target with the underlying content's name/project/owner (AC-3) via
+              // the shared best-effort helper. No task list is pre-fetched here, so the helper lists
+              // tasks once, finds this id, then does ONE content lookup + ONE owner lookup. A resolve
+              // failure degrades to an id-only target and never blocks the update.
+              const resolveTarget = async (): Promise<MutationTarget> =>
+                resolveExtractRefreshTaskTarget({
+                  restApi,
+                  siteId: restApi.siteId,
+                  taskId: args.taskId,
+                  logger: 'update-cloud-extract-refresh-task',
+                });
               const evidence = new RegistryEvidence();
               const binding = scheduleBinding(args.schedule);
               const guardResult = await guardMutation({
@@ -274,11 +286,12 @@ export const getUpdateCloudExtractRefreshTaskTool = async (
                 return new Ok(
                   `Preview — extract refresh task '${args.taskId}' would be updated to: ${frequency}${window}. ` +
                     'No change has been made. ' +
-                    'NEXT STEP — REQUIRED: present this change to the user and ask them to explicitly ' +
-                    'confirm it. Do NOT apply without the user’s approval. ' +
-                    `Once approved, call again with confirm: true and confirmationToken: "${nonce}" ` +
-                    '(the server will verify and consume this single-use token, which is bound to this ' +
-                    'exact schedule, before applying the update).',
+                    renderTokenConfirmNextStep({
+                      subject: 'present this change',
+                      approvalClause: 'confirm it. Do NOT apply',
+                      nonce,
+                      tail: ', which is bound to this exact schedule, before applying the update).',
+                    }),
                 );
               }
 


### PR DESCRIPTION
## What & why

Scope-completes GUS **W-23125362** ("Common mutation-tool safety layer: enforced HITL approval + authoritative audit across all TMCP mutation tools"). The shared guard + evidence model + audit lifecycle already landed and cover the four content/task mutators (`delete-content` wb/ds/task, `confirm-delete-content`, `update-cloud-extract-refresh-task`, `confirm-update-cloud-extract-refresh-task`). This PR finishes the in-scope remainder.

Three items were **deliberately forked** to a follow-up story (they require new architecture, not completion of this layer): auditing the OAuth session tools (`revoke-access-token`, `reset-consent`), a durable/tamper-resistant external sink, and the e2e test tiers.

## Changes

**AC-3 (Gap B) — enrich extract-refresh-task audit target**
- Audit records for extract-refresh-task paths carried only `{id, kind}`. Now populate `name`/`project`/`owner`, derived from the underlying datasource (else workbook) — a task's natural identity.
- New shared helper `resolveExtractRefreshTaskTarget.ts`; best-effort, degrades to id-only on Server sites or 403/404 and **never blocks or fails the mutation**.
- Applied to all four task paths. The `delete-content` task branch reuses its existing existence-check task list (no extra round-trip); the other three paths do a best-effort list+content+owner lookup (no single-task GET endpoint exists).

**AC-4 (Gap D) — centralize tool-side HITL text**
- Prompt-side text was already centralized; the tool-side "NEXT STEP — REQUIRED", confirm-closed, and `PreviewNotRunError` recovery strings were hand-rolled per branch.
- Extracted into new `hitlText.ts` (kept in `tools/_lib` to avoid a tools→prompts cross-layer import). Byte-for-byte behavior-preserving; rethreaded `delete-content`, `update-cloud-extract-refresh-task`, and the guard's PreviewNotRun branch.

**AC-3 (Gap C, doc) — durability contract**
- Documented that authoritative audit records emit as structured JSON on the dedicated `audit` logger (bypasses `LOG_LEVEL`), and that durable retention is the deployment's responsibility (ship the stream to an immutable store). Added to `auditRecord.ts` and `delete-content.md`. No new sink built.

**AC-6 (Gap E, unit) — per-tool audit test completeness**
- For the four in-scope mutators: forged-confirm rejected, happy preview→confirm, and audit record fields on **both allow and deny** — including assertions that the newly enriched `name`/`project`/`owner` appear. Unit tier only (e2e forked).

## Testing
- `npx vitest run` — **150 files / 2306 tests, all pass**
- `npx tsc --noEmit`, `npm run lint`, `npm run build` — clean
- Version 3.1.3 → **3.1.4**

## Notes
- No tools added/removed; `tests/e2e/server.test.ts` "should list tools" unaffected.
- Enrichment is best-effort by design — on Server-only sites or lookup failures, task targets degrade to id-only (documented in code + `delete-content.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)