### PR TITLE
fix(desktop): carry ancestor xmlns declarations onto extracted sheet/dashboard XML

### DIFF
--- a/src/desktop/metadata/dashboards.test.ts
+++ b/src/desktop/metadata/dashboards.test.ts
@@ -1,0 +1,63 @@
+import { wellFormedXmlRule } from '../validation/rules/wellFormedXml.js';
+import { extractDashboardXml, listWorkbookDashboards } from './dashboards.js';
+
+// Same shape as the worksheet regression (sheets.test.ts): the <workbook> root declares
+// xmlns:user, and a zone's filter carries a user:-prefixed attribute. The declaration lives on
+// the ancestor <workbook> element, not on <dashboard> itself.
+const WORKBOOK_WITH_USER_NAMESPACE = `<?xml version='1.0' encoding='utf-8' ?>
+<workbook original-version='18.1' source-build='0.0.0 (0000.26.0531.2046)' source-platform='mac' version='18.1' xmlns:user='http://www.tableausoftware.com/xml/user'>
+  <dashboards>
+    <dashboard name='Overview'>
+      <zones>
+        <zone type-v2='layout-basic'>
+          <groupfilter function='level-members' level='[none:Region:nk]' user:ui-enumeration='all' />
+        </zone>
+      </zones>
+    </dashboard>
+  </dashboards>
+</workbook>`;
+
+describe('extractDashboardXml', () => {
+  it('finds and extracts an existing dashboard', () => {
+    const xml = extractDashboardXml(WORKBOOK_WITH_USER_NAMESPACE, 'Overview');
+    expect(xml).not.toBeNull();
+    expect(xml).toContain('<dashboard');
+    expect(xml).toContain('name="Overview"');
+  });
+
+  it('returns null for a dashboard that does not exist', () => {
+    expect(extractDashboardXml(WORKBOOK_WITH_USER_NAMESPACE, 'Does Not Exist')).toBeNull();
+  });
+
+  // Same live-bug shape as extractSheetXml (sheets.test.ts): an untouched get-dashboard-xml ->
+  // apply-dashboard round-trip must pass the same well-formed-xml preflight apply-dashboard runs.
+  it('carries the xmlns:user declaration from the workbook root onto the extracted dashboard', () => {
+    const xml = extractDashboardXml(WORKBOOK_WITH_USER_NAMESPACE, 'Overview');
+    expect(xml).not.toBeNull();
+    expect(xml).toContain('user:ui-enumeration');
+
+    const issues = wellFormedXmlRule.validate(xml!);
+    const errors = issues.filter((i) => i.severity === 'error');
+    expect(errors).toEqual([]);
+  });
+
+  it('does not overwrite a namespace declaration the dashboard already carries itself', () => {
+    const workbookWithConflict = `<?xml version='1.0' encoding='utf-8' ?>
+<workbook xmlns:user='http://www.tableausoftware.com/xml/user'>
+  <dashboards>
+    <dashboard name='q' xmlns:user='http://example.com/already-declared'>
+      <zones></zones>
+    </dashboard>
+  </dashboards>
+</workbook>`;
+    const xml = extractDashboardXml(workbookWithConflict, 'q');
+    expect(xml).toContain('http://example.com/already-declared');
+    expect(xml).not.toContain('http://www.tableausoftware.com/xml/user');
+  });
+});
+
+describe('listWorkbookDashboards', () => {
+  it('lists dashboard names', () => {
+    expect(listWorkbookDashboards(WORKBOOK_WITH_USER_NAMESPACE)).toEqual(['Overview']);
+  });
+});

--- a/src/desktop/metadata/dashboards.ts
+++ b/src/desktop/metadata/dashboards.ts
@@ -1,4 +1,10 @@
-import { generateUUID, normalizeArray, parseXML, serializeXML } from './parser.js';
+import {
+  carryNamespaceDeclarations,
+  generateUUID,
+  normalizeArray,
+  parseXML,
+  serializeXML,
+} from './parser.js';
 import type { ParsedDashboard, ParsedWindow, ParsedWorkbook } from './types.js';
 
 type SizingMode =
@@ -165,6 +171,7 @@ export function extractDashboardXml(workbookXml: string, dashboardName: string):
   if (!dashboard) {
     return null;
   }
+  carryNamespaceDeclarations(workbook.workbook, dashboard);
   return serializeXML({ dashboard });
 }
 

--- a/src/desktop/metadata/parser.ts
+++ b/src/desktop/metadata/parser.ts
@@ -95,6 +95,28 @@ export function findAllWorksheets(workbook: ParsedWorkbook): ParsedWorksheet[] {
   return normalizeArray(workbook.workbook?.worksheets?.worksheet);
 }
 
+// fast-xml-parser attaches an `xmlns`/`xmlns:*` declaration as a plain attribute on whichever
+// element declares it — typically the <workbook> root (e.g. `xmlns:user`). Lifting a subtree
+// (a <worksheet> or <dashboard>) out of the document with a naive `{ worksheet }` re-serialize
+// drops that declaration even though descendants of the subtree may use the prefix (e.g.
+// `user:ui-enumeration` on a level-members groupfilter) — the extracted fragment is then
+// namespace-invalid on its own, even though it was never modified. Call this before serializing
+// an extracted subtree to carry ancestor namespace declarations forward onto its root, without
+// overwriting a declaration the subtree already carries itself.
+export function carryNamespaceDeclarations<T extends Record<string, any>>(
+  ancestor: Record<string, any> | undefined,
+  element: T,
+): T {
+  if (!ancestor) return element;
+  const target: Record<string, any> = element;
+  for (const key of Object.keys(ancestor)) {
+    if ((key === '@_xmlns' || key.startsWith('@_xmlns:')) && !(key in target)) {
+      target[key] = ancestor[key];
+    }
+  }
+  return element;
+}
+
 export function generateUUID(): string {
   const uuid = randomUUID();
   return `{${uuid.toUpperCase()}}`;

--- a/src/desktop/metadata/sheets.test.ts
+++ b/src/desktop/metadata/sheets.test.ts
@@ -1,0 +1,77 @@
+import { wellFormedXmlRule } from '../validation/rules/wellFormedXml.js';
+import { addSheet, deleteSheet, extractSheetXml, listSheets } from './sheets.js';
+
+// Real-world shape: the <workbook> root declares xmlns:user, and a worksheet's level-members
+// filter carries a user:-prefixed attribute (confirmed pattern, see refineWorksheet.test.ts).
+// The declaration lives on the ancestor <workbook> element, not on <worksheet> itself.
+const WORKBOOK_WITH_USER_NAMESPACE = `<?xml version='1.0' encoding='utf-8' ?>
+<workbook original-version='18.1' source-build='0.0.0 (0000.26.0531.2046)' source-platform='mac' version='18.1' xmlns:user='http://www.tableausoftware.com/xml/user'>
+  <worksheets>
+    <worksheet name='Sales by Region'>
+      <table>
+        <view>
+          <filter class='categorical' column='[none:Region:nk]'>
+            <groupfilter function='level-members' level='[none:Region:nk]' user:ui-enumeration='all' />
+          </filter>
+        </view>
+      </table>
+    </worksheet>
+  </worksheets>
+</workbook>`;
+
+describe('extractSheetXml', () => {
+  it('finds and extracts an existing worksheet', () => {
+    const xml = extractSheetXml(WORKBOOK_WITH_USER_NAMESPACE, 'Sales by Region');
+    expect(xml).not.toBeNull();
+    expect(xml).toContain('<worksheet');
+    expect(xml).toContain('name="Sales by Region"');
+  });
+
+  it('returns null for a worksheet that does not exist', () => {
+    expect(extractSheetXml(WORKBOOK_WITH_USER_NAMESPACE, 'Does Not Exist')).toBeNull();
+  });
+
+  // Live-bug regression (Tableau Desktop, get-worksheet-xml -> unmodified apply-worksheet):
+  // extracting a <worksheet> subtree that uses a user:-prefixed attribute, out of a <workbook>
+  // that declares xmlns:user only on its own root, must not strip the namespace declaration.
+  // An untouched get -> apply round-trip must always pass the same well-formed-xml preflight
+  // that apply-worksheet runs — a NamespaceError here is exactly the live failure mode.
+  it('carries the xmlns:user declaration from the workbook root onto the extracted worksheet', () => {
+    const xml = extractSheetXml(WORKBOOK_WITH_USER_NAMESPACE, 'Sales by Region');
+    expect(xml).not.toBeNull();
+    expect(xml).toContain('user:ui-enumeration');
+
+    const issues = wellFormedXmlRule.validate(xml!);
+    const errors = issues.filter((i) => i.severity === 'error');
+    expect(errors).toEqual([]);
+  });
+
+  it('does not overwrite a namespace declaration the worksheet already carries itself', () => {
+    const workbookWithConflict = `<?xml version='1.0' encoding='utf-8' ?>
+<workbook xmlns:user='http://www.tableausoftware.com/xml/user'>
+  <worksheets>
+    <worksheet name='q' xmlns:user='http://example.com/already-declared'>
+      <table></table>
+    </worksheet>
+  </worksheets>
+</workbook>`;
+    const xml = extractSheetXml(workbookWithConflict, 'q');
+    expect(xml).toContain('http://example.com/already-declared');
+    expect(xml).not.toContain('http://www.tableausoftware.com/xml/user');
+  });
+});
+
+describe('listSheets', () => {
+  it('lists worksheet names', () => {
+    expect(listSheets(WORKBOOK_WITH_USER_NAMESPACE)).toEqual(['Sales by Region']);
+  });
+});
+
+describe('addSheet / deleteSheet', () => {
+  it('round-trips add then delete', () => {
+    const added = addSheet(WORKBOOK_WITH_USER_NAMESPACE, 'New Sheet');
+    expect(listSheets(added)).toContain('New Sheet');
+    const deleted = deleteSheet(added, 'New Sheet');
+    expect(listSheets(deleted)).not.toContain('New Sheet');
+  });
+});

--- a/src/desktop/metadata/sheets.ts
+++ b/src/desktop/metadata/sheets.ts
@@ -1,4 +1,11 @@
-import { findWorksheet, generateUUID, normalizeArray, parseXML, serializeXML } from './parser.js';
+import {
+  carryNamespaceDeclarations,
+  findWorksheet,
+  generateUUID,
+  normalizeArray,
+  parseXML,
+  serializeXML,
+} from './parser.js';
 import type { ParsedWindow, ParsedWorksheet } from './types.js';
 
 export function addSheet(workbookXml: string, sheetName: string): string {
@@ -120,6 +127,7 @@ export function extractSheetXml(workbookXml: string, sheetName: string): string 
   if (!worksheet) {
     return null;
   }
+  carryNamespaceDeclarations(workbook.workbook, worksheet);
   return serializeXML({ worksheet });
 }
 


### PR DESCRIPTION
## What
`extractSheetXml`/`extractDashboardXml` sliced a node out of the parsed workbook and re-serialized it standalone, silently dropping namespace declarations living on the `<workbook>` root. A worksheet whose subtree uses `user:`-prefixed attributes (every top-N filter's `groupfilter` does) then fails the `well-formed-xml` apply preflight — on its own unmodified output. New shared `carryNamespaceDeclarations` helper copies `xmlns`/`xmlns:*` from the root onto the extracted element (skipping prefixes the element already declares); both extraction paths use it. Validator strictness unchanged.

## Why
Live incident, 2026-07-19: during the first Sonnet 5 audition the model's untouched get→apply round-trip failed with `NamespaceError: prefix is non-null and namespace is null` and it had to hand-repair the namespace to proceed. An untouched round-trip must always validate clean. (Transport context: reproduced on the External API path — `TABLEAU_EXTERNAL_API=true` — which is exactly the client-side extraction this fixes.)

## Verification
- Failing-first regression tests reproduce the live error message verbatim, then pass with the fix (sheets + dashboards)
- Metadata tree: 7 files / 101 tests green; broader touched-module sweep 217 green; `tsc --noEmit` clean

Authored by a Sonnet 5 builder subagent; adjudicated, independently re-verified, and committed by the session orchestrator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)