### PR TITLE
fix(desktop): refine-worksheet polls its confirmation readback (async-apply race)

### DIFF
--- a/src/tools/desktop/worksheet/refineWorksheet.test.ts
+++ b/src/tools/desktop/worksheet/refineWorksheet.test.ts
@@ -69,8 +69,16 @@ interface MockOpts {
   source?: string;
   fetchErr?: ErrOf<GetResult>;
   applyErr?: ErrOf<LoadResult>;
-  /** Readback: 'echo' (the applied XML, default) or 'source' (Tableau silently dropped it). */
-  readback?: 'echo' | 'source';
+  /**
+   * Readback shape:
+   *  - 'echo' (default): every readback poll immediately returns the applied XML.
+   *  - 'source': the async apply NEVER settles within the poll budget — every readback
+   *    poll keeps returning the un-patched source (Tableau silently dropped the change).
+   *  - a number N: simulates the confirmed live race — the apply landed, but the FIRST
+   *    readback(s) run before it settles. Polls 1..N-1 return the pre-apply source; poll N
+   *    onward returns the applied XML.
+   */
+  readback?: 'echo' | 'source' | number;
 }
 
 const getMock = (): ReturnType<typeof vi.mocked<typeof getWorksheetXmlModule.getWorksheetXml>> =>
@@ -82,6 +90,7 @@ function setupMocks(opts: MockOpts = {}): { applied: () => string | null } {
   const source = opts.source ?? SOURCE;
   let lastApplied: string | null = null;
   let getCalls = 0;
+  let readbackCalls = 0;
 
   getMock().mockImplementation(async (): Promise<GetResult> => {
     getCalls += 1;
@@ -89,8 +98,13 @@ function setupMocks(opts: MockOpts = {}): { applied: () => string | null } {
       // The fetch.
       return (opts.fetchErr ? Err(opts.fetchErr) : Ok(source)) as GetResult;
     }
-    // The readback.
-    return (opts.readback === 'source' ? Ok(source) : Ok(lastApplied ?? source)) as GetResult;
+    // A readback poll.
+    readbackCalls += 1;
+    if (opts.readback === 'source') return Ok(source) as GetResult;
+    if (typeof opts.readback === 'number') {
+      return (readbackCalls < opts.readback ? Ok(source) : Ok(lastApplied ?? source)) as GetResult;
+    }
+    return Ok(lastApplied ?? source) as GetResult;
   });
 
   loadMock().mockImplementation(async ({ xml }: { xml: string }): Promise<LoadResult> => {
@@ -171,6 +185,75 @@ describe('refineWorksheetTool — sort_direction happy path', () => {
   });
 });
 
+describe('refineWorksheetTool — readback race (async apply settle)', () => {
+  beforeEach(() => vi.clearAllMocks());
+  afterEach(() => vi.useRealTimers());
+
+  it('confirms refined:true once a later poll catches the async apply landing', async () => {
+    // The live bug: the apply DID land, but the first 2 readback polls race the async
+    // settle and still see the pre-apply source. Poll 3 catches the landed XML.
+    vi.useFakeTimers();
+    const { applied } = setupMocks({ readback: 3 });
+    const resultPromise = getToolResult({
+      worksheetName: 'Sales by Region',
+      operation: 'top_n',
+      topN: { n: 5 },
+    });
+    await vi.advanceTimersByTimeAsync(8 * 250);
+    const result = await resultPromise;
+
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+    const parsed = successSchema.parse(JSON.parse(result.content[0].text));
+    expect(parsed.refined).toBe(true);
+
+    // Applied exactly once — the fix polls the READBACK, it never re-applies.
+    expect(loadMock()).toHaveBeenCalledTimes(1);
+    // 1 fetch + 3 readback polls (2 misses that raced the settle, then the hit).
+    expect(getMock()).toHaveBeenCalledTimes(4);
+    expect(applied()!).toMatch(/function='end'\s+end='top'\s+count='5'/);
+  });
+
+  it('confirms refined:true on the very last poll (attempt 8 of 8)', async () => {
+    vi.useFakeTimers();
+    setupMocks({ readback: 8 });
+    const resultPromise = getToolResult({
+      worksheetName: 'Sales by Region',
+      operation: 'top_n',
+      topN: { n: 5 },
+    });
+    await vi.advanceTimersByTimeAsync(8 * 250);
+    const result = await resultPromise;
+
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+    const parsed = successSchema.parse(JSON.parse(result.content[0].text));
+    expect(parsed.refined).toBe(true);
+    expect(getMock()).toHaveBeenCalledTimes(9); // 1 fetch + 8 readback polls
+  });
+
+  it('a filter that genuinely never lands still reports refined:false after exhausting the polls', async () => {
+    // Distinguishes "raced the settle" (above, eventually true) from "never applied"
+    // (always false) — both must reach the SAME poll budget before the tool decides.
+    vi.useFakeTimers();
+    setupMocks({ readback: 'source' });
+    const resultPromise = getToolResult({
+      worksheetName: 'Sales by Region',
+      operation: 'top_n',
+      topN: { n: 5 },
+    });
+    await vi.advanceTimersByTimeAsync(8 * 250);
+    const result = await resultPromise;
+
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+    const parsed = refusalSchema.parse(JSON.parse(result.content[0].text));
+    expect(parsed.refined).toBe(false);
+    expect(parsed.reason).toMatch(/async-settle miss/);
+    expect(getMock()).toHaveBeenCalledTimes(9);
+  });
+});
+
 describe('refineWorksheetTool — refusals and errors', () => {
   beforeEach(() => vi.clearAllMocks());
 
@@ -239,20 +322,29 @@ describe('refineWorksheetTool — refusals and errors', () => {
     expect(loadMock()).toHaveBeenCalledTimes(1);
   });
 
-  it('refuses when readback does not confirm the expected node (applied once)', async () => {
-    // Apply succeeds, but readback returns the un-patched source (Tableau silently
-    // dropped the filter) → confirmation fails → refuse, no retry.
+  it('refuses when readback never confirms the expected node, after exhausting all polls (applied once)', async () => {
+    // Apply succeeds, but every readback poll returns the un-patched source (the filter
+    // genuinely never lands) → confirmation fails on every poll → refuse after the poll
+    // budget, no retry beyond it.
+    vi.useFakeTimers();
     setupMocks({ readback: 'source' });
-    const result = await getToolResult({
+    const resultPromise = getToolResult({
       worksheetName: 'Sales by Region',
       operation: 'top_n',
       topN: { n: 5 },
     });
+    await vi.advanceTimersByTimeAsync(8 * 250);
+    const result = await resultPromise;
+    vi.useRealTimers();
+
     expect(result.isError).toBe(false);
     invariant(result.content[0].type === 'text');
     const parsed = refusalSchema.parse(JSON.parse(result.content[0].text));
     expect(parsed.reason).toMatch(/readback did not contain/);
+    expect(parsed.reason).toMatch(/after 8 polls/);
     expect(loadMock()).toHaveBeenCalledTimes(1);
+    // 1 fetch + 8 readback polls, all exhausted — never retries the apply.
+    expect(getMock()).toHaveBeenCalledTimes(9);
   });
 
   it('refuses an out-of-range n (kill criterion surfaced through the tool)', async () => {

--- a/src/tools/desktop/worksheet/refineWorksheet.ts
+++ b/src/tools/desktop/worksheet/refineWorksheet.ts
@@ -11,6 +11,7 @@
 // under src/desktop/refine/refineWorksheet.ts; this file is the I/O wrapper + registration.
 
 import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { setTimeout as setTimeoutPromise } from 'timers/promises';
 import { Ok } from 'ts-results-es';
 import { z } from 'zod';
 
@@ -43,6 +44,16 @@ type RefineOperation = 'top_n' | 'sort_direction';
 type RefineWorksheetToolResult =
   | { refined: true; operation: RefineOperation; worksheetName: string; message: string }
   | { refined: false; operation: RefineOperation; worksheetName: string; reason: string };
+
+// Commands apply asynchronously after SUCCEEDED (see
+// resources/desktop/knowledge/tactics/data/notional-spec-authoring.md) — the apply-once
+// call above returning does not mean the patch has landed in Desktop's live document yet.
+// A single readback immediately after apply can race that settle and see the PRE-apply
+// XML, which would misreport a durable apply as `refined: false`. Poll instead of reading
+// once; 250ms intervals are the interval documented to work for this same class of race
+// elsewhere (list-worksheets/list-dashboards polling after new-worksheet/new-dashboard).
+const READBACK_POLL_MAX_ATTEMPTS = 8;
+const READBACK_POLL_INTERVAL_MS = 250;
 
 /** A hand-back-to-the-standard-path refusal — not an error, so isError stays false. */
 function refusal(
@@ -207,40 +218,51 @@ export const getRefineWorksheetTool = (
             }
           }
 
-          // 6. Read back and confirm the expected node landed durably.
-          const readback = await getWorksheetXml({
-            worksheetName,
-            executor,
-            signal: extra.signal,
-          });
-          if (readback.isErr()) {
-            const { type, error } = readback.error;
-            switch (type) {
-              case 'get-worksheet-xml-error':
-                return new GetWorksheetXmlFailedError(error).toErr();
-              case 'execute-command-error':
-                return new DesktopCommandExecutionError(error).toErr();
-              default: {
-                const _: never = type;
-                return new UnknownError(error).toErr();
+          // 6. Read back and confirm the expected node landed durably. The apply is async
+          // after SUCCEEDED, so poll rather than trusting one immediate readback — the
+          // first read can race the settle and still show pre-apply XML.
+          for (let attempt = 1; attempt <= READBACK_POLL_MAX_ATTEMPTS; attempt++) {
+            const readback = await getWorksheetXml({
+              worksheetName,
+              executor,
+              signal: extra.signal,
+            });
+            if (readback.isErr()) {
+              const { type, error } = readback.error;
+              switch (type) {
+                case 'get-worksheet-xml-error':
+                  return new GetWorksheetXmlFailedError(error).toErr();
+                case 'execute-command-error':
+                  return new DesktopCommandExecutionError(error).toErr();
+                default: {
+                  const _: never = type;
+                  return new UnknownError(error).toErr();
+                }
               }
             }
-          }
-          if (!confirm(readback.value)) {
-            return refusal(
-              operation,
-              worksheetName,
-              `applied, but the readback did not contain the expected ${nodeLabel} — the ` +
-                'refinement was not durable. Not retrying; fall back to the standard path.',
-            );
+            if (confirm(readback.value)) {
+              return new Ok({
+                refined: true,
+                operation,
+                worksheetName,
+                message: `Applied ${operation} to worksheet "${worksheetName}" and confirmed the ${nodeLabel} on readback.`,
+              });
+            }
+            if (attempt < READBACK_POLL_MAX_ATTEMPTS) {
+              await setTimeoutPromise(READBACK_POLL_INTERVAL_MS, undefined, {
+                signal: extra.signal,
+              });
+            }
           }
 
-          return new Ok({
-            refined: true,
+          return refusal(
             operation,
             worksheetName,
-            message: `Applied ${operation} to worksheet "${worksheetName}" and confirmed the ${nodeLabel} on readback.`,
-          });
+            `applied, but the readback did not contain the expected ${nodeLabel} after ` +
+              `${READBACK_POLL_MAX_ATTEMPTS} polls (${READBACK_POLL_INTERVAL_MS}ms apart) — ` +
+              'the refinement was not durable, or this is an async-settle miss. Not retrying ' +
+              'further; fall back to the standard path.',
+          );
         },
       });
     },


### PR DESCRIPTION
## What
`refine-worksheet`'s post-apply confirmation was a single read racing the platform's async apply. It now polls up to 8×250ms (the interval the notional-spec knowledge doc documents as working), returns `refined:true` on first structural match, and keeps the honest refusal on exhaustion — now naming the async-settle possibility. Fetch and apply stay exactly-once.

## Why
Confirmed live with a minimal repro in today's Sonnet 5 audition receipts: the tool applied a top-N filter, read back too early, reported `refined:false` — and its own next invocation refused with *"a Top-N (function=\"end\") filter already exists"*. The model then burned a fallback path repairing a chart that wasn't broken.

## Verification
Race-simulation tests with fake timers (settle on poll 3, boundary poll 8-of-8, genuinely-never-lands still refuses after exhaustion); 228 tests green across the touched tree; tsc clean.

## Flagged, not fixed (own ticket)
`verifyPostApplyWorksheetReadback` (src/desktop/commands/workbook/loadWorksheetXml.ts:83) — the host-verification seam behind every worksheet apply — has the identical single-read shape with a much larger caller fan-out.

Authored by a Sonnet 5 builder subagent; adjudicated, independently re-verified, and committed by the session orchestrator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)