### PR TITLE
build(desktop): add watch mode for fast rebuild loop

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "build": "tsx src/scripts/build.ts && tsc --project tsconfig.providers.json",
     "build:desktop": "tsx src/scripts/build.ts --variant desktop && tsc --project tsconfig.providers.json",
     "build:desktop:dirty": "tsx src/scripts/build.ts --variant desktop --dirty && tsc --project tsconfig.providers.json",
+    "build:desktop:watch": "tsx src/scripts/build.ts --variant desktop --dev --watch",
     "build:combined": "tsx src/scripts/build.ts --variant combined && tsc --project tsconfig.providers.json",
     "build:dev": "tsx src/scripts/build.ts --dev && tsc --project tsconfig.providers.json",
     "build:docker": "docker build -t tableau-mcp .",

--- a/src/scripts/build.ts
+++ b/src/scripts/build.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 
-import { build, BuildOptions } from 'esbuild';
+import { build, BuildOptions, context } from 'esbuild';
 import { cpSync } from 'fs';
 import { chmod, copyFile, cp, mkdir, rm } from 'fs/promises';
 import { resolve } from 'path';
@@ -12,6 +12,7 @@ import { isVariant, variants } from './variants.js';
 
 const dev = process.argv.includes('--dev');
 const dirty = process.argv.includes('--dirty');
+const watch = process.argv.includes('--watch');
 const variant = process.argv.includes('--variant')
   ? process.argv[process.argv.indexOf('--variant') + 1]
   : 'default';
@@ -205,6 +206,42 @@ const globalValues: Record<GlobalIdentifierName, string> = {
   } catch (error) {
     console.error('❌ Failed to build MCP Apps:', error);
     process.exit(1);
+  }
+
+  if (watch) {
+    // Watch re-bundles ONLY the main entry — the fast TS edit loop. Telemetry, features.json,
+    // desktop data, and the MCP Apps are built once above; editing those needs a full rebuild.
+    // esbuild cannot push new code into the already-running MCP process, so each rebuild still
+    // requires reconnecting the stdio server (/mcp) to take effect.
+    const ctx = await context({
+      ...buildOptions,
+      plugins: [
+        ...(buildOptions.plugins ?? []),
+        {
+          name: 'watch-reporter',
+          setup(build) {
+            build.onEnd(async (result) => {
+              for (const error of result.errors) {
+                console.log(`❌ ${error.text}`);
+              }
+              for (const warning of result.warnings) {
+                console.log(`⚠️ ${warning.text}`);
+              }
+              if (result.errors.length === 0 && buildOptions.outfile) {
+                await chmod(buildOptions.outfile, '755');
+                console.log(
+                  `✅ Rebuilt ${buildOptions.outfile} — reconnect the MCP (/mcp) to load it.`,
+                );
+              }
+            });
+          },
+        },
+      ],
+    });
+    await ctx.watch();
+    console.log(
+      `\n👀 Watching src for changes (re-bundling ${buildOptions.outfile} only). Ctrl-C to stop.`,
+    );
   }
 })();
 


### PR DESCRIPTION
## Description

Adds `npm run build:desktop:watch` for a fast desktop dev loop. It runs the full desktop build once (main bundle, telemetry, `features.json`, staged desktop data, MCP Apps), then enters an esbuild watch context that re-bundles **only** `build/index.desktop.js` on each source save, re-`chmod`s it, and prints a reminder to reconnect the MCP.

Implementation: a `--watch` flag in `src/scripts/build.ts` that opens an esbuild `context()` reusing the same `buildOptions` as the one-shot build, plus a small `onEnd` reporter plugin for errors/warnings and the rebuild message. The npm script pairs `--watch` with `--dev` (unminified, external packages) and deliberately omits the trailing `&& tsc` since watch never exits.

## Motivation and Context

The desktop MCP is a stdio server: Claude Code spawns `node build/index.desktop.js` once and holds the bundle in memory, so new code only takes effect after a rebuild **and** a reconnect. Previously every iteration meant running `build:desktop` by hand. Watch mode automates the rebuild half of that loop (~100ms re-bundle on save), leaving only the `/mcp` reconnect.

**Scope/limits (by design):**
- Watch re-bundles only the main entry. Editing telemetry, `features.json`, desktop `data/`, or the MCP Apps (`src/web/apps/`) still needs a full `npm run build:desktop` — re-running vite on every save would make the loop slow.
- esbuild can't push code into the already-running stdio process, so the `/mcp` reconnect is still required to load a rebuild. Watch only removes the manual build step.

## Type of Change

- [x] Other (please describe): developer tooling — new build script, no runtime/shipped-code change

## How Has This Been Tested?

- `npm run build:desktop:watch` — full build completes, then prints the watching banner.
- Touched `src/index.ts` while watching → observed `✅ Rebuilt ./build/index.desktop.js` and the reconnect reminder fire.
- `npx eslint src/scripts/build.ts` passes.
- Existing `npm run build:desktop` / `build:desktop:dirty` are unchanged (no `--watch` → the watch block is skipped).

## Related Issues

<!-- none -->

## Checklist

- [ ] I have updated the version in the package.json file by using `npm run version`. — N/A, dev-tooling only, no published-package change
- [x] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works — N/A, build-script tooling
- [x] New and existing unit tests pass locally with my changes
- [x] I have documented any breaking changes in the PR description. — none

🤖 Generated with [Claude Code](https://claude.com/claude-code)
