### PR TITLE
feat(fields): add verbosity=slim to list-available-fields

### DIFF
--- a/src/desktop/metadata/field-builder.ts
+++ b/src/desktop/metadata/field-builder.ts
@@ -280,6 +280,11 @@ export function listAvailableFields(
     const datasourceName = datasource['@_name'];
     if (!datasourceName || datasourceName === 'Parameters') continue;
 
+    // A PUBLISHED datasource carries a repository-location whose id is its
+    // contentUrl (the input resolve-datasource-luid needs). Embedded/local
+    // datasources have no repository-location, so this stays undefined.
+    const contentUrl = datasource['repository-location']?.['@_id'];
+
     // Map to track all columns by name (to deduplicate)
     const columnMap = new Map<
       string,
@@ -444,6 +449,7 @@ export function listAvailableFields(
 
       const fieldRef: FieldReference = {
         datasource: datasourceName,
+        contentUrl: contentUrl,
         columnName: columnName,
         columnInstanceName: constructedInstance,
         derivation: defaultAgg,

--- a/src/desktop/metadata/types.ts
+++ b/src/desktop/metadata/types.ts
@@ -30,6 +30,10 @@ export interface FieldInfo {
 
 export interface FieldReference {
   datasource: string;
+  // Published datasource's contentUrl (from the workbook's repository-location);
+  // the input `resolve-datasource-luid` needs to get the server LUID. Undefined
+  // for embedded/local datasources, which have no server copy.
+  contentUrl?: string;
   columnName: string;
   columnInstanceName: string;
   derivation: AggregationType;

--- a/src/tools/desktop/fields/listAvailableFields.test.ts
+++ b/src/tools/desktop/fields/listAvailableFields.test.ts
@@ -77,14 +77,22 @@ describe('listAvailableFieldsTool', () => {
     vi.clearAllMocks();
   });
 
-  it('should create a tool instance with correct properties', () => {
+  it('should create a tool instance with correct properties', async () => {
     const tool = getListAvailableFieldsTool(new DesktopMcpServer());
+    const paramsSchema = await Provider.from(tool.paramsSchema);
+
     expect(tool.name).toBe('list-available-fields');
-    expect(tool.description).toContain('List ALL fields available in workbook datasources');
-    expect(tool.paramsSchema).toMatchObject({
+    expect(tool.description).toContain('List datasource fields');
+    expect(paramsSchema).toMatchObject({
       session: expect.any(Object),
       workbookFile: expect.any(Object),
+      verbosity: expect.any(Object),
     });
+    expect(paramsSchema.verbosity.description).toContain('full (default)');
+    expect(paramsSchema.verbosity.description).toContain('slim');
+    expect(paramsSchema.verbosity.safeParse('slim').success).toBe(true);
+    expect(paramsSchema.verbosity.safeParse('full').success).toBe(true);
+    expect(paramsSchema.verbosity.safeParse('verbose').success).toBe(false);
     expect(tool.annotations).toMatchObject({
       title: 'List All Available Fields in Workbook Datasources',
       readOnlyHint: false,
@@ -136,6 +144,25 @@ describe('listAvailableFieldsTool', () => {
     expect(body.message).toContain('Text');
     expect(body.message).toContain('Number (decimal)');
     expect(body.fields).toHaveLength(2);
+  });
+
+  it('omitted verbosity is byte-for-byte identical to explicit full output', async () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue('<workbook/>');
+    vi.mocked(metadataModule.listAvailableFields).mockReturnValue(mockFields as any);
+
+    const defaultResult = await getResult({ workbookFile: '/workbook.xml' });
+    const fullResult = await getResult({ workbookFile: '/workbook.xml', verbosity: 'full' });
+
+    expect(defaultResult.isError).toBe(false);
+    expect(fullResult.isError).toBe(false);
+    invariant(defaultResult.content[0].type === 'text');
+    invariant(fullResult.content[0].type === 'text');
+    expect(defaultResult.content[0].text).toBe(fullResult.content[0].text);
+    const body = resultSchema.parse(JSON.parse(defaultResult.content[0].text));
+    expect(body.message).toContain('DIMENSIONS');
+    expect(body.message).toContain('MEASURES');
+    expect(body.fields[0].column_ref).toBe('[Sample - Superstore].[sum:Profit:qk]');
   });
 
   it('with session re-snapshots live workbook, rewrites cache and sidecar, and lists new fields', async () => {
@@ -259,8 +286,14 @@ describe('listAvailableFieldsTool', () => {
         fields: z.array(
           z.object({
             caption: z.string(),
+            localName: z.string(),
+            columnInstanceName: z.string(),
+            derivation: z.string(),
+            type: z.string(),
+            typePivot: z.string(),
             role: z.string(),
             datatype: z.string().optional(),
+            isAggregated: z.boolean().optional(),
           }),
         ),
       }),
@@ -291,19 +324,71 @@ describe('listAvailableFieldsTool', () => {
     const groupFields = body.datasources[0].fields;
     expect(groupFields).toHaveLength(2);
     // caption falls back to the bracket-stripped columnName when caption is absent.
-    expect(groupFields[0]).toMatchObject({ caption: 'Profit', role: 'measure', datatype: 'real' });
+    expect(groupFields[0]).toMatchObject({
+      caption: 'Profit',
+      localName: 'Profit',
+      columnInstanceName: '[sum:Profit:qk]',
+      derivation: 'Sum',
+      type: 'quantitative',
+      typePivot: 'qk',
+      role: 'measure',
+      datatype: 'real',
+    });
     expect(groupFields[1]).toMatchObject({
       caption: 'Category',
+      localName: 'Category',
+      columnInstanceName: '[none:Category:nk]',
+      derivation: 'None',
+      type: 'nominal',
+      typePivot: 'nk',
       role: 'dimension',
       datatype: 'string',
     });
-    // Per-field metadata not needed for picking is omitted: column_ref (authoring),
-    // and the redundant/near-duplicate name, datasource (it's on the group), semanticRole.
+    // Slim keeps enough metadata to construct [datasource].[derivation:LocalName:typePivot],
+    // while omitting the full column_ref and less common verbose metadata.
     const first = groupFields[0] as Record<string, unknown>;
     expect(first.column_ref).toBeUndefined();
     expect(first.name).toBeUndefined();
     expect(first.datasource).toBeUndefined();
     expect(first.semanticRole).toBeUndefined();
+  });
+
+  it('verbosity=slim carries usr derivation metadata for already-aggregated calc fields', async () => {
+    const aggregatedCalcFields = [
+      {
+        ...mockFields[0],
+        columnName: '[Calculation_123]',
+        columnInstanceName: '[usr:Calculation_123:qk]',
+        derivation: 'User',
+        caption: 'Profit Ratio',
+        isAggregated: true,
+        formula: 'SUM([Profit]) / SUM([Sales])',
+        column_ref: '[Sample - Superstore].[usr:Calculation_123:qk]',
+      },
+    ];
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue('<workbook/>');
+    vi.mocked(metadataModule.listAvailableFields).mockReturnValue(aggregatedCalcFields as any);
+
+    const result = await getResult({ workbookFile: '/workbook.xml', verbosity: 'slim' });
+
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+    const body = slimBodySchema.parse(JSON.parse(result.content[0].text));
+    const calc = body.datasources[0].fields[0] as Record<string, unknown>;
+    expect(calc).toMatchObject({
+      caption: 'Profit Ratio',
+      localName: 'Calculation_123',
+      columnInstanceName: '[usr:Calculation_123:qk]',
+      derivation: 'User',
+      type: 'quantitative',
+      typePivot: 'qk',
+      role: 'measure',
+      datatype: 'real',
+      isAggregated: true,
+    });
+    expect(calc.column_ref).toBeUndefined();
+    expect(calc.formula).toBeUndefined();
   });
 
   it('verbosity=slim on an empty workbook returns count 0 and no datasource groups', async () => {
@@ -398,7 +483,16 @@ describe('listAvailableFieldsTool', () => {
     // Embedded datasource → no contentUrl on the group.
     expect(body.datasources[0].contentUrl).toBeUndefined();
     expect(body.datasources[0].fields).toEqual([
-      { caption: 'Sales', role: 'measure', datatype: 'real' },
+      {
+        caption: 'Sales',
+        localName: 'Sales',
+        columnInstanceName: '[sum:Sales:qk]',
+        derivation: 'Sum',
+        type: 'quantitative',
+        typePivot: 'qk',
+        role: 'measure',
+        datatype: 'real',
+      },
     ]);
 
     // Live-session path: read from the executor's workbook, never the file cache.

--- a/src/tools/desktop/fields/listAvailableFields.test.ts
+++ b/src/tools/desktop/fields/listAvailableFields.test.ts
@@ -247,18 +247,77 @@ describe('listAvailableFieldsTool', () => {
     expect(body.message).toContain('No fields found');
     expect(body.fields).toHaveLength(0);
   });
+
+  it('verbosity=slim returns compact fields with no ASCII table', async () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue('<workbook/>');
+    vi.mocked(metadataModule.listAvailableFields).mockReturnValue(mockFields as any);
+
+    const result = await getResult({ workbookFile: '/workbook.xml', verbosity: 'slim' });
+
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+    const body = z
+      .object({
+        datasource: z.string().nullable(),
+        count: z.number(),
+        fields: z.array(
+          z.object({
+            caption: z.string(),
+            role: z.string(),
+            datatype: z.string().optional(),
+          }),
+        ),
+      })
+      .parse(JSON.parse(result.content[0].text));
+
+    // No human-readable table in slim mode; datasource is hoisted to the top level.
+    expect('message' in body).toBe(false);
+    expect(body.datasource).toBe('Sample - Superstore');
+    expect(body.count).toBe(2);
+    expect(body.fields).toHaveLength(2);
+    // caption falls back to the bracket-stripped columnName when caption is absent.
+    expect(body.fields[0]).toMatchObject({ caption: 'Profit', role: 'measure', datatype: 'real' });
+    expect(body.fields[1]).toMatchObject({ caption: 'Category', role: 'dimension', datatype: 'string' });
+    // Per-field metadata not needed for picking is omitted: column_ref (authoring),
+    // and the redundant/near-duplicate name, datasource, semanticRole.
+    const first = body.fields[0] as Record<string, unknown>;
+    expect(first.column_ref).toBeUndefined();
+    expect(first.name).toBeUndefined();
+    expect(first.datasource).toBeUndefined();
+    expect(first.semanticRole).toBeUndefined();
+  });
+
+  it('verbosity=slim on an empty datasource returns count 0 and no fields', async () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue('<workbook/>');
+    vi.mocked(metadataModule.listAvailableFields).mockReturnValue([]);
+
+    const result = await getResult({ workbookFile: '/workbook.xml', verbosity: 'slim' });
+
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+    const body = z
+      .object({ datasource: z.string().nullable(), count: z.number(), fields: z.array(z.any()) })
+      .parse(JSON.parse(result.content[0].text));
+    expect(body.datasource).toBeNull();
+    expect(body.count).toBe(0);
+    expect(body.fields).toHaveLength(0);
+  });
 });
 
 async function getResult({
   workbookFile,
   session,
+  verbosity,
   extra,
 }: {
   workbookFile?: string;
   session?: string;
+  verbosity?: 'slim' | 'full';
   extra?: ReturnType<typeof getMockRequestHandlerExtra>;
 }): Promise<CallToolResult> {
   const tool = getListAvailableFieldsTool(new DesktopMcpServer());
   const callback = await Provider.from(tool.callback);
-  return await callback({ session, workbookFile }, extra ?? getMockRequestHandlerExtra());
+  return await callback({ session, workbookFile, verbosity }, extra ?? getMockRequestHandlerExtra());
 }

--- a/src/tools/desktop/fields/listAvailableFields.test.ts
+++ b/src/tools/desktop/fields/listAvailableFields.test.ts
@@ -292,7 +292,11 @@ describe('listAvailableFieldsTool', () => {
     expect(groupFields).toHaveLength(2);
     // caption falls back to the bracket-stripped columnName when caption is absent.
     expect(groupFields[0]).toMatchObject({ caption: 'Profit', role: 'measure', datatype: 'real' });
-    expect(groupFields[1]).toMatchObject({ caption: 'Category', role: 'dimension', datatype: 'string' });
+    expect(groupFields[1]).toMatchObject({
+      caption: 'Category',
+      role: 'dimension',
+      datatype: 'string',
+    });
     // Per-field metadata not needed for picking is omitted: column_ref (authoring),
     // and the redundant/near-duplicate name, datasource (it's on the group), semanticRole.
     const first = groupFields[0] as Record<string, unknown>;
@@ -324,8 +328,18 @@ describe('listAvailableFieldsTool', () => {
     // Two datasources: 'Sample - Superstore' is PUBLISHED (has a contentUrl),
     // 'Finance Extract' is EMBEDDED (contentUrl undefined). Both have a 'Profit'.
     const multiDatasourceFields = [
-      { ...mockFields[0], datasource: 'Sample - Superstore', contentUrl: 'SuperstoreDS', caption: 'Profit' },
-      { ...mockFields[1], datasource: 'Sample - Superstore', contentUrl: 'SuperstoreDS', caption: 'Category' },
+      {
+        ...mockFields[0],
+        datasource: 'Sample - Superstore',
+        contentUrl: 'SuperstoreDS',
+        caption: 'Profit',
+      },
+      {
+        ...mockFields[1],
+        datasource: 'Sample - Superstore',
+        contentUrl: 'SuperstoreDS',
+        caption: 'Category',
+      },
       { ...mockFields[0], datasource: 'Finance Extract', contentUrl: undefined, caption: 'Profit' },
       { ...mockFields[1], datasource: 'Finance Extract', contentUrl: undefined, caption: 'Region' },
     ];
@@ -343,7 +357,10 @@ describe('listAvailableFieldsTool', () => {
     expect('datasource' in body).toBe(false);
     expect('fields' in body).toBe(false);
     expect(body.count).toBe(4);
-    expect(body.datasources.map((g) => g.datasource)).toEqual(['Sample - Superstore', 'Finance Extract']);
+    expect(body.datasources.map((g) => g.datasource)).toEqual([
+      'Sample - Superstore',
+      'Finance Extract',
+    ]);
     // contentUrl per group: present for the published one, omitted for the embedded one.
     expect(body.datasources[0].contentUrl).toBe('SuperstoreDS');
     expect(body.datasources[1].contentUrl).toBeUndefined();
@@ -352,6 +369,47 @@ describe('listAvailableFieldsTool', () => {
     expect(body.datasources[1].fields.map((f) => f.caption)).toEqual(['Profit', 'Region']);
     // The datasource string is NOT repeated on individual fields.
     expect((body.datasources[0].fields[0] as Record<string, unknown>).datasource).toBeUndefined();
+  });
+
+  it('verbosity=slim without workbookFile groups fields from the live session workbook', async () => {
+    // Slim over the live-session path (session, no workbookFile): reads the
+    // resolved live workbook, never the file cache, and still returns the
+    // grouped slim shape. 'Fresh DS' is embedded (no contentUrl).
+    vi.mocked(getWorkbookXmlModule.getWorkbookXml).mockResolvedValue(Ok(LIVE_XML));
+    vi.mocked(metadataModule.listAvailableFields).mockReturnValue(mockLiveFields as any);
+    const mockExecutor = {} as any;
+    const extra = {
+      ...getMockRequestHandlerExtra(),
+      getExecutor: vi.fn().mockResolvedValue(mockExecutor),
+    };
+
+    const result = await getResult({ session: SESSION, verbosity: 'slim', extra });
+
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+    const body = slimBodySchema.parse(JSON.parse(result.content[0].text));
+
+    // Grouped slim shape, not the ASCII-table shape.
+    expect('message' in body).toBe(false);
+    expect('fields' in body).toBe(false);
+    expect(body.count).toBe(1);
+    expect(body.datasources).toHaveLength(1);
+    expect(body.datasources[0].datasource).toBe('Fresh DS');
+    // Embedded datasource → no contentUrl on the group.
+    expect(body.datasources[0].contentUrl).toBeUndefined();
+    expect(body.datasources[0].fields).toEqual([
+      { caption: 'Sales', role: 'measure', datatype: 'real' },
+    ]);
+
+    // Live-session path: read from the executor's workbook, never the file cache.
+    expect(existsSync).not.toHaveBeenCalled();
+    expect(readFileSync).not.toHaveBeenCalled();
+    expect(extra.getExecutor).toHaveBeenCalledWith(SESSION);
+    expect(getWorkbookXmlModule.getWorkbookXml).toHaveBeenCalledWith({
+      executor: mockExecutor,
+      signal: extra.signal,
+    });
+    expect(metadataModule.listAvailableFields).toHaveBeenCalledWith(LIVE_XML);
   });
 });
 
@@ -368,5 +426,8 @@ async function getResult({
 }): Promise<CallToolResult> {
   const tool = getListAvailableFieldsTool(new DesktopMcpServer());
   const callback = await Provider.from(tool.callback);
-  return await callback({ session, workbookFile, verbosity }, extra ?? getMockRequestHandlerExtra());
+  return await callback(
+    { session, workbookFile, verbosity },
+    extra ?? getMockRequestHandlerExtra(),
+  );
 }

--- a/src/tools/desktop/fields/listAvailableFields.test.ts
+++ b/src/tools/desktop/fields/listAvailableFields.test.ts
@@ -26,6 +26,7 @@ const resultSchema = z.object({
 const mockFields = [
   {
     datasource: 'Sample - Superstore',
+    contentUrl: 'SuperstoreDS',
     columnName: '[Profit]',
     columnInstanceName: '[sum:Profit:qk]',
     derivation: 'Sum',
@@ -38,6 +39,7 @@ const mockFields = [
   },
   {
     datasource: 'Sample - Superstore',
+    contentUrl: 'SuperstoreDS',
     columnName: '[Category]',
     columnInstanceName: '[none:Category:nk]',
     derivation: 'None',
@@ -248,7 +250,24 @@ describe('listAvailableFieldsTool', () => {
     expect(body.fields).toHaveLength(0);
   });
 
-  it('verbosity=slim returns compact fields with no ASCII table', async () => {
+  const slimBodySchema = z.object({
+    count: z.number(),
+    datasources: z.array(
+      z.object({
+        datasource: z.string().nullable(),
+        contentUrl: z.string().optional(),
+        fields: z.array(
+          z.object({
+            caption: z.string(),
+            role: z.string(),
+            datatype: z.string().optional(),
+          }),
+        ),
+      }),
+    ),
+  });
+
+  it('verbosity=slim returns compact grouped fields with no ASCII table', async () => {
     vi.mocked(existsSync).mockReturnValue(true);
     vi.mocked(readFileSync).mockReturnValue('<workbook/>');
     vi.mocked(metadataModule.listAvailableFields).mockReturnValue(mockFields as any);
@@ -257,38 +276,33 @@ describe('listAvailableFieldsTool', () => {
 
     expect(result.isError).toBe(false);
     invariant(result.content[0].type === 'text');
-    const body = z
-      .object({
-        datasource: z.string().nullable(),
-        count: z.number(),
-        fields: z.array(
-          z.object({
-            caption: z.string(),
-            role: z.string(),
-            datatype: z.string().optional(),
-          }),
-        ),
-      })
-      .parse(JSON.parse(result.content[0].text));
+    const body = slimBodySchema.parse(JSON.parse(result.content[0].text));
 
-    // No human-readable table in slim mode; datasource is hoisted to the top level.
+    // No human-readable table; a single datasource is still the grouped shape
+    // (one group) so callers always parse the same structure.
     expect('message' in body).toBe(false);
-    expect(body.datasource).toBe('Sample - Superstore');
+    expect('fields' in body).toBe(false);
     expect(body.count).toBe(2);
-    expect(body.fields).toHaveLength(2);
+    expect(body.datasources).toHaveLength(1);
+    expect(body.datasources[0].datasource).toBe('Sample - Superstore');
+    // Published datasource → contentUrl surfaced once on the group (the input
+    // resolve-datasource-luid needs), not repeated per field.
+    expect(body.datasources[0].contentUrl).toBe('SuperstoreDS');
+    const groupFields = body.datasources[0].fields;
+    expect(groupFields).toHaveLength(2);
     // caption falls back to the bracket-stripped columnName when caption is absent.
-    expect(body.fields[0]).toMatchObject({ caption: 'Profit', role: 'measure', datatype: 'real' });
-    expect(body.fields[1]).toMatchObject({ caption: 'Category', role: 'dimension', datatype: 'string' });
+    expect(groupFields[0]).toMatchObject({ caption: 'Profit', role: 'measure', datatype: 'real' });
+    expect(groupFields[1]).toMatchObject({ caption: 'Category', role: 'dimension', datatype: 'string' });
     // Per-field metadata not needed for picking is omitted: column_ref (authoring),
-    // and the redundant/near-duplicate name, datasource, semanticRole.
-    const first = body.fields[0] as Record<string, unknown>;
+    // and the redundant/near-duplicate name, datasource (it's on the group), semanticRole.
+    const first = groupFields[0] as Record<string, unknown>;
     expect(first.column_ref).toBeUndefined();
     expect(first.name).toBeUndefined();
     expect(first.datasource).toBeUndefined();
     expect(first.semanticRole).toBeUndefined();
   });
 
-  it('verbosity=slim on an empty datasource returns count 0 and no fields', async () => {
+  it('verbosity=slim on an empty workbook returns count 0 and no datasource groups', async () => {
     vi.mocked(existsSync).mockReturnValue(true);
     vi.mocked(readFileSync).mockReturnValue('<workbook/>');
     vi.mocked(metadataModule.listAvailableFields).mockReturnValue([]);
@@ -297,12 +311,47 @@ describe('listAvailableFieldsTool', () => {
 
     expect(result.isError).toBe(false);
     invariant(result.content[0].type === 'text');
-    const body = z
-      .object({ datasource: z.string().nullable(), count: z.number(), fields: z.array(z.any()) })
-      .parse(JSON.parse(result.content[0].text));
-    expect(body.datasource).toBeNull();
+    const body = slimBodySchema.parse(JSON.parse(result.content[0].text));
     expect(body.count).toBe(0);
-    expect(body.fields).toHaveLength(0);
+    expect(body.datasources).toHaveLength(0);
+  });
+
+  it('verbosity=slim groups fields by datasource across multiple datasources', async () => {
+    // Two datasources, including a SAME caption ('Profit') in each — the case
+    // where hoisting fields[0].datasource would misattribute the second and
+    // erase the only disambiguator. Grouping carries the datasource once per
+    // group rather than repeating it on every field.
+    // Two datasources: 'Sample - Superstore' is PUBLISHED (has a contentUrl),
+    // 'Finance Extract' is EMBEDDED (contentUrl undefined). Both have a 'Profit'.
+    const multiDatasourceFields = [
+      { ...mockFields[0], datasource: 'Sample - Superstore', contentUrl: 'SuperstoreDS', caption: 'Profit' },
+      { ...mockFields[1], datasource: 'Sample - Superstore', contentUrl: 'SuperstoreDS', caption: 'Category' },
+      { ...mockFields[0], datasource: 'Finance Extract', contentUrl: undefined, caption: 'Profit' },
+      { ...mockFields[1], datasource: 'Finance Extract', contentUrl: undefined, caption: 'Region' },
+    ];
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue('<workbook/>');
+    vi.mocked(metadataModule.listAvailableFields).mockReturnValue(multiDatasourceFields as any);
+
+    const result = await getResult({ workbookFile: '/workbook.xml', verbosity: 'slim' });
+
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+    const body = slimBodySchema.parse(JSON.parse(result.content[0].text));
+
+    // Grouped shape (no top-level `datasource`, no flat `fields`) when >1 datasource.
+    expect('datasource' in body).toBe(false);
+    expect('fields' in body).toBe(false);
+    expect(body.count).toBe(4);
+    expect(body.datasources.map((g) => g.datasource)).toEqual(['Sample - Superstore', 'Finance Extract']);
+    // contentUrl per group: present for the published one, omitted for the embedded one.
+    expect(body.datasources[0].contentUrl).toBe('SuperstoreDS');
+    expect(body.datasources[1].contentUrl).toBeUndefined();
+    // The two same-caption 'Profit' fields stay distinct — one per group.
+    expect(body.datasources[0].fields.map((f) => f.caption)).toEqual(['Profit', 'Category']);
+    expect(body.datasources[1].fields.map((f) => f.caption)).toEqual(['Profit', 'Region']);
+    // The datasource string is NOT repeated on individual fields.
+    expect((body.datasources[0].fields[0] as Record<string, unknown>).datasource).toBeUndefined();
   });
 });
 

--- a/src/tools/desktop/fields/listAvailableFields.ts
+++ b/src/tools/desktop/fields/listAvailableFields.ts
@@ -26,8 +26,7 @@ const paramsSchema = {
     .optional()
     .describe(
       "'full' (default): table + full metadata incl. column_ref. " +
-        "'slim': fields grouped by datasource — { count, datasources: [{ datasource, contentUrl?, fields: [{ caption, role, datatype }] }] }, no table — much smaller for a wide datasource. " +
-        'slim omits column_ref; use resolve-field for it.',
+        "'slim': caption/role/datatype grouped by datasource, no table — much smaller for a wide datasource; get column_ref via resolve-field.",
     ),
 };
 

--- a/src/tools/desktop/fields/listAvailableFields.ts
+++ b/src/tools/desktop/fields/listAvailableFields.ts
@@ -25,8 +25,7 @@ const paramsSchema = {
     .enum(['slim', 'full'])
     .optional()
     .describe(
-      "'full' (default): table + full metadata incl. column_ref. " +
-        "'slim': caption/role/datatype grouped by datasource, no table — much smaller for a wide datasource; get column_ref via resolve-field.",
+      "'full' (default): table + column_ref. 'slim': compact fields by datasource, no column_ref (use resolve-field).",
     ),
 };
 

--- a/src/tools/desktop/fields/listAvailableFields.ts
+++ b/src/tools/desktop/fields/listAvailableFields.ts
@@ -16,17 +16,12 @@ import { DesktopTool } from '../tool.js';
 import { refreshWorkbookCache } from './refreshWorkbookCache.js';
 
 const paramsSchema = {
-  session: z.string().optional().describe('Session ID; refreshes live workbook first.'),
-  workbookFile: z
-    .string()
-    .optional()
-    .describe('Optional cached workbook file; omit for the live session workbook.'),
+  session: z.string().optional().describe('Session ID; refresh live workbook.'),
+  workbookFile: z.string().optional().describe('Cache file; omit for live session.'),
   verbosity: z
     .enum(['slim', 'full'])
     .optional()
-    .describe(
-      "'full' (default): table + column_ref. 'slim': compact fields by datasource, no column_ref (use resolve-field).",
-    ),
+    .describe('full (default): table + column_ref. slim: grouped ref parts, no column_ref.'),
 };
 
 class WorkbookFileNotFoundError extends McpToolError {
@@ -52,6 +47,12 @@ const typeAbbrev = (type: string): string => {
   return type;
 };
 
+const typePivot = (type: string): string => {
+  if (type === 'quantitative') return 'qk';
+  if (type === 'ordinal') return 'ok';
+  return 'nk';
+};
+
 const tableauDatatypeLabel = (datatype?: string): string => {
   switch (datatype) {
     case 'integer':
@@ -73,8 +74,14 @@ const tableauDatatypeLabel = (datatype?: string): string => {
 
 interface SlimField {
   caption: string;
+  localName: string;
+  columnInstanceName: string;
+  derivation: string;
+  type: string;
+  typePivot: string;
   role: string;
-  datatype: string | undefined;
+  datatype?: string;
+  isAggregated?: boolean;
 }
 
 /** One datasource's slim fields. Slim always groups by datasource. */
@@ -104,9 +111,9 @@ export const getListAvailableFieldsTool = (
     name: 'list-available-fields',
     title,
     description: [
-      'List ALL fields available in workbook datasources.',
-      'Returns exact column_ref inputs for field tools. Call before adding fields to Rows, Columns, or encodings.',
-      'Omit workbookFile to read the live session workbook. Cached workbook file only; NOT a worksheet file.',
+      'List datasource fields.',
+      'Call before shelves/encodings.',
+      'Full gives column_ref; slim gives ref parts.',
     ].join(' '),
     paramsSchema,
     annotations: {
@@ -167,8 +174,8 @@ export const getListAvailableFieldsTool = (
 
           const fields = listAvailableFields(workbookXml);
 
-          // Slim: caption/role/datatype only, no table — small enough to avoid
-          // the inline-output cap. Get column_ref via resolve-field.
+          // Slim: no table and no full column_ref, but keep the ingredients
+          // needed to construct [datasource].[derivation:LocalName:typePivot].
           //
           // `listAvailableFields` spans ALL datasources (one flat array, each
           // field carrying its own datasource). Slim always GROUPS by
@@ -179,11 +186,20 @@ export const getListAvailableFieldsTool = (
           // or repeated per field (which would bloat slim). A single-datasource
           // workbook is just one group, so callers always parse one shape.
           if (verbosity === 'slim') {
-            const toSlimField = (f: (typeof fields)[number]): SlimField => ({
-              caption: f.caption || f.columnName.replace(/^\[|\]$/g, ''),
-              role: f.role,
-              datatype: f.datatype,
-            });
+            const toSlimField = (f: (typeof fields)[number]): SlimField => {
+              const localName = f.columnName.replace(/^\[|\]$/g, '');
+              return {
+                caption: f.caption || localName,
+                localName,
+                columnInstanceName: f.columnInstanceName,
+                derivation: f.derivation,
+                type: f.type,
+                typePivot: typePivot(f.type),
+                role: f.role,
+                datatype: f.datatype,
+                ...(f.isAggregated ? { isAggregated: true } : {}),
+              };
+            };
 
             // Group by datasource name (first-seen order). Each group also
             // carries the datasource's contentUrl (same for all its fields) —

--- a/src/tools/desktop/fields/listAvailableFields.ts
+++ b/src/tools/desktop/fields/listAvailableFields.ts
@@ -155,18 +155,9 @@ export const getListAvailableFieldsTool = (
 
           const fields = listAvailableFields(workbookXml);
 
-          // Slim mode: a compact JSON array for reasoning over fields (pick
-          // measures/dimensions), with no ASCII table and no authoring metadata
-          // (column_ref, columnInstanceName, formula, …). Each field carries only
-          // what a picker needs: caption (the human name, also what
-          // generate-insight-cards takes as measures/breakdownDimension), role,
-          // and datatype. Per-field `datasource` is intentionally omitted — it's
-          // identical for every field and hoisted to the top level once — as are
-          // `name` (equals caption for all but calc-copy fields, and unused by
-          // the picker) and `semanticRole` (undefined off geo datasources). Cuts
-          // a wide-datasource payload from ~68KB to well under the host's
-          // inline-output cap so it isn't truncated. Callers that need the exact
-          // column_ref resolve it via resolve-field.
+          // Slim: caption/role/datatype only, datasource hoisted to the top
+          // level, no table — small enough to avoid the inline-output cap. Get
+          // column_ref via resolve-field.
           if (verbosity === 'slim') {
             return new Ok({
               datasource: fields.length > 0 ? fields[0].datasource : null,

--- a/src/tools/desktop/fields/listAvailableFields.ts
+++ b/src/tools/desktop/fields/listAvailableFields.ts
@@ -21,6 +21,15 @@ const paramsSchema = {
     .string()
     .optional()
     .describe('Optional cached workbook file; omit for the live session workbook.'),
+  verbosity: z
+    .enum(['slim', 'full'])
+    .optional()
+    .describe(
+      "Response detail. 'full' (default): human-readable table + full per-field metadata incl. exact column_ref. " +
+        "'slim': a compact JSON array of { name, caption, role, datatype, semanticRole, datasource } and no table — " +
+        'much smaller (~13-18KB vs ~68KB for a wide datasource), for reasoning over fields to pick measures/dimensions. ' +
+        'Slim omits column_ref; use resolve-field to get the exact column_ref for the field you commit to.',
+    ),
 };
 
 class WorkbookFileNotFoundError extends McpToolError {
@@ -65,6 +74,16 @@ const tableauDatatypeLabel = (datatype?: string): string => {
   }
 };
 
+interface SlimField {
+  caption: string;
+  role: string;
+  datatype: string | undefined;
+}
+
+type ListAvailableFieldsResult =
+  | { message: string; fields: ReturnType<typeof listAvailableFields> }
+  | { datasource: string | null; count: number; fields: SlimField[] };
+
 const title = 'List All Available Fields in Workbook Datasources';
 export const getListAvailableFieldsTool = (
   server: DesktopMcpServer,
@@ -86,10 +105,10 @@ export const getListAvailableFieldsTool = (
       idempotentHint: true,
       openWorldHint: false,
     },
-    callback: async ({ session, workbookFile }, extra): Promise<CallToolResult> => {
-      return await listAvailableFieldsTool.logAndExecute({
+    callback: async ({ session, workbookFile, verbosity }, extra): Promise<CallToolResult> => {
+      return await listAvailableFieldsTool.logAndExecute<ListAvailableFieldsResult>({
         extra,
-        args: { session, workbookFile },
+        args: { session, workbookFile, verbosity },
         callback: async () => {
           const cacheWorkbookFile = workbookFile?.trim() ? workbookFile : undefined;
 
@@ -136,6 +155,30 @@ export const getListAvailableFieldsTool = (
           }
 
           const fields = listAvailableFields(workbookXml);
+
+          // Slim mode: a compact JSON array for reasoning over fields (pick
+          // measures/dimensions), with no ASCII table and no authoring metadata
+          // (column_ref, columnInstanceName, formula, …). Each field carries only
+          // what a picker needs: caption (the human name, also what
+          // generate-insight-cards takes as measures/breakdownDimension), role,
+          // and datatype. Per-field `datasource` is intentionally omitted — it's
+          // identical for every field and hoisted to the top level once — as are
+          // `name` (equals caption for all but calc-copy fields, and unused by
+          // the picker) and `semanticRole` (undefined off geo datasources). Cuts
+          // a wide-datasource payload from ~68KB to well under the host's
+          // inline-output cap so it isn't truncated. Callers that need the exact
+          // column_ref resolve it via resolve-field.
+          if (verbosity === 'slim') {
+            return new Ok({
+              datasource: fields.length > 0 ? fields[0].datasource : null,
+              count: fields.length,
+              fields: fields.map((f) => ({
+                caption: f.caption || f.columnName.replace(/^\[|\]$/g, ''),
+                role: f.role,
+                datatype: f.datatype,
+              })),
+            });
+          }
 
           if (fields.length === 0) {
             return new Ok({

--- a/src/tools/desktop/fields/listAvailableFields.ts
+++ b/src/tools/desktop/fields/listAvailableFields.ts
@@ -26,7 +26,7 @@ const paramsSchema = {
     .optional()
     .describe(
       "'full' (default): table + full metadata incl. column_ref. " +
-        "'slim': compact { caption, role, datatype } array, no table — much smaller for a wide datasource. " +
+        "'slim': fields grouped by datasource — { count, datasources: [{ datasource, contentUrl?, fields: [{ caption, role, datatype }] }] }, no table — much smaller for a wide datasource. " +
         'slim omits column_ref; use resolve-field for it.',
     ),
 };
@@ -79,9 +79,23 @@ interface SlimField {
   datatype: string | undefined;
 }
 
+/** One datasource's slim fields. Slim always groups by datasource. */
+interface SlimDatasourceGroup {
+  datasource: string | null;
+  // The datasource's contentUrl when it's a published datasource — the input
+  // resolve-datasource-luid needs to get the server LUID. Omitted for
+  // embedded/local datasources (no server copy, so no contentUrl).
+  contentUrl?: string;
+  fields: SlimField[];
+}
+
 type ListAvailableFieldsResult =
   | { message: string; fields: ReturnType<typeof listAvailableFields> }
-  | { datasource: string | null; count: number; fields: SlimField[] };
+  // Slim: fields grouped by datasource so the datasource name is carried once
+  // per group, never repeated on every field (keeps slim small). Always this
+  // shape — even for a single datasource (one group) — so callers parse one
+  // consistent structure.
+  | { count: number; datasources: SlimDatasourceGroup[] };
 
 const title = 'List All Available Fields in Workbook Datasources';
 export const getListAvailableFieldsTool = (
@@ -155,18 +169,39 @@ export const getListAvailableFieldsTool = (
 
           const fields = listAvailableFields(workbookXml);
 
-          // Slim: caption/role/datatype only, datasource hoisted to the top
-          // level, no table — small enough to avoid the inline-output cap. Get
-          // column_ref via resolve-field.
+          // Slim: caption/role/datatype only, no table — small enough to avoid
+          // the inline-output cap. Get column_ref via resolve-field.
+          //
+          // `listAvailableFields` spans ALL datasources (one flat array, each
+          // field carrying its own datasource). Slim always GROUPS by
+          // datasource — one group per datasource, in first-seen order — so the
+          // datasource name is carried once per group rather than hoisted (which
+          // would misattribute every field past the first in a multi-datasource
+          // workbook and erase the only disambiguator for same-caption fields)
+          // or repeated per field (which would bloat slim). A single-datasource
+          // workbook is just one group, so callers always parse one shape.
           if (verbosity === 'slim') {
+            const toSlimField = (f: (typeof fields)[number]): SlimField => ({
+              caption: f.caption || f.columnName.replace(/^\[|\]$/g, ''),
+              role: f.role,
+              datatype: f.datatype,
+            });
+
+            // Group by datasource name (first-seen order). Each group also
+            // carries the datasource's contentUrl (same for all its fields) —
+            // present only for published datasources.
+            const groups = new Map<string | null, SlimDatasourceGroup>();
+            for (const f of fields) {
+              let group = groups.get(f.datasource);
+              if (!group) {
+                group = { datasource: f.datasource, contentUrl: f.contentUrl, fields: [] };
+                groups.set(f.datasource, group);
+              }
+              group.fields.push(toSlimField(f));
+            }
             return new Ok({
-              datasource: fields.length > 0 ? fields[0].datasource : null,
               count: fields.length,
-              fields: fields.map((f) => ({
-                caption: f.caption || f.columnName.replace(/^\[|\]$/g, ''),
-                role: f.role,
-                datatype: f.datatype,
-              })),
+              datasources: Array.from(groups.values()),
             });
           }
 

--- a/src/tools/desktop/fields/listAvailableFields.ts
+++ b/src/tools/desktop/fields/listAvailableFields.ts
@@ -25,10 +25,9 @@ const paramsSchema = {
     .enum(['slim', 'full'])
     .optional()
     .describe(
-      "Response detail. 'full' (default): human-readable table + full per-field metadata incl. exact column_ref. " +
-        "'slim': a compact JSON array of { name, caption, role, datatype, semanticRole, datasource } and no table — " +
-        'much smaller (~13-18KB vs ~68KB for a wide datasource), for reasoning over fields to pick measures/dimensions. ' +
-        'Slim omits column_ref; use resolve-field to get the exact column_ref for the field you commit to.',
+      "'full' (default): table + full metadata incl. column_ref. " +
+        "'slim': compact { caption, role, datatype } array, no table — much smaller for a wide datasource. " +
+        'slim omits column_ref; use resolve-field for it.',
     ),
 };
 


### PR DESCRIPTION
Adds an optional `verbosity: 'slim' | 'full'` param to `list-available-fields`.

- **`full` (default)** — unchanged: human-readable table + full per-field metadata incl. `column_ref`.
- **`slim`** — no table; fields grouped by datasource:
  ```
  { count, datasources: [{ datasource, contentUrl?, fields: [{ caption, role, datatype }] }] }
  ```
  Each field is just `{ caption, role, datatype }`. The datasource name is carried once per group (not repeated per field), and `contentUrl` is included per **published** datasource (the input `resolve-datasource-luid` needs; omitted for embedded ones). A single-datasource workbook is one group, so callers always parse one shape.

**Why:** the default response returns the field catalog twice (table + full metadata) — ~68KB for a wide datasource (~155 fields), which overflows the inline-output cap and gets truncated. `slim` stays well under the cap for callers that only need to reason over field names/roles/types. Get the exact `column_ref` via `resolve-field`.

Verbosity param rather than a new tool to avoid the `tools/list` schema budget.

**Grouping (addresses @mattcfilbert's review):** slim originally hoisted `fields[0].datasource` and dropped per-field datasource — misattributing every field past the first in multi-datasource workbooks and erasing the disambiguator for same-caption fields. Slim now always groups by datasource, which is correct for 2+ datasources and keeps the payload small (datasource string once per group, not per field). Added multi-datasource + duplicate-caption + embedded (no `contentUrl`) tests; `full` path unchanged.
