### PR TITLE
feat(desktop): param-contract guard for every command + live-verified overrides (modal-killer)

### DIFF
--- a/src/desktop/paramContractGuard.test.ts
+++ b/src/desktop/paramContractGuard.test.ts
@@ -1,0 +1,228 @@
+const mocks = vi.hoisted(() => ({
+  readDataAsset: vi.fn(),
+}));
+
+vi.mock('./assets.js', () => ({
+  readDataAsset: mocks.readDataAsset,
+}));
+
+const REFERENCE = {
+  commands: [
+    {
+      fully_qualified_serialized_name: 'tabdoc:mock-goto',
+      opens_blocking_dialog: false,
+      parameters: [
+        {
+          direction: 'in',
+          local_name: 'WindowLocator',
+          required: true,
+          comment: 'locator for the window',
+        },
+        { direction: 'out', local_name: 'ConnectionAttemptInfo', required: false },
+      ],
+    },
+    {
+      fully_qualified_serialized_name: 'tabui:copy-sheet-image-u-i',
+      opens_blocking_dialog: true,
+      parameters: [
+        { direction: 'in', local_name: 'Sheet', required: true, comment: 'sheet to copy' },
+      ],
+    },
+    {
+      fully_qualified_serialized_name: 'tabdoc:save',
+      opens_blocking_dialog: false,
+      parameters: [],
+    },
+    {
+      fully_qualified_serialized_name: 'tabdoc:generate-viz-from-notional-spec',
+      opens_blocking_dialog: false,
+      parameters: [],
+    },
+    {
+      fully_qualified_serialized_name: 'tabdoc:delete-sheet',
+      opens_blocking_dialog: false,
+      parameters: [
+        { direction: 'in', local_name: 'Sheet', required: true, comment: 'Target sheet' },
+        {
+          direction: 'in',
+          local_name: 'DeleteOrphans',
+          required: false,
+          comment: 'Delete orphans',
+        },
+      ],
+    },
+  ],
+};
+
+describe('paramContractGuard', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mocks.readDataAsset.mockReset();
+  });
+
+  it('rejects a known command called with an unknown param key, naming the key and the valid ones', async () => {
+    mocks.readDataAsset.mockReturnValue(JSON.stringify(REFERENCE));
+    const { validateCommandParams } = await import('./paramContractGuard.js');
+
+    // The live incident's shape: goto-sheet's only "in" param is WindowLocator, not Sheet.
+    const result = validateCommandParams('tabdoc:mock-goto', { Sheet: 'Sheet 1' });
+
+    expect(result).toEqual({
+      ok: false,
+      message:
+        'Unknown parameter(s) for Tableau command "tabdoc:mock-goto": Sheet. NOT sent, to avoid a Tableau ' +
+        'Desktop parameter-error dialog. Valid "in" params: WindowLocator (required: true) - locator for the ' +
+        'window. FIX: use one of the valid param names above.',
+    });
+  });
+
+  it('accepts goto-sheet called with its correct required param', async () => {
+    mocks.readDataAsset.mockReturnValue(JSON.stringify(REFERENCE));
+    const { validateCommandParams } = await import('./paramContractGuard.js');
+
+    expect(validateCommandParams('tabdoc:mock-goto', { WindowLocator: 'Sheet 1' })).toEqual({
+      ok: true,
+    });
+  });
+
+  it('rejects a missing required param, naming it', async () => {
+    mocks.readDataAsset.mockReturnValue(JSON.stringify(REFERENCE));
+    const { validateCommandParams } = await import('./paramContractGuard.js');
+
+    const result = validateCommandParams('tabdoc:mock-goto', {});
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toContain(
+        'Missing required parameter(s) for Tableau command "tabdoc:mock-goto"',
+      );
+      expect(result.message).toContain('WindowLocator');
+    }
+  });
+
+  it('gives a stricter message for an unknown param on an opens_blocking_dialog command', async () => {
+    mocks.readDataAsset.mockReturnValue(JSON.stringify(REFERENCE));
+    const { validateCommandParams } = await import('./paramContractGuard.js');
+
+    const result = validateCommandParams('tabui:copy-sheet-image-u-i', { SheetName: 'Sheet 1' });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toContain(
+        'Unknown parameter(s) for Tableau command "tabui:copy-sheet-image-u-i"',
+      );
+      expect(result.message).toContain('opens_blocking_dialog=true');
+      expect(result.message).toContain("pops a blocking modal error dialog on the user's screen");
+    }
+  });
+
+  it('gives a stricter message for a missing required param on an opens_blocking_dialog command', async () => {
+    mocks.readDataAsset.mockReturnValue(JSON.stringify(REFERENCE));
+    const { validateCommandParams } = await import('./paramContractGuard.js');
+
+    const result = validateCommandParams('tabui:copy-sheet-image-u-i', {});
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toContain('Missing required parameter(s)');
+      expect(result.message).toContain('opens_blocking_dialog=true');
+    }
+  });
+
+  it('skips the unknown-key check for a command with zero declared "in" params', async () => {
+    mocks.readDataAsset.mockReturnValue(JSON.stringify(REFERENCE));
+    const { validateCommandParams } = await import('./paramContractGuard.js');
+
+    // generate-viz-from-notional-spec's contract has no declared "in" params (pane-invoked
+    // commands are dropped by the reference's extraction pass) — the deeper NotionalSpec
+    // payload guard validates its actual shape, not this generic key check.
+    expect(
+      validateCommandParams('tabdoc:generate-viz-from-notional-spec', {
+        NotionalSpecJson: '{}',
+        ClearSheet: true,
+      }),
+    ).toEqual({ ok: true });
+  });
+
+  it('leaves an arbitrary valid command call untouched', async () => {
+    mocks.readDataAsset.mockReturnValue(JSON.stringify(REFERENCE));
+    const { validateCommandParams } = await import('./paramContractGuard.js');
+
+    expect(
+      validateCommandParams('tabdoc:delete-sheet', { Sheet: 'Sheet 1', DeleteOrphans: true }),
+    ).toEqual({
+      ok: true,
+    });
+    expect(validateCommandParams('tabdoc:save', {})).toEqual({ ok: true });
+  });
+
+  it('fails open when the command has no entry in the reference', async () => {
+    mocks.readDataAsset.mockReturnValue(JSON.stringify(REFERENCE));
+    const { validateCommandParams } = await import('./paramContractGuard.js');
+
+    expect(validateCommandParams('tabdoc:not-in-reference', { anything: 'goes' })).toEqual({
+      ok: true,
+    });
+  });
+
+  it('fails open when the bundled reference is unreadable', async () => {
+    mocks.readDataAsset.mockReturnValue(null);
+    const { validateCommandParams } = await import('./paramContractGuard.js');
+
+    expect(validateCommandParams('tabdoc:mock-goto', { Sheet: 'Sheet 1' })).toEqual({ ok: true });
+  });
+
+  it('fails open when the bundled reference is malformed', async () => {
+    mocks.readDataAsset.mockReturnValue('{not json');
+    const { validateCommandParams } = await import('./paramContractGuard.js');
+
+    expect(validateCommandParams('tabdoc:mock-goto', { Sheet: 'Sheet 1' })).toEqual({ ok: true });
+  });
+
+  it('treats undefined args the same as an empty object', async () => {
+    mocks.readDataAsset.mockReturnValue(JSON.stringify(REFERENCE));
+    const { validateCommandParams } = await import('./paramContractGuard.js');
+
+    const result = validateCommandParams('tabdoc:mock-goto', undefined);
+    expect(result.ok).toBe(false);
+  });
+});
+
+describe('live param overrides (runtime truth beats the reference)', () => {
+  it('accepts goto-sheet with "Sheet" — the live-verified /v0 contract', async () => {
+    const { validateCommandParams } = await import('./paramContractGuard.js');
+    expect(validateCommandParams('tabdoc:goto-sheet', { Sheet: 'Sheet 1' })).toEqual({ ok: true });
+  });
+
+  it('rejects goto-sheet with "WindowLocator" — the reference-declared param that pops a modal live', async () => {
+    const { validateCommandParams } = await import('./paramContractGuard.js');
+    const result = validateCommandParams('tabdoc:goto-sheet', { WindowLocator: 'Sheet 1' });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toContain(
+        'Unknown parameter(s) for Tableau command "tabdoc:goto-sheet": WindowLocator',
+      );
+      expect(result.message).toContain('"Sheet"');
+      expect(result.message).toContain('blocking error dialog');
+    }
+  });
+
+  it('rejects goto-sheet with no args — Sheet is required by the live contract', async () => {
+    const { validateCommandParams } = await import('./paramContractGuard.js');
+    const result = validateCommandParams('tabdoc:goto-sheet', undefined);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toContain(
+        'Missing required parameter(s) for Tableau command "tabdoc:goto-sheet": Sheet',
+      );
+    }
+  });
+
+  it('override wins even when the bundled reference is unreadable', async () => {
+    const { validateCommandParams } = await import('./paramContractGuard.js');
+    mocks.readDataAsset.mockImplementation(() => {
+      throw new Error('unreadable');
+    });
+    expect(validateCommandParams('tabdoc:goto-sheet', { Sheet: 'x' })).toEqual({ ok: true });
+  });
+});

--- a/src/desktop/paramContractGuard.ts
+++ b/src/desktop/paramContractGuard.ts
@@ -1,0 +1,217 @@
+// Agent-side command PARAMETER guard — bad param shapes never reach Desktop.
+//
+// Live incident (2026-07-19, on the user's screen, twice): a model invoked
+// tabdoc:goto-sheet through execute-tableau-command with a fabricated param
+// key. Tableau does not fail this silently — it pops a BLOCKING modal error
+// dialog ("Error in parameters for command 'goto-sheet' — bad value: sheet —
+// Error Code: 47BF7751"), and a stuck-open modal can fail every subsequent
+// command until a human dismisses it. commandRegistry.ts already refuses an
+// UNKNOWN COMMAND VERB; this guard is the companion check one level down —
+// it refuses a KNOWN command called with the WRONG PARAM SHAPE, using the
+// same bundled reference's per-command `parameters[]` contract:
+//   - an "in" param name not present on the command's contract -> rejected,
+//     naming the offending key and listing the valid ones
+//   - a "required": true "in" param missing from the call -> rejected,
+//     naming the missing key(s)
+// Commands the reference flags via `opens_blocking_dialog: true` get a
+// stricter message on either rejection, since a bad call to one of THESE is
+// exactly the class of failure that interrupts the user with a modal.
+//
+// A command with a KNOWN contract but ZERO declared "in" params (e.g.
+// tabdoc:generate-viz-from-notional-spec — pane-invoked commands are dropped
+// by the reference's parameter-extraction pass, see its provenance_note) has
+// no positive list to validate keys against, so the unknown-key check is
+// skipped for it; the deeper NotionalSpec payload guard is the one that
+// validates that command's actual shape.
+
+import { readDataAsset } from './assets.js';
+import type { CommandValidationResult } from './commandRegistry.js';
+
+const COMMANDS_REFERENCE_ASSET = 'tableau-desktop-commands-reference.json';
+
+type CommandParameter = {
+  direction?: unknown;
+  local_name?: unknown;
+  required?: unknown;
+  comment?: unknown;
+};
+
+type CommandReferenceEntry = {
+  fully_qualified_serialized_name?: unknown;
+  parameters?: unknown;
+  opens_blocking_dialog?: unknown;
+};
+
+type CommandReference = {
+  commands?: unknown;
+};
+
+let commandsByNameCache: Map<string, CommandReferenceEntry> | null | undefined;
+
+function commandsByName(): Map<string, CommandReferenceEntry> | null {
+  if (commandsByNameCache !== undefined) {
+    return commandsByNameCache;
+  }
+
+  try {
+    const raw = readDataAsset(COMMANDS_REFERENCE_ASSET);
+    if (raw === null) {
+      commandsByNameCache = null;
+      return commandsByNameCache;
+    }
+
+    const reference = JSON.parse(raw) as CommandReference;
+    if (!reference || typeof reference !== 'object' || !Array.isArray(reference.commands)) {
+      commandsByNameCache = null;
+      return commandsByNameCache;
+    }
+
+    const map = new Map<string, CommandReferenceEntry>();
+    for (const entry of reference.commands as CommandReferenceEntry[]) {
+      const fq = entry?.fully_qualified_serialized_name;
+      if (typeof fq === 'string' && fq.length > 0) {
+        map.set(fq, entry);
+      }
+    }
+    commandsByNameCache = map;
+    return commandsByNameCache;
+  } catch {
+    commandsByNameCache = null;
+    return commandsByNameCache;
+  }
+}
+
+function inParams(entry: CommandReferenceEntry): CommandParameter[] {
+  if (!Array.isArray(entry.parameters)) {
+    return [];
+  }
+  return (entry.parameters as CommandParameter[]).filter(
+    (param): param is CommandParameter => param?.direction === 'in',
+  );
+}
+
+function localName(param: CommandParameter): string | null {
+  return typeof param.local_name === 'string' && param.local_name.length > 0
+    ? param.local_name
+    : null;
+}
+
+function formatParam(param: CommandParameter): string {
+  const name = localName(param) ?? '(unnamed)';
+  const required = param.required === true ? 'true' : 'false';
+  const comment =
+    typeof param.comment === 'string' && param.comment.trim() ? ` - ${param.comment.trim()}` : '';
+  return `${name} (required: ${required})${comment}`;
+}
+
+function blockingDialogNote(entry: CommandReferenceEntry): string {
+  return entry.opens_blocking_dialog === true
+    ? ' This command is flagged opens_blocking_dialog=true — a wrong call here pops a blocking modal error ' +
+        "dialog on the user's screen (and a stuck-open modal can fail subsequent commands too)."
+    : '';
+}
+
+/**
+ * Validates a known command's `args` against its bundled parameter contract.
+ * Call AFTER validateKnownCommand() confirms the verb is real. Fails open
+ * (returns ok: true) when the reference can't be loaded, the command has no
+ * entry in it, or its contract declares zero "in" params (nothing to check
+ * unknown keys against — see the module doc for generate-viz-from-notional-spec).
+ */
+/**
+ * Live-verified runtime contracts that OVERRIDE the commands-reference where the
+ * reference's declared params are wrong at the /v0 runtime. Evidence anchors are
+ * mandatory per entry. First occupant (2026-07-19, three live receipts each way):
+ * tabdoc:goto-sheet — the reference declares WindowLocator (required:true) as the
+ * only "in" param, but at the /v0 External API runtime {"WindowLocator": name}
+ * fails 500 AND pops a blocking modal (Error 47BF7751) on the user's screen,
+ * while {"Sheet": name} — absent from the reference — SUCCEEDS and activates the
+ * sheet. Until the reference generator learns the /v0 dialect, this table is
+ * where live-verified corrections accumulate.
+ */
+const LIVE_PARAM_OVERRIDES: Map<string, { allowed: Set<string>; required: Set<string> }> = new Map([
+  ['tabdoc:goto-sheet', { allowed: new Set(['Sheet']), required: new Set(['Sheet']) }],
+]);
+
+export function validateCommandParams(
+  command: string,
+  args: Record<string, unknown> | undefined,
+): CommandValidationResult {
+  const override = LIVE_PARAM_OVERRIDES.get(command);
+  if (override) {
+    const providedArgs = args && typeof args === 'object' ? args : {};
+    const providedKeys = Object.keys(providedArgs);
+    const unknownKeys = providedKeys.filter((key) => !override.allowed.has(key));
+    if (unknownKeys.length > 0) {
+      return {
+        ok: false,
+        message:
+          `Unknown parameter(s) for Tableau command "${command}": ${unknownKeys.join(', ')}. NOT sent — ` +
+          "a wrong parameter for this command pops a blocking error dialog on the user's screen " +
+          `(live-verified 2026-07-19). FIX: use exactly ${[...override.allowed].map((k) => `"${k}"`).join(', ')} ` +
+          "(the live-verified /v0 contract; the bundled reference's declared params are wrong for this command).",
+      };
+    }
+    const missing = [...override.required].filter((key) => !(key in providedArgs));
+    if (missing.length > 0) {
+      return {
+        ok: false,
+        message:
+          `Missing required parameter(s) for Tableau command "${command}": ${missing.join(', ')}. ` +
+          `FIX: provide ${missing.map((k) => `"${k}"`).join(', ')} (live-verified /v0 contract).`,
+      };
+    }
+    return { ok: true };
+  }
+
+  const commands = commandsByName();
+  if (commands === null) {
+    return { ok: true };
+  }
+
+  const entry = commands.get(command);
+  if (!entry) {
+    return { ok: true };
+  }
+
+  const expected = inParams(entry);
+  if (expected.length === 0) {
+    return { ok: true };
+  }
+
+  const expectedNames = new Set(
+    expected.map(localName).filter((name): name is string => name !== null),
+  );
+  const providedArgs = args && typeof args === 'object' ? args : {};
+  const providedKeys = Object.keys(providedArgs);
+
+  const unknownKeys = providedKeys.filter((key) => !expectedNames.has(key));
+  if (unknownKeys.length > 0) {
+    return {
+      ok: false,
+      message:
+        `Unknown parameter(s) for Tableau command "${command}": ${unknownKeys.join(', ')}. NOT sent, to avoid ` +
+        `a Tableau Desktop parameter-error dialog.${blockingDialogNote(entry)} Valid "in" params: ` +
+        `${expected.map(formatParam).join('; ')}. FIX: use one of the valid param names above.`,
+    };
+  }
+
+  const required = expected.filter((param) => param.required === true);
+  const missing = required.filter((param) => {
+    const name = localName(param);
+    return name !== null && !Object.prototype.hasOwnProperty.call(providedArgs, name);
+  });
+
+  if (missing.length > 0) {
+    const missingNames = missing.map((param) => localName(param)).join(', ');
+    return {
+      ok: false,
+      message:
+        `Missing required parameter(s) for Tableau command "${command}": ${missingNames}. NOT sent, to avoid ` +
+        `a Tableau Desktop parameter-error dialog.${blockingDialogNote(entry)} Expected "in" params: ` +
+        `${expected.map(formatParam).join('; ')}. FIX: provide the missing param(s) above.`,
+    };
+  }
+
+  return { ok: true };
+}

--- a/src/tools/desktop/commands/executeTableauCommand.test.ts
+++ b/src/tools/desktop/commands/executeTableauCommand.test.ts
@@ -89,8 +89,10 @@ describe('executeTableauCommandTool', () => {
     const executeCommand = vi.fn().mockResolvedValue(new Ok({ command_id: 'c1', result: null }));
     const extra = makeExtra(executeCommand);
 
+    // Live-verified /v0 contract (2026-07-19): goto-sheet takes "Sheet"; the bundled
+    // reference's WindowLocator is wrong at runtime (500 + blocking modal).
     await getResult(
-      { session: SESSION, command: 'tabdoc:goto-sheet', args: { sheet: 'Sheet1' } },
+      { session: SESSION, command: 'tabdoc:goto-sheet', args: { Sheet: 'Sheet1' } },
       extra,
     );
 
@@ -99,7 +101,7 @@ describe('executeTableauCommandTool', () => {
       expect.objectContaining({
         namespace: 'tabdoc',
         command: 'goto-sheet',
-        args: { sheet: 'Sheet1' },
+        args: { Sheet: 'Sheet1' },
       }),
     );
   });
@@ -138,7 +140,12 @@ describe('executeTableauCommandTool', () => {
     const executeCommand = vi.fn().mockResolvedValue({ isErr: () => true, error: commandError });
     const extra = makeExtra(executeCommand);
 
-    const result = await getResult({ session: SESSION, command: 'tabdoc:goto-sheet' }, extra);
+    // "Sheet" is the live-verified param for goto-sheet; provide it so the param guard
+    // lets this call through to the (mocked) failing executor, per this test's intent.
+    const result = await getResult(
+      { session: SESSION, command: 'tabdoc:goto-sheet', args: { Sheet: 'Sheet1' } },
+      extra,
+    );
 
     expect(result.isError).toBe(true);
     invariant(result.content[0].type === 'text');
@@ -164,6 +171,130 @@ describe('executeTableauCommandTool', () => {
     expect(executeCommand).toHaveBeenCalledWith(
       expect.objectContaining({ namespace: 'tabui', command: 'export-theme' }),
     );
+  });
+
+  describe('param-contract guard', () => {
+    it('rejects goto-sheet called with an invalid param key before resolving an executor (the live-incident shape)', async () => {
+      const extra = getMockRequestHandlerExtra();
+      extra.getExecutor = vi.fn();
+
+      // THE live-incident shape (2026-07-19, twice): {"WindowLocator": ...} → 500 +
+      // blocking modal 47BF7751. The reference DECLARES WindowLocator required, but the
+      // /v0 runtime accepts "Sheet" — the guard's live-override encodes the runtime truth.
+      const result = await getResult(
+        { session: SESSION, command: 'tabdoc:goto-sheet', args: { WindowLocator: 'Sheet1' } },
+        extra,
+      );
+
+      expect(result.isError).toBe(true);
+      invariant(result.content[0].type === 'text');
+      expect(result.content[0].text).toContain(
+        'Unknown parameter(s) for Tableau command "tabdoc:goto-sheet": WindowLocator',
+      );
+      expect(result.content[0].text).toContain('"Sheet"');
+      expect(extra.getExecutor).not.toHaveBeenCalled();
+    });
+
+    it('accepts goto-sheet called with its correct required param', async () => {
+      const executeCommand = vi.fn().mockResolvedValue(new Ok({ command_id: 'c1', result: null }));
+      const extra = makeExtra(executeCommand);
+
+      const result = await getResult(
+        { session: SESSION, command: 'tabdoc:goto-sheet', args: { Sheet: 'Sheet1' } },
+        extra,
+      );
+
+      expect(result.isError).toBeFalsy();
+      expect(executeCommand).toHaveBeenCalled();
+    });
+
+    it('rejects a missing required param before resolving an executor', async () => {
+      const extra = getMockRequestHandlerExtra();
+      extra.getExecutor = vi.fn();
+
+      const result = await getResult(
+        { session: SESSION, command: 'tabdoc:goto-sheet', args: {} },
+        extra,
+      );
+
+      expect(result.isError).toBe(true);
+      invariant(result.content[0].type === 'text');
+      expect(result.content[0].text).toContain(
+        'Missing required parameter(s) for Tableau command "tabdoc:goto-sheet": Sheet',
+      );
+      expect(extra.getExecutor).not.toHaveBeenCalled();
+    });
+
+    it('gives a stricter message for an unknown param key on an opens_blocking_dialog command', async () => {
+      const extra = getMockRequestHandlerExtra();
+      extra.getExecutor = vi.fn();
+
+      const result = await getResult(
+        { session: SESSION, command: 'tabui:copy-sheet-image-u-i', args: { SheetName: 'Sheet1' } },
+        extra,
+      );
+
+      expect(result.isError).toBe(true);
+      invariant(result.content[0].type === 'text');
+      expect(result.content[0].text).toContain(
+        'Unknown parameter(s) for Tableau command "tabui:copy-sheet-image-u-i"',
+      );
+      expect(result.content[0].text).toContain('opens_blocking_dialog=true');
+      expect(result.content[0].text).toContain(
+        "pops a blocking modal error dialog on the user's screen",
+      );
+      expect(extra.getExecutor).not.toHaveBeenCalled();
+    });
+
+    it('lets generate-viz-from-notional-spec pass through with its NotionalSpecJson/ClearSheet args', async () => {
+      const executeCommand = vi.fn().mockResolvedValue(new Ok({ command_id: 'c1', result: null }));
+      const extra = makeExtra(executeCommand);
+
+      const result = await getResult(
+        {
+          session: SESSION,
+          command: 'tabdoc:generate-viz-from-notional-spec',
+          args: {
+            NotionalSpecJson:
+              '{"version":"0.2.0","chart":"bar","fields":[{"caption":"Region","data":"string","type":"discrete","role":"dimension","encoding":"x"},{"caption":"Sales","data":"number","type":"continuous","role":"measure","aggregation":"sum","encoding":"y"}]}',
+            ClearSheet: true,
+          },
+        },
+        extra,
+      );
+
+      expect(result.isError).toBeFalsy();
+      expect(executeCommand).toHaveBeenCalledWith(
+        expect.objectContaining({
+          namespace: 'tabdoc',
+          command: 'generate-viz-from-notional-spec',
+          args: {
+            NotionalSpecJson:
+              '{"version":"0.2.0","chart":"bar","fields":[{"caption":"Region","data":"string","type":"discrete","role":"dimension","encoding":"x"},{"caption":"Sales","data":"number","type":"continuous","role":"measure","aggregation":"sum","encoding":"y"}]}',
+            ClearSheet: true,
+          },
+        }),
+      );
+    });
+
+    it('leaves an arbitrary valid command call untouched', async () => {
+      const executeCommand = vi.fn().mockResolvedValue(new Ok({ command_id: 'c1', result: null }));
+      const extra = makeExtra(executeCommand);
+
+      const result = await getResult(
+        { session: SESSION, command: 'tabdoc:delete-sheet', args: { Sheet: 'Sheet1' } },
+        extra,
+      );
+
+      expect(result.isError).toBeFalsy();
+      expect(executeCommand).toHaveBeenCalledWith(
+        expect.objectContaining({
+          namespace: 'tabdoc',
+          command: 'delete-sheet',
+          args: { Sheet: 'Sheet1' },
+        }),
+      );
+    });
   });
 });
 

--- a/src/tools/desktop/commands/executeTableauCommand.ts
+++ b/src/tools/desktop/commands/executeTableauCommand.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 
 import { validateKnownCommand } from '../../../desktop/commandRegistry.js';
 import { validateNotionalSpecArgs } from '../../../desktop/notionalSpecGuard.js';
+import { validateCommandParams } from '../../../desktop/paramContractGuard.js';
 import { resolveSession } from '../../../desktop/sessionResolution.js';
 import { ArgsValidationError, DesktopCommandExecutionError } from '../../../errors/mcpToolError.js';
 import { DesktopMcpServer } from '../../../server.desktop.js';
@@ -65,6 +66,14 @@ export const getExecuteTableauCommandTool = (
           const commandValidation = validateKnownCommand(command);
           if (!commandValidation.ok) {
             return new ArgsValidationError(commandValidation.message).toErr();
+          }
+
+          // Generic param-contract guard: runs after the verb is confirmed known,
+          // before the deeper NotionalSpec payload guard. Fails open on commands
+          // with zero declared "in" params so the two never contradict.
+          const paramValidation = validateCommandParams(command, args);
+          if (!paramValidation.ok) {
+            return new ArgsValidationError(paramValidation.message).toErr();
           }
 
           const notionalSpecValidation = validateNotionalSpecArgs(command, args);


### PR DESCRIPTION
## What
`execute-tableau-command` now validates every command's args against the bundled reference's per-command `parameters[]` contract (unknown keys rejected naming valid ones; missing `required` params rejected; `opens_blocking_dialog` commands get a stricter warning), chained after `validateKnownCommand` and before #545's NotionalSpec payload guard. Fails open on unreadable reference / zero-in-param commands. Port of a2td #232, generalized.

## The finding worth reading twice
The builder subagent flagged (correctly, instead of silently resolving) that the task narrative and the reference schema contradicted each other on `goto-sheet`. Live probes settled it: **the reference is wrong at /v0 runtime** — its declared required param `WindowLocator` produces 500 + blocking modal 47BF7751 (reproduced twice on a human's screen today), while `Sheet` — absent from the reference — succeeded three times. New `LIVE_PARAM_OVERRIDES` table encodes runtime-verified contracts over the reference, with mandatory evidence anchors per entry.

## Why
Live incident, 2026-07-19: a model probing param names put two blocking error dialogs on the user's screen; an open modal then failed every subsequent command. This class dies at the tool boundary now.

## Flagged, not fixed (own ticket)
`focusAppliedSheet.ts` invokes `goto-sheet` internally with `{sheet: name}` through the executor directly — bypasses this guard, matches no known contract; potential second modal source.

## Verification
15 guard unit tests + 6 integration tests (incl. both live-incident shapes verbatim); desktop tree 179 files / 2458 tests green; tsc + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)