### PR TITLE
feat(desktop): pre-dispatch guard for generate-viz-from-notional-spec (fabricated specs die at the tool, not as product 500s)

### DIFF
--- a/src/desktop/notionalSpecGuard.test.ts
+++ b/src/desktop/notionalSpecGuard.test.ts
@@ -1,0 +1,150 @@
+import { validateNotionalSpecArgs } from './notionalSpecGuard.js';
+
+const COMMAND = 'tabdoc:generate-viz-from-notional-spec';
+
+const EXAMPLE_1_SPEC = {
+  version: '0.2.0',
+  chart: 'bar',
+  fields: [
+    { caption: 'Region', data: 'string', type: 'discrete', role: 'dimension', encoding: 'x' },
+    {
+      caption: 'Sales',
+      data: 'number',
+      type: 'continuous',
+      role: 'measure',
+      aggregation: 'sum',
+      encoding: 'y',
+    },
+  ],
+  sort: { field: 'Region', by: 'Sales', aggregation: 'sum', direction: 'desc' },
+};
+
+describe('validateNotionalSpecArgs', () => {
+  it('passes through other commands unchanged, even with arbitrary args', () => {
+    expect(
+      validateNotionalSpecArgs('tabdoc:goto-sheet', { WorksheetId: 'anything', mark: 'bar' }),
+    ).toEqual({ ok: true });
+  });
+
+  it('accepts the doc Example 1 spec', () => {
+    const result = validateNotionalSpecArgs(COMMAND, {
+      NotionalSpecJson: JSON.stringify(EXAMPLE_1_SPEC),
+    });
+    expect(result).toEqual({ ok: true });
+  });
+
+  it('accepts Example 1 with optional ClearSheet', () => {
+    const result = validateNotionalSpecArgs(COMMAND, {
+      NotionalSpecJson: JSON.stringify(EXAMPLE_1_SPEC),
+      ClearSheet: true,
+    });
+    expect(result).toEqual({ ok: true });
+  });
+
+  it('rejects the fabricated mark/columns/rows/title schema', () => {
+    const result = validateNotionalSpecArgs(COMMAND, {
+      NotionalSpecJson: JSON.stringify({
+        mark: 'bar',
+        columns: ['Region'],
+        rows: ['Sales'],
+        title: 'Sales by Region',
+      }),
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected failure');
+    expect(result.message).toContain('Unknown top-level key "mark"');
+    expect(result.message).toContain('FIX:');
+    expect(result.message).toContain('"version": "0.2.0"');
+    expect(result.message).toContain('expertise://tableau/tactics/data/notional-spec-authoring');
+  });
+
+  it('rejects a worksheetName parameter', () => {
+    const result = validateNotionalSpecArgs(COMMAND, {
+      NotionalSpecJson: JSON.stringify(EXAMPLE_1_SPEC),
+      worksheetName: 'Sheet 1',
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected failure');
+    expect(result.message).toContain('Unknown parameter "worksheetName"');
+    expect(result.message).toContain('FIX:');
+  });
+
+  it('rejects a WorksheetId parameter with the documented-500 guidance', () => {
+    const result = validateNotionalSpecArgs(COMMAND, {
+      NotionalSpecJson: JSON.stringify(EXAMPLE_1_SPEC),
+      WorksheetId: 'abc123',
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected failure');
+    expect(result.message).toContain('Unknown parameter "WorksheetId"');
+    expect(result.message).toContain('500');
+    expect(result.message).toContain('goto-sheet');
+  });
+
+  it('rejects a chart value outside the v0.2 enum', () => {
+    const result = validateNotionalSpecArgs(COMMAND, {
+      NotionalSpecJson: JSON.stringify({ ...EXAMPLE_1_SPEC, chart: 'sankey' }),
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected failure');
+    expect(result.message).toContain('not in the v0.2 chart enum');
+    expect(result.message).toContain('FIX:');
+  });
+
+  it('rejects a non-string NotionalSpecJson', () => {
+    const result = validateNotionalSpecArgs(COMMAND, {
+      NotionalSpecJson: { version: '0.2.0', fields: [] },
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected failure');
+    expect(result.message).toContain('requires "NotionalSpecJson" as a JSON string');
+    expect(result.message).toContain('FIX:');
+  });
+
+  it('rejects malformed JSON in NotionalSpecJson', () => {
+    const result = validateNotionalSpecArgs(COMMAND, {
+      NotionalSpecJson: '{ not valid json',
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected failure');
+    expect(result.message).toContain('not valid JSON');
+  });
+
+  it('rejects a missing NotionalSpecJson parameter', () => {
+    const result = validateNotionalSpecArgs(COMMAND, {});
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected failure');
+    expect(result.message).toContain('requires "NotionalSpecJson" as a JSON string');
+    expect(result.message).toContain('got undefined');
+  });
+
+  it('rejects a spec missing version', () => {
+    const result = validateNotionalSpecArgs(COMMAND, {
+      NotionalSpecJson: JSON.stringify({ fields: [{ caption: 'Region' }] }),
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected failure');
+    expect(result.message).toContain('missing a valid "version" string');
+  });
+
+  it('rejects a spec with an empty fields array', () => {
+    const result = validateNotionalSpecArgs(COMMAND, {
+      NotionalSpecJson: JSON.stringify({ version: '0.2.0', fields: [] }),
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected failure');
+    expect(result.message).toContain('non-empty "fields" array');
+  });
+
+  it('rejects a field missing caption', () => {
+    const result = validateNotionalSpecArgs(COMMAND, {
+      NotionalSpecJson: JSON.stringify({
+        version: '0.2.0',
+        fields: [{ data: 'string', role: 'dimension' }],
+      }),
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected failure');
+    expect(result.message).toContain('field at index 0 is missing a non-empty "caption"');
+  });
+});

--- a/src/desktop/notionalSpecGuard.ts
+++ b/src/desktop/notionalSpecGuard.ts
@@ -1,0 +1,194 @@
+/**
+ * Pre-dispatch guard: tabdoc:generate-viz-from-notional-spec
+ *
+ * Confirmed incident (2026-07-19, live Sonnet 5 session driving Tableau Desktop): the
+ * agent invoked this command with a fabricated schema ({"mark","columns","rows","title"}
+ * plus a "worksheetName" parameter) instead of the real contract. The product does not
+ * validate the args client-side — it returned a raw 500 and the agent lost the fast
+ * path. This guard rejects a malformed invocation BEFORE it reaches the product, with a
+ * FIX message that carries the correct minimal example and points at the knowledge
+ * module that documents the contract.
+ *
+ * Contract source of truth: resources/desktop/knowledge/tactics/data/notional-spec-authoring.md
+ * (expertise://tableau/tactics/data/notional-spec-authoring). Keep this guard in sync
+ * with that doc if the v0.2 schema changes.
+ */
+import type { CommandValidationResult } from './commandRegistry.js';
+
+export const GENERATE_VIZ_FROM_NOTIONAL_SPEC_COMMAND = 'tabdoc:generate-viz-from-notional-spec';
+
+const KNOWLEDGE_URI = 'expertise://tableau/tactics/data/notional-spec-authoring';
+
+const ALLOWED_ARG_KEYS = new Set(['NotionalSpecJson', 'ClearSheet']);
+
+const ALLOWED_TOP_LEVEL_SPEC_KEYS = new Set([
+  'version',
+  'fields',
+  'chart',
+  'relativeDateFilters',
+  'dateRangeFilters',
+  'rangeFilters',
+  'categoricalFilters',
+  'sort',
+]);
+
+const V0_2_CHART_ENUM = new Set([
+  'text',
+  'heatmap',
+  'bar',
+  'stackedbar',
+  'line',
+  'area',
+  'gantt',
+  'scatterplot',
+  'histogram',
+  'symbolmap',
+  'filledmap',
+  'treemap',
+  'pie',
+  'dualline',
+  'boxplot',
+  'bullet',
+  'bubble',
+]);
+
+const EXAMPLE_1 = `{
+  "version": "0.2.0",
+  "chart": "bar",
+  "fields": [
+    { "caption": "Region", "data": "string", "type": "discrete",
+      "role": "dimension", "encoding": "x" },
+    { "caption": "Sales", "data": "number", "type": "continuous",
+      "role": "measure", "aggregation": "sum", "encoding": "y" }
+  ],
+  "sort": { "field": "Region", "by": "Sales",
+            "aggregation": "sum", "direction": "desc" }
+}`;
+
+function fixFooter(fix: string): string {
+  return (
+    `FIX: ${fix} Minimal valid example (NotionalSpecJson value):\n${EXAMPLE_1}\n` +
+    `See ${KNOWLEDGE_URI} for the full v0.2 contract.`
+  );
+}
+
+function fail(problem: string, fix: string): CommandValidationResult {
+  return { ok: false, message: `${problem} ${fixFooter(fix)}` };
+}
+
+/**
+ * Validates args for tabdoc:generate-viz-from-notional-spec BEFORE dispatch. Returns
+ * { ok: true } for every other command — this guard is scoped to the one command.
+ */
+export function validateNotionalSpecArgs(
+  command: string,
+  args: Record<string, unknown> | undefined,
+): CommandValidationResult {
+  if (command !== GENERATE_VIZ_FROM_NOTIONAL_SPEC_COMMAND) {
+    return { ok: true };
+  }
+
+  const safeArgs = args ?? {};
+
+  if ('WorksheetId' in safeArgs) {
+    return fail(
+      `Unknown parameter "WorksheetId" for ${GENERATE_VIZ_FROM_NOTIONAL_SPEC_COMMAND}. ` +
+        'Passing WorksheetId is documented as producing a 500 — the command renders on the ' +
+        'current worksheet. Target the sheet with tabdoc:goto-sheet first, then call this ' +
+        'command with only NotionalSpecJson (and optional ClearSheet).',
+      'Remove the WorksheetId parameter and call tabdoc:goto-sheet beforehand instead.',
+    );
+  }
+
+  for (const key of Object.keys(safeArgs)) {
+    if (!ALLOWED_ARG_KEYS.has(key)) {
+      return fail(
+        `Unknown parameter "${key}" for ${GENERATE_VIZ_FROM_NOTIONAL_SPEC_COMMAND}. ` +
+          'Only "NotionalSpecJson" (required JSON string) and "ClearSheet" (optional boolean) ' +
+          'are accepted.',
+        `Remove "${key}" and pass the spec as a JSON string in "NotionalSpecJson".`,
+      );
+    }
+  }
+
+  const notionalSpecJson = safeArgs.NotionalSpecJson;
+  if (typeof notionalSpecJson !== 'string') {
+    return fail(
+      `${GENERATE_VIZ_FROM_NOTIONAL_SPEC_COMMAND} requires "NotionalSpecJson" as a JSON string ` +
+        `(got ${notionalSpecJson === undefined ? 'undefined' : typeof notionalSpecJson}).`,
+      'Serialize the spec object to a JSON string and pass it as "NotionalSpecJson".',
+    );
+  }
+
+  let parsedSpec: unknown;
+  try {
+    parsedSpec = JSON.parse(notionalSpecJson);
+  } catch (error) {
+    return fail(
+      `"NotionalSpecJson" is not valid JSON (${error instanceof Error ? error.message : String(error)}).`,
+      'Fix the JSON syntax in "NotionalSpecJson".',
+    );
+  }
+
+  if (typeof parsedSpec !== 'object' || parsedSpec === null || Array.isArray(parsedSpec)) {
+    return fail(
+      '"NotionalSpecJson" must parse to a JSON object, not an array or primitive.',
+      'Wrap the spec in a top-level object with "version" and "fields".',
+    );
+  }
+
+  const spec = parsedSpec as Record<string, unknown>;
+
+  for (const key of Object.keys(spec)) {
+    if (!ALLOWED_TOP_LEVEL_SPEC_KEYS.has(key)) {
+      return fail(
+        `Unknown top-level key "${key}" in the NotionalSpec. Valid top-level keys are: ` +
+          'version, fields, chart, relativeDateFilters, dateRangeFilters, rangeFilters, ' +
+          'categoricalFilters, sort.',
+        `Remove "${key}" — NotionalSpec is not a chart-primitive schema (no "mark"/"columns"/` +
+          '"rows"/"title" keys); it is version + fields (+ optional chart/filters/sort).',
+      );
+    }
+  }
+
+  if (typeof spec.version !== 'string' || spec.version.trim().length === 0) {
+    return fail(
+      'The NotionalSpec is missing a valid "version" string (e.g. "0.2.0").',
+      'Add "version": "0.2.0" at the top level.',
+    );
+  }
+
+  if (!Array.isArray(spec.fields) || spec.fields.length === 0) {
+    return fail(
+      'The NotionalSpec is missing a non-empty "fields" array.',
+      'Add at least one field object under "fields", each with a "caption" string.',
+    );
+  }
+
+  for (const [index, field] of spec.fields.entries()) {
+    if (
+      typeof field !== 'object' ||
+      field === null ||
+      typeof (field as Record<string, unknown>).caption !== 'string' ||
+      ((field as Record<string, unknown>).caption as string).trim().length === 0
+    ) {
+      return fail(
+        `NotionalSpec field at index ${index} is missing a non-empty "caption" string.`,
+        'Every entry in "fields" requires a "caption" (the field name in the datasource).',
+      );
+    }
+  }
+
+  if (spec.chart !== undefined) {
+    if (typeof spec.chart !== 'string' || !V0_2_CHART_ENUM.has(spec.chart)) {
+      return fail(
+        `"chart" value ${JSON.stringify(spec.chart)} is not in the v0.2 chart enum ` +
+          `(${[...V0_2_CHART_ENUM].join(', ')}).`,
+        'Use a chart value from the v0.2 enum, or omit "chart" and fall back to XML authoring ' +
+          'for chart families outside it.',
+      );
+    }
+  }
+
+  return { ok: true };
+}

--- a/src/tools/desktop/commands/executeTableauCommand.ts
+++ b/src/tools/desktop/commands/executeTableauCommand.ts
@@ -3,6 +3,7 @@ import { Ok } from 'ts-results-es';
 import { z } from 'zod';
 
 import { validateKnownCommand } from '../../../desktop/commandRegistry.js';
+import { validateNotionalSpecArgs } from '../../../desktop/notionalSpecGuard.js';
 import { resolveSession } from '../../../desktop/sessionResolution.js';
 import { ArgsValidationError, DesktopCommandExecutionError } from '../../../errors/mcpToolError.js';
 import { DesktopMcpServer } from '../../../server.desktop.js';
@@ -64,6 +65,11 @@ export const getExecuteTableauCommandTool = (
           const commandValidation = validateKnownCommand(command);
           if (!commandValidation.ok) {
             return new ArgsValidationError(commandValidation.message).toErr();
+          }
+
+          const notionalSpecValidation = validateNotionalSpecArgs(command, args);
+          if (!notionalSpecValidation.ok) {
+            return new ArgsValidationError(notionalSpecValidation.message).toErr();
           }
 
           const executor = await extra.getExecutor(resolvedSession);


### PR DESCRIPTION
## What
Pre-dispatch validation for `tabdoc:generate-viz-from-notional-spec` in `execute-tableau-command`: rejects unknown parameters (`WorksheetId`/`worksheetName` — the documented 500), requires `NotionalSpecJson` to be a parseable JSON string, and validates the parsed spec against the v0.2 contract (version + captioned fields, top-level key allowlist, chart enum). Failures answer with FIX lines carrying the knowledge module's minimal valid example and the `expertise://tableau/tactics/data/notional-spec-authoring` URI.

## Why
Live incident, 2026-07-19: the first real Sonnet 5 audition through tab-agent-south invoked the command with a fabricated schema (`mark`/`columns`/`rows`/`title` + `worksheetName`) — the product returned a raw 500 and the model lost the semantic fast path to fallback. The contract existed only in the knowledge doc; nothing enforced it at the tool boundary. Twin of a2td #232's param-contract guard, extended to the spec payload.

## Verification
- 13 new colocated tests (happy path = the doc's live-verified Example 1; every fabrication class rejected)
- Desktop tree: 176 files / 2423 tests green; `tsc --noEmit` clean; eslint clean
- Guard no-ops (`{ok:true}`) for every other command — byte-identical behavior confirmed by existing suites

Authored by a Sonnet 5 builder subagent; adjudicated, independently re-verified, and committed by the session orchestrator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)