### PR TITLE
fix(ci): widen vitest teardown window to stop flaky onTaskUpdate RPC timeout

### DIFF
--- a/configShared.ts
+++ b/configShared.ts
@@ -5,6 +5,12 @@ export const configShared = {
     globals: true,
     watch: false,
     include: ['**/*.test.ts'],
+    // CI ran ~157s of parallel tests and the pool→reporter RPC starved, throwing
+    // `[vitest-worker]: Timeout calling "onTaskUpdate"` as an *unhandled error* AFTER
+    // all 317 files passed — a flaky red on green code (seen on #564; #565 same suite
+    // passed clean). Widen the teardown/RPC window so the final task-update exchange
+    // completes under load instead of timing out.
+    teardownTimeout: 30_000,
     reporters: [
       [
         'default',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "2.29.0",
+  "version": "2.29.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "2.29.0",
+      "version": "2.29.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.7.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "2.29.0",
+  "version": "2.29.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"


### PR DESCRIPTION
## What
Sets `teardownTimeout: 30_000` in the shared vitest config (`configShared.ts`).

## Why
The CI **Tests** step went red on #564 with:
```
Unhandled Error: [vitest-worker]: Timeout calling "onTaskUpdate"
Test Files  317 passed (317)
##[error]Process completed with exit code 1.
```
**All 317 test files PASSED** — the failure is a pool→reporter RPC (`onTaskUpdate`) that timed out under a ~157s parallel run and surfaced as an *unhandled error*, which makes vitest exit 1. It's flaky infra, not a code defect: **#565 ran the same suite on the same base and passed both Node jobs.** Because `configShared` is shared, this flake can redden any PR.

## Fix
Widen the teardown/RPC window (default ~10s → 30s) so the final worker→reporter task-update exchange completes under CI load instead of timing out. Minimal, config-only.

## Validation
- Local `vitest run` on a representative subset: green (config loads, `teardownTimeout` accepted).
- Project `tsc --noEmit`: clean · `npm run lint`: clean.
- Version 2.29.0 → **2.29.1** (patch — infra fix).

Once this lands, #564 (whose only red is this exact flake) goes green on its next run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)