### PR TITLE
feat(desktop): propose/classify field identity — a2td W2c lockstep twin

### DIFF
--- a/lockstep.hashes.json
+++ b/lockstep.hashes.json
@@ -1,6 +1,6 @@
 {
   "src/desktop/binder/calc-derivation.ts": "5105d466e3c31019affa91320edf3047259301ca5cd27aeb5883ba1faa251098",
-  "src/desktop/binder/classify.ts": "8f0dc7d25a2ef7878c753b3f8e6f8dd709d323111c257d7efa5795c5bfaf9b54",
+  "src/desktop/binder/classify.ts": "871936861366e41c73f86e41f82ee27b198e8985b1e79d542291fa3bec02807a",
   "src/desktop/binder/escape.ts": "3c79bcf77c33fad64975e95ea57df5fb3e416008633e15dc7a585018fbc92d3f",
   "src/desktop/binder/manifest-types.ts": "9ce310c1e294d3784084b854edf52ef4f7c4cf7a8e13ebba7071dc3957c6114d",
   "src/desktop/binder/manifest-validation.ts": "e29ecfa9e10e57593a4f72e498f35ca8b1b28a1227fc0cb4aed057870566df60",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "2.25.1",
+  "version": "2.25.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/src/desktop/binder/classify.ts
+++ b/src/desktop/binder/classify.ts
@@ -75,7 +75,14 @@ export interface LlmProposeInput {
       derivation?: Derivation;
     }>;
   }>;
-  fields: Array<{ name: string; role: 'dimension' | 'measure'; type: string; datatype: string }>;
+  fields: Array<{
+    name: string;
+    role: 'dimension' | 'measure';
+    type: string;
+    datatype: string;
+    datasource?: string;
+    column_ref?: string;
+  }>;
   /**
    * FIELD-NARROWING signal (stage 2B, adjudicated attack 1): present ONLY when
    * `fields` was capped — `count` is how many relevant-but-lower-ranked fields
@@ -804,6 +811,30 @@ function isMeasure(f: SchemaField): boolean {
 }
 function isCategorical(f: SchemaField): boolean {
   return f.role === 'dimension' && !isTemporal(f) && (f.type === 'nominal' || f.type === 'ordinal');
+}
+
+function shouldExposeFieldIdentity(fields: SchemaField[]): boolean {
+  const datasources = new Set<string>();
+  const names = new Set<string>();
+  for (const f of fields) {
+    datasources.add(f.datasource);
+    if (names.has(f.name)) return true;
+    names.add(f.name);
+  }
+  return datasources.size > 1;
+}
+
+function proposeField(
+  f: SchemaField,
+  exposeIdentity: boolean,
+): LlmProposeInput['fields'][number] {
+  return {
+    name: f.name,
+    role: f.role,
+    type: f.type,
+    datatype: f.datatype,
+    ...(exposeIdentity ? { datasource: f.datasource, column_ref: f.column_ref } : {}),
+  };
 }
 
 /**
@@ -1567,6 +1598,7 @@ export function buildLlmInput(
   const { fields: narrowed } = narrowFields(ask, rankPool, kinds, maxFields);
   const withheld = summary.fields.length - narrowed.length;
 
+  const exposeFieldIdentity = shouldExposeFieldIdentity(summary.fields);
   const result: LlmProposeInput = {
     ask,
     candidate_templates: top.map(({ m }) => ({
@@ -1585,12 +1617,7 @@ export function buildLlmInput(
           derivation: slot.derivation, // template default; override only if the ask differs
         })),
     })),
-    fields: narrowed.map((f) => ({
-      name: f.name,
-      role: f.role,
-      type: f.type,
-      datatype: f.datatype,
-    })),
+    fields: narrowed.map((f) => proposeField(f, exposeFieldIdentity)),
   };
 
   if (withheld > 0) {


### PR DESCRIPTION
Coordinated lockstep twin of a2td `claude/w2c-propose-identity` (the Fix-A remainder of the multi-datasource spec — a2td PR to follow once its base merges). Per the CLS-003 twin procedure: `src/desktop/binder/classify.ts` byte-synced from the a2td canonical, manifest regenerated with `check-lockstep --update`; both repos' manifests carry the identical `87193686…` hash.

**Behavior:** `LlmProposeInput.fields` entries gain optional `datasource`/`column_ref`, populated ONLY when the workbook summary has >1 datasource or duplicate display names — single-datasource payloads stay byte-identical. Deliberately INERT on this side until the propose-instruction/prewarm surfaces plumb the qualified identities (same landing pattern as #511's semanticRole); that plumbing is coordinated with the #535 fields-tool thread rather than a parallel port — see the port-debt ledger.

**Validation (orchestrator, firsthand):** full suite 4,346 green (298 files), `tsc --noEmit` clean, `check-lockstep` 6/6. No tool-describe changes — combined-lean surface untouched (45,843/46,000 stands).

🤖 Generated with [Claude Code](https://claude.com/claude-code)