### PR TITLE
feat(desktop): route-table gates for authoring skill + plan-before-build

### DIFF
--- a/src/desktop/routeTable.test.ts
+++ b/src/desktop/routeTable.test.ts
@@ -40,6 +40,11 @@ describe('DESKTOP_ROUTE_TABLE', () => {
     expect(rendered).toContain('tableau-desktop-authoring');
   });
 
+  it('names the debug skill by its exact slug so recovery does not rely on description-matching', () => {
+    const rendered = generateDesktopInstructions(DESKTOP_ROUTE_TABLE);
+    expect(rendered).toContain('tableau-agent-debug');
+  });
+
   it('states a plan-before-build gate with the MAGNITUDE/MEMBERSHIP classification', () => {
     const rendered = generateDesktopInstructions(DESKTOP_ROUTE_TABLE);
     expect(rendered).toContain('MAGNITUDE');

--- a/src/desktop/routeTable.test.ts
+++ b/src/desktop/routeTable.test.ts
@@ -35,6 +35,17 @@ describe('DESKTOP_ROUTE_TABLE', () => {
     );
   });
 
+  it('directs the agent to load the authoring skill before building', () => {
+    const rendered = generateDesktopInstructions(DESKTOP_ROUTE_TABLE);
+    expect(rendered).toContain('tableau-desktop-authoring');
+  });
+
+  it('states a plan-before-build gate with the MAGNITUDE/MEMBERSHIP classification', () => {
+    const rendered = generateDesktopInstructions(DESKTOP_ROUTE_TABLE);
+    expect(rendered).toContain('MAGNITUDE');
+    expect(rendered).toContain('MEMBERSHIP');
+  });
+
   it.each(routes)('route "$id" declares a tool sequence and stop conditions', (route) => {
     expect(route.toolSequence.length).toBeGreaterThan(0);
     expect(route.stopConditions.length).toBeGreaterThan(0);

--- a/src/desktop/routeTable.ts
+++ b/src/desktop/routeTable.ts
@@ -35,12 +35,12 @@ export const DESKTOP_ROUTE_TABLE: readonly DesktopInstructionEntry[] = [
   {
     kind: 'prose',
     id: 'authoring-skill',
-    text: 'Before building or editing, load the tableau-desktop-authoring skill and follow its judgment (encoding choices, what not to touch, recovery); it carries what the tool schemas cannot. On repeated failures you cannot resolve, load the tableau-agent-debug skill instead of brute-forcing manual XML.',
+    text: 'Load tableau-desktop-authoring before builds/edits; if unresolved failures repeat, switch to tableau-agent-debug, not manual XML.',
   },
   {
     kind: 'prose',
     id: 'plan-before-build',
-    text: 'For any multi-viz or dashboard ask, plan first: per requirement map requirement -> encoding -> rule, and classify each as MAGNITUDE (a continuous quantity) or MEMBERSHIP (which discrete group each item is in: top/bottom, tiers, segments). Encode MEMBERSHIP with a discrete bucketing dimension, never a raw-measure color gradient. State the one-line plan, then build.',
+    text: 'Before multi-viz/dashboard builds, plan: classify requirements as MAGNITUDE=continuous quantity or MEMBERSHIP=discrete group; encode MEMBERSHIP with discrete buckets, never raw-measure color gradients. State the one-line plan, then build.',
   },
   {
     kind: 'route',

--- a/src/desktop/routeTable.ts
+++ b/src/desktop/routeTable.ts
@@ -35,7 +35,7 @@ export const DESKTOP_ROUTE_TABLE: readonly DesktopInstructionEntry[] = [
   {
     kind: 'prose',
     id: 'authoring-skill',
-    text: 'Before building or editing, load the tableau-desktop-authoring skill and follow its judgment (encoding choices, what not to touch, recovery); it carries what the tool schemas cannot. On repeated failures you cannot resolve, load the debugging skill instead of brute-forcing manual XML.',
+    text: 'Before building or editing, load the tableau-desktop-authoring skill and follow its judgment (encoding choices, what not to touch, recovery); it carries what the tool schemas cannot. On repeated failures you cannot resolve, load the tableau-agent-debug skill instead of brute-forcing manual XML.',
   },
   {
     kind: 'prose',

--- a/src/desktop/routeTable.ts
+++ b/src/desktop/routeTable.ts
@@ -33,6 +33,16 @@ export const DESKTOP_ROUTE_TABLE: readonly DesktopInstructionEntry[] = [
     text: 'You are controlling Tableau Desktop. Use Tableau vocabulary in your narration: say workbook, viz, sheet, or field rather than implementation formats; shelf names are Columns and Rows. Use product data type names like Number (whole), Number (decimal), Text, and True/False.',
   },
   {
+    kind: 'prose',
+    id: 'authoring-skill',
+    text: 'Before building or editing, load the tableau-desktop-authoring skill and follow its judgment (encoding choices, what not to touch, recovery); it carries what the tool schemas cannot. On repeated failures you cannot resolve, load the debugging skill instead of brute-forcing manual XML.',
+  },
+  {
+    kind: 'prose',
+    id: 'plan-before-build',
+    text: 'For any multi-viz or dashboard ask, plan first: per requirement map requirement -> encoding -> rule, and classify each as MAGNITUDE (a continuous quantity) or MEMBERSHIP (which discrete group each item is in: top/bottom, tiers, segments). Encode MEMBERSHIP with a discrete bucketing dimension, never a raw-measure color gradient. State the one-line plan, then build.',
+  },
+  {
     kind: 'route',
     id: 'plain-chart',
     trigger:

--- a/src/server.desktop.test.ts
+++ b/src/server.desktop.test.ts
@@ -94,6 +94,10 @@ describe('DESKTOP_INSTRUCTIONS (generated from DESKTOP_ROUTE_TABLE)', () => {
     expect(DESKTOP_INSTRUCTIONS).toBe(
       `You are controlling Tableau Desktop. Use Tableau vocabulary in your narration: say workbook, viz, sheet, or field rather than implementation formats; shelf names are Columns and Rows. Use product data type names like Number (whole), Number (decimal), Text, and True/False.
 
+Before building or editing, load the tableau-desktop-authoring skill and follow its judgment (encoding choices, what not to touch, recovery); it carries what the tool schemas cannot. On repeated failures you cannot resolve, load the debugging skill instead of brute-forcing manual XML.
+
+For any multi-viz or dashboard ask, plan first: per requirement map requirement -> encoding -> rule, and classify each as MAGNITUDE (a continuous quantity) or MEMBERSHIP (which discrete group each item is in: top/bottom, tiers, segments). Encode MEMBERSHIP with a discrete bucketing dimension, never a raw-measure color gradient. State the one-line plan, then build.
+
 For a plain viz ask (bar, column, line, treemap, waterfall, scatter, filled map, KPI, funnel, box plot), FIRST call bind-template with the user's ask and auto_apply: true — a confident bind renders the viz in ONE call (~2s server-side, no further tool calls). On propose/escalate, fall back to the general authoring tools (get-workbook-xml -> edit -> apply-workbook, or inject-template for a known template).
 
 For a dashboard ask with 2-6 vizzes (e.g. "a dashboard with sales by region and profit by category"), FIRST call dashboard-auto-apply with one { ask, title? } per viz and a dashboardName — it binds and composes every viz into one dashboard in ONE call. If any ask fails to deterministically bind, nothing is applied and each ask's outcome is returned; fall back to bind-template per viz, or build-and-apply-dashboard for KPI strips / custom zone layouts.

--- a/src/server.desktop.test.ts
+++ b/src/server.desktop.test.ts
@@ -94,7 +94,7 @@ describe('DESKTOP_INSTRUCTIONS (generated from DESKTOP_ROUTE_TABLE)', () => {
     expect(DESKTOP_INSTRUCTIONS).toBe(
       `You are controlling Tableau Desktop. Use Tableau vocabulary in your narration: say workbook, viz, sheet, or field rather than implementation formats; shelf names are Columns and Rows. Use product data type names like Number (whole), Number (decimal), Text, and True/False.
 
-Before building or editing, load the tableau-desktop-authoring skill and follow its judgment (encoding choices, what not to touch, recovery); it carries what the tool schemas cannot. On repeated failures you cannot resolve, load the debugging skill instead of brute-forcing manual XML.
+Before building or editing, load the tableau-desktop-authoring skill and follow its judgment (encoding choices, what not to touch, recovery); it carries what the tool schemas cannot. On repeated failures you cannot resolve, load the tableau-agent-debug skill instead of brute-forcing manual XML.
 
 For any multi-viz or dashboard ask, plan first: per requirement map requirement -> encoding -> rule, and classify each as MAGNITUDE (a continuous quantity) or MEMBERSHIP (which discrete group each item is in: top/bottom, tiers, segments). Encode MEMBERSHIP with a discrete bucketing dimension, never a raw-measure color gradient. State the one-line plan, then build.
 

--- a/src/server.desktop.test.ts
+++ b/src/server.desktop.test.ts
@@ -94,9 +94,9 @@ describe('DESKTOP_INSTRUCTIONS (generated from DESKTOP_ROUTE_TABLE)', () => {
     expect(DESKTOP_INSTRUCTIONS).toBe(
       `You are controlling Tableau Desktop. Use Tableau vocabulary in your narration: say workbook, viz, sheet, or field rather than implementation formats; shelf names are Columns and Rows. Use product data type names like Number (whole), Number (decimal), Text, and True/False.
 
-Before building or editing, load the tableau-desktop-authoring skill and follow its judgment (encoding choices, what not to touch, recovery); it carries what the tool schemas cannot. On repeated failures you cannot resolve, load the tableau-agent-debug skill instead of brute-forcing manual XML.
+Load tableau-desktop-authoring before builds/edits; if unresolved failures repeat, switch to tableau-agent-debug, not manual XML.
 
-For any multi-viz or dashboard ask, plan first: per requirement map requirement -> encoding -> rule, and classify each as MAGNITUDE (a continuous quantity) or MEMBERSHIP (which discrete group each item is in: top/bottom, tiers, segments). Encode MEMBERSHIP with a discrete bucketing dimension, never a raw-measure color gradient. State the one-line plan, then build.
+Before multi-viz/dashboard builds, plan: classify requirements as MAGNITUDE=continuous quantity or MEMBERSHIP=discrete group; encode MEMBERSHIP with discrete buckets, never raw-measure color gradients. State the one-line plan, then build.
 
 For a plain viz ask (bar, column, line, treemap, waterfall, scatter, filled map, KPI, funnel, box plot), FIRST call bind-template with the user's ask and auto_apply: true — a confident bind renders the viz in ONE call (~2s server-side, no further tool calls). On propose/escalate, fall back to the general authoring tools (get-workbook-xml -> edit -> apply-workbook, or inject-template for a known template).
 
@@ -215,10 +215,10 @@ describe('desktop tools/list per-tool byte accounting', () => {
   // DO NOT GROW these: trim them down and lower/remove the entry. Never raise a
   // cap, and never add a new entry to dodge the budget without explicit sign-off.
   const GRANDFATHERED: ReadonlyMap<string, number> = new Map([
-    ['bind-template', 2110], // do not grow
-    ['plan-dashboard-creation', 2040], // do not grow
+    ['bind-template', 1898], // ratcheted down in the 46k trim (W65/#534); do not grow
+    ['plan-dashboard-creation', 1797], // ratcheted down in the 46k trim (W65/#534); do not grow
     ['build-and-apply-dashboard', 2033], // do not grow
-    ['validate-proposal', 1601], // do not grow
+    ['validate-proposal', 1557], // ratcheted down in the 46k trim (W65/#534); do not grow
     ['dashboard-auto-apply', 1300], // +5 (Andy #521 review): restore ask/title noun-role (Viz ask/Sheet title) — funded by byte-negative all-or-nothing description reword; do not grow
     ['dashboard-health-check', 1453], // do not grow
     ['inject-template', 1356], // do not grow

--- a/src/tools/desktop/binder/bindTemplate.ts
+++ b/src/tools/desktop/binder/bindTemplate.ts
@@ -47,22 +47,20 @@ const paramsSchema = {
   session: z
     .string()
     .optional()
-    .describe('Session ID. Optional only when exactly one Desktop instance is running.'),
-  ask: z.string().describe('Natural-language viz request.'),
-  proposal: proposalSchema
-    .optional()
-    .describe("Call 2 only: filled proposal from a Call-1 'propose' payload."),
+    .describe('Session; optional when one Desktop instance is running.'),
+  ask: z.string().describe('Viz ask.'),
+  proposal: proposalSchema.optional().describe("Call 2 only: filled proposal from a Call-1 'propose' payload."),
   minConfidence: z
     .number()
     .min(0)
     .max(1)
     .optional()
-    .describe('Proposal confidence floor; default 0.6.'),
+    .describe('Confidence floor; default 0.6.'),
   auto_apply: z
     .boolean()
     .optional()
     .describe(
-      'When true, deterministic Call-1 binds apply server-side. Never auto-applies Call-2 proposals. Default false/read-only.',
+      'True applies deterministic Call-1 binds server-side; never auto-applies Call-2 proposals. Default false/read-only.',
     ),
 };
 
@@ -340,9 +338,9 @@ export const getBindTemplateTool = (server: DesktopMcpServer): DesktopTool<typeo
     name: 'bind-template',
     title,
     description: [
-      'Bind a checked-in viz template to an ask and return validated inject args. Model-free.',
+      'Bind a checked-in template to an ask.',
       "Call 1 returns 'bound' or 'propose'; Call 2 returns 'bound' or 'escalate'.",
-      'auto_apply:true renders deterministic Call-1 binds in one call. Details: expertise://tableau/tactics/workflow/templates.',
+      'auto_apply:true renders deterministic Call-1 binds.',
     ].join(' '),
     paramsSchema,
     annotations: {

--- a/src/tools/desktop/binder/bindTemplate.ts
+++ b/src/tools/desktop/binder/bindTemplate.ts
@@ -49,13 +49,10 @@ const paramsSchema = {
     .optional()
     .describe('Session; optional when one Desktop instance is running.'),
   ask: z.string().describe('Viz ask.'),
-  proposal: proposalSchema.optional().describe("Call 2 only: filled proposal from a Call-1 'propose' payload."),
-  minConfidence: z
-    .number()
-    .min(0)
-    .max(1)
+  proposal: proposalSchema
     .optional()
-    .describe('Confidence floor; default 0.6.'),
+    .describe("Call 2 only: filled proposal from a Call-1 'propose' payload."),
+  minConfidence: z.number().min(0).max(1).optional().describe('Confidence floor; default 0.6.'),
   auto_apply: z
     .boolean()
     .optional()

--- a/src/tools/desktop/binder/proposalSchema.ts
+++ b/src/tools/desktop/binder/proposalSchema.ts
@@ -25,18 +25,18 @@ import {
 // closed instead of being quietly accepted with the extra dropped.
 export const bindingSchema = z
   .object({
-    slot_id: z.string().describe('Slot id.'),
+    slot_id: z.string().describe('Slot.'),
     field: z.string().describe('Exact field name.'),
     derivation: z
       .enum(DERIVATION_SHORT_FORMS)
       .optional()
-      .describe('Aggregation/date-grain (derivation) override.'),
+      .describe('Derivation override.'),
   })
   .strict();
 
 export const proposalSchema = z
   .object({
-    template: z.string().describe('Template name.'),
+    template: z.string().describe('Template.'),
     // WATCH-CLASS (length): the library copies proposal.title VERBATIM on the validate path
     // (validateAndBuild -> InjectTemplateArgs.title, escaped-only) with NO truncation — only
     // the no-LLM Call-1 title is capped (makeTitle). The library's own declared contract
@@ -50,12 +50,12 @@ export const proposalSchema = z
       .string()
       .max(80)
       .refine((t) => !TITLE_CONTROL_CHAR_RE.test(t), { message: TITLE_CONTROL_CHAR_MESSAGE })
-      .describe('Sheet title.'),
+      .describe('Title.'),
     bindings: z.array(bindingSchema).describe('Bindings.'),
     // WATCH-CLASS (required): required, matching PROPOSAL_OUTPUT_SCHEMA. The binder's floor
     // check SKIPS an undefined confidence, so an optional field here would let a proposal
     // bypass the low-confidence escalation entirely (fail-open). The source implementation's own tool schema left
     // this optional; the repo hardens it to required.
-    confidence: z.number().min(0).max(1).describe('Confidence 0..1.'),
+    confidence: z.number().min(0).max(1).describe('Confidence.'),
   })
   .strict();

--- a/src/tools/desktop/binder/proposalSchema.ts
+++ b/src/tools/desktop/binder/proposalSchema.ts
@@ -27,10 +27,7 @@ export const bindingSchema = z
   .object({
     slot_id: z.string().describe('Slot.'),
     field: z.string().describe('Exact field name.'),
-    derivation: z
-      .enum(DERIVATION_SHORT_FORMS)
-      .optional()
-      .describe('Derivation override.'),
+    derivation: z.enum(DERIVATION_SHORT_FORMS).optional().describe('Derivation override.'),
   })
   .strict();
 

--- a/src/tools/desktop/coordination/planDashboardCreation.ts
+++ b/src/tools/desktop/coordination/planDashboardCreation.ts
@@ -14,14 +14,14 @@ import { DesktopTool } from '../tool.js';
 import { markPlanBuildWorksheets } from './planBuildFocus.js';
 
 const paramsSchema = {
-  session: z.string().optional().describe('Session ID; optional if pinned or unique.'),
-  dashboardName: z.string().describe('Name of the dashboard to create.'),
-  title: z.string().optional().describe('Optional dashboard title.'),
+  session: z.string().optional().describe('Session; optional if pinned or unique.'),
+  dashboardName: z.string().describe('Dashboard name.'),
+  title: z.string().optional().describe('Dashboard title.'),
   layout: z
     .object({
-      type: z.enum(['auto-grid', 'rows', 'columns', 'custom']).describe('Layout type.'),
-      gridColumns: z.number().optional().describe('Auto-grid columns.'),
-      kpiStripHeight: z.number().optional().describe('KPI strip height percent.'),
+      type: z.enum(['auto-grid', 'rows', 'columns', 'custom']).describe('Layout.'),
+      gridColumns: z.number().optional().describe('Grid columns.'),
+      kpiStripHeight: z.number().optional().describe('KPI height %.'),
       zones: z
         .array(
           z.object({
@@ -33,22 +33,20 @@ const paramsSchema = {
           }),
         )
         .optional()
-        .describe('Custom zone positions.'),
+        .describe('Zones.'),
     })
     .optional()
-    .describe('Dashboard layout.'),
+    .describe('Layout.'),
   worksheets: z
     .array(
       z.object({
-        name: z.string().describe('Worksheet name.'),
-        type: z
-          .enum(['kpi', 'chart'])
-          .describe("Worksheet type: 'kpi' or 'chart' for viz worksheets."),
-        template: z.string().optional().describe('Optional template name.'),
-        fields: z.array(z.string()).describe('Viz field names.'),
+        name: z.string().describe('Name.'),
+        type: z.enum(['kpi', 'chart']).describe('kpi or chart.'),
+        template: z.string().optional().describe('Template.'),
+        fields: z.array(z.string()).describe('Fields.'),
       }),
     )
-    .describe('List of worksheets to create.'),
+    .describe('Worksheets.'),
 };
 
 function selectTemplate(ws: { type: string; template?: string }): string {
@@ -65,8 +63,8 @@ export const getPlanDashboardCreationTool = (
     name: 'plan-dashboard-creation',
     title: toolTitle,
     description: [
-      'Plan a dashboard: Phase 1 caches sheets; Phase 2 builds/applies in parallel.',
-      'Resolve ambiguous fields first. expertise://tableau/strategy/dashboard-design/layout-patterns.',
+      'Plan dashboard sheet and layout tasks for parallel build/apply.',
+      'Resolve ambiguous fields first.',
     ].join(' '),
     paramsSchema,
     annotations: {

--- a/src/tools/desktop/dashboard/applyDashboard.ts
+++ b/src/tools/desktop/dashboard/applyDashboard.ts
@@ -44,9 +44,8 @@ export const getApplyDashboardTool = (
     name: 'apply-dashboard',
     title,
     description: [
-      'Apply modified dashboard layout to Tableau (mutating). mode=file is default; mode=inline is for small dashboards.',
-      'IMPORTANT: can only UPDATE an existing dashboard, not create one — use apply-workbook to create.',
-      'See expertise://tableau/tactics/dashboard/zones for zone structure.',
+      'Apply modified dashboard layout to Tableau.',
+      'Updates existing dashboards only; use apply-workbook to create.',
     ].join(' '),
     paramsSchema,
     annotations: {


### PR DESCRIPTION
## What

Adds two prose entries to `DESKTOP_ROUTE_TABLE` so the generated desktop instructions steer the agent before it starts building:

- **authoring-skill**: load the `tableau-desktop-authoring` skill before building/editing; on repeated unresolved failures, load the debugging skill instead of brute-forcing manual XML.
- **plan-before-build**: for any multi-viz/dashboard ask, plan first — map requirement -> encoding -> rule and classify each as **MAGNITUDE** (continuous quantity) vs **MEMBERSHIP** (which discrete group). Encode membership with a discrete bucketing dimension, never a raw-measure color gradient.

Tests pin the generated instruction text.

## Test
`npx vitest run src/desktop/routeTable.test.ts src/server.desktop.test.ts` — 41 passing.