### PR TITLE
Fix misleading 'Pulse not available on Tableau Server' error on Cloud

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "4.1.0",
+      "version": "4.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1095.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/src/sdks/tableau/methods/pulseMethods.ts
+++ b/src/sdks/tableau/methods/pulseMethods.ts
@@ -218,7 +218,7 @@ async function guardAgainstPulseDisabled<T>(callback: () => Promise<T>): Promise
     return new Ok(await callback());
   } catch (error) {
     if (isAxiosError(error)) {
-      if (error.response?.status === 404) {
+      if (error.response?.status === 404 && !error.response?.data?.code) {
         return new PulseNotAvailableError().toErr();
       }
 

--- a/src/tools/web/pulse/generateMetricValueInsightBundle/generatePulseMetricValueInsightBundleTool.test.ts
+++ b/src/tools/web/pulse/generateMetricValueInsightBundle/generatePulseMetricValueInsightBundleTool.test.ts
@@ -202,7 +202,7 @@ describe('getGeneratePulseMetricValueInsightBundleTool', () => {
     expect(result.content[0].text).toContain('bundleRequest');
   });
 
-  it('should return an error when executing the tool against Tableau Server', async () => {
+  it('should return Tableau Server error for bare 404 without error code', async () => {
     mocks.mockGeneratePulseMetricValueInsightBundle.mockResolvedValue(
       new PulseNotAvailableError().toErr(),
     );
@@ -210,6 +210,18 @@ describe('getGeneratePulseMetricValueInsightBundleTool', () => {
     expect(result.isError).toBe(true);
     invariant(result.content[0].type === 'text');
     expect(result.content[0].text).toContain('Pulse is not available on Tableau Server.');
+  });
+
+  it('should return actionable error for 404 with a Pulse error code', async () => {
+    const formatted = formatPulseInsightsApiError(404, { code: '404900', message: '0x00000000' });
+    const apiError = new PulseInsightsApiError(formatted.message, 404, formatted.errorCode);
+    mocks.mockGeneratePulseMetricValueInsightBundle.mockResolvedValue(apiError.toErr());
+    const result = await getToolResult();
+    expect(result.isError).toBe(true);
+    invariant(result.content[0].type === 'text');
+    expect(result.content[0].text).toContain('Pulse Insights API returned HTTP 404');
+    expect(result.content[0].text).toContain('404900');
+    expect(result.content[0].text).not.toContain('Tableau Server');
   });
 
   it('should return an error when Pulse is disabled', async () => {


### PR DESCRIPTION
The 404 handler in guardAgainstPulseDisabled treated all 404 responses as "Pulse is not available on Tableau Server". On Tableau Cloud, a 404 can instead indicate a real Pulse API error (e.g., definition not found, datasource not found, metric not found) which has a Pulse error code in the response body.

Now checks whether the 404 response contains an error code. If it does, it falls through to the PulseInsightsApiError handler which surfaces the actual error with actionable guidance. Only bare 404s (no error code) are treated as "Pulse not available".

**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of
the pull request._

# Pull Request Template

<!-- Thank you for your contribution! Please fill out the following template to help us review your pull
request! -->

## Description

<!-- Please include a summary of the change. -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## How Has This Been Tested?

<!-- Please describe the tests that you performed to verify your changes. -->

## Related Issues

<!-- List any related issues, pull requests, or discussions. -->

## Checklist

- [ ] I have updated the version in the package.json file by using `npm run version`. For example,
      use `npm run version:patch` for a patch version bump.
- [ ] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have documented any breaking changes in the PR description. For example, renaming a config
      environment variable or changing its default value.

## Contributor Agreement

By submitting this pull request, I confirm that:

- [ ] I have read the [CONTRIBUTING guidelines](../../CONTRIBUTING.md) for this project and followed
      its Contribution Checklist.
