### PR TITLE
fix(desktop): search-commands no-match recommendation steers semantic-first, not straight to XML

### DIFF
--- a/src/desktop/data/tableau-desktop-commands-reference.json
+++ b/src/desktop/data/tableau-desktop-commands-reference.json
@@ -54,7 +54,7 @@
   },
   "total_commands": 333,
   "usage_notes_for_agents": "Invoke via ExecuteCommand(CommandId, params). Use serialized_name when calling from JavaScript. Context-filled params (e.g. UPI_Workspace) are provided by the app; only required binary/unserialized params set requires_binary_or_unserialized_args. See command_names_requiring_context_or_binary_args for commands that cannot be fully invoked via executeCommandAsync. Filter by agent_can_invoke: true for commands safe to invoke via MCP; when no such command matches, use recommendation_when_no_invocable_match. Commands with opens_blocking_dialog: true open a blocking UI dialog and can cause CDP socket hang. Evidence paths and usage_count may include references from test/ and testlib/; treat those as non-customer usage.",
-  "recommendation_when_no_invocable_match": "No MCP-invocable command found for this action. Use workbook JSON editing instead.",
+  "recommendation_when_no_invocable_match": "No MCP-invocable command found for this action. For a chart/viz ask, use the NotionalSpec loop (tabdoc:generate-viz-from-notional-spec — see expertise://tableau/tactics/data/notional-spec-authoring); for calculated fields, use the workbook-document round-trip (see notional-spec-calc-authoring). Fall back to workbook XML editing only when neither covers the ask.",
   "command_names_requiring_context_or_binary_args": [
     "AddReferenceLine",
     "AddSubtotals",

--- a/src/desktop/search/searchLibrary.ts
+++ b/src/desktop/search/searchLibrary.ts
@@ -41,7 +41,7 @@ function ensureCommandsSearchIndex(): any {
   const blockingNames = new Set<string>(ref.command_names_opening_blocking_dialog || []);
   const recommendation: string =
     ref.recommendation_when_no_invocable_match ||
-    'No simple MCP-invocable command found. Use workbook JSON editing via get_workbook -> modify -> try_set_workbook.';
+    'No simple MCP-invocable command found. For chart/viz asks use the NotionalSpec loop (tabdoc:generate-viz-from-notional-spec); for calcs use the workbook-document round-trip; fall back to workbook JSON editing only when neither covers the ask.';
 
   const invocable = allCommands.filter((cmd: any) => {
     if (!cmd || typeof cmd !== 'object') return false;


### PR DESCRIPTION
One string, one steering layer: the commands-reference's `recommendation_when_no_invocable_match` (plus the code fallback in `searchLibrary.ts`) answered every empty search with *"Use workbook JSON editing instead"* — an anti-semantic steer observed live (2026-07-19 Sonnet 5 audition) nudging the model toward XML surgery mid-chart-build. Now it names the NotionalSpec loop for viz asks and the workbook-document round-trip for calcs, XML last. Aligns the last dissenting instruction string with #543/#544's semantic-first routing (standing-question-11 hygiene: every layer steers the same way).

Search suite 48 green, tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)