### PR TITLE
feat(desktop): exact column_ref first-class + shared ref helpers (a2td #217+#222 port, seam-1 packet A)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "2.25.2",
+  "version": "2.25.4",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/src/desktop/binder/explicit-bind.test.ts
+++ b/src/desktop/binder/explicit-bind.test.ts
@@ -9,19 +9,21 @@ function field(p: {
   role: 'dimension' | 'measure';
   type: string;
   datatype: string;
+  datasource?: string;
   refDerivation?: string;
 }): SchemaField {
   const suffix = p.type === 'quantitative' ? 'qk' : p.type === 'ordinal' ? 'ok' : 'nk';
   const deriv = p.refDerivation ?? (p.role === 'measure' ? 'sum' : 'none');
+  const datasource = p.datasource ?? 'Superstore';
   return {
     name: p.name,
     columnName: `[${p.name}]`,
     role: p.role,
     type: p.type,
     datatype: p.datatype,
-    datasource: 'Superstore',
+    datasource,
     isAggregated: false,
-    column_ref: `[Superstore].[${deriv}:${p.name}:${suffix}]`,
+    column_ref: `[${datasource}].[${deriv}:${p.name}:${suffix}]`,
   };
 }
 
@@ -229,6 +231,82 @@ describe('bindExplicitTemplate', () => {
     if (result.ok) {
       expect(result.fieldMapping['Order Date@mn']).toBe('[Superstore].[mn:Order Date:ok]');
       expect(result.fieldMapping['Order Date@yr']).toBe('[Superstore].[yr:Order Date:ok]');
+    }
+  });
+
+  it('still resolves bare column-instance refs by discarding caller derivation', () => {
+    const result = bindExplicitTemplate(
+      'x-latlon',
+      {
+        Longitude: '[avg:Longitude:qk]',
+        Latitude: '[sum:Latitude:qk]',
+        Detail: '[none:City:nk]',
+        Measure: '[avg:Sales:qk]',
+      },
+      SUMMARY,
+      { manifests: manifests(LATLON) },
+    );
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.fieldMapping.Longitude).toBe('[Superstore].[avg:Longitude:qk]');
+      expect(result.fieldMapping.Latitude).toBe('[Superstore].[avg:Latitude:qk]');
+      expect(result.fieldMapping.Measure).toBe('[Superstore].[sum:Sales:qk]');
+    }
+  });
+
+  it('resolves datasource-qualified refs when datasource and field names contain dots or colons', () => {
+    const dottedSummary: SchemaSummary = {
+      datasource: 'Orders.Primary',
+      fields: [
+        field({
+          name: 'Longitude',
+          role: 'measure',
+          type: 'quantitative',
+          datatype: 'real',
+          datasource: 'Orders.Primary',
+        }),
+        field({
+          name: 'Latitude',
+          role: 'measure',
+          type: 'quantitative',
+          datatype: 'real',
+          datasource: 'Orders.Primary',
+        }),
+        field({
+          name: 'City.Region',
+          role: 'dimension',
+          type: 'nominal',
+          datatype: 'string',
+          datasource: 'Orders.Primary',
+        }),
+        field({
+          name: 'Profit:Ratio',
+          role: 'measure',
+          type: 'quantitative',
+          datatype: 'real',
+          datasource: 'Orders.Primary',
+        }),
+      ],
+    };
+
+    const result = bindExplicitTemplate(
+      'x-latlon',
+      {
+        Longitude: '[Orders.Primary].[sum:Longitude:qk]',
+        Latitude: '[Orders.Primary].[sum:Latitude:qk]',
+        Detail: '[Orders.Primary].[none:City.Region:nk]',
+        Measure: '[Orders.Primary].[sum:Profit:Ratio:qk]',
+      },
+      dottedSummary,
+      { manifests: manifests(LATLON) },
+    );
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.datasource).toBe('Orders.Primary');
+      expect(result.fieldMapping.Detail).toBe('[Orders.Primary].[none:City.Region:nk]');
+      expect(result.fieldMapping.Measure).toBe('[Orders.Primary].[sum:Profit:Ratio:qk]');
     }
   });
 });

--- a/src/desktop/binder/explicit-bind.ts
+++ b/src/desktop/binder/explicit-bind.ts
@@ -1,3 +1,7 @@
+import {
+  parseColumnInstanceRef,
+  parseDatasourceQualifiedColumnRef,
+} from '../metadata/field-resolver.js';
 import { loadManifests } from './manifest.js';
 import type { Derivation, SlotSpec, TemplateManifest } from './manifest-types.js';
 import { bareName, type SchemaField, type SchemaSummary } from './schema-summary.js';
@@ -337,13 +341,16 @@ function resolveSource(raw: string, schema: SchemaSummary): ResolvedSource | Exp
 }
 
 function parseColumnRef(raw: string): { datasource?: string; base: string } | null {
-  const match = /^(?:\[([^\]]+)\]\.)?\[(.+)\]$/.exec(raw.trim());
-  if (!match) return null;
-  const first = match[2].indexOf(':');
-  const last = match[2].lastIndexOf(':');
-  if (first <= 0 || last <= first) return null;
-  const base = match[2].slice(first + 1, last);
-  return base ? { datasource: match[1], base } : null;
+  const trimmed = raw.trim();
+  const qualified = parseDatasourceQualifiedColumnRef(trimmed);
+  if (qualified) {
+    const instance = parseColumnInstanceRef(qualified.columnInstanceName);
+    return instance ? { datasource: qualified.datasource, base: instance.localFieldName } : null;
+  }
+
+  // Keep bare instances for legacy explicit mappings; fields.ts only accepts full refs.
+  const instance = parseColumnInstanceRef(trimmed);
+  return instance ? { base: instance.localFieldName } : null;
 }
 
 const TEMPORAL_DATATYPES: ReadonlySet<string> = new Set(['date', 'datetime']);

--- a/src/desktop/binder/validate.test.ts
+++ b/src/desktop/binder/validate.test.ts
@@ -174,6 +174,107 @@ describe('binder/validate — gate 2: field resolution', () => {
         r.blockers.some((b) => b.code === 'ambiguous-field' && (b.candidates?.length ?? 0) >= 2),
       ).toBe(true);
   });
+
+  it('no-fire: exact column_ref binds duplicate names from the intended datasource', () => {
+    const twoDs: SchemaSummary = {
+      datasource: 'DS_A',
+      fields: [
+        field({
+          columnName: '[Region]',
+          role: 'dimension',
+          type: 'nominal',
+          datatype: 'string',
+          datasource: 'DS_A',
+        }),
+        {
+          ...field({
+            columnName: '[Sales]',
+            role: 'measure',
+            type: 'quantitative',
+            datatype: 'real',
+            datasource: 'DS_A',
+          }),
+          column_ref: '[DS_A].[sum:Sales:qk]',
+        },
+        field({
+          columnName: '[Region]',
+          role: 'dimension',
+          type: 'nominal',
+          datatype: 'string',
+          datasource: 'DS_B',
+        }),
+        {
+          ...field({
+            columnName: '[Sales]',
+            role: 'measure',
+            type: 'quantitative',
+            datatype: 'real',
+            datasource: 'DS_B',
+          }),
+          column_ref: '[DS_B].[sum:Sales:qk]',
+        },
+      ],
+    };
+    const m = manifests.get('ranking-ordered-bar')!;
+    const p: BindingProposal = {
+      template: m.template,
+      title: 't',
+      bindings: [
+        { slot_id: 'region', field: '[DS_B].[none:Region:nk]' },
+        { slot_id: 'sales', field: '[DS_B].[sum:Sales:qk]' },
+      ],
+    };
+    const r = validateBinding(m, p, twoDs);
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.datasource).toBe('DS_B');
+      expect(r.field_mapping).toEqual({
+        Region: '[DS_B].[none:Region:nk]',
+        Sales: '[DS_B].[sum:Sales:qk]',
+      });
+    }
+  });
+
+  it('fire: column_ref-shaped miss fails closed without fuzzy candidates', () => {
+    const s: SchemaSummary = {
+      datasource: 'DS_A',
+      fields: [
+        field({
+          columnName: '[Region]',
+          role: 'dimension',
+          type: 'nominal',
+          datatype: 'string',
+          datasource: 'DS_A',
+        }),
+        {
+          ...field({
+            columnName: '[Sales]',
+            role: 'measure',
+            type: 'quantitative',
+            datatype: 'real',
+            datasource: 'DS_A',
+          }),
+          column_ref: '[DS_A].[sum:Sales:qk]',
+        },
+      ],
+    };
+    const m = manifests.get('ranking-ordered-bar')!;
+    const p: BindingProposal = {
+      template: m.template,
+      title: 't',
+      bindings: [
+        { slot_id: 'region', field: '[DS_A].[none:Region:nk]' },
+        { slot_id: 'sales', field: '[DS_A].[sum:Sale:qk]' },
+      ],
+    };
+    const r = validateBinding(m, p, s);
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      const blocker = r.blockers.find((b) => b.slot_id === 'sales');
+      expect(blocker?.code).toBe('field-not-found');
+      expect(blocker?.candidates).toEqual([]);
+    }
+  });
 });
 
 describe('binder/validate — gate 3: kind/role compatibility', () => {

--- a/src/desktop/binder/validate.ts
+++ b/src/desktop/binder/validate.ts
@@ -31,6 +31,7 @@
 
 import Fuse from 'fuse.js';
 
+import { COLUMN_REF_REGEX } from '../metadata/field-resolver.js';
 import { matchAvoidWhen } from './classify.js';
 import { escapeXml } from './escape.js';
 import type {
@@ -235,6 +236,12 @@ function resolveInSummary(s: SchemaSummary, query: string): Resolution {
   const q = query.trim();
   if (!q) return { kind: 'not_found', candidates: [] };
   const qBare = bareName(q);
+
+  // Exact column_ref is already datasource-qualified, so resolve it before names/captions.
+  const refMatches = s.fields.filter((f) => f.column_ref === q);
+  if (refMatches.length === 1) return { kind: 'exact', field: refMatches[0] };
+  if (refMatches.length > 1) return { kind: 'ambiguous', candidates: refMatches };
+  if (COLUMN_REF_REGEX.test(q)) return { kind: 'not_found', candidates: [] };
 
   // Phase 1: exact (case-sensitive) on friendly name, caption, or bare column name.
   const exact = s.fields.filter(

--- a/src/desktop/metadata/field-resolver.test.ts
+++ b/src/desktop/metadata/field-resolver.test.ts
@@ -1,4 +1,8 @@
-import { resolveField } from './field-resolver.js';
+import {
+  formatCanonicalColumnRef,
+  parseCanonicalColumnRef,
+  resolveField,
+} from './field-resolver.js';
 
 const WB_TWO_DATASOURCES = `<?xml version="1.0" encoding="UTF-8"?>
 <workbook>
@@ -8,6 +12,18 @@ const WB_TWO_DATASOURCES = `<?xml version="1.0" encoding="UTF-8"?>
       <column name="[Region]" datatype="string" role="dimension" type="nominal"/>
     </datasource>
     <datasource name="ds2" caption="Sample - Coffee Chain">
+      <column name="[Profit]" datatype="real" role="measure" type="quantitative"/>
+    </datasource>
+  </datasources>
+</workbook>`;
+
+const WB_DUPLICATE_DATASOURCE_CAPTIONS = `<?xml version="1.0" encoding="UTF-8"?>
+<workbook>
+  <datasources>
+    <datasource name="ds1" caption="Shared Caption">
+      <column name="[Profit]" datatype="real" role="measure" type="quantitative"/>
+    </datasource>
+    <datasource name="ds2" caption="Shared Caption">
       <column name="[Profit]" datatype="real" role="measure" type="quantitative"/>
     </datasource>
   </datasources>
@@ -42,6 +58,36 @@ describe('resolveField', () => {
     expect(r.datasource).toBe('ds1');
   });
 
+  it('resolves an exact column_ref as already disambiguated', () => {
+    const r = resolveField(WB_TWO_DATASOURCES, '[ds2].[sum:Profit:qk]');
+    expect(r.kind).toBe('exact');
+    expect(r.column_ref).toBe('[ds2].[sum:Profit:qk]');
+    expect(r.datasource).toBe('ds2');
+  });
+
+  it('returns not_found for a column_ref-shaped miss without fuzzy fallback', () => {
+    const r = resolveField(WB_TWO_DATASOURCES, '[missing_ds].[sum:Profit:qk]');
+    expect(r.kind).toBe('not_found');
+    expect(r.candidates).toEqual([]);
+  });
+
+  it('collapses ambiguity when a unique datasource caption is supplied', () => {
+    const r = resolveField(WB_TWO_DATASOURCES, 'Profit', {
+      datasource: 'Sample - Coffee Chain',
+    });
+    expect(r.kind).toBe('exact');
+    expect(r.column_ref).toBe('[ds2].[sum:Profit:qk]');
+    expect(r.datasource).toBe('ds2');
+  });
+
+  it('returns ambiguous when the datasource caption selector is not unique', () => {
+    const r = resolveField(WB_DUPLICATE_DATASOURCE_CAPTIONS, 'Profit', {
+      datasource: 'Shared Caption',
+    });
+    expect(r.kind).toBe('ambiguous');
+    expect(r.candidates?.map((c) => c.datasource).sort()).toEqual(['ds1', 'ds2']);
+  });
+
   it('should return not_found for an empty query', () => {
     const r = resolveField(WB_TWO_DATASOURCES, '');
     expect(r.kind).toBe('not_found');
@@ -73,5 +119,43 @@ describe('resolveField', () => {
     expect(r.kind).toBe('rewritten');
     expect(r.rewrites).toContain('ignored-redundant-aggregation');
     expect(r.reason).toMatch(/already aggregated/);
+  });
+});
+
+describe('canonical column_ref helpers', () => {
+  it.each([
+    {
+      datasource: 'federated.ds2',
+      derivation: 'sum',
+      localFieldName: 'Profit',
+      pivot: 'qk',
+    },
+    {
+      datasource: 'Orders.Primary',
+      derivation: 'none',
+      localFieldName: 'Customer.Segment',
+      pivot: 'nk',
+    },
+    {
+      datasource: 'Calculations',
+      derivation: 'usr',
+      localFieldName: 'Profit:Ratio',
+      pivot: 'qk',
+    },
+    {
+      datasource: 'Dates',
+      derivation: 'yr',
+      localFieldName: 'Order.Date:Fiscal',
+      pivot: 'ok',
+    },
+  ])('round-trips canonical refs for $datasource / $localFieldName', (parts) => {
+    expect(parseCanonicalColumnRef(formatCanonicalColumnRef(parts))).toEqual({
+      ...parts,
+      columnInstanceName: `[${parts.derivation}:${parts.localFieldName}:${parts.pivot}]`,
+    });
+  });
+
+  it('returns null for datasource-qualified refs that are not canonical instances', () => {
+    expect(parseCanonicalColumnRef('[Sample].[Profit]')).toBeNull();
   });
 });

--- a/src/desktop/metadata/field-resolver.ts
+++ b/src/desktop/metadata/field-resolver.ts
@@ -25,6 +25,7 @@
 import Fuse from 'fuse.js';
 
 import { listAvailableFields } from './field-builder.js';
+import { normalizeArray, parseXML } from './parser.js';
 import { AggregationType, type FieldReference } from './types.js';
 
 export type FieldResolutionKind = 'exact' | 'rewritten' | 'ambiguous' | 'not_found';
@@ -75,6 +76,77 @@ export interface FieldResolveOptions {
 
 const AGG_PREFIX_REGEX =
   /^(sum|avg|average|mean|min|minimum|max|maximum|count|countd|count\s*distinct|countdistinct|median|stdev|stdevp|var|varp)\s+of\s+(.+)$/i;
+
+export const COLUMN_REF_REGEX = /^\[([^\]]+)\]\.\[([^\]]+)\]$/;
+
+export interface DatasourceQualifiedColumnRef {
+  datasource: string;
+  columnInstanceName: string;
+}
+
+export interface ColumnInstanceRefParts {
+  derivation: string;
+  localFieldName: string;
+  pivot: string;
+  columnInstanceName: string;
+}
+
+export type CanonicalColumnRefParts = Omit<ColumnInstanceRefParts, 'columnInstanceName'> & {
+  datasource: string;
+};
+
+export type ParsedCanonicalColumnRef = CanonicalColumnRefParts & {
+  columnInstanceName: string;
+};
+
+export function parseDatasourceQualifiedColumnRef(
+  columnRef: string,
+): DatasourceQualifiedColumnRef | null {
+  const match = COLUMN_REF_REGEX.exec(columnRef);
+  if (!match) return null;
+  return {
+    datasource: match[1],
+    columnInstanceName: `[${match[2]}]`,
+  };
+}
+
+export function parseColumnInstanceRef(columnInstanceRef: string): ColumnInstanceRefParts | null {
+  if (!columnInstanceRef.startsWith('[') || !columnInstanceRef.endsWith(']')) {
+    return null;
+  }
+
+  const instance = columnInstanceRef.slice(1, -1);
+  const first = instance.indexOf(':');
+  const last = instance.lastIndexOf(':');
+  if (first <= 0 || last <= first) return null;
+
+  const localFieldName = instance.slice(first + 1, last);
+  if (!localFieldName) return null;
+
+  return {
+    derivation: instance.slice(0, first),
+    localFieldName,
+    pivot: instance.slice(last + 1),
+    columnInstanceName: `[${instance}]`,
+  };
+}
+
+export function parseCanonicalColumnRef(columnRef: string): ParsedCanonicalColumnRef | null {
+  const qualified = parseDatasourceQualifiedColumnRef(columnRef);
+  if (!qualified) return null;
+
+  const instance = parseColumnInstanceRef(qualified.columnInstanceName);
+  if (!instance || !instance.pivot) return null;
+
+  return {
+    datasource: qualified.datasource,
+    ...instance,
+  };
+}
+
+export function formatCanonicalColumnRef(parts: CanonicalColumnRefParts): string {
+  return `[${parts.datasource}].[${parts.derivation}:${parts.localFieldName}:${parts.pivot}]`;
+}
 
 function normalizeName(s: string): string {
   return s.replace(/^\[|\]$/g, '').trim();
@@ -134,7 +206,12 @@ function buildAggregatedRef(
   const bareName = normalizeName(base.columnName);
   const suffix = typeSuffixFor(base.type);
   const prefix = aggregationPrefix(agg);
-  return `[${base.datasource}].[${prefix}:${bareName}:${suffix}]`;
+  return formatCanonicalColumnRef({
+    datasource: base.datasource,
+    derivation: prefix,
+    localFieldName: bareName,
+    pivot: suffix,
+  });
 }
 
 function toCandidate(field: FieldReference & { column_ref: string }): FieldCandidate {
@@ -146,6 +223,56 @@ function toCandidate(field: FieldReference & { column_ref: string }): FieldCandi
     role: field.role,
     is_aggregated: !!field.isAggregated,
   };
+}
+
+function datasourceCaptionMap(workbookXml: string): Map<string, Set<string>> {
+  const workbook = parseXML(workbookXml);
+  const datasources = normalizeArray<any>(workbook.workbook?.datasources?.datasource);
+  const captions = new Map<string, Set<string>>();
+
+  for (const datasource of datasources) {
+    const name = datasource?.['@_name'];
+    const caption = datasource?.['@_caption'];
+    if (!name || !caption || name === 'Parameters') continue;
+
+    const names = captions.get(caption) ?? new Set<string>();
+    names.add(name);
+    captions.set(caption, names);
+  }
+
+  return captions;
+}
+
+function matchingFieldsForDatasource(
+  workbookXml: string,
+  fields: Array<FieldReference & { column_ref: string }>,
+  datasource: string,
+):
+  | { kind: 'exact'; fields: Array<FieldReference & { column_ref: string }> }
+  | { kind: 'ambiguous'; fields: Array<FieldReference & { column_ref: string }> }
+  | { kind: 'not_found'; fields: [] } {
+  const internalMatches = fields.filter((f) => f.datasource === datasource);
+  if (internalMatches.length > 0) {
+    return { kind: 'exact', fields: internalMatches };
+  }
+
+  const captionNames = datasourceCaptionMap(workbookXml).get(datasource);
+  if (!captionNames || captionNames.size === 0) {
+    return { kind: 'not_found', fields: [] };
+  }
+
+  const captionFields = fields.filter((f) => captionNames.has(f.datasource));
+  if (captionNames.size === 1) {
+    return { kind: 'exact', fields: captionFields };
+  }
+  return { kind: 'ambiguous', fields: captionFields };
+}
+
+function matchingCandidates(
+  fields: Array<FieldReference & { column_ref: string }>,
+  query: string,
+): Array<FieldReference & { column_ref: string }> {
+  return fields.filter((f) => fieldMatchesExact(f, query) || fieldMatchesByBareName(f, query));
 }
 
 /**
@@ -168,8 +295,37 @@ export function resolveField(
   }
 
   let allFields = listAvailableFields(workbookXml);
+  const exactRefMatch = allFields.find((f) => f.column_ref === trimmed);
+  if (exactRefMatch) {
+    return {
+      kind: 'exact',
+      query,
+      column_ref: exactRefMatch.column_ref,
+      datasource: exactRefMatch.datasource,
+    };
+  }
+  // A datasource-qualified ref is already disambiguated; a miss must not fuzzy-match.
+  if (COLUMN_REF_REGEX.test(trimmed)) {
+    return {
+      kind: 'not_found',
+      query,
+      reason: `no field matches exact column_ref "${trimmed}"`,
+      candidates: [],
+    };
+  }
+
   if (options.datasource) {
-    allFields = allFields.filter((f) => f.datasource === options.datasource);
+    const scoped = matchingFieldsForDatasource(workbookXml, allFields, options.datasource);
+    if (scoped.kind === 'ambiguous') {
+      const matches = matchingCandidates(scoped.fields, trimmed);
+      return {
+        kind: 'ambiguous',
+        query,
+        candidates: (matches.length > 0 ? matches : scoped.fields).map(toCandidate),
+        reason: `datasource selector "${options.datasource}" matches multiple datasources; use an internal datasource name or exact column_ref.`,
+      };
+    }
+    allFields = scoped.fields;
   }
 
   if (allFields.length === 0) {

--- a/src/desktop/metadata/fields.test.ts
+++ b/src/desktop/metadata/fields.test.ts
@@ -108,6 +108,48 @@ describe('addFieldToRows / removeFieldFromRows', () => {
     expect(rowFields).toHaveLength(1);
     expect(rowFields[0]?.column).toBe('[Sample].[sum:Sales:qk]');
   });
+
+  it('requires datasource-qualified refs when adding to rows', () => {
+    expect(() => addFieldToRows(WORKSHEET_XML, '[sum:Profit:qk]')).toThrow(
+      /Invalid column reference format/,
+    );
+  });
+
+  it('keeps the legacy column-instance validation error for datasource-qualified non-instance refs', () => {
+    expect(() => addFieldToRows(WORKSHEET_XML, '[Sample].[Profit]')).toThrow(
+      /Invalid column-instance name format: \[Profit\]/,
+    );
+  });
+});
+
+describe('addFieldToRows dotted and colon refs', () => {
+  const DOTTED_COLON_XML = `<?xml version="1.0" encoding="UTF-8"?>
+<worksheet name="Sheet 1">
+  <table>
+    <view>
+      <datasources>
+        <datasource name="Orders.Primary" caption="Orders"/>
+      </datasources>
+      <datasource-dependencies datasource="Orders.Primary">
+        <column name="[City.Region]" datatype="string" role="dimension" type="nominal"/>
+        <column name="[Profit:Ratio]" datatype="real" role="measure" type="quantitative"/>
+        <column-instance name="[none:City.Region:nk]" column="[City.Region]" derivation="None" pivot="key" type="nominal"/>
+      </datasource-dependencies>
+    </view>
+    <rows>[Orders.Primary].[none:City.Region:nk]</rows>
+  </table>
+</worksheet>`;
+
+  it('adds a datasource-qualified ref when datasource and field names contain dots or colons', () => {
+    const modified = addFieldToRows(DOTTED_COLON_XML, '[Orders.Primary].[sum:Profit:Ratio:qk]');
+    const rowFields = listFields(modified).filter((f) => f.location === 'rows');
+    expect(rowFields.map((f) => f.column)).toContain(
+      '[Orders.Primary].[sum:Profit:Ratio:qk]',
+    );
+    expect(modified).toContain(
+      '<column-instance name="[sum:Profit:Ratio:qk]" column="[Profit:Ratio]"',
+    );
+  });
 });
 
 describe('addFieldToRows date-part derivations', () => {

--- a/src/desktop/metadata/fields.test.ts
+++ b/src/desktop/metadata/fields.test.ts
@@ -143,9 +143,7 @@ describe('addFieldToRows dotted and colon refs', () => {
   it('adds a datasource-qualified ref when datasource and field names contain dots or colons', () => {
     const modified = addFieldToRows(DOTTED_COLON_XML, '[Orders.Primary].[sum:Profit:Ratio:qk]');
     const rowFields = listFields(modified).filter((f) => f.location === 'rows');
-    expect(rowFields.map((f) => f.column)).toContain(
-      '[Orders.Primary].[sum:Profit:Ratio:qk]',
-    );
+    expect(rowFields.map((f) => f.column)).toContain('[Orders.Primary].[sum:Profit:Ratio:qk]');
     expect(modified).toContain(
       '<column-instance name="[sum:Profit:Ratio:qk]" column="[Profit:Ratio]"',
     );

--- a/src/desktop/metadata/fields.ts
+++ b/src/desktop/metadata/fields.ts
@@ -3,6 +3,7 @@
  * Note: Ordering matters for all field operations
  */
 
+import { parseColumnInstanceRef, parseDatasourceQualifiedColumnRef } from './field-resolver.js';
 import { emitFieldRewrite } from './field-rewrite-listener.js';
 import { normalizeArray, parseXML, serializeXML } from './parser.js';
 import type { EncodingType, FieldInfo, ParsedEncoding, ParsedWorksheet } from './types.js';
@@ -67,7 +68,7 @@ export function addFieldToEncoding(
   }
 
   // Parse column reference to get datasource and column-instance
-  const parsedRef = parseColumnRef(columnRef);
+  const parsedRef = parseDatasourceQualifiedColumnRef(columnRef);
   if (!parsedRef) {
     throw new Error(
       `Invalid column reference format: ${columnRef}. Expected format: [Datasource Name].[column-instance-name]`,
@@ -415,23 +416,6 @@ function serializeShelfValue(fields: string[]): string {
 }
 
 /**
- * Parse column reference to extract datasource and column-instance name
- * Format: [Datasource Name].[column-instance-name]
- */
-function parseColumnRef(
-  columnRef: string,
-): { datasource: string; columnInstanceName: string } | null {
-  const match = columnRef.match(/^\[([^\]]+)\]\.\[([^\]]+)\]$/);
-  if (!match) {
-    return null;
-  }
-  return {
-    datasource: match[1],
-    columnInstanceName: `[${match[2]}]`,
-  };
-}
-
-/**
  * Map lowercase derivation abbreviations to proper-case derivation names
  * Column-instance names use lowercase (e.g., [ctd:Field:qk]) but derivation attributes use proper case (CountD)
  */
@@ -508,14 +492,15 @@ function typeFromPivotSuffix(columnInstanceName: string): string | null {
  */
 function parseColumnInstanceName(
   columnInstanceName: string,
-): { column: string; derivation: string } | null {
-  const match = columnInstanceName.match(/^\[([^:]+):([^:]+):[^\]]+\]$/);
-  if (!match) {
-    return null;
-  }
+): { column: string; derivation: string; localFieldName: string; pivot: string } | null {
+  const parsed = parseColumnInstanceRef(columnInstanceName);
+  if (!parsed || !parsed.pivot) return null;
+
   return {
-    column: `[${match[2]}]`,
-    derivation: mapDerivationToProperCase(match[1]),
+    column: `[${parsed.localFieldName}]`,
+    derivation: mapDerivationToProperCase(parsed.derivation),
+    localFieldName: parsed.localFieldName,
+    pivot: parsed.pivot,
   };
 }
 
@@ -683,21 +668,18 @@ function ensureColumnInstanceInDependencies(
     const hasAggregation = aggFunctions.some((fn) => formula.toUpperCase().includes(fn));
 
     if (hasAggregation && parsed.derivation !== 'User') {
-      const nameMatch = columnInstanceName.match(/^\[([^:]+):([^:]+):([^\]]+)\]$/);
-      if (nameMatch) {
-        correctedInstanceName = `[usr:${nameMatch[2]}:${nameMatch[3]}]`;
-        console.error(
-          `[DEBUG] Correcting column reference for calculated field with aggregation: ${columnInstanceName} -> ${correctedInstanceName}`,
-        );
-        emitFieldRewrite({
-          requested: columnInstanceName,
-          applied: correctedInstanceName,
-          reason: `calculated field "${parsed.column}" already aggregates in its formula; switching ${parsed.derivation} → User to avoid double aggregation`,
-          datasource,
-        });
-        // Check if the corrected instance already exists
-        exists = columnInstances.some((ci: any) => ci['@_name'] === correctedInstanceName);
-      }
+      correctedInstanceName = `[usr:${parsed.localFieldName}:${parsed.pivot}]`;
+      console.error(
+        `[DEBUG] Correcting column reference for calculated field with aggregation: ${columnInstanceName} -> ${correctedInstanceName}`,
+      );
+      emitFieldRewrite({
+        requested: columnInstanceName,
+        applied: correctedInstanceName,
+        reason: `calculated field "${parsed.column}" already aggregates in its formula; switching ${parsed.derivation} → User to avoid double aggregation`,
+        datasource,
+      });
+      // Check if the corrected instance already exists
+      exists = columnInstances.some((ci: any) => ci['@_name'] === correctedInstanceName);
     }
   }
 
@@ -851,20 +833,16 @@ function ensureColumnInstanceInDependencies(
           `[DEBUG] Calculated field "${parsedCorrected.column}" has aggregation in formula, correcting from "${parsedCorrected.derivation}" to "User"`,
         );
         actualDerivation = 'User';
-        // Also fix the column-instance name to use 'usr' prefix instead of aggregation prefix
-        // Parse format: [prefix:ColumnName:type] -> [usr:ColumnName:type]
-        const nameMatch = correctedInstanceName.match(/^\[([^:]+):([^:]+):([^\]]+)\]$/);
-        if (nameMatch) {
-          actualColumnInstanceName = `[usr:${nameMatch[2]}:${nameMatch[3]}]`;
-          console.error(`[DEBUG] Corrected column-instance name: ${actualColumnInstanceName}`);
-          if (actualColumnInstanceName !== correctedInstanceName) {
-            emitFieldRewrite({
-              requested: correctedInstanceName,
-              applied: actualColumnInstanceName,
-              reason: `calculated field "${parsedCorrected.column}" already aggregates; final derivation forced to User`,
-              datasource,
-            });
-          }
+        // Also fix the column-instance name to use 'usr' prefix instead of aggregation prefix.
+        actualColumnInstanceName = `[usr:${parsedCorrected.localFieldName}:${parsedCorrected.pivot}]`;
+        console.error(`[DEBUG] Corrected column-instance name: ${actualColumnInstanceName}`);
+        if (actualColumnInstanceName !== correctedInstanceName) {
+          emitFieldRewrite({
+            requested: correctedInstanceName,
+            applied: actualColumnInstanceName,
+            reason: `calculated field "${parsedCorrected.column}" already aggregates; final derivation forced to User`,
+            datasource,
+          });
         }
       }
     }
@@ -920,7 +898,7 @@ function addFieldToShelf(
   }
 
   // Parse column reference to get datasource and column-instance
-  const parsedRef = parseColumnRef(columnRef);
+  const parsedRef = parseDatasourceQualifiedColumnRef(columnRef);
   if (!parsedRef) {
     throw new Error(
       `Invalid column reference format: ${columnRef}. Expected format: [Datasource Name].[column-instance-name]`,


### PR DESCRIPTION
Port-wave packet A (a2td #217 + #222 twins), from the content-signature port audit — the resolver half of the seam-1 multi-datasource correctness cluster, worth having in the feature/desktop binary: a duplicate `Profit` across datasources currently resolves by name-affinity and can silently bind the wrong one.

**#222 half:** shared exported ref helpers in `field-resolver.ts` (`COLUMN_REF_REGEX`, `parseDatasourceQualifiedColumnRef`, `parseColumnInstanceRef`, `parseCanonicalColumnRef`, `formatCanonicalColumnRef` — same API as a2td); private regexes in `fields.ts`/`explicit-bind.ts` replaced. Documented divergence preserved (explicit-bind accepts bare `[deriv:Base:sfx]`; fields require datasource-qualified). Colon-tolerant instance parsing — the minion's red run caught `[Profit:Ratio]` being mis-parsed as `[Profit]` and pinned it.

**#217 half:** `resolveField` and proposal-binding `resolveInSummary` recognize an exact canonical `column_ref` FIRST — a hit resolves `exact`; a ref-SHAPED miss fails closed as `not_found` (never falls through to fuzzy). Datasource selector matches internal name or UNIQUE caption; ambiguous captions refuse with guidance (`Parameters` excluded). Gate 5b single-datasource closure untouched. `listAvailableFields` untouched (#535's file — coordinated, not collided).

**Validation (orchestrator, firsthand):** full suite 4,362 green (298 files), all three wrong-bind invariant suites green (210 tests — portability, bind-behavior-matrix, carrier-uniqueness), `tsc` clean, lockstep 6/6, eslint clean (4 fixable errors fixed at adjudication). Version 2.25.4 assumes #538 (2.25.3) merges first — resolve upward on conflict.

Companions: #538 (receipt honesty, packet C) already open; packet B (planner/apply datasource selection, a2td #219+#220) stacks on this branch next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
**Adversarial review adjudication (fresh-context GPT review, orchestrator-verified):** the review returned two findings, both **refuted by reference-parity** — (1) ref-match-before-name ordering in `resolveInSummary` is byte-for-byte the a2td-merged design (explicit comment in a2td `validate.ts:217`: refs are already datasource-qualified, so they resolve before duplicate captions — the ordering that closed #217's bug class; the trigger requires a field *named* as another field's canonical ref string, adversarial not user input); (2) internal-name-beats-caption selector precedence is identical in a2td's `matchingFieldsForDatasource` — deterministic, with explicit refusal on caption-side ambiguity. Review's clean lenses: call-site enumeration, colon-parsing edge cases, old-vs-new regex grammar preservation. No port-introduced behavior deltas found.