### PR TITLE
feat(desktop): TOOL_PROFILE=spec-loop — the 5-tool semantic-first surface (fold-in from experiment)

### DIFF
--- a/src/server.desktop.test.ts
+++ b/src/server.desktop.test.ts
@@ -5,10 +5,10 @@ import * as configModule from './config.desktop.js';
 import * as loggerModule from './logging/logger.js';
 import {
   DEMO_TOOL_PROFILE,
-  SPEC_LOOP_TOOL_PROFILE,
   DESKTOP_INSTRUCTIONS,
   DesktopMcpServer,
   selectToolsForProfile,
+  SPEC_LOOP_TOOL_PROFILE,
 } from './server.desktop.js';
 import { DesktopTool } from './tools/desktop/tool.js';
 import { desktopToolNames } from './tools/desktop/toolName.js';

--- a/src/server.desktop.test.ts
+++ b/src/server.desktop.test.ts
@@ -5,6 +5,7 @@ import * as configModule from './config.desktop.js';
 import * as loggerModule from './logging/logger.js';
 import {
   DEMO_TOOL_PROFILE,
+  SPEC_LOOP_TOOL_PROFILE,
   DESKTOP_INSTRUCTIONS,
   DesktopMcpServer,
   selectToolsForProfile,
@@ -316,6 +317,30 @@ describe('selectToolsForProfile (TOOL_PROFILE, W60 spike lever 1 / preamble P1)'
     ]) {
       expect(selected.map((t) => t.name)).toContain(fallback);
     }
+  });
+
+  it('every spec-loop-profile name is a real desktop tool name', () => {
+    for (const name of SPEC_LOOP_TOOL_PROFILE) {
+      expect(desktopToolNames).toContain(name);
+    }
+  });
+
+  it('TOOL_PROFILE=spec-loop registers exactly the ruthless 5-tool set — no XML tools, no templates', () => {
+    const selected = selectToolsForProfile(allTools(), 'spec-loop');
+    expect(new Set(selected.map((t) => t.name))).toEqual(SPEC_LOOP_TOOL_PROFILE);
+    // The whole point: the XML/template surface must be GONE.
+    for (const banished of [
+      'get-workbook-xml',
+      'apply-workbook',
+      'apply-worksheet',
+      'inject-template',
+      'bind-template',
+      'batch-create-and-cache-sheets',
+    ]) {
+      expect(selected.map((t) => t.name)).not.toContain(banished);
+    }
+    // execute-tableau-command is the one load-bearing tool — it must survive.
+    expect(selected.map((t) => t.name)).toContain('execute-tableau-command');
   });
 
   it('unset ("") profile returns the full set unchanged, byte-identical order', () => {

--- a/src/server.desktop.ts
+++ b/src/server.desktop.ts
@@ -53,6 +53,27 @@ export const DEMO_TOOL_PROFILE: ReadonlySet<DesktopToolName> = new Set<DesktopTo
 ]);
 
 /**
+ * EXPERIMENT (experiment/spec-loop-studio): the ruthless spec-loop-first surface,
+ * selected by TOOL_PROFILE=spec-loop. Hypothesis under test: the native semantic
+ * loop — generate-viz-from-notional-spec for charts, the whole-document GET/POST
+ * for calcs, both dispatched through execute-tableau-command on the /v0 External
+ * API — is sufficient on its own, with NO XML tools, NO templates, NO bind-template.
+ * Everything a chart/calc/dashboard ask needs routes through execute-tableau-command;
+ * the rest is discovery + readback (the /v0 generic route is write-blind, so the
+ * list-* tools are how the model observes state). Proven by hand 2026-07-19: a full
+ * analytics workbook (calcs + charts + dashboard) authored live in seconds, zero XML.
+ * The known-command guard (from #542) makes the single execute-tableau-command tool
+ * safe against hallucinated verbs.
+ */
+export const SPEC_LOOP_TOOL_PROFILE: ReadonlySet<DesktopToolName> = new Set<DesktopToolName>([
+  'execute-tableau-command',
+  'list-instances',
+  'list-available-fields',
+  'list-worksheets',
+  'list-dashboards',
+]);
+
+/**
  * Select the tools to register for a given TOOL_PROFILE value (already normalized by
  * Config: trim + lowercase). 'demo' → the slim {@link DEMO_TOOL_PROFILE} subset; '' (unset)
  * or 'full' → the full set unchanged (same array reference — byte-identical behavior); any
@@ -65,6 +86,9 @@ export function selectToolsForProfile<T extends { name: DesktopToolName }>(
 ): T[] {
   if (profile === 'demo') {
     return tools.filter((tool) => DEMO_TOOL_PROFILE.has(tool.name));
+  }
+  if (profile === 'spec-loop') {
+    return tools.filter((tool) => SPEC_LOOP_TOOL_PROFILE.has(tool.name));
   }
   // 'combined-lean' means "full desktop surface, lazy web surface" — the web half is
   // handled by WebMcpServer; the desktop half registers everything, same as 'full'.


### PR DESCRIPTION
Folds `experiment/spec-loop-studio`'s single commit into feature/desktop so the experiment branch can be deleted: `TOOL_PROFILE=spec-loop` registers exactly 5 tools (execute-tableau-command + list-instances/available-fields/worksheets/dashboards). Default remains the full set — the profile is opt-in via env, zero behavior change unless selected.

Context: with #542 (guard), #543 (knowledge + semantic-first routing) and this profile, the whole spec-loop story lives on feature/desktop; no side branch to maintain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)