### PR TITLE
fix(desktop): teach the known-live-500 fallback on tabdoc:sort-nested errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "2.26.1",
+  "version": "2.26.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "2.26.1",
+      "version": "2.26.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.7.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "2.26.1",
+  "version": "2.26.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/src/errors/mcpToolError.ts
+++ b/src/errors/mcpToolError.ts
@@ -257,10 +257,10 @@ export class AdminInsightsUnavailableError extends McpToolError {
 }
 
 export class DesktopCommandExecutionError extends McpToolError {
-  constructor(error: ExecuteCommandError) {
+  constructor(error: ExecuteCommandError, fix?: string) {
     super({
       type: 'desktop-command-execution-error',
-      message: JSON.stringify(error),
+      message: fix ? `${JSON.stringify(error)}\n${fix}` : JSON.stringify(error),
       statusCode: 500,
     });
   }

--- a/src/tools/desktop/commands/executeTableauCommand.test.ts
+++ b/src/tools/desktop/commands/executeTableauCommand.test.ts
@@ -36,6 +36,8 @@ const GENERATED_VIZ_READBACK_XML = `<workbook>
     <window class="worksheet" name="Revenue by Region" active="true"/>
   </windows>
 </workbook>`;
+const SORT_NESTED_LIVE_500_FIX =
+  'FIX: tabdoc:sort-nested is known to fail (HTTP 500) on current Desktop builds regardless of parameters — do not retry it. Sort instead via the bind-template sort proposal (preferred for template-bound sheets) or the document round-trip (tabui:save-underlying-metadata → edit the computed-sort → tabui:load-underlying-metadata).';
 
 function makeExtra(
   executeCommandImpl: (...args: any[]) => any,
@@ -159,7 +161,7 @@ describe('executeTableauCommandTool', () => {
     expect(result.content[0].text).toContain('no result data');
   });
 
-  it('should return error when executeCommand fails', async () => {
+  it('keeps unmapped executeCommand failure text unchanged', async () => {
     const commandError = {
       type: 'command-failed' as const,
       error: { code: 'ERR', message: 'fail', recoverable: false },
@@ -177,6 +179,60 @@ describe('executeTableauCommandTool', () => {
     expect(result.isError).toBe(true);
     invariant(result.content[0].type === 'text');
     expect(result.content[0].text).toBe(new DesktopCommandExecutionError(commandError).message);
+  });
+
+  it('appends the known-live failure fix when mapped command execution fails', async () => {
+    const commandError = {
+      type: 'command-failed' as const,
+      error: { code: 'ERR', message: 'live 500', recoverable: false },
+    };
+    const executeCommand = vi.fn().mockResolvedValue({ isErr: () => true, error: commandError });
+    const extra = makeExtra(executeCommand);
+
+    const result = await getResult(
+      {
+        session: SESSION,
+        command: 'tabdoc:sort-nested',
+        args: {
+          DimensionToSort: '[Sample - Superstore].[Category]',
+          Worksheet: 'Sheet 1',
+          MeasureName: '[Sample - Superstore].[Sales]',
+          ShelfType: 'rows',
+        },
+      },
+      extra,
+    );
+
+    expect(result.isError).toBe(true);
+    invariant(result.content[0].type === 'text');
+    expect(result.content[0].text).toContain(
+      new DesktopCommandExecutionError(commandError).message,
+    );
+    expect(result.content[0].text).toContain(SORT_NESTED_LIVE_500_FIX);
+  });
+
+  it('does not append the known-live failure fix when mapped command execution succeeds', async () => {
+    const executeCommand = vi.fn().mockResolvedValue(new Ok({ command_id: 'c1', result: null }));
+    const extra = makeExtra(executeCommand);
+
+    const result = await getResult(
+      {
+        session: SESSION,
+        command: 'tabdoc:sort-nested',
+        args: {
+          DimensionToSort: '[Sample - Superstore].[Category]',
+          Worksheet: 'Sheet 1',
+          MeasureName: '[Sample - Superstore].[Sales]',
+          ShelfType: 'rows',
+        },
+      },
+      extra,
+    );
+
+    expect(result.isError).toBeFalsy();
+    invariant(result.content[0].type === 'text');
+    expect(result.content[0].text).not.toContain('FIX:');
+    expect(result.content[0].text).not.toContain(SORT_NESTED_LIVE_500_FIX);
   });
 
   it('should default args to empty object when not provided', async () => {

--- a/src/tools/desktop/commands/executeTableauCommand.ts
+++ b/src/tools/desktop/commands/executeTableauCommand.ts
@@ -27,6 +27,12 @@ import { DesktopTool } from '../tool.js';
 
 const LOAD_UNDERLYING_METADATA_COMMAND = 'tabui:load-underlying-metadata';
 const GENERATE_VIZ_FROM_NOTIONAL_SPEC_COMMAND = 'tabdoc:generate-viz-from-notional-spec';
+const KNOWN_LIVE_FAILURE_FIXES = new Map<string, string>([
+  [
+    'tabdoc:sort-nested',
+    'FIX: tabdoc:sort-nested is known to fail (HTTP 500) on current Desktop builds regardless of parameters — do not retry it. Sort instead via the bind-template sort proposal (preferred for template-bound sheets) or the document round-trip (tabui:save-underlying-metadata → edit the computed-sort → tabui:load-underlying-metadata).',
+  ],
+]);
 
 const paramsSchema = {
   session: z.string().optional().describe('Session ID; optional if pinned or unique.'),
@@ -133,7 +139,10 @@ export const getExecuteTableauCommandTool = (
           });
 
           if (result.isErr()) {
-            return new DesktopCommandExecutionError(result.error).toErr();
+            return new DesktopCommandExecutionError(
+              result.error,
+              KNOWN_LIVE_FAILURE_FIXES.get(command),
+            ).toErr();
           }
 
           const resultText = result.value.result


### PR DESCRIPTION
**Live eval receipt (m1 waterfall song, 2026-07-20):** `tabdoc:sort-nested` passed local param validation, then returned HTTP 500 from the live API — three retries before the singer fell back to the document round-trip. ~30s and several model turns burned on the known "passes our guard, 500s live" class.

**Change (error-path teaching only, fail-open):**
- `KNOWN_LIVE_FAILURE_FIXES` map in `executeTableauCommand.ts`; on execution error for a mapped command, the model-visible error text gains a FIX line naming both blessed fallbacks (bind-template sort proposal — preferred for template-bound sheets — or `tabui:save-underlying-metadata` → edit → `tabui:load-underlying-metadata`).
- No pre-dispatch block: the server may fix the command on any build, so the command still dispatches; only the *error* teaches.
- Unmapped commands: byte-identical error text (test-pinned).

**Tests:** mapped-error carries FIX / unmapped unchanged / mapped-success clean. Full suite 4603 green, lint clean (run firsthand). v2.26.2.

Durable fix remains wave-2 command ground-truthing against the External Client API allowlist; this kills the retry burn until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)