### PR TITLE
fix(desktop): promised-sort readback loss fails the verification receipt (a2td #216 port)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "2.25.2",
+  "version": "2.25.3",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/src/desktop/validation/promise-check.test.ts
+++ b/src/desktop/validation/promise-check.test.ts
@@ -5,9 +5,21 @@ import {
   formatWorkbookPromiseCheck,
   formatWorksheetPromiseCheck,
 } from './promise-check.js';
+import type { ReadbackFinding } from './readback-verify.js';
 import type { ValidationIssue } from './types.js';
 
 const warning = (): ValidationIssue => ({ ruleId: 'x', severity: 'warning', message: 'w' });
+const sortWarning = (
+  node: 'computed-sort' | 'shelf-sort-v2',
+  readback: 'missing' | 'changed' = 'missing',
+): ReadbackFinding => ({
+  kind: 'sort',
+  node,
+  column: '[DS].[none:State:nk]',
+  intended: `<${node} column="[DS].[none:State:nk]">`,
+  readback,
+  severity: 'warning',
+});
 
 describe('promise check receipt (W-23447506)', () => {
   it('formats clean readback as verified', () => {
@@ -46,6 +58,49 @@ describe('promise check receipt (W-23447506)', () => {
     });
     expect(text).toContain('HOST VERIFICATION — failed');
     expect(text).toContain('readback FAILED');
+  });
+
+  it('escalates promised computed-sort loss from warning to failed', () => {
+    const text = formatWorksheetPromiseCheck({
+      validationWarnings: [],
+      readback: { ok: true, status: 'warning' },
+      readbackFindings: [sortWarning('computed-sort')],
+    });
+
+    expect(text).toContain('HOST VERIFICATION — failed');
+    expect(text).toContain('promised sort NOT verified');
+    expect(text).not.toContain('HOST VERIFICATION — verified');
+  });
+
+  it('escalates promised shelf-sort-v2 loss from warning to failed', () => {
+    const text = formatWorksheetPromiseCheck({
+      validationWarnings: [],
+      readback: { ok: true, status: 'warning' },
+      readbackFindings: [sortWarning('shelf-sort-v2', 'changed')],
+    });
+
+    expect(text).toContain('HOST VERIFICATION — failed');
+    expect(text).toContain('promised sort NOT verified');
+    expect(text).not.toContain('HOST VERIFICATION — verified');
+  });
+
+  it('keeps non-sort readback warnings verified', () => {
+    const text = formatWorksheetPromiseCheck({
+      validationWarnings: [],
+      readback: { ok: true, status: 'warning' },
+      readbackFindings: [
+        {
+          kind: 'mark',
+          node: 'mark',
+          intended: '<mark class="Bar">',
+          readback: 'changed',
+          severity: 'warning',
+        },
+      ],
+    });
+
+    expect(text).toContain('HOST VERIFICATION — verified');
+    expect(text).not.toContain('promised sort NOT verified');
   });
 
   it('formats workbook applies as honestly unverified', () => {

--- a/src/desktop/validation/promise-check.ts
+++ b/src/desktop/validation/promise-check.ts
@@ -11,7 +11,7 @@
  *
  * Ported from agent-to-tableau-desktop.
  */
-import type { ReadbackVerificationResult } from './readback-verify.js';
+import type { ReadbackFinding, ReadbackVerificationResult } from './readback-verify.js';
 import type { ValidationIssue } from './types.js';
 
 export type PromiseOutcome = 'verified' | 'unverified' | 'failed';
@@ -19,6 +19,15 @@ export type PromiseOutcome = 'verified' | 'unverified' | 'failed';
 export interface WorksheetReceiptInput {
   validationWarnings: ValidationIssue[];
   readback: ReadbackVerificationResult | undefined;
+  readbackFindings?: ReadbackFinding[];
+}
+
+function isPromisedSortLossWarning(finding: ReadbackFinding): boolean {
+  return (
+    finding.kind === 'sort' &&
+    finding.severity === 'warning' &&
+    (finding.node === 'computed-sort' || finding.node === 'shelf-sort-v2')
+  );
 }
 
 function formatPreflight(validationWarnings: ValidationIssue[]): string {
@@ -49,6 +58,10 @@ export function formatWorksheetPromiseCheck(input: WorksheetReceiptInput): strin
       outcome = 'unverified';
       parts.push('readback unavailable');
       break;
+  }
+  if (outcome === 'verified' && input.readbackFindings?.some(isPromisedSortLossWarning)) {
+    outcome = 'failed';
+    parts.push('promised sort NOT verified (sort node dropped/changed on readback)');
   }
   const guard =
     outcome === 'verified'

--- a/src/tools/desktop/coordination/buildAndApplyWorksheet.test.ts
+++ b/src/tools/desktop/coordination/buildAndApplyWorksheet.test.ts
@@ -23,6 +23,7 @@ import { sessionRouteState } from '../../../desktop/route/route-state.js';
 import { rewriteFieldReferences } from '../../../desktop/templates/fieldReferenceRewriter.js';
 import { getTemplateColumnRequirements } from '../../../desktop/templates/templateColumnRequirements.js';
 import { readTemplate } from '../../../desktop/templates/templatePath.js';
+import type { ReadbackFinding } from '../../../desktop/validation/readback-verify.js';
 import { TableauDesktopRequestHandlerExtra } from '../toolContext.js';
 import { markPlanBuildWorksheets, resetPlanBuildWorksheets } from './planBuildFocus.js';
 
@@ -75,6 +76,15 @@ const TASK_SPEC_BASE = {
   workbookFile: '/cache/workbook.xml',
 };
 
+const promisedSortLossWarning: ReadbackFinding = {
+  kind: 'sort',
+  node: 'shelf-sort-v2',
+  column: '[DS].[none:Region:nk]',
+  intended: '<shelf-sort-v2 column="[DS].[none:Region:nk]">',
+  readback: 'changed',
+  severity: 'warning',
+};
+
 describe('buildAndApplyWorksheetTool', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -116,6 +126,24 @@ describe('buildAndApplyWorksheetTool', () => {
     expect(result.content[0].text).toContain('HOST VERIFICATION — unverified');
     expect(result.content[0].text).toContain('readback unavailable');
     expect(result.content[0].text).not.toMatch(/\bverified\b/i);
+  });
+
+  it('fails the receipt when readback warnings show promised sort loss', async () => {
+    const extra = makeExtra();
+    vi.mocked(loadWorksheetXml).mockResolvedValue(
+      new Ok({
+        readbackWarnings: [promisedSortLossWarning],
+        readbackVerification: { ok: true, status: 'warning' },
+      }),
+    );
+
+    const result = await getResult({ session: SESSION, taskSpec: TASK_SPEC_BASE }, extra);
+
+    expect(result.isError).toBeFalsy();
+    invariant(result.content[0].type === 'text');
+    expect(result.content[0].text).toContain('HOST VERIFICATION — failed');
+    expect(result.content[0].text).toContain('promised sort NOT verified');
+    expect(result.content[0].text).not.toContain('HOST VERIFICATION — verified');
   });
 
   it('should return error when workbook file does not exist', async () => {

--- a/src/tools/desktop/coordination/buildAndApplyWorksheet.ts
+++ b/src/tools/desktop/coordination/buildAndApplyWorksheet.ts
@@ -319,6 +319,7 @@ export const getBuildAndApplyWorksheetTool = (
             ? formatWorksheetPromiseCheck({
                 validationWarnings: applyResult.value.validationWarnings ?? [],
                 readback: applyResult.value.readbackVerification,
+                readbackFindings: applyResult.value.readbackWarnings,
               })
             : '';
 

--- a/src/tools/desktop/worksheet/applyWorksheet.test.ts
+++ b/src/tools/desktop/worksheet/applyWorksheet.test.ts
@@ -4,6 +4,7 @@ import { Err, Ok } from 'ts-results-es';
 import { z } from 'zod';
 
 import * as loadWorksheetXmlModule from '../../../desktop/commands/workbook/loadWorksheetXml.js';
+import type { ReadbackFinding } from '../../../desktop/validation/readback-verify.js';
 import {
   ArgsValidationError,
   DesktopCommandExecutionError,
@@ -28,6 +29,14 @@ describe('applyWorksheetTool', () => {
     ok: true,
     status: 'skipped' as const,
     message: 'worksheet busy',
+  };
+  const promisedSortLossWarning: ReadbackFinding = {
+    kind: 'sort',
+    node: 'computed-sort',
+    column: '[DS].[none:State:nk]',
+    intended: '<computed-sort column="[DS].[none:State:nk]">',
+    readback: 'missing',
+    severity: 'warning',
   };
 
   beforeEach(() => {
@@ -152,6 +161,31 @@ describe('applyWorksheetTool', () => {
     expect(message).toContain('HOST VERIFICATION — unverified');
     expect(message).toContain('readback unavailable');
     expect(message).not.toMatch(/\bverified\b/i);
+  });
+
+  it('fails the receipt when readback warnings show promised sort loss', async () => {
+    const mockXml = '<worksheet name="Sheet 1"><table></table></worksheet>';
+    vi.spyOn(loadWorksheetXmlModule, 'loadWorksheetXml').mockResolvedValue(
+      Ok({
+        readbackWarnings: [promisedSortLossWarning],
+        readbackVerification: { ok: true, status: 'warning' },
+      }),
+    );
+
+    const result = await getToolResult({
+      session: '12345',
+      worksheetName: 'Sheet 1',
+      mode: 'inline',
+      worksheetXml: mockXml,
+      mockExecutor: vi.fn().mockResolvedValue({}),
+    });
+
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+    const message = resultSchema.parse(JSON.parse(result.content[0].text)).message;
+    expect(message).toContain('HOST VERIFICATION — failed');
+    expect(message).toContain('promised sort NOT verified');
+    expect(message).not.toContain('HOST VERIFICATION — verified');
   });
 
   it('should return error when inline mode is used without worksheetXml', async () => {

--- a/src/tools/desktop/worksheet/applyWorksheet.ts
+++ b/src/tools/desktop/worksheet/applyWorksheet.ts
@@ -157,6 +157,7 @@ export const getApplyWorksheetTool = (
             ? formatWorksheetPromiseCheck({
                 validationWarnings: result.value.validationWarnings ?? [],
                 readback: result.value.readbackVerification,
+                readbackFindings: result.value.readbackWarnings,
               })
             : '';
 


### PR DESCRIPTION
Port-wave packet C (a2td #216 twin), from the content-signature port audit. The verified gap: `promise-check.ts:39` mapped readback status `warning` → outcome `verified`, while readback classifies dropped `computed-sort`/`shelf-sort-v2` nodes as warning severity — so an apply that silently lost a promised sort still stamped **HOST VERIFICATION — verified**. That's the false-PASS class #216 closed in a2td, and the one worth fixing before the feature/desktop binary publishes.

**Change:** receipt input gains optional `readbackFindings` (threaded from `LoadWorksheetXmlOk.readbackWarnings`, which already existed — the readback verifier's shape is unchanged); a promised-sort-loss warning escalates the receipt to `failed` with an explicit line. All other warnings keep today's behavior; the stricter error-severity loss path is untouched.

**Validation (orchestrator, firsthand):** full suite 4,351 green (298 files), `tsc --noEmit` clean, `check-lockstep` 6/6. No describe()/schema text changes — surface untouched. Cursor-minion port adjudicated per playbook.

Companion packets: A (seam-1 resolver, in flight) and B (planner/apply, follows A+C — shares `buildAndApplyWorksheet.ts` with this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)