### PR TITLE
fix(desktop): honor session pin when stamping cache sidecars

### DIFF
--- a/src/tools/desktop/cache/writeCachedXml.test.ts
+++ b/src/tools/desktop/cache/writeCachedXml.test.ts
@@ -1,6 +1,7 @@
 import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { resolve } from 'path';
 
+import * as configModule from '../../../config.desktop.js';
 import { DesktopMcpServer } from '../../../server.desktop.js';
 import invariant from '../../../utils/invariant.js';
 import { Provider } from '../../../utils/provider.js';
@@ -32,10 +33,19 @@ function setupCacheMock(): void {
   );
 }
 
+function mockPinnedSession(desktopSessionId: string | undefined): void {
+  const base = new configModule.Config();
+  vi.spyOn(configModule, 'getDesktopConfig').mockReturnValue({
+    ...base,
+    desktopSessionId,
+  } as configModule.Config);
+}
+
 describe('writeCachedXmlTool', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     setupCacheMock();
+    mockPinnedSession(undefined);
     vi.mocked(writeFileSync).mockImplementation(() => {});
   });
 
@@ -69,6 +79,26 @@ describe('writeCachedXmlTool', () => {
     await getResult(CACHED_FILE, VALID_XML);
 
     expect(cacheFingerprintModule.writeSidecar).toHaveBeenCalledWith(resolve(CACHED_FILE), SESSION);
+  });
+
+  it('stamps the sidecar with the pinned session, not the requested one', async () => {
+    mockPinnedSession(SESSION);
+
+    await getResult(CACHED_FILE, VALID_XML, {}, undefined);
+
+    expect(cacheFingerprintModule.writeSidecar).toHaveBeenCalledWith(resolve(CACHED_FILE), SESSION);
+  });
+
+  it('rejects and writes no sidecar when the requested session conflicts with the pin', async () => {
+    mockPinnedSession('99999');
+
+    const result = await getResult(CACHED_FILE, VALID_XML, {}, SESSION);
+
+    expect(result.isError).toBe(true);
+    invariant(result.content[0].type === 'text');
+    expect(result.content[0].text).toContain('99999');
+    expect(cacheFingerprintModule.writeSidecar).not.toHaveBeenCalled();
+    expect(writeFileSync).not.toHaveBeenCalled();
   });
 
   it('should return error for malformed XML without writing', async () => {
@@ -251,12 +281,13 @@ async function getResult(
   filePath: string,
   xmlContent: string,
   selectors: { worksheet?: string; dashboard?: string } = {},
+  session: string | undefined = SESSION,
 ): Promise<CallToolResult> {
   const tool = getWriteCachedXmlTool(new DesktopMcpServer());
   const callback = await Provider.from(tool.callback);
   return await callback(
     {
-      session: SESSION,
+      session,
       filePath,
       xmlContent,
       worksheet: selectors.worksheet,

--- a/src/tools/desktop/cache/writeCachedXml.test.ts
+++ b/src/tools/desktop/cache/writeCachedXml.test.ts
@@ -281,8 +281,9 @@ async function getResult(
   filePath: string,
   xmlContent: string,
   selectors: { worksheet?: string; dashboard?: string } = {},
-  session: string | undefined = SESSION,
+  ...requestedSession: [string | undefined] | []
 ): Promise<CallToolResult> {
+  const session = (requestedSession.length > 0 ? requestedSession[0] : SESSION) as string;
   const tool = getWriteCachedXmlTool(new DesktopMcpServer());
   const callback = await Provider.from(tool.callback);
   return await callback(

--- a/src/tools/desktop/cache/writeCachedXml.ts
+++ b/src/tools/desktop/cache/writeCachedXml.ts
@@ -5,6 +5,7 @@ import { Ok } from 'ts-results-es';
 import { z } from 'zod';
 
 import { writeSidecar } from '../../../desktop/commands/workbook/cacheFingerprint.js';
+import { resolveSession } from '../../../desktop/sessionResolution.js';
 import { wellFormedXmlRule } from '../../../desktop/validation/rules/wellFormedXml.js';
 import { parseOuterElement, replaceElement } from '../../../desktop/xmlElement.js';
 import {
@@ -52,6 +53,12 @@ export const getWriteCachedXmlTool = (
         extra,
         args: { session, filePath, xmlContent, worksheet, dashboard },
         callback: async () => {
+          const sessionResult = resolveSession(session);
+          if (sessionResult.isErr()) {
+            return sessionResult.error.toErr();
+          }
+          const resolvedSession = sessionResult.value;
+
           const absolutePath = resolve(filePath);
           const cacheDir = getCacheDir();
 
@@ -131,7 +138,7 @@ export const getWriteCachedXmlTool = (
 
           try {
             writeFileSync(absolutePath, contentToWrite, 'utf-8');
-            writeSidecar(absolutePath, session);
+            writeSidecar(absolutePath, resolvedSession);
             return new Ok({
               filePath,
               bytes: contentToWrite.length,

--- a/src/tools/desktop/fields/addField.test.ts
+++ b/src/tools/desktop/fields/addField.test.ts
@@ -2,6 +2,7 @@ import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { existsSync, readFileSync, writeFileSync } from 'fs';
 import { z } from 'zod';
 
+import * as configModule from '../../../config.desktop.js';
 import * as cacheFingerprintModule from '../../../desktop/commands/workbook/cacheFingerprint.js';
 import * as metadataModule from '../../../desktop/metadata/index.js';
 import {
@@ -31,12 +32,21 @@ const resultSchema = z.object({
 const WORKSHEET_FILE = '/cache/worksheet.xml';
 const SESSION = '12345';
 const WORKBOOK_FILE = '/cache/workbook.xml';
+
+function mockPinnedSession(desktopSessionId: string | undefined): void {
+  const base = new configModule.Config();
+  vi.spyOn(configModule, 'getDesktopConfig').mockReturnValue({
+    ...base,
+    desktopSessionId,
+  } as configModule.Config);
+}
 const COLUMN_REF = '[Sample - Superstore].[sum:Profit:qk]';
 const MODIFIED_XML = '<worksheet name="Sheet 1"><table></table></worksheet>';
 
 describe('addFieldTool', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockPinnedSession(undefined);
   });
 
   it('should create a tool instance with correct properties', () => {
@@ -135,6 +145,44 @@ describe('addFieldTool', () => {
     await getResult({ worksheetFile: WORKSHEET_FILE, target: 'rows', columnRef: COLUMN_REF });
 
     expect(cacheFingerprintModule.writeSidecar).toHaveBeenCalledWith(WORKSHEET_FILE, SESSION);
+  });
+
+  it('stamps the sidecar with the pinned session, not the requested one', async () => {
+    mockPinnedSession(SESSION);
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue('<worksheet/>');
+    vi.mocked(metadataModule.addFieldToRows).mockReturnValue(MODIFIED_XML);
+    vi.mocked(writeFileSync).mockReturnValue(undefined);
+
+    await getResult({
+      worksheetFile: WORKSHEET_FILE,
+      target: 'rows',
+      columnRef: COLUMN_REF,
+      session: undefined,
+    });
+
+    expect(cacheFingerprintModule.writeSidecar).toHaveBeenCalledWith(WORKSHEET_FILE, SESSION);
+  });
+
+  it('rejects and writes no sidecar when the requested session conflicts with the pin', async () => {
+    mockPinnedSession('99999');
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue('<worksheet/>');
+    vi.mocked(metadataModule.addFieldToRows).mockReturnValue(MODIFIED_XML);
+    vi.mocked(writeFileSync).mockReturnValue(undefined);
+
+    const result = await getResult({
+      worksheetFile: WORKSHEET_FILE,
+      target: 'rows',
+      columnRef: COLUMN_REF,
+      session: SESSION,
+    });
+
+    expect(result.isError).toBe(true);
+    invariant(result.content[0].type === 'text');
+    expect(result.content[0].text).toContain('99999');
+    expect(cacheFingerprintModule.writeSidecar).not.toHaveBeenCalled();
+    expect(writeFileSync).not.toHaveBeenCalled();
   });
 
   it('does not use the Tableau command channel after a successful field edit', async () => {
@@ -433,6 +481,7 @@ async function getResult({
   encodingType,
   index,
   workbookFile,
+  session = SESSION,
 }: {
   worksheetFile: string;
   target: Target;
@@ -440,11 +489,12 @@ async function getResult({
   encodingType?: EncodingType;
   index?: number;
   workbookFile?: string;
+  session?: string;
 }): Promise<CallToolResult> {
   const tool = getAddFieldTool(new DesktopMcpServer());
   const callback = await Provider.from(tool.callback);
   return await callback(
-    { session: SESSION, worksheetFile, target, columnRef, encodingType, index, workbookFile },
+    { session, worksheetFile, target, columnRef, encodingType, index, workbookFile },
     getMockRequestHandlerExtra(),
   );
 }

--- a/src/tools/desktop/fields/addField.test.ts
+++ b/src/tools/desktop/fields/addField.test.ts
@@ -474,15 +474,7 @@ describe('addFieldTool', () => {
   });
 });
 
-async function getResult({
-  worksheetFile,
-  target,
-  columnRef,
-  encodingType,
-  index,
-  workbookFile,
-  session = SESSION,
-}: {
+async function getResult(params: {
   worksheetFile: string;
   target: Target;
   columnRef: string;
@@ -491,6 +483,8 @@ async function getResult({
   workbookFile?: string;
   session?: string;
 }): Promise<CallToolResult> {
+  const { worksheetFile, target, columnRef, encodingType, index, workbookFile } = params;
+  const session = ('session' in params ? params.session : SESSION) as string;
   const tool = getAddFieldTool(new DesktopMcpServer());
   const callback = await Provider.from(tool.callback);
   return await callback(

--- a/src/tools/desktop/fields/addField.ts
+++ b/src/tools/desktop/fields/addField.ts
@@ -9,6 +9,7 @@ import {
   addFieldToEncoding,
   addFieldToRows,
 } from '../../../desktop/metadata/index.js';
+import { resolveSession } from '../../../desktop/sessionResolution.js';
 import { wellFormedXmlRule } from '../../../desktop/validation/rules/wellFormedXml.js';
 import {
   ArgsValidationError,
@@ -71,6 +72,12 @@ export const getAddFieldTool = (server: DesktopMcpServer): DesktopTool<typeof pa
         extra,
         args: { session, worksheetFile, target, columnRef, encodingType, index, workbookFile },
         callback: async () => {
+          const sessionResult = resolveSession(session);
+          if (sessionResult.isErr()) {
+            return sessionResult.error.toErr();
+          }
+          const resolvedSession = sessionResult.value;
+
           if (!existsSync(worksheetFile)) {
             return new FileNotFoundError(worksheetFile).toErr();
           }
@@ -140,7 +147,7 @@ export const getAddFieldTool = (server: DesktopMcpServer): DesktopTool<typeof pa
 
           try {
             writeFileSync(worksheetFile, modifiedXml, 'utf-8');
-            writeSidecar(worksheetFile, session);
+            writeSidecar(worksheetFile, resolvedSession);
           } catch (error) {
             return new FileReadError(error).toErr();
           }

--- a/src/tools/desktop/fields/removeField.test.ts
+++ b/src/tools/desktop/fields/removeField.test.ts
@@ -370,19 +370,15 @@ describe('removeFieldTool', () => {
   });
 });
 
-async function getResult({
-  worksheetFile,
-  target,
-  columnRef,
-  encodingType,
-  session = SESSION,
-}: {
+async function getResult(params: {
   worksheetFile: string;
   target: Target;
   columnRef: string;
   encodingType?: EncodingType;
   session?: string;
 }): Promise<CallToolResult> {
+  const { worksheetFile, target, columnRef, encodingType } = params;
+  const session = ('session' in params ? params.session : SESSION) as string;
   const tool = getRemoveFieldTool(new DesktopMcpServer());
   const callback = await Provider.from(tool.callback);
   return await callback(

--- a/src/tools/desktop/fields/removeField.test.ts
+++ b/src/tools/desktop/fields/removeField.test.ts
@@ -2,6 +2,7 @@ import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { existsSync, readFileSync, writeFileSync } from 'fs';
 import { z } from 'zod';
 
+import * as configModule from '../../../config.desktop.js';
 import * as cacheFingerprintModule from '../../../desktop/commands/workbook/cacheFingerprint.js';
 import * as metadataModule from '../../../desktop/metadata/index.js';
 import {
@@ -33,9 +34,18 @@ const SESSION = '12345';
 const COLUMN_REF = '[Sample - Superstore].[sum:Profit:qk]';
 const MODIFIED_XML = '<worksheet name="Sheet 1"><table></table></worksheet>';
 
+function mockPinnedSession(desktopSessionId: string | undefined): void {
+  const base = new configModule.Config();
+  vi.spyOn(configModule, 'getDesktopConfig').mockReturnValue({
+    ...base,
+    desktopSessionId,
+  } as configModule.Config);
+}
+
 describe('removeFieldTool', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockPinnedSession(undefined);
   });
 
   it('should create a tool instance with correct properties', () => {
@@ -135,6 +145,44 @@ describe('removeFieldTool', () => {
     await getResult({ worksheetFile: WORKSHEET_FILE, target: 'rows', columnRef: COLUMN_REF });
 
     expect(cacheFingerprintModule.writeSidecar).toHaveBeenCalledWith(WORKSHEET_FILE, SESSION);
+  });
+
+  it('stamps the sidecar with the pinned session, not the requested one', async () => {
+    mockPinnedSession(SESSION);
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue('<worksheet/>');
+    vi.mocked(metadataModule.removeFieldFromRows).mockReturnValue(MODIFIED_XML);
+    vi.mocked(writeFileSync).mockReturnValue(undefined);
+
+    await getResult({
+      worksheetFile: WORKSHEET_FILE,
+      target: 'rows',
+      columnRef: COLUMN_REF,
+      session: undefined,
+    });
+
+    expect(cacheFingerprintModule.writeSidecar).toHaveBeenCalledWith(WORKSHEET_FILE, SESSION);
+  });
+
+  it('rejects and writes no sidecar when the requested session conflicts with the pin', async () => {
+    mockPinnedSession('99999');
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue('<worksheet/>');
+    vi.mocked(metadataModule.removeFieldFromRows).mockReturnValue(MODIFIED_XML);
+    vi.mocked(writeFileSync).mockReturnValue(undefined);
+
+    const result = await getResult({
+      worksheetFile: WORKSHEET_FILE,
+      target: 'rows',
+      columnRef: COLUMN_REF,
+      session: SESSION,
+    });
+
+    expect(result.isError).toBe(true);
+    invariant(result.content[0].type === 'text');
+    expect(result.content[0].text).toContain('99999');
+    expect(cacheFingerprintModule.writeSidecar).not.toHaveBeenCalled();
+    expect(writeFileSync).not.toHaveBeenCalled();
   });
 
   it('does not use the Tableau command channel after a successful field edit', async () => {
@@ -327,16 +375,18 @@ async function getResult({
   target,
   columnRef,
   encodingType,
+  session = SESSION,
 }: {
   worksheetFile: string;
   target: Target;
   columnRef: string;
   encodingType?: EncodingType;
+  session?: string;
 }): Promise<CallToolResult> {
   const tool = getRemoveFieldTool(new DesktopMcpServer());
   const callback = await Provider.from(tool.callback);
   return await callback(
-    { session: SESSION, worksheetFile, target, columnRef, encodingType },
+    { session, worksheetFile, target, columnRef, encodingType },
     getMockRequestHandlerExtra(),
   );
 }

--- a/src/tools/desktop/fields/removeField.ts
+++ b/src/tools/desktop/fields/removeField.ts
@@ -9,6 +9,7 @@ import {
   removeFieldFromEncoding,
   removeFieldFromRows,
 } from '../../../desktop/metadata/index.js';
+import { resolveSession } from '../../../desktop/sessionResolution.js';
 import { wellFormedXmlRule } from '../../../desktop/validation/rules/wellFormedXml.js';
 import {
   ArgsValidationError,
@@ -69,6 +70,12 @@ export const getRemoveFieldTool = (server: DesktopMcpServer): DesktopTool<typeof
         extra,
         args: { session, worksheetFile, target, columnRef, encodingType },
         callback: async () => {
+          const sessionResult = resolveSession(session);
+          if (sessionResult.isErr()) {
+            return sessionResult.error.toErr();
+          }
+          const resolvedSession = sessionResult.value;
+
           if (!existsSync(worksheetFile)) {
             return new FileNotFoundError(worksheetFile).toErr();
           }
@@ -123,7 +130,7 @@ export const getRemoveFieldTool = (server: DesktopMcpServer): DesktopTool<typeof
 
           try {
             writeFileSync(worksheetFile, modifiedXml, 'utf-8');
-            writeSidecar(worksheetFile, session);
+            writeSidecar(worksheetFile, resolvedSession);
           } catch (error) {
             return new FileReadError(error).toErr();
           }

--- a/src/tools/desktop/template/injectTemplate.test.ts
+++ b/src/tools/desktop/template/injectTemplate.test.ts
@@ -1,6 +1,7 @@
 import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { resolve } from 'path';
 
+import * as configModule from '../../../config.desktop.js';
 import * as cacheFingerprintModule from '../../../desktop/commands/workbook/cacheFingerprint.js';
 import { removeSameNamedWorksheet } from '../../../desktop/templates/injectTemplateCore.js';
 import { DesktopMcpServer } from '../../../server.desktop.js';
@@ -57,9 +58,18 @@ function makeExtra(): TableauDesktopRequestHandlerExtra {
   return extra;
 }
 
+function mockPinnedSession(desktopSessionId: string | undefined): void {
+  const base = new configModule.Config();
+  vi.spyOn(configModule, 'getDesktopConfig').mockReturnValue({
+    ...base,
+    desktopSessionId,
+  } as configModule.Config);
+}
+
 describe('injectTemplateTool', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockPinnedSession(undefined);
   });
 
   it('should create a tool instance with correct properties', () => {
@@ -98,6 +108,29 @@ describe('injectTemplateTool', () => {
       resolve(WORKBOOK_FILE),
       SESSION,
     );
+  });
+
+  it('stamps the sidecar with the pinned session, not the requested one', async () => {
+    mockPinnedSession(SESSION);
+
+    await getResult({ ...BASE_PARAMS, session: undefined as unknown as string });
+
+    expect(cacheFingerprintModule.writeSidecar).toHaveBeenCalledWith(
+      resolve(WORKBOOK_FILE),
+      SESSION,
+    );
+  });
+
+  it('rejects and writes no sidecar when the requested session conflicts with the pin', async () => {
+    mockPinnedSession('99999');
+
+    const result = await getResult(BASE_PARAMS);
+
+    expect(result.isError).toBe(true);
+    invariant(result.content[0].type === 'text');
+    expect(result.content[0].text).toContain('99999');
+    expect(cacheFingerprintModule.writeSidecar).not.toHaveBeenCalled();
+    expect(writeFileSync).not.toHaveBeenCalled();
   });
 
   it('should return error when workbook file does not exist', async () => {

--- a/src/tools/desktop/template/injectTemplate.ts
+++ b/src/tools/desktop/template/injectTemplate.ts
@@ -12,6 +12,7 @@ import {
 import { summarizeSchema } from '../../../desktop/binder/schema-summary.js';
 import { writeSidecar } from '../../../desktop/commands/workbook/cacheFingerprint.js';
 import { parseDatasourceQualifiedColumnRef } from '../../../desktop/metadata/field-resolver.js';
+import { resolveSession } from '../../../desktop/sessionResolution.js';
 import { buildInjectedWorkbookXml } from '../../../desktop/templates/injectTemplateCore.js';
 import { listTemplateNames, readTemplate } from '../../../desktop/templates/templatePath.js';
 import {
@@ -94,6 +95,12 @@ export const getInjectTemplateTool = (
           relativeSheetName,
         },
         callback: async () => {
+          const sessionResult = resolveSession(session);
+          if (sessionResult.isErr()) {
+            return sessionResult.error.toErr();
+          }
+          const resolvedSession = sessionResult.value;
+
           if (!existsSync(resolve(workbookFile))) {
             return new FileNotFoundError(workbookFile).toErr();
           }
@@ -179,7 +186,7 @@ export const getInjectTemplateTool = (
             }
 
             writeFileSync(resolve(workbookFile), result.xml, 'utf-8');
-            writeSidecar(resolve(workbookFile), session);
+            writeSidecar(resolve(workbookFile), resolvedSession);
 
             return new Ok({
               workbookFile,


### PR DESCRIPTION
## What

Four cache-mutation desktop tools stamped the fingerprint sidecar with the raw agent-supplied `session` arg instead of the resolved session pin:

- `write-cached-xml`
- `add-field`
- `remove-field`
- `inject-template`

When `TABLEAU_DESKTOP_SESSION_ID` is set, a mismatched (or absent) `session` arg produced a sidecar fingerprinted to the wrong instance. Downstream `apply-*` tools then either failed closed with `CacheSessionMismatchError` or silently bled cache across instances - which is the "agent connected to a different workbook in a different instance" bug.

## Fix

Each tool now calls `resolveSession(session)` at the top of its callback:
- rejects a conflicting explicit `session` when a pin is set,
- stamps the sidecar with the resolved pin, matching the connect-side invariant everywhere else in the desktop server.

## Flow

```mermaid
flowchart LR
  A[agent session arg] --> B[resolveSession]
  P[TABLEAU_DESKTOP_SESSION_ID] --> B
  B -->|pin wins / conflict rejected| C[writeSidecar resolvedSession]
  C --> D[apply-* verifies sidecar - matches pin]
```

## Tests

Each tool gets two new cases: sidecar stamped with the pin (not the requested session), and reject-without-write on genuine conflict. Full desktop suite green, lint + typecheck clean.