### PR TITLE
fix(desktop): verify applied sheet exists before goto-sheet (modal 47BF7751 killer)

### DIFF
--- a/src/desktop/commands/workbook/focusAppliedSheet.ts
+++ b/src/desktop/commands/workbook/focusAppliedSheet.ts
@@ -1,7 +1,45 @@
 import { log } from '../../../logging/logger.js';
 import { WithExecutorAndAbortSignal } from '../../toolExecutor/toolExecutor.js';
+import { listDashboards } from './listDashboards.js';
+import { listWorksheets } from './listWorksheets.js';
 
 type ApplyCommand = 'load-worksheet' | 'load-dashboard';
+
+// goto-sheet at a name Desktop doesn't know throws a BLOCKING modal
+// (47BF7751 "bad value: sheet") instead of returning an error — and an apply
+// is async enough that its sheet can be missing at focus time (live-reproduced
+// twice, 2026-07-19). Confirm the sheet exists before offering to focus it;
+// a skipped focus is a log line, a modal is a wedged stage.
+const FOCUS_POLL_ATTEMPTS = 4;
+const FOCUS_POLL_DELAY_MS = 250;
+
+async function appliedSheetVisible({
+  sheetName,
+  appliedVia,
+  executor,
+  signal,
+}: {
+  sheetName: string;
+  appliedVia: ApplyCommand;
+} & WithExecutorAndAbortSignal): Promise<boolean> {
+  for (let attempt = 0; attempt < FOCUS_POLL_ATTEMPTS; attempt++) {
+    if (attempt > 0) {
+      await new Promise((resolve) => setTimeout(resolve, FOCUS_POLL_DELAY_MS));
+    }
+    if (appliedVia === 'load-dashboard') {
+      const result = await listDashboards({ executor, signal });
+      if (result.isOk() && result.value.dashboards.includes(sheetName)) {
+        return true;
+      }
+    } else {
+      const result = await listWorksheets({ executor, signal });
+      if (result.isOk() && result.value.worksheets.includes(sheetName)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
 
 export async function focusAppliedSheetBestEffort({
   sheetName,
@@ -13,6 +51,17 @@ export async function focusAppliedSheetBestEffort({
   appliedVia: ApplyCommand;
 } & WithExecutorAndAbortSignal): Promise<void> {
   try {
+    if (!(await appliedSheetVisible({ sheetName, appliedVia, executor, signal }))) {
+      log({
+        level: 'warning',
+        message:
+          'skipping goto-sheet: applied sheet not visible yet — focusing an unknown name throws a blocking Desktop modal',
+        logger: 'workbookCommands',
+        data: { sheetName, appliedVia },
+      });
+      return;
+    }
+
     const result = await executor.executeCommand({
       namespace: 'tabdoc',
       command: 'goto-sheet',

--- a/src/desktop/commands/workbook/loadDashboardXml.test.ts
+++ b/src/desktop/commands/workbook/loadDashboardXml.test.ts
@@ -13,6 +13,40 @@ describe('loadDashboardXml (Agent API transport, default)', () => {
   const dashboardName = 'Sales Dashboard';
   const validXml = '<dashboard name="Sales Dashboard"><zones></zones></dashboard>';
 
+  // Dispatching mock: the pre-focus existence check (modal-killer) polls
+  // list-dashboards between apply and goto, so strict Nth-call sequences
+  // can't model the wire anymore. Answers the poll with the canonical names
+  // from the applied XML unless overridden.
+  function dispatchingAgentExecutor(
+    appliedXml: string,
+    overrides: Partial<Record<string, unknown>> = {},
+  ): {
+    executor: LocalExecutor;
+    calls: Array<{ namespace: string; command: string; args?: Record<string, unknown> }>;
+  } {
+    const calls: Array<{ namespace: string; command: string; args?: Record<string, unknown> }> = [];
+    const executeCommand = vi.fn(async (params: any) => {
+      calls.push({ namespace: params.namespace, command: params.command, args: params.args });
+      if (params.command in overrides) return overrides[params.command];
+      if (params.command === 'list-dashboards') {
+        const names = [...appliedXml.matchAll(/dashboard name="([^"]*)"/g)].map((m) => m[1]);
+        return Ok({
+          command_id: 'cmd-list',
+          status: 'completed',
+          submitted_at: '',
+          parsedResult: {
+            dashboards: JSON.stringify({
+              count: names.length,
+              dashboards: names.map((name) => ({ name })),
+            }),
+          },
+        });
+      }
+      return Ok({ command_id: 'cmd-ok', status: 'completed', submitted_at: '' });
+    });
+    return { executor: { executeCommand } as unknown as LocalExecutor, calls };
+  }
+
   beforeEach(() => {
     vi.clearAllMocks();
     vi.spyOn(loggerModule, 'log').mockImplementation(() => undefined);
@@ -47,32 +81,44 @@ describe('loadDashboardXml (Agent API transport, default)', () => {
   });
 
   it('focuses the dashboard after a successful apply', async () => {
-    const mockExecutor = {
-      executeCommand: vi
-        .fn()
-        .mockResolvedValueOnce(Ok({ command_id: 'cmd-123', status: 'completed', submitted_at: '' }))
-        .mockResolvedValueOnce(
-          Ok({ command_id: 'cmd-goto', status: 'completed', submitted_at: '' }),
-        ),
-    } as unknown as LocalExecutor;
+    const { executor, calls } = dispatchingAgentExecutor(validXml);
 
     const result = await loadDashboardXml({
       dashboardName,
       xml: validXml,
-      executor: mockExecutor,
+      executor,
       signal: mockSignal,
     });
 
     expect(result.isOk()).toBe(true);
-    expect(mockExecutor.executeCommand).toHaveBeenNthCalledWith(
-      2,
-      expect.objectContaining({
-        namespace: 'tabdoc',
-        command: 'goto-sheet',
-        args: { sheet: dashboardName },
-        signal: mockSignal,
+    expect(calls.at(-1)).toMatchObject({
+      namespace: 'tabdoc',
+      command: 'goto-sheet',
+      args: { sheet: dashboardName },
+    });
+  });
+
+  it('skips goto-sheet when the applied dashboard never becomes visible (modal-killer)', async () => {
+    const { executor, calls } = dispatchingAgentExecutor(validXml, {
+      'list-dashboards': Ok({
+        command_id: 'cmd-list',
+        status: 'completed',
+        submitted_at: '',
+        parsedResult: {
+          dashboards: JSON.stringify({ count: 0, dashboards: [] as Array<{ name: string }> }),
+        },
       }),
-    );
+    });
+
+    const result = await loadDashboardXml({
+      dashboardName,
+      xml: validXml,
+      executor,
+      signal: mockSignal,
+    });
+
+    expect(result.isOk()).toBe(true); // apply still succeeds
+    expect(calls.some((c) => c.command === 'goto-sheet')).toBe(false); // no focus, no modal
   });
 
   it('keeps dashboard apply successful when focusing the dashboard throws', async () => {
@@ -181,71 +227,48 @@ describe('loadDashboardXml (Agent API transport, default)', () => {
     expect(nfcName).not.toBe(nfdName); // different code points…
     expect(nfcName.normalize('NFC')).toBe(nfdName.normalize('NFC')); // …but NFC-equal
     const nfcXml = `<dashboard name="${nfcName}"><zones></zones></dashboard>`;
-    const executeCommand = vi
-      .fn()
-      .mockResolvedValueOnce(Ok({ command_id: 'cmd-123', status: 'completed', submitted_at: '' }))
-      .mockResolvedValueOnce(Ok({ command_id: 'cmd-goto', status: 'completed', submitted_at: '' }));
-    const mockExecutor = { executeCommand } as unknown as LocalExecutor;
+    const { executor, calls } = dispatchingAgentExecutor(nfcXml);
 
     const result = await loadDashboardXml({
       dashboardName: nfdName,
       xml: nfcXml,
-      executor: mockExecutor,
+      executor,
       signal: mockSignal,
     });
 
     expect(result.isOk()).toBe(true);
-    expect(executeCommand).toHaveBeenNthCalledWith(
-      1,
-      expect.objectContaining({
-        namespace: 'tabui',
-        command: 'load-dashboard',
-        args: { dashboardName: nfcName, dashboardXml: nfcXml },
-      }),
-    );
-    expect(executeCommand).toHaveBeenNthCalledWith(
-      2,
-      expect.objectContaining({
-        namespace: 'tabdoc',
-        command: 'goto-sheet',
-        args: { sheet: nfcName },
-      }),
-    );
+    expect(calls.find((c) => c.command === 'load-dashboard')?.args).toMatchObject({
+      dashboardName: nfcName,
+      dashboardXml: nfcXml,
+    });
+    expect(calls.at(-1)).toMatchObject({
+      namespace: 'tabdoc',
+      command: 'goto-sheet',
+      args: { sheet: nfcName },
+    });
   });
 
   it('focuses the canonical XML dashboard name (not the raw caller arg) after a matched apply', async () => {
-    const executeCommand = vi
-      .fn()
-      .mockResolvedValueOnce(Ok({ command_id: 'cmd-123', status: 'completed', submitted_at: '' }))
-      .mockResolvedValueOnce(Ok({ command_id: 'cmd-goto', status: 'completed', submitted_at: '' }));
-    const mockExecutor = { executeCommand } as unknown as LocalExecutor;
+    const { executor, calls } = dispatchingAgentExecutor(validXml);
 
     const result = await loadDashboardXml({
       dashboardName: '  Sales Dashboard  ', // matches "Sales Dashboard" after trim
       xml: validXml,
-      executor: mockExecutor,
+      executor,
       signal: mockSignal,
     });
 
     expect(result.isOk()).toBe(true);
     // The load command and the final goto-sheet both use the canonical, trimmed name.
-    expect(mockExecutor.executeCommand).toHaveBeenNthCalledWith(
-      1,
-      expect.objectContaining({
-        namespace: 'tabui',
-        command: 'load-dashboard',
-        args: { dashboardName: 'Sales Dashboard', dashboardXml: validXml },
-      }),
-    );
-    expect(mockExecutor.executeCommand).toHaveBeenNthCalledWith(
-      2,
-      expect.objectContaining({
-        namespace: 'tabdoc',
-        command: 'goto-sheet',
-        args: { sheet: 'Sales Dashboard' },
-        signal: mockSignal,
-      }),
-    );
+    expect(calls.find((c) => c.command === 'load-dashboard')?.args).toMatchObject({
+      dashboardName: 'Sales Dashboard',
+      dashboardXml: validXml,
+    });
+    expect(calls.at(-1)).toMatchObject({
+      namespace: 'tabdoc',
+      command: 'goto-sheet',
+      args: { sheet: 'Sales Dashboard' },
+    });
   });
 
   it('should return invalid-xml error when xml is empty', async () => {

--- a/src/desktop/commands/workbook/loadWorksheetXml.test.ts
+++ b/src/desktop/commands/workbook/loadWorksheetXml.test.ts
@@ -78,6 +78,24 @@ describe('loadWorksheetXml (Agent API transport, default)', () => {
           parsedResult: { worksheetXml: readbackXml },
         });
       }
+      if (params.command === 'list-worksheets') {
+        // The pre-focus existence check (modal-killer) polls this; answer
+        // with the names present in the applied XML (canonical spellings)
+        // unless a test overrides it.
+        const xmlNames = [...readbackXml.matchAll(/worksheet name="([^"]*)"/g)].map((m) => m[1]);
+        const names = xmlNames.length > 0 ? xmlNames : [worksheetName];
+        return Ok({
+          command_id: 'cmd-list',
+          status: 'completed',
+          submitted_at: '',
+          parsedResult: {
+            worksheets: JSON.stringify({
+              count: names.length,
+              worksheets: names.map((name) => ({ name })),
+            }),
+          },
+        });
+      }
       return Ok({ command_id: 'cmd-ok', status: 'completed', submitted_at: '' });
     });
     return { executor: { executeCommand } as unknown as LocalExecutor, calls, executeCommand };
@@ -101,6 +119,30 @@ describe('loadWorksheetXml (Agent API transport, default)', () => {
       command: 'goto-sheet',
       args: { sheet: worksheetName },
     });
+  });
+
+  it('skips goto-sheet when the applied sheet never becomes visible (modal-killer)', async () => {
+    // goto-sheet at an unknown name throws blocking Desktop modal 47BF7751
+    // instead of returning an error — reproduce the async-apply race by
+    // answering the existence poll with an empty workbook.
+    const { executor, calls } = dispatchingAgentExecutor(validXml, {
+      'list-worksheets': Ok({
+        command_id: 'cmd-list',
+        status: 'completed',
+        submitted_at: '',
+        parsedResult: { worksheets: JSON.stringify({ count: 0, worksheets: [] as Array<{ name: string }> }) },
+      }),
+    });
+
+    const result = await loadWorksheetXml({
+      worksheetName,
+      xml: validXml,
+      executor,
+      signal: mockSignal,
+    });
+
+    expect(result.isOk()).toBe(true); // apply still succeeds
+    expect(calls.some((c) => c.command === 'goto-sheet')).toBe(false); // no focus, no modal
   });
 
   it('suppresses the post-apply goto-sheet when suppressFocus is set (compose-focus seam)', async () => {

--- a/src/desktop/commands/workbook/loadWorksheetXml.test.ts
+++ b/src/desktop/commands/workbook/loadWorksheetXml.test.ts
@@ -130,7 +130,9 @@ describe('loadWorksheetXml (Agent API transport, default)', () => {
         command_id: 'cmd-list',
         status: 'completed',
         submitted_at: '',
-        parsedResult: { worksheets: JSON.stringify({ count: 0, worksheets: [] as Array<{ name: string }> }) },
+        parsedResult: {
+          worksheets: JSON.stringify({ count: 0, worksheets: [] as Array<{ name: string }> }),
+        },
       }),
     });
 


### PR DESCRIPTION
## Why

`goto-sheet` at a name Desktop doesn't know throws a **blocking modal** (47BF7751, "bad value: sheet") instead of returning an error. An apply is async enough that its sheet can be missing at focus time — reproduced three times tonight on a live eval stage, one modal per apply.

Probe matrix (live /v0, disposable instance):
- lowercase `sheet` param + valid value → SUCCEEDED
- capital `Sheet` + valid value → SUCCEEDED
- any param + bogus value → the modal (and a hung operation)

So the param name was never the problem — the *value's existence* is.

## What

`focusAppliedSheetBestEffort` now confirms the sheet is visible (polls `list-worksheets`/`list-dashboards`, 4×250ms) before issuing `goto-sheet`, and skips focus with a warning log if it never appears. A skipped focus is a log line; a modal is a wedged stage.

Tests: dispatching executors answer the existence poll with canonical names from the applied XML (NFC/NFD assertions preserved); new modal-killer tests pin the skip path for worksheets and dashboards. Full suite green locally; `tsc --noEmit` clean.

## Follow-up (not this PR)

The Desktop-side defect — a command error surfacing as a blocking modal — needs a monolith-side fix; this PR removes our trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)