### PR TITLE
fix(desktop): pin External Client API schemas to the captured 0.1.0 openapi

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "2.26.0",
+  "version": "2.26.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "2.26.0",
+      "version": "2.26.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.7.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "2.26.0",
+  "version": "2.26.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/src/desktop/externalApi/__fixtures__/externalClientApi-openapi.json
+++ b/src/desktop/externalApi/__fixtures__/externalClientApi-openapi.json
@@ -1,0 +1,1743 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Tableau External Client API",
+    "version": "0.1.0",
+    "description": "Loopback HTTP interface for reading and authoring the open Tableau Desktop document. Clients authenticate with the bearer token published in the per-user discovery file."
+  },
+  "servers": [
+    {
+      "url": "/",
+      "description": "The Tableau Desktop loopback origin. The bound port is published in the per-user discovery file."
+    }
+  ],
+  "paths": {
+    "/.well-known/oauth-protected-resource": {
+      "get": {
+        "summary": "Get protected-resource metadata",
+        "description": "Returns the RFC 9728 OAuth Protected Resource Metadata document.",
+        "operationId": "getOAuthProtectedResource",
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Returns the RFC 9728 OAuth Protected Resource Metadata document.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProtectedResourceMetadata"
+                }
+              }
+            }
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          }
+        }
+      }
+    },
+    "/openapi.json": {
+      "get": {
+        "summary": "Get the OpenAPI document",
+        "description": "Returns the OpenAPI 3.1 description of this API.",
+        "operationId": "getOpenApi",
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Returns the OpenAPI 3.1 description of this API.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          }
+        }
+      }
+    },
+    "/v0/": {
+      "get": {
+        "summary": "Get the API root",
+        "description": "Returns the API and application versions and the link map to available resources.",
+        "operationId": "getRoot",
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Returns the API and application versions and the link map to available resources.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiRoot"
+                }
+              }
+            }
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          }
+        }
+      }
+    },
+    "/v0/app": {
+      "get": {
+        "summary": "Get application info",
+        "description": "Returns the running Tableau Desktop version, edition, locale, and paths.",
+        "operationId": "getApp",
+        "responses": {
+          "200": {
+            "description": "Returns the running Tableau Desktop version, edition, locale, and paths.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AppInfo"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "421": {
+            "$ref": "#/components/responses/MisdirectedRequest"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          },
+          "503": {
+            "$ref": "#/components/responses/ServiceUnavailable"
+          }
+        }
+      }
+    },
+    "/v0/health": {
+      "get": {
+        "summary": "Check API liveness",
+        "operationId": "getHealth",
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "The requested representation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Health"
+                }
+              }
+            }
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          }
+        }
+      }
+    },
+    "/v0/site": {
+      "get": {
+        "summary": "Get the connected site",
+        "description": "Returns the site the user is signed in to, or 404 when there is no connected site.",
+        "operationId": "getSite",
+        "responses": {
+          "200": {
+            "description": "Returns the site the user is signed in to, or 404 when there is no connected site.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Site"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "421": {
+            "$ref": "#/components/responses/MisdirectedRequest"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          },
+          "503": {
+            "$ref": "#/components/responses/ServiceUnavailable"
+          }
+        }
+      }
+    },
+    "/v0/site/datasources": {
+      "get": {
+        "summary": "List published datasources",
+        "description": "Lists datasources published to the connected site.",
+        "operationId": "listSiteDatasources",
+        "responses": {
+          "200": {
+            "description": "Lists datasources published to the connected site.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SiteDatasourceList"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "421": {
+            "$ref": "#/components/responses/MisdirectedRequest"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          },
+          "503": {
+            "$ref": "#/components/responses/ServiceUnavailable"
+          }
+        }
+      }
+    },
+    "/v0/site/workbooks": {
+      "get": {
+        "summary": "List published workbooks",
+        "description": "Lists workbooks published to the connected site.",
+        "operationId": "listSiteWorkbooks",
+        "responses": {
+          "200": {
+            "description": "Lists workbooks published to the connected site.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SiteWorkbookList"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "421": {
+            "$ref": "#/components/responses/MisdirectedRequest"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          },
+          "503": {
+            "$ref": "#/components/responses/ServiceUnavailable"
+          }
+        }
+      }
+    },
+    "/v0/workbook": {
+      "get": {
+        "summary": "Get the open workbook",
+        "description": "Returns metadata and the sheet inventory of the open workbook, or 404 when none is open.",
+        "operationId": "getWorkbook",
+        "responses": {
+          "200": {
+            "description": "Returns metadata and the sheet inventory of the open workbook, or 404 when none is open.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkbookInventory"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "421": {
+            "$ref": "#/components/responses/MisdirectedRequest"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          },
+          "503": {
+            "$ref": "#/components/responses/ServiceUnavailable"
+          }
+        }
+      }
+    },
+    "/v0/workbook/dashboards": {
+      "get": {
+        "summary": "List dashboards",
+        "description": "Lists the dashboards in the open workbook.",
+        "operationId": "listDashboards",
+        "responses": {
+          "200": {
+            "description": "Lists the dashboards in the open workbook.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DashboardList"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "421": {
+            "$ref": "#/components/responses/MisdirectedRequest"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          },
+          "503": {
+            "$ref": "#/components/responses/ServiceUnavailable"
+          }
+        }
+      }
+    },
+    "/v0/workbook/dashboards/{id}": {
+      "get": {
+        "summary": "Get a dashboard",
+        "description": "Returns metadata for a single dashboard by id.",
+        "operationId": "getDashboard",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns metadata for a single dashboard by id.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DashboardItem"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "421": {
+            "$ref": "#/components/responses/MisdirectedRequest"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          },
+          "503": {
+            "$ref": "#/components/responses/ServiceUnavailable"
+          }
+        }
+      }
+    },
+    "/v0/workbook/dashboards/{id}/document": {
+      "get": {
+        "summary": "Get a dashboard document",
+        "description": "Returns a single dashboard as a Tableau XML subtree.",
+        "operationId": "getDashboardDocument",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "X-Tableau-Effective-Payload-Version",
+            "in": "header",
+            "required": false,
+            "description": "Tableau payload (file-format) version the client authored the document against.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns a single dashboard as a Tableau XML subtree.",
+            "content": {
+              "application/xml": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "headers": {
+              "X-Tableau-Application-Version": {
+                "description": "Running Tableau Desktop build.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "X-Tableau-XSD-Payload-Version": {
+                "description": "Payload (file-format) version the document was served as.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "421": {
+            "$ref": "#/components/responses/MisdirectedRequest"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          },
+          "503": {
+            "$ref": "#/components/responses/ServiceUnavailable"
+          }
+        }
+      }
+    },
+    "/v0/workbook/datasources": {
+      "get": {
+        "summary": "List workbook datasources",
+        "description": "Lists the datasources used by the open workbook.",
+        "operationId": "listWorkbookDatasources",
+        "responses": {
+          "200": {
+            "description": "Lists the datasources used by the open workbook.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DatasourceList"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "421": {
+            "$ref": "#/components/responses/MisdirectedRequest"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          },
+          "503": {
+            "$ref": "#/components/responses/ServiceUnavailable"
+          }
+        }
+      }
+    },
+    "/v0/workbook/document": {
+      "get": {
+        "summary": "Get the workbook document",
+        "description": "Returns the full open workbook as Tableau XML.",
+        "operationId": "getWorkbookDocument",
+        "parameters": [
+          {
+            "name": "X-Tableau-Effective-Payload-Version",
+            "in": "header",
+            "required": false,
+            "description": "Tableau payload (file-format) version the client authored the document against.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns the full open workbook as Tableau XML.",
+            "content": {
+              "application/xml": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "headers": {
+              "X-Tableau-Application-Version": {
+                "description": "Running Tableau Desktop build.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "X-Tableau-XSD-Payload-Version": {
+                "description": "Payload (file-format) version the document was served as.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "421": {
+            "$ref": "#/components/responses/MisdirectedRequest"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          },
+          "503": {
+            "$ref": "#/components/responses/ServiceUnavailable"
+          }
+        }
+      },
+      "post": {
+        "summary": "Apply a workbook document",
+        "description": "Replaces the open workbook with the submitted Tableau XML.",
+        "operationId": "applyWorkbookDocument",
+        "parameters": [
+          {
+            "name": "X-Tableau-Effective-Payload-Version",
+            "in": "header",
+            "required": false,
+            "description": "Tableau payload (file-format) version the client authored the document against.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "description": "The workbook document as Tableau XML.",
+          "content": {
+            "application/xml": {
+              "schema": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Replaces the open workbook with the submitted Tableau XML.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Operation"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "415": {
+            "$ref": "#/components/responses/UnsupportedMediaType"
+          },
+          "421": {
+            "$ref": "#/components/responses/MisdirectedRequest"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          },
+          "503": {
+            "$ref": "#/components/responses/ServiceUnavailable"
+          }
+        }
+      }
+    },
+    "/v0/workbook/document:validate": {
+      "post": {
+        "summary": "Validate a workbook document",
+        "description": "Validates the submitted Tableau XML against the schema without applying it.",
+        "operationId": "validateWorkbookDocument",
+        "parameters": [
+          {
+            "name": "X-Tableau-Effective-Payload-Version",
+            "in": "header",
+            "required": false,
+            "description": "Tableau payload (file-format) version the client authored the document against.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "description": "The workbook document as Tableau XML.",
+          "content": {
+            "application/xml": {
+              "schema": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Validates the submitted Tableau XML against the schema without applying it.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "415": {
+            "$ref": "#/components/responses/UnsupportedMediaType"
+          },
+          "421": {
+            "$ref": "#/components/responses/MisdirectedRequest"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          },
+          "503": {
+            "$ref": "#/components/responses/ServiceUnavailable"
+          }
+        }
+      }
+    },
+    "/v0/workbook/storyboards": {
+      "get": {
+        "summary": "List storyboards",
+        "description": "Lists the storyboards in the open workbook.",
+        "operationId": "listStoryboards",
+        "responses": {
+          "200": {
+            "description": "Lists the storyboards in the open workbook.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StoryboardList"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "421": {
+            "$ref": "#/components/responses/MisdirectedRequest"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          },
+          "503": {
+            "$ref": "#/components/responses/ServiceUnavailable"
+          }
+        }
+      }
+    },
+    "/v0/workbook/storyboards/{id}": {
+      "get": {
+        "summary": "Get a storyboard",
+        "description": "Returns metadata for a single storyboard by id.",
+        "operationId": "getStoryboard",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns metadata for a single storyboard by id.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StoryboardItem"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "421": {
+            "$ref": "#/components/responses/MisdirectedRequest"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          },
+          "503": {
+            "$ref": "#/components/responses/ServiceUnavailable"
+          }
+        }
+      }
+    },
+    "/v0/workbook/storyboards/{id}/document": {
+      "get": {
+        "summary": "Get a storyboard document",
+        "description": "Returns a single storyboard as a Tableau XML subtree.",
+        "operationId": "getStoryboardDocument",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "X-Tableau-Effective-Payload-Version",
+            "in": "header",
+            "required": false,
+            "description": "Tableau payload (file-format) version the client authored the document against.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns a single storyboard as a Tableau XML subtree.",
+            "content": {
+              "application/xml": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "headers": {
+              "X-Tableau-Application-Version": {
+                "description": "Running Tableau Desktop build.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "X-Tableau-XSD-Payload-Version": {
+                "description": "Payload (file-format) version the document was served as.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "421": {
+            "$ref": "#/components/responses/MisdirectedRequest"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          },
+          "503": {
+            "$ref": "#/components/responses/ServiceUnavailable"
+          }
+        }
+      }
+    },
+    "/v0/workbook/worksheets": {
+      "get": {
+        "summary": "List worksheets",
+        "description": "Lists the worksheets in the open workbook.",
+        "operationId": "listWorksheets",
+        "responses": {
+          "200": {
+            "description": "Lists the worksheets in the open workbook.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorksheetList"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "421": {
+            "$ref": "#/components/responses/MisdirectedRequest"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          },
+          "503": {
+            "$ref": "#/components/responses/ServiceUnavailable"
+          }
+        }
+      }
+    },
+    "/v0/workbook/worksheets/{id}": {
+      "get": {
+        "summary": "Get a worksheet",
+        "description": "Returns metadata for a single worksheet by id.",
+        "operationId": "getWorksheet",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns metadata for a single worksheet by id.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorksheetItem"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "421": {
+            "$ref": "#/components/responses/MisdirectedRequest"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          },
+          "503": {
+            "$ref": "#/components/responses/ServiceUnavailable"
+          }
+        }
+      }
+    },
+    "/v0/workbook/worksheets/{id}/document": {
+      "get": {
+        "summary": "Get a worksheet document",
+        "description": "Returns a single worksheet as a Tableau XML subtree.",
+        "operationId": "getWorksheetDocument",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "X-Tableau-Effective-Payload-Version",
+            "in": "header",
+            "required": false,
+            "description": "Tableau payload (file-format) version the client authored the document against.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns a single worksheet as a Tableau XML subtree.",
+            "content": {
+              "application/xml": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "headers": {
+              "X-Tableau-Application-Version": {
+                "description": "Running Tableau Desktop build.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "X-Tableau-XSD-Payload-Version": {
+                "description": "Payload (file-format) version the document was served as.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "421": {
+            "$ref": "#/components/responses/MisdirectedRequest"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          },
+          "503": {
+            "$ref": "#/components/responses/ServiceUnavailable"
+          }
+        }
+      }
+    },
+    "/v0/workbook/worksheets/{id}/summaryData": {
+      "get": {
+        "summary": "Get worksheet summary data",
+        "description": "Returns the summary (logical table) data for a worksheet as JSON.",
+        "operationId": "getWorksheetSummaryData",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "maxRows",
+            "in": "query",
+            "required": false,
+            "description": "Maximum number of data rows to return.",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "ignoreAliases",
+            "in": "query",
+            "required": false,
+            "description": "Return underlying values instead of display aliases.",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "ignoreSelection",
+            "in": "query",
+            "required": false,
+            "description": "Return all data rather than only the current selection.",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "columnsToIncludeByFieldName",
+            "in": "query",
+            "required": false,
+            "description": "Comma-separated field names to restrict the returned columns.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns the summary (logical table) data for a worksheet as JSON.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SummaryData"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "421": {
+            "$ref": "#/components/responses/MisdirectedRequest"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          },
+          "503": {
+            "$ref": "#/components/responses/ServiceUnavailable"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "bearerAuth": {
+        "type": "http",
+        "scheme": "bearer"
+      }
+    },
+    "schemas": {
+      "Problem": {
+        "type": "object",
+        "description": "RFC 9457 Problem Details. Structured extension members, such as tableauErrorCode, may appear as additional top-level fields.",
+        "required": [
+          "code",
+          "status",
+          "instance"
+        ],
+        "properties": {
+          "code": {
+            "type": "string",
+            "description": "Stable machine-readable error identity clients branch on.",
+            "x-extensible-enum": [
+              "api-disabled",
+              "host-not-allowed",
+              "origin-not-allowed",
+              "unauthenticated",
+              "missing-user-agent",
+              "invalid-request-body",
+              "unsupported-content-type",
+              "missing-payload-version",
+              "payload-version-unsupported",
+              "not-found",
+              "sheet-not-found",
+              "method-not-allowed",
+              "not-implemented",
+              "command-not-found",
+              "invalid-command-parameter",
+              "operation-failed"
+            ]
+          },
+          "status": {
+            "type": "integer"
+          },
+          "title": {
+            "type": "string"
+          },
+          "instance": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": true
+      },
+      "Operation": {
+        "type": "object",
+        "description": "The state of a dispatched operation.",
+        "required": [
+          "id",
+          "kind",
+          "state"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "kind": {
+            "type": "string"
+          },
+          "state": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "string"
+          },
+          "completedAt": {
+            "type": "string"
+          },
+          "error": {
+            "$ref": "#/components/schemas/OperationError"
+          },
+          "warnings": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OperationWarning"
+            }
+          }
+        }
+      },
+      "OperationError": {
+        "type": "object",
+        "required": [
+          "code"
+        ],
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": true
+      },
+      "OperationWarning": {
+        "type": "object",
+        "required": [
+          "code",
+          "message"
+        ],
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        }
+      },
+      "WorksheetItem": {
+        "type": "object",
+        "description": "A worksheet in the open workbook.",
+        "required": [
+          "id",
+          "name",
+          "hidden"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "x-extensible-enum": [
+              "WORKSHEET",
+              "DASHBOARD",
+              "STORYBOARD"
+            ]
+          },
+          "hidden": {
+            "type": "boolean"
+          },
+          "index": {
+            "type": "integer"
+          },
+          "datasources": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "DashboardItem": {
+        "type": "object",
+        "description": "A dashboard in the open workbook.",
+        "required": [
+          "id",
+          "name",
+          "hidden"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "x-extensible-enum": [
+              "WORKSHEET",
+              "DASHBOARD",
+              "STORYBOARD"
+            ]
+          },
+          "hidden": {
+            "type": "boolean"
+          },
+          "index": {
+            "type": "integer"
+          },
+          "containedSheets": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "StoryboardItem": {
+        "type": "object",
+        "description": "A storyboard in the open workbook.",
+        "required": [
+          "id",
+          "name",
+          "hidden"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "x-extensible-enum": [
+              "WORKSHEET",
+              "DASHBOARD",
+              "STORYBOARD"
+            ]
+          },
+          "hidden": {
+            "type": "boolean"
+          },
+          "index": {
+            "type": "integer"
+          },
+          "storyPointCount": {
+            "type": "integer"
+          }
+        }
+      },
+      "WorkbookInventory": {
+        "type": "object",
+        "description": "Metadata and sheet inventory of the open workbook.",
+        "required": [
+          "title",
+          "unsavedChanges"
+        ],
+        "properties": {
+          "title": {
+            "type": "string"
+          },
+          "location": {
+            "type": "string",
+            "nullable": true
+          },
+          "unsavedChanges": {
+            "type": "boolean"
+          },
+          "worksheets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/WorksheetItem"
+            }
+          },
+          "dashboards": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DashboardItem"
+            }
+          },
+          "storyboards": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/StoryboardItem"
+            }
+          }
+        }
+      },
+      "WorksheetList": {
+        "type": "object",
+        "properties": {
+          "worksheets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/WorksheetItem"
+            }
+          }
+        }
+      },
+      "DashboardList": {
+        "type": "object",
+        "properties": {
+          "dashboards": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DashboardItem"
+            }
+          }
+        }
+      },
+      "StoryboardList": {
+        "type": "object",
+        "properties": {
+          "storyboards": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/StoryboardItem"
+            }
+          }
+        }
+      },
+      "DatasourceItem": {
+        "type": "object",
+        "description": "A datasource used by the open workbook.",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "caption": {
+            "type": "string"
+          }
+        }
+      },
+      "DatasourceList": {
+        "type": "object",
+        "properties": {
+          "datasources": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DatasourceItem"
+            }
+          }
+        }
+      },
+      "SiteWorkbookItem": {
+        "type": "object",
+        "description": "A workbook published to the connected site.",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "luid": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "project": {
+            "type": "string"
+          }
+        }
+      },
+      "SiteWorkbookList": {
+        "type": "object",
+        "properties": {
+          "workbooks": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SiteWorkbookItem"
+            }
+          }
+        }
+      },
+      "SiteDatasourceItem": {
+        "type": "object",
+        "description": "A datasource published to the connected site.",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "luid": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "caption": {
+            "type": "string"
+          },
+          "project": {
+            "type": "string"
+          }
+        }
+      },
+      "SiteDatasourceList": {
+        "type": "object",
+        "properties": {
+          "datasources": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SiteDatasourceItem"
+            }
+          }
+        }
+      },
+      "SummaryData": {
+        "type": "object",
+        "description": "Worksheet summary (logical table) data.",
+        "properties": {
+          "columns": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "dataType": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "rows": {
+            "type": "array",
+            "items": {
+              "type": "array"
+            }
+          }
+        }
+      },
+      "ValidationResult": {
+        "type": "object",
+        "description": "The outcome of validating a workbook document.",
+        "required": [
+          "isValid"
+        ],
+        "properties": {
+          "isValid": {
+            "type": "boolean"
+          },
+          "validationIssues": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "ApiRoot": {
+        "type": "object",
+        "description": "API versions and the resource link map.",
+        "properties": {
+          "apiVersion": {
+            "type": "string"
+          },
+          "applicationVersion": {
+            "type": "string"
+          },
+          "links": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "AppInfo": {
+        "type": "object",
+        "description": "Running Tableau Desktop process information.",
+        "properties": {
+          "applicationVersion": {
+            "type": "string"
+          },
+          "edition": {
+            "type": "string"
+          },
+          "build": {
+            "type": "string"
+          },
+          "os": {
+            "type": "string"
+          },
+          "locale": {
+            "type": "string"
+          },
+          "repositoryLocation": {
+            "type": "string"
+          },
+          "logLocation": {
+            "type": "string"
+          }
+        }
+      },
+      "Site": {
+        "type": "object",
+        "description": "The connected Tableau site.",
+        "properties": {
+          "siteId": {
+            "type": "string"
+          },
+          "authenticatedUserId": {
+            "type": "string"
+          }
+        }
+      },
+      "Health": {
+        "type": "object",
+        "description": "Liveness probe result.",
+        "properties": {
+          "status": {
+            "type": "string"
+          }
+        }
+      },
+      "ProtectedResourceMetadata": {
+        "type": "object",
+        "description": "RFC 9728 OAuth Protected Resource Metadata.",
+        "properties": {
+          "authorization_servers": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "bearer_methods_supported": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "responses": {
+      "BadRequest": {
+        "description": "The request was malformed. The code field identifies the specific problem, such as a missing required header or an unreadable body.",
+        "content": {
+          "application/problem+json": {
+            "schema": {
+              "$ref": "#/components/schemas/Problem"
+            }
+          }
+        }
+      },
+      "Unauthorized": {
+        "description": "The bearer token was missing or invalid. The response carries a WWW-Authenticate challenge.",
+        "content": {
+          "application/problem+json": {
+            "schema": {
+              "$ref": "#/components/schemas/Problem"
+            }
+          }
+        }
+      },
+      "Forbidden": {
+        "description": "The request origin was not permitted.",
+        "content": {
+          "application/problem+json": {
+            "schema": {
+              "$ref": "#/components/schemas/Problem"
+            }
+          }
+        }
+      },
+      "NotFound": {
+        "description": "The addressed resource does not exist. The code field distinguishes an unknown route from a valid resource with an unknown id.",
+        "content": {
+          "application/problem+json": {
+            "schema": {
+              "$ref": "#/components/schemas/Problem"
+            }
+          }
+        }
+      },
+      "MethodNotAllowed": {
+        "description": "The path exists but does not support this HTTP method.",
+        "content": {
+          "application/problem+json": {
+            "schema": {
+              "$ref": "#/components/schemas/Problem"
+            }
+          }
+        }
+      },
+      "Conflict": {
+        "description": "The request conflicts with the current state, such as an unsupported payload version.",
+        "content": {
+          "application/problem+json": {
+            "schema": {
+              "$ref": "#/components/schemas/Problem"
+            }
+          }
+        }
+      },
+      "UnsupportedMediaType": {
+        "description": "The request Content-Type is not accepted by this endpoint.",
+        "content": {
+          "application/problem+json": {
+            "schema": {
+              "$ref": "#/components/schemas/Problem"
+            }
+          }
+        }
+      },
+      "MisdirectedRequest": {
+        "description": "The request Host header was not a loopback address.",
+        "content": {
+          "application/problem+json": {
+            "schema": {
+              "$ref": "#/components/schemas/Problem"
+            }
+          }
+        }
+      },
+      "ServerError": {
+        "description": "An unexpected error occurred.",
+        "content": {
+          "application/problem+json": {
+            "schema": {
+              "$ref": "#/components/schemas/Problem"
+            }
+          }
+        }
+      },
+      "ServiceUnavailable": {
+        "description": "The External Client API is disabled or shutting down.",
+        "content": {
+          "application/problem+json": {
+            "schema": {
+              "$ref": "#/components/schemas/Problem"
+            }
+          }
+        }
+      }
+    }
+  },
+  "security": [
+    {
+      "bearerAuth": []
+    }
+  ]
+}

--- a/src/desktop/externalApi/externalApiContract.test.ts
+++ b/src/desktop/externalApi/externalApiContract.test.ts
@@ -1,0 +1,152 @@
+import { readFileSync } from 'fs';
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+
+import {
+  EXTERNAL_API_ROUTES,
+  operationEnvelopeSchema,
+  operationErrorSchema,
+  operationWarningSchema,
+  PROBLEM_CODES,
+  problemResponseSchema,
+} from './types.js';
+
+/**
+ * Contract-intake harness: validates OUR zod schemas against the captured
+ * `/openapi.json` artifact. When the API owner ships a new spec, overwrite the
+ * fixture with it and rerun — every drift (new field, changed requiredness, enum
+ * growth, route add/remove) surfaces as a red/green diff instead of a manual reread.
+ *
+ * Fixture provenance: live Desktop `/openapi.json`, `info.version` 0.1.0,
+ * captured 2026-07-20.
+ */
+
+type SpecSchema = {
+  required?: Array<string>;
+  properties?: Record<string, { 'x-extensible-enum'?: Array<string> }>;
+};
+
+const spec = JSON.parse(
+  readFileSync(path.join(__dirname, '__fixtures__', 'externalClientApi-openapi.json'), 'utf-8'),
+) as {
+  paths: Record<string, unknown>;
+  components: { schemas: Record<string, SpecSchema> };
+};
+
+const specSchema = (name: string): SpecSchema => {
+  const schema = spec.components.schemas[name];
+  expect(schema, `spec component schema ${name} missing`).toBeDefined();
+  return schema;
+};
+
+const declaredKeys = (schema: z.AnyZodObject): Array<string> => Object.keys(schema.shape);
+
+const requiredKeys = (schema: z.AnyZodObject): Array<string> =>
+  declaredKeys(schema).filter((key) => !(schema.shape[key] as z.ZodTypeAny).isOptional());
+
+describe('external client API contract (captured openapi fixture)', () => {
+  describe('Operation ↔ operationEnvelopeSchema', () => {
+    const operation = specSchema('Operation');
+
+    it('declares every spec property', () => {
+      const missing = Object.keys(operation.properties ?? {}).filter(
+        (key) => !declaredKeys(operationEnvelopeSchema).includes(key),
+      );
+      expect(missing).toEqual([]);
+    });
+
+    it('only carries `result` beyond the spec (kept until Ask-1(b) output-param behavior is confirmed)', () => {
+      const extras = declaredKeys(operationEnvelopeSchema).filter(
+        (key) => !(key in (operation.properties ?? {})),
+      );
+      expect(extras).toEqual(['result']);
+    });
+
+    it('matches the spec required set exactly', () => {
+      expect(requiredKeys(operationEnvelopeSchema).sort()).toEqual(
+        [...(operation.required ?? [])].sort(),
+      );
+    });
+  });
+
+  describe('OperationError / OperationWarning', () => {
+    it.each([
+      ['OperationError', operationErrorSchema],
+      ['OperationWarning', operationWarningSchema],
+    ] as const)('%s: properties and required set match', (name, schema) => {
+      const component = specSchema(name);
+      expect(declaredKeys(schema).sort()).toEqual(Object.keys(component.properties ?? {}).sort());
+      expect(requiredKeys(schema).sort()).toEqual([...(component.required ?? [])].sort());
+    });
+  });
+
+  describe('Problem ↔ problemResponseSchema', () => {
+    const problem = specSchema('Problem');
+
+    it('declares every spec property (extras `type`/`detail` are RFC-9457 members additionalProperties admits)', () => {
+      const missing = Object.keys(problem.properties ?? {}).filter(
+        (key) => !declaredKeys(problemResponseSchema).includes(key),
+      );
+      expect(missing).toEqual([]);
+      const extras = declaredKeys(problemResponseSchema).filter(
+        (key) => !(key in (problem.properties ?? {})),
+      );
+      expect(extras.sort()).toEqual(['detail', 'type']);
+    });
+
+    it('PROBLEM_CODES equals the spec x-extensible-enum exactly', () => {
+      expect([...PROBLEM_CODES].sort()).toEqual(
+        [...(problem.properties?.code?.['x-extensible-enum'] ?? [])].sort(),
+      );
+    });
+
+    // Deliberately NO requiredness parity: problemResponseSchema keeps every field
+    // optional so error extraction fails open on a partially-parseable Problem.
+    it('accepts a spec-minimal Problem payload', () => {
+      expect(
+        problemResponseSchema.safeParse({ code: 'sheet-not-found', status: 404, instance: '/v0/x' })
+          .success,
+      ).toBe(true);
+    });
+  });
+
+  describe('routes', () => {
+    it.each([
+      EXTERNAL_API_ROUTES.health,
+      EXTERNAL_API_ROUTES.app,
+      EXTERNAL_API_ROUTES.workbookDocument,
+      EXTERNAL_API_ROUTES.openapi,
+      EXTERNAL_API_ROUTES.oauthProtectedResource,
+    ])('spec documents %s', (route) => {
+      expect(Object.keys(spec.paths)).toContain(route);
+    });
+
+    it('invokeCommand stays deliberately undocumented (hidden route, owned separately)', () => {
+      expect(Object.keys(spec.paths)).not.toContain(EXTERNAL_API_ROUTES.invokeCommand);
+    });
+  });
+
+  describe('envelope wire acceptance', () => {
+    it('parses a full spec-shaped Operation', () => {
+      const parsed = operationEnvelopeSchema.safeParse({
+        id: 'op-1',
+        kind: 'workbook.document.apply',
+        state: 'FAILED',
+        createdAt: '2026-07-20T10:00:00Z',
+        completedAt: '2026-07-20T10:00:01Z',
+        error: { code: 'operation-failed', message: 'nope' },
+        warnings: [{ code: 'partial', message: 'one sheet skipped' }],
+      });
+      expect(parsed.success).toBe(true);
+    });
+
+    it.each([
+      ['id', { kind: 'k', state: 's' }],
+      ['kind', { id: 'op-1', state: 's' }],
+      ['state', { id: 'op-1', kind: 'k' }],
+    ])('rejects an Operation missing required `%s`', (_key, payload) => {
+      expect(operationEnvelopeSchema.safeParse(payload).success).toBe(false);
+    });
+  });
+});

--- a/src/desktop/externalApi/externalApiToolExecutor.ts
+++ b/src/desktop/externalApi/externalApiToolExecutor.ts
@@ -15,7 +15,7 @@ import {
   ExternalApiError,
   ExternalApiInstance,
   OperationEnvelope,
-  ProblemResponse,
+  OperationError,
 } from './types.js';
 
 /** The single "get whole workbook document" command, routed to GET /v0/workbook/document. */
@@ -45,7 +45,7 @@ type NoInstance = { type: 'no-instance'; pinnedPid?: number };
 type RawOutcome = {
   result: Record<string, unknown> | undefined;
   state: string | undefined;
-  envelopeError: ProblemResponse | undefined;
+  envelopeError: OperationError | undefined;
   createdAt: string | undefined;
   completedAt: string | undefined;
   operationId: string | undefined;
@@ -303,7 +303,7 @@ function normalizeEnvelope(envelope: OperationEnvelope): RawOutcome {
     envelopeError: envelope.error,
     createdAt: envelope.createdAt,
     completedAt: envelope.completedAt,
-    operationId: envelope.operationId,
+    operationId: envelope.id,
   };
 }
 
@@ -319,10 +319,7 @@ function buildCommandStatus(
       type: 'command-failed',
       error: {
         code: outcome.envelopeError?.code ?? 'operation-failed',
-        message:
-          outcome.envelopeError?.detail ??
-          outcome.envelopeError?.title ??
-          `Command ${namespace}:${command} failed`,
+        message: outcome.envelopeError?.message ?? `Command ${namespace}:${command} failed`,
         recoverable: false,
       },
     });

--- a/src/desktop/externalApi/mockExternalApiServer.ts
+++ b/src/desktop/externalApi/mockExternalApiServer.ts
@@ -56,9 +56,13 @@ const sendJson = (res: ServerResponse, status: number, payload: unknown): void =
   res.end(body);
 };
 
+// Models the live 0.1.0 Problem shape: `type: 'problem'` + required code/status/instance,
+// human text in `title`. `detail` is an RFC-9457 member additionalProperties admits.
 const sendProblem = (res: ServerResponse, status: number, code: string, detail: string): void => {
   res.writeHead(status, { 'content-type': 'application/problem+json' });
-  res.end(JSON.stringify({ type: `about:blank#${code}`, title: code, status, detail, code }));
+  res.end(
+    JSON.stringify({ type: 'problem', title: detail, status, instance: '/v0/mock', detail, code }),
+  );
 };
 
 export async function startMockExternalApiServer(
@@ -79,7 +83,7 @@ export async function startMockExternalApiServer(
 
     // Bearer auth: a mismatched/absent token models a stale discovery file → 401.
     if (authorization !== `Bearer ${token}`) {
-      sendProblem(res, 401, 'unauthorized', 'Stale or missing bearer token.');
+      sendProblem(res, 401, 'unauthenticated', 'Stale or missing bearer token.');
       return;
     }
 
@@ -124,7 +128,8 @@ export async function startMockExternalApiServer(
         return;
       }
       sendJson(res, 200, {
-        operationId: 'op-doc-1',
+        id: 'op-doc-1',
+        kind: 'workbook.document.apply',
         state: 'succeeded',
         createdAt: '2026-07-07T10:00:00Z',
         completedAt: '2026-07-07T10:00:01Z',
@@ -152,17 +157,19 @@ export async function startMockExternalApiServer(
       }
       if (parsed.command === 'fail-op') {
         sendJson(res, 200, {
-          operationId: 'op-fail-1',
+          id: 'op-fail-1',
+          kind: 'command.invoke',
           state: 'failed',
           createdAt: '2026-07-07T10:00:00Z',
           completedAt: '2026-07-07T10:00:01Z',
-          error: { code: 'operation-failed', title: 'operation-failed', detail: 'command blew up' },
+          error: { code: 'operation-failed', message: 'command blew up' },
         });
         return;
       }
 
       sendJson(res, 200, {
-        operationId: 'op-cmd-1',
+        id: 'op-cmd-1',
+        kind: 'command.invoke',
         state: 'succeeded',
         createdAt: '2026-07-07T10:00:00Z',
         completedAt: '2026-07-07T10:00:01Z',

--- a/src/desktop/externalApi/types.ts
+++ b/src/desktop/externalApi/types.ts
@@ -3,11 +3,11 @@ import { z } from 'zod';
 /**
  * Types and schemas for the Tableau Desktop "External Client API" (Athena V0).
  *
- * Contract derived from monolith PRs #57536 → #59383 (ApiRoutePaths.h + handlers,
- * PR #59238 head 88276855). Where the exact wire shape was not fully pinned down by
- * the PR evidence, schemas are intentionally permissive (`.passthrough()` /
- * optional fields) and the ambiguity is recorded as residual risk in the deliverable
- * report. A live `/openapi.json` diff is the intended follow-up to tighten these.
+ * Contract originally derived from monolith PRs #57536 → #59383, then tightened
+ * against the live `/openapi.json` (OpenAPI 3.1, `info.version` 0.1.0, captured
+ * 2026-07-20) plus live probes against the running 0.1.0 build. Envelope fields the
+ * spec marks required are required here; everything else stays permissive
+ * (`.passthrough()` / optional) because the spec is read-complete but write-thin.
  */
 
 /** Route paths served by the running Desktop loopback host. */
@@ -51,46 +51,93 @@ export type ExternalApiInstance = {
   apiVersion?: string;
 };
 
-/** RFC-7807-style Problem codes surfaced by the API's error model. */
+/**
+ * RFC-9457 Problem `code` values — the `x-extensible-enum` from the live
+ * `/openapi.json` (0.1.0). Extensible on the wire: treat unknown codes as valid.
+ */
 export const PROBLEM_CODES = [
+  'api-disabled',
+  'host-not-allowed',
+  'origin-not-allowed',
+  'unauthenticated',
+  'missing-user-agent',
   'invalid-request-body',
   'unsupported-content-type',
+  'missing-payload-version',
+  'payload-version-unsupported',
+  'not-found',
+  'sheet-not-found',
+  'method-not-allowed',
+  'not-implemented',
   'command-not-found',
   'invalid-command-parameter',
   'operation-failed',
 ] as const;
 export type ProblemCode = (typeof PROBLEM_CODES)[number];
 
-/** RFC-7807 Problem response body. `code` carries the API-specific error code. */
+/**
+ * RFC-9457 Problem Details body. The spec requires `code`/`status`/`instance`, but
+ * this schema keeps every field optional so error extraction fails open — a Problem
+ * we can only partially parse should still surface its `code`/`title`, never fall
+ * back to raw text. (`instance` population is unverified on the live build; `detail`
+ * is an RFC-9457 member the spec omits but `additionalProperties: true` allows.)
+ */
 export const problemResponseSchema = z
   .object({
     type: z.string().optional(),
     title: z.string().optional(),
     status: z.number().optional(),
+    instance: z.string().optional(),
     detail: z.string().optional(),
     code: z.string().optional(),
   })
   .passthrough();
 export type ProblemResponse = z.infer<typeof problemResponseSchema>;
 
+/** Operation-level `error` — distinct from {@link problemResponseSchema} (HTTP-level). */
+export const operationErrorSchema = z
+  .object({
+    code: z.string(),
+    message: z.string().optional(),
+  })
+  .passthrough();
+export type OperationError = z.infer<typeof operationErrorSchema>;
+
+/** Non-fatal warning attached to an Operation. */
+export const operationWarningSchema = z
+  .object({
+    code: z.string(),
+    message: z.string(),
+  })
+  .passthrough();
+export type OperationWarning = z.infer<typeof operationWarningSchema>;
+
 /**
  * Operation envelope returned by `POST /v0/workbook/document` and
- * `POST /v0/app:invokeCommand`. `result` is captured on success; `state` +
- * `createdAt`/`completedAt` (ISO8601-Z) describe the operation lifecycle.
+ * `POST /v0/app:invokeCommand`. `id`/`kind`/`state` are required per the spec.
+ * `result` is ABSENT from the spec's Operation schema but kept optional here until
+ * output-param behavior is confirmed with the API owner (Ask 1(b)) — do not tighten
+ * it out, and do not rely on it being populated.
  */
 export const operationEnvelopeSchema = z
   .object({
-    operationId: z.string().optional(),
-    state: z.string().optional(),
+    id: z.string(),
+    kind: z.string(),
+    state: z.string(),
     result: z.unknown().optional(),
-    error: problemResponseSchema.optional(),
+    error: operationErrorSchema.optional(),
+    warnings: z.array(operationWarningSchema).optional(),
     createdAt: z.string().optional(),
     completedAt: z.string().optional(),
   })
   .passthrough();
 export type OperationEnvelope = z.infer<typeof operationEnvelopeSchema>;
 
-/** Typed error surfaced by {@link ExternalApiClient} methods. */
+/**
+ * Typed error surfaced by {@link ExternalApiClient} methods. The internal
+ * `'unauthorized'` variant corresponds to the wire code `'unauthenticated'` —
+ * mapped at the 401 boundary; the internal name is kept (many refs).
+ */
 export type ExternalApiError =
   | { type: 'unauthorized'; status: number }
   | { type: 'problem'; status: number; code?: string; title?: string; detail?: string }


### PR DESCRIPTION
## What

Tightens the hand-derived External Client API ("Athena V0") contract in `src/desktop/externalApi/` against the captured live `/openapi.json` (0.1.0, 2026-07-20) plus live-probe evidence from the running build.

- **Operation envelope**: `operationId` → `id`, adds `kind`, makes `id`/`kind`/`state` required, adds `warnings[]`; `error` becomes a distinct `OperationError {code, message}` (was conflated with the HTTP-level Problem shape). `result` stays optional — it is absent from the spec's `Operation`, but output-param behavior (Ask 1(b)) is still unconfirmed with the API owner, so it is deliberately not tightened out.
- **Problem**: RFC-9457 shape (adds `instance`), `PROBLEM_CODES` grows 5 → the spec's 16-value `x-extensible-enum`. All fields stay optional so error extraction fails open on a partially-parseable Problem (`instance` population on the live build is unverified). The internal `'unauthorized'` error variant is kept (many refs) and documented as mapping to the wire code `'unauthenticated'` at the 401 boundary.
- **Mock server** now emits the spec-true wire shapes (spec Problem model, envelope `id`/`kind`, `OperationError`).
- **NEW contract-intake harness** (`externalApiContract.test.ts` + the captured spec as a fixture): drop the API owner's next spec into the fixture and every drift — new field, requiredness change, enum growth, route add/remove — surfaces as a red/green test diff keyed off OUR schemas. Also pins that `/v0/app:invokeCommand` is deliberately undocumented (hidden route, owned separately — untouched here).

Known incoming drift (deliberately NOT pre-applied): monolith PR #60392 (the OpenApiGenerator build-out) adds a 17th code `invalid-query-parameter`. `code` parses as an open string so nothing breaks; the harness flags it on the next spec capture.

## Validation

- Full unit suite: **4600 passed, 1 (pre-existing) skipped**, 315 files
- `src/desktop/externalApi/`: 58/58 (18 new contract tests)
- `eslint --no-cache src/desktop/externalApi/` clean; `tsc --noEmit` clean
- No tool-surface/describe changes — byte ratchets untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)