### PR TITLE
feat(web): slim param on generate-pulse-metric-value-insight-bundle

### DIFF
--- a/src/sdks/tableau/types/pulse.ts
+++ b/src/sdks/tableau/types/pulse.ts
@@ -480,29 +480,6 @@ export const pulseInsightBriefResponseSchema = z.object({
 export type PulseBundleResponse = z.infer<typeof pulseBundleResponseSchema>;
 export type PulseInsightBriefResponse = z.infer<typeof pulseInsightBriefResponseSchema>;
 
-/**
- * The per-bundle choices from a `bundleRequest`, surfaced so a card UI can read the metric's
- * identity directly instead of parsing it out of markup: curated flat fields (metric name,
- * measure, time dimension, breakdown dimensions). The request `input` is deliberately NOT echoed
- * here — a caller that needs an uncurated request field already holds the request it sent (it is
- * carried on the `tool_use` block, correlated to this result by id), so echoing it back into the
- * response would be redundant payload weight in a param whose purpose is to stay slim.
- */
-export const metricContextSchema = z.object({
-  name: z.string().optional(),
-  measure: z.string().optional(),
-  time_dimension: z.string().optional(),
-  breakdown_dimensions: z.array(z.string()),
-});
-
-export type MetricContext = z.infer<typeof metricContextSchema>;
-
-/**
- * A `PulseBundleResponse` augmented with `metric_context`. Returned by
- * `generate-pulse-metric-value-insight-bundle` when called with `slim: true`.
- */
-export type PulseBundleResponseSlim = PulseBundleResponse & { metric_context: MetricContext };
-
 export const pulseInsightBundleTypeEnum = ['ban', 'springboard', 'basic', 'detail'] as const;
 export type PulseInsightBundleType = (typeof pulseInsightBundleTypeEnum)[number];
 

--- a/src/sdks/tableau/types/pulse.ts
+++ b/src/sdks/tableau/types/pulse.ts
@@ -342,6 +342,30 @@ export const pulseInsightBriefRequestSchema = z.object({
   time_zone: z.string().optional(),
 });
 
+// The `input` of a bundle request — extracted so `metric_context.input` (the
+// slim response's verbatim echo of the request input) can reuse the same shape.
+export const pulseBundleInputSchema = z.object({
+  metadata: z.object({
+    name: z.string().optional(),
+    metric_id: z.string().optional(),
+    definition_id: z.string().optional(),
+  }),
+  metric: z.object({
+    definition: z.object({
+      datasource: z.object({
+        id: z.string(),
+      }),
+      basic_specification: pulseBasicSpecificationSchema,
+      is_running_total: z.boolean(),
+    }),
+    metric_specification: pulseMetricSpecificationSchema,
+    extension_options: pulseExtensionOptionsSchema.optional(),
+    representation_options: pulseRepresentationOptionsSchema.optional(),
+    insights_options: insightOptionsSchema.optional(),
+    goals: pulseGoalsSchema.optional(),
+  }),
+});
+
 export const pulseBundleRequestSchema = z.object({
   bundle_request: z.object({
     version: z.number(),
@@ -351,27 +375,7 @@ export const pulseBundleRequestSchema = z.object({
       language: languageEnumSchema,
       locale: localeEnumSchema,
     }),
-    input: z.object({
-      metadata: z.object({
-        name: z.string().optional(),
-        metric_id: z.string().optional(),
-        definition_id: z.string().optional(),
-      }),
-      metric: z.object({
-        definition: z.object({
-          datasource: z.object({
-            id: z.string(),
-          }),
-          basic_specification: pulseBasicSpecificationSchema,
-          is_running_total: z.boolean(),
-        }),
-        metric_specification: pulseMetricSpecificationSchema,
-        extension_options: pulseExtensionOptionsSchema.optional(),
-        representation_options: pulseRepresentationOptionsSchema.optional(),
-        insights_options: insightOptionsSchema.optional(),
-        goals: pulseGoalsSchema.optional(),
-      }),
-    }),
+    input: pulseBundleInputSchema,
   }),
 });
 
@@ -479,6 +483,29 @@ export const pulseInsightBriefResponseSchema = z.object({
 
 export type PulseBundleResponse = z.infer<typeof pulseBundleResponseSchema>;
 export type PulseInsightBriefResponse = z.infer<typeof pulseInsightBriefResponseSchema>;
+
+/**
+ * The per-bundle choices from a `bundleRequest`, surfaced so a card UI can read them directly
+ * instead of parsing them out of markup. Two tiers: curated flat fields (metric name, measure,
+ * time dimension, breakdown dimensions) as the clean primary interface, plus `input` — the
+ * request's `input` echoed VERBATIM — as an escape hatch for any request field not surfaced flat
+ * (e.g. the comparison kind at `input.metric.metric_specification.comparison.comparison`).
+ */
+export const metricContextSchema = z.object({
+  name: z.string().optional(),
+  measure: z.string().optional(),
+  time_dimension: z.string().optional(),
+  breakdown_dimensions: z.array(z.string()),
+  input: pulseBundleInputSchema,
+});
+
+export type MetricContext = z.infer<typeof metricContextSchema>;
+
+/**
+ * A `PulseBundleResponse` augmented with `metric_context`. Returned by
+ * `generate-pulse-metric-value-insight-bundle` when called with `slim: true`.
+ */
+export type PulseBundleResponseSlim = PulseBundleResponse & { metric_context: MetricContext };
 
 export const pulseInsightBundleTypeEnum = ['ban', 'springboard', 'basic', 'detail'] as const;
 export type PulseInsightBundleType = (typeof pulseInsightBundleTypeEnum)[number];

--- a/src/sdks/tableau/types/pulse.ts
+++ b/src/sdks/tableau/types/pulse.ts
@@ -342,30 +342,6 @@ export const pulseInsightBriefRequestSchema = z.object({
   time_zone: z.string().optional(),
 });
 
-// The `input` of a bundle request — extracted so `metric_context.input` (the
-// slim response's verbatim echo of the request input) can reuse the same shape.
-export const pulseBundleInputSchema = z.object({
-  metadata: z.object({
-    name: z.string().optional(),
-    metric_id: z.string().optional(),
-    definition_id: z.string().optional(),
-  }),
-  metric: z.object({
-    definition: z.object({
-      datasource: z.object({
-        id: z.string(),
-      }),
-      basic_specification: pulseBasicSpecificationSchema,
-      is_running_total: z.boolean(),
-    }),
-    metric_specification: pulseMetricSpecificationSchema,
-    extension_options: pulseExtensionOptionsSchema.optional(),
-    representation_options: pulseRepresentationOptionsSchema.optional(),
-    insights_options: insightOptionsSchema.optional(),
-    goals: pulseGoalsSchema.optional(),
-  }),
-});
-
 export const pulseBundleRequestSchema = z.object({
   bundle_request: z.object({
     version: z.number(),
@@ -375,7 +351,27 @@ export const pulseBundleRequestSchema = z.object({
       language: languageEnumSchema,
       locale: localeEnumSchema,
     }),
-    input: pulseBundleInputSchema,
+    input: z.object({
+      metadata: z.object({
+        name: z.string().optional(),
+        metric_id: z.string().optional(),
+        definition_id: z.string().optional(),
+      }),
+      metric: z.object({
+        definition: z.object({
+          datasource: z.object({
+            id: z.string(),
+          }),
+          basic_specification: pulseBasicSpecificationSchema,
+          is_running_total: z.boolean(),
+        }),
+        metric_specification: pulseMetricSpecificationSchema,
+        extension_options: pulseExtensionOptionsSchema.optional(),
+        representation_options: pulseRepresentationOptionsSchema.optional(),
+        insights_options: insightOptionsSchema.optional(),
+        goals: pulseGoalsSchema.optional(),
+      }),
+    }),
   }),
 });
 
@@ -485,18 +481,18 @@ export type PulseBundleResponse = z.infer<typeof pulseBundleResponseSchema>;
 export type PulseInsightBriefResponse = z.infer<typeof pulseInsightBriefResponseSchema>;
 
 /**
- * The per-bundle choices from a `bundleRequest`, surfaced so a card UI can read them directly
- * instead of parsing them out of markup. Two tiers: curated flat fields (metric name, measure,
- * time dimension, breakdown dimensions) as the clean primary interface, plus `input` — the
- * request's `input` echoed VERBATIM — as an escape hatch for any request field not surfaced flat
- * (e.g. the comparison kind at `input.metric.metric_specification.comparison.comparison`).
+ * The per-bundle choices from a `bundleRequest`, surfaced so a card UI can read the metric's
+ * identity directly instead of parsing it out of markup: curated flat fields (metric name,
+ * measure, time dimension, breakdown dimensions). The request `input` is deliberately NOT echoed
+ * here — a caller that needs an uncurated request field already holds the request it sent (it is
+ * carried on the `tool_use` block, correlated to this result by id), so echoing it back into the
+ * response would be redundant payload weight in a param whose purpose is to stay slim.
  */
 export const metricContextSchema = z.object({
   name: z.string().optional(),
   measure: z.string().optional(),
   time_dimension: z.string().optional(),
   breakdown_dimensions: z.array(z.string()),
-  input: pulseBundleInputSchema,
 });
 
 export type MetricContext = z.infer<typeof metricContextSchema>;

--- a/src/tools/web/pulse/generateMetricValueInsightBundle/generatePulseMetricValueInsightBundleTool.test.ts
+++ b/src/tools/web/pulse/generateMetricValueInsightBundle/generatePulseMetricValueInsightBundleTool.test.ts
@@ -334,6 +334,8 @@ describe('getGeneratePulseMetricValueInsightBundleTool', () => {
       'There was a decrease of -$5.53 (-22.1%) over January 2024.',
     );
     expect(group.summaries[0].result.markup).toBe('<b>Summary</b>');
+    // slim strips viz only — it does not add a metric_context sibling.
+    expect(parsed).not.toHaveProperty('metric_context');
   });
 
   it('returns viz verbatim when slim is omitted or false', async () => {
@@ -352,62 +354,6 @@ describe('getGeneratePulseMetricValueInsightBundleTool', () => {
     const parsedExplicitFalse = JSON.parse(explicitFalse.content[0].text);
     expect(parsedExplicitFalse).toEqual(mockPopulatedResponse);
     expect(parsedExplicitFalse).not.toHaveProperty('metric_context');
-  });
-
-  it('attaches a metric_context built from the bundleRequest when slim is true', async () => {
-    mocks.mockGeneratePulseMetricValueInsightBundle.mockResolvedValue(
-      new Ok(mockPopulatedResponse),
-    );
-    const result = await getToolResult('ban', true);
-    expect(result.isError).toBe(false);
-    invariant(result.content[0].type === 'text');
-    const parsed = JSON.parse(result.content[0].text);
-
-    // Curated flat fields only.
-    expect(parsed.metric_context.name).toBe('Pulse Metric');
-    expect(parsed.metric_context.measure).toBe('Sales');
-    expect(parsed.metric_context.time_dimension).toBe('Order Date');
-    expect(parsed.metric_context.breakdown_dimensions).toEqual([]);
-    // The request input is intentionally NOT echoed back — the caller already
-    // holds the request it sent (carried on the tool_use block), so metric_context
-    // stays lean and carries only curated fields.
-    expect(parsed.metric_context).not.toHaveProperty('input');
-    // viz is still stripped alongside the new metric_context.
-    const group = parsed.bundle_response.result.insight_groups[0];
-    expect(group.insights[0].result).not.toHaveProperty('viz');
-    expect(group.summaries[0].result).not.toHaveProperty('viz');
-  });
-
-  it('passes through populated breakdown_dimensions in metric_context when slim is true', async () => {
-    const bundleRequestWithDimensions = {
-      bundle_request: {
-        ...bundleRequest.bundle_request,
-        input: {
-          ...bundleRequest.bundle_request.input,
-          metric: {
-            ...bundleRequest.bundle_request.input.metric,
-            extension_options: {
-              ...bundleRequest.bundle_request.input.metric.extension_options,
-              allowed_dimensions: ['Region', 'Category'],
-            },
-          },
-        },
-      },
-    };
-    mocks.mockGeneratePulseMetricValueInsightBundle.mockResolvedValue(
-      new Ok(mockPopulatedResponse),
-    );
-
-    const tool = getGeneratePulseMetricValueInsightBundleTool(new WebMcpServer());
-    const callback = await Provider.from(tool.callback);
-    const result = await callback(
-      { bundleRequest: bundleRequestWithDimensions, bundleType: 'ban', slim: true },
-      getMockRequestHandlerExtra(),
-    );
-    invariant(result.content[0].type === 'text');
-    const parsed = JSON.parse(result.content[0].text);
-
-    expect(parsed.metric_context.breakdown_dimensions).toEqual(['Region', 'Category']);
   });
 
   async function getToolResult(

--- a/src/tools/web/pulse/generateMetricValueInsightBundle/generatePulseMetricValueInsightBundleTool.test.ts
+++ b/src/tools/web/pulse/generateMetricValueInsightBundle/generatePulseMetricValueInsightBundleTool.test.ts
@@ -115,6 +115,52 @@ describe('getGeneratePulseMetricValueInsightBundleTool', () => {
     },
   };
 
+  // A populated response with `viz` blobs in both an insight result and a
+  // summary result — used to exercise the `slim` viz-stripping path.
+  const mockPopulatedResponse = {
+    bundle_response: {
+      result: {
+        insight_groups: [
+          {
+            type: 'ban',
+            insights: [
+              {
+                insight_type: 'popc',
+                result: {
+                  type: 'popc',
+                  version: 1,
+                  markup: 'There was a decrease of -$5.53 (-22.1%) over January 2024.',
+                  viz: { $schema: 'https://vega.github.io/schema/vega-lite/v5.json', mark: 'line' },
+                  facts: {
+                    target_period_value: { raw: 19.47, formatted: '$19.47' },
+                    difference: {
+                      direction: 'down',
+                      relative: { raw: -0.221, formatted: '-22.1%' },
+                    },
+                  },
+                  question: 'How has Sales changed?',
+                  score: 1,
+                },
+              },
+            ],
+            summaries: [
+              {
+                result: {
+                  id: 'summary-1',
+                  markup: '<b>Summary</b>',
+                  viz: { $schema: 'https://vega.github.io/schema/vega-lite/v5.json', mark: 'bar' },
+                  generation_id: 'gen-1',
+                },
+              },
+            ],
+          },
+        ],
+        has_errors: false,
+        characterization: 'CHARACTERIZATION_UNSPECIFIED',
+      },
+    },
+  };
+
   beforeEach(() => {
     vi.clearAllMocks();
     vi.unstubAllEnvs();
@@ -268,9 +314,110 @@ describe('getGeneratePulseMetricValueInsightBundleTool', () => {
     expect(mocks.mockGeneratePulseMetricValueInsightBundle).not.toHaveBeenCalled();
   });
 
-  async function getToolResult(bundleType?: PulseInsightBundleType): Promise<CallToolResult> {
+  it('strips viz from every insight and summary result when slim is true', async () => {
+    mocks.mockGeneratePulseMetricValueInsightBundle.mockResolvedValue(
+      new Ok(mockPopulatedResponse),
+    );
+    const result = await getToolResult('ban', true);
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+    const parsed = JSON.parse(result.content[0].text);
+    const group = parsed.bundle_response.result.insight_groups[0];
+    // viz removed everywhere it appears...
+    expect(group.insights[0].result).not.toHaveProperty('viz');
+    expect(group.summaries[0].result).not.toHaveProperty('viz');
+    // ...but the fields the UI renders are retained.
+    expect(group.insights[0].result.facts).toEqual(
+      mockPopulatedResponse.bundle_response.result.insight_groups[0].insights[0].result.facts,
+    );
+    expect(group.insights[0].result.markup).toBe(
+      'There was a decrease of -$5.53 (-22.1%) over January 2024.',
+    );
+    expect(group.summaries[0].result.markup).toBe('<b>Summary</b>');
+  });
+
+  it('returns viz verbatim when slim is omitted or false', async () => {
+    mocks.mockGeneratePulseMetricValueInsightBundle.mockResolvedValue(
+      new Ok(mockPopulatedResponse),
+    );
+
+    const defaultResult = await getToolResult('ban');
+    invariant(defaultResult.content[0].type === 'text');
+    const parsedDefault = JSON.parse(defaultResult.content[0].text);
+    expect(parsedDefault).toEqual(mockPopulatedResponse);
+    expect(parsedDefault).not.toHaveProperty('metric_context');
+
+    const explicitFalse = await getToolResult('ban', false);
+    invariant(explicitFalse.content[0].type === 'text');
+    const parsedExplicitFalse = JSON.parse(explicitFalse.content[0].text);
+    expect(parsedExplicitFalse).toEqual(mockPopulatedResponse);
+    expect(parsedExplicitFalse).not.toHaveProperty('metric_context');
+  });
+
+  it('attaches a metric_context built from the bundleRequest when slim is true', async () => {
+    mocks.mockGeneratePulseMetricValueInsightBundle.mockResolvedValue(
+      new Ok(mockPopulatedResponse),
+    );
+    const result = await getToolResult('ban', true);
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+    const parsed = JSON.parse(result.content[0].text);
+
+    // Curated flat fields.
+    expect(parsed.metric_context.name).toBe('Pulse Metric');
+    expect(parsed.metric_context.measure).toBe('Sales');
+    expect(parsed.metric_context.time_dimension).toBe('Order Date');
+    expect(parsed.metric_context.breakdown_dimensions).toEqual([]);
+    // The full request input is echoed verbatim as an escape hatch — e.g. the
+    // comparison kind lives under it.
+    expect(parsed.metric_context.input).toEqual(bundleRequest.bundle_request.input);
+    expect(parsed.metric_context.input.metric.metric_specification.comparison.comparison).toBe(
+      'TIME_COMPARISON_PREVIOUS_PERIOD',
+    );
+    // viz is still stripped alongside the new metric_context.
+    const group = parsed.bundle_response.result.insight_groups[0];
+    expect(group.insights[0].result).not.toHaveProperty('viz');
+    expect(group.summaries[0].result).not.toHaveProperty('viz');
+  });
+
+  it('passes through populated breakdown_dimensions in metric_context when slim is true', async () => {
+    const bundleRequestWithDimensions = {
+      bundle_request: {
+        ...bundleRequest.bundle_request,
+        input: {
+          ...bundleRequest.bundle_request.input,
+          metric: {
+            ...bundleRequest.bundle_request.input.metric,
+            extension_options: {
+              ...bundleRequest.bundle_request.input.metric.extension_options,
+              allowed_dimensions: ['Region', 'Category'],
+            },
+          },
+        },
+      },
+    };
+    mocks.mockGeneratePulseMetricValueInsightBundle.mockResolvedValue(
+      new Ok(mockPopulatedResponse),
+    );
+
     const tool = getGeneratePulseMetricValueInsightBundleTool(new WebMcpServer());
     const callback = await Provider.from(tool.callback);
-    return await callback({ bundleRequest, bundleType }, getMockRequestHandlerExtra());
+    const result = await callback(
+      { bundleRequest: bundleRequestWithDimensions, bundleType: 'ban', slim: true },
+      getMockRequestHandlerExtra(),
+    );
+    invariant(result.content[0].type === 'text');
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(parsed.metric_context.breakdown_dimensions).toEqual(['Region', 'Category']);
+  });
+
+  async function getToolResult(
+    bundleType?: PulseInsightBundleType,
+    slim?: boolean,
+  ): Promise<CallToolResult> {
+    const tool = getGeneratePulseMetricValueInsightBundleTool(new WebMcpServer());
+    const callback = await Provider.from(tool.callback);
+    return await callback({ bundleRequest, bundleType, slim }, getMockRequestHandlerExtra());
   }
 });

--- a/src/tools/web/pulse/generateMetricValueInsightBundle/generatePulseMetricValueInsightBundleTool.test.ts
+++ b/src/tools/web/pulse/generateMetricValueInsightBundle/generatePulseMetricValueInsightBundleTool.test.ts
@@ -363,17 +363,15 @@ describe('getGeneratePulseMetricValueInsightBundleTool', () => {
     invariant(result.content[0].type === 'text');
     const parsed = JSON.parse(result.content[0].text);
 
-    // Curated flat fields.
+    // Curated flat fields only.
     expect(parsed.metric_context.name).toBe('Pulse Metric');
     expect(parsed.metric_context.measure).toBe('Sales');
     expect(parsed.metric_context.time_dimension).toBe('Order Date');
     expect(parsed.metric_context.breakdown_dimensions).toEqual([]);
-    // The full request input is echoed verbatim as an escape hatch — e.g. the
-    // comparison kind lives under it.
-    expect(parsed.metric_context.input).toEqual(bundleRequest.bundle_request.input);
-    expect(parsed.metric_context.input.metric.metric_specification.comparison.comparison).toBe(
-      'TIME_COMPARISON_PREVIOUS_PERIOD',
-    );
+    // The request input is intentionally NOT echoed back — the caller already
+    // holds the request it sent (carried on the tool_use block), so metric_context
+    // stays lean and carries only curated fields.
+    expect(parsed.metric_context).not.toHaveProperty('input');
     // viz is still stripped alongside the new metric_context.
     const group = parsed.bundle_response.result.insight_groups[0];
     expect(group.insights[0].result).not.toHaveProperty('viz');

--- a/src/tools/web/pulse/generateMetricValueInsightBundle/generatePulseMetricValueInsightBundleTool.ts
+++ b/src/tools/web/pulse/generateMetricValueInsightBundle/generatePulseMetricValueInsightBundleTool.ts
@@ -6,13 +6,12 @@ import { useRestApi } from '../../../../restApiInstance.js';
 import {
   pulseBundleRequestSchema,
   PulseBundleResponse,
-  PulseBundleResponseSlim,
   pulseInsightBundleTypeEnum,
 } from '../../../../sdks/tableau/types/pulse.js';
 import { WebMcpServer } from '../../../../server.web.js';
 import { WebTool } from '../../tool.js';
 import { validateBundleRequest } from '../validatePulsePayload.js';
-import { buildMetricContext, slimBundle } from './slimBundle.js';
+import { slimBundle } from './slimBundle.js';
 
 const paramsSchema = {
   bundleRequest: pulseBundleRequestSchema,
@@ -151,9 +150,7 @@ Generate an insight bundle for the current aggregated value for Pulse Metric usi
       openWorldHint: false,
     },
     callback: async ({ bundleRequest, bundleType, slim }, extra): Promise<CallToolResult> => {
-      return await generatePulseMetricValueInsightBundleTool.logAndExecute<
-        PulseBundleResponse | PulseBundleResponseSlim
-      >({
+      return await generatePulseMetricValueInsightBundleTool.logAndExecute<PulseBundleResponse>({
         extra,
         args: { bundleRequest, bundleType, slim },
         callback: async () => {
@@ -191,9 +188,7 @@ Generate an insight bundle for the current aggregated value for Pulse Metric usi
         constrainSuccessResult: (insightBundle) => {
           return {
             type: 'success',
-            result: slim
-              ? { ...slimBundle(insightBundle), metric_context: buildMetricContext(bundleRequest) }
-              : insightBundle,
+            result: slim ? slimBundle(insightBundle) : insightBundle,
           };
         },
       });

--- a/src/tools/web/pulse/generateMetricValueInsightBundle/generatePulseMetricValueInsightBundleTool.ts
+++ b/src/tools/web/pulse/generateMetricValueInsightBundle/generatePulseMetricValueInsightBundleTool.ts
@@ -6,15 +6,25 @@ import { useRestApi } from '../../../../restApiInstance.js';
 import {
   pulseBundleRequestSchema,
   PulseBundleResponse,
+  PulseBundleResponseSlim,
   pulseInsightBundleTypeEnum,
 } from '../../../../sdks/tableau/types/pulse.js';
 import { WebMcpServer } from '../../../../server.web.js';
 import { WebTool } from '../../tool.js';
 import { validateBundleRequest } from '../validatePulsePayload.js';
+import { buildMetricContext, slimBundle } from './slimBundle.js';
 
 const paramsSchema = {
   bundleRequest: pulseBundleRequestSchema,
   bundleType: z.optional(z.enum(pulseInsightBundleTypeEnum)),
+  slim: z
+    .optional(z.boolean())
+    .describe(
+      'When true, strips the large viz (Vega chart-spec) blobs from every insight and summary ' +
+        'result, returning only the facts/markup fields a text/card UI renders — use this to ' +
+        'reduce payload size when the caller does not need chart specs. Defaults to false, which ' +
+        'returns the response verbatim, including viz.',
+    ),
 };
 
 export const getGeneratePulseMetricValueInsightBundleTool = (
@@ -37,6 +47,7 @@ Generate an insight bundle for the current aggregated value for Pulse Metric usi
   - 'springboard' - Return a springboard insight bundle with the current value, period over period change, and the highest ranked insight for the metric.
   - 'basic' - Similar to a springboard insight, but data is focused on the dimensions of a metric that are low bandwidth because they have small value sets. It shows the current value, period over period change, and the highest ranked insight for the metric for that data.
   - 'detail' - Shows insights on performance over time of the metric, a summary visualization of metric highs and lows and trends, breakdowns of top contributors for each filterable dimension of the metric, and followup insights based on the top ranked insights not already presented.
+- \`slim\` (optional): When true, strips the large \`viz\` (Vega chart-spec) blobs from every insight and summary result, returning only the \`facts\`/\`markup\` fields a text/card UI renders. Use this to reduce payload size when chart specs are not needed. Defaults to false, which returns the response verbatim, including \`viz\`.
 
 **Example Usage:**
 - Generate the default insight bundle for the Pulse metric:
@@ -139,10 +150,12 @@ Generate an insight bundle for the current aggregated value for Pulse Metric usi
       idempotentHint: true,
       openWorldHint: false,
     },
-    callback: async ({ bundleRequest, bundleType }, extra): Promise<CallToolResult> => {
-      return await generatePulseMetricValueInsightBundleTool.logAndExecute<PulseBundleResponse>({
+    callback: async ({ bundleRequest, bundleType, slim }, extra): Promise<CallToolResult> => {
+      return await generatePulseMetricValueInsightBundleTool.logAndExecute<
+        PulseBundleResponse | PulseBundleResponseSlim
+      >({
         extra,
-        args: { bundleRequest, bundleType },
+        args: { bundleRequest, bundleType, slim },
         callback: async () => {
           const validationError = validateBundleRequest(bundleRequest);
           if (validationError) {
@@ -178,7 +191,9 @@ Generate an insight bundle for the current aggregated value for Pulse Metric usi
         constrainSuccessResult: (insightBundle) => {
           return {
             type: 'success',
-            result: insightBundle,
+            result: slim
+              ? { ...slimBundle(insightBundle), metric_context: buildMetricContext(bundleRequest) }
+              : insightBundle,
           };
         },
       });

--- a/src/tools/web/pulse/generateMetricValueInsightBundle/slimBundle.ts
+++ b/src/tools/web/pulse/generateMetricValueInsightBundle/slimBundle.ts
@@ -1,0 +1,74 @@
+import { z } from 'zod';
+
+import {
+  MetricContext,
+  pulseBundleRequestSchema,
+  PulseBundleResponse,
+} from '../../../../sdks/tableau/types/pulse.js';
+
+type BundleRequest = z.infer<typeof pulseBundleRequestSchema>;
+
+/**
+ * Returns a slimmed-down copy of a `PulseBundleResponse` — the response a text/card UI (e.g.
+ * Tableau Studio) actually renders, with the large fields it never reads stripped off to reduce
+ * payload size.
+ *
+ * Today that means removing every `viz` (Vega chart-spec) blob from
+ * `insight_groups[].insights[].result` and `insight_groups[].summaries[].result`; the UI renders
+ * from `facts`/`markup` alone. This is the single seam for that slimming — as more
+ * unused-by-the-UI fields are identified, drop them here so the `slim` tool param keeps meaning
+ * "the lean response" without the caller needing to know which fields changed. Does not mutate
+ * `bundle`.
+ */
+export function slimBundle(bundle: PulseBundleResponse): PulseBundleResponse {
+  return {
+    ...bundle,
+    bundle_response: {
+      ...bundle.bundle_response,
+      result: {
+        ...bundle.bundle_response.result,
+        insight_groups: bundle.bundle_response.result.insight_groups.map((insightGroup) => ({
+          ...insightGroup,
+          insights: insightGroup.insights.map((insight) => {
+            const { viz: _viz, ...resultWithoutViz } = insight.result;
+            return {
+              ...insight,
+              result: resultWithoutViz,
+            };
+          }),
+          summaries: insightGroup.summaries.map((summary) => {
+            const { viz: _viz, ...resultWithoutViz } = summary.result;
+            return {
+              ...summary,
+              result: resultWithoutViz,
+            };
+          }),
+        })),
+      },
+    },
+  };
+}
+
+/**
+ * Builds the `metric_context` surfaced alongside a slim bundle response — the agent's per-bundle
+ * choices, read straight off the `bundleRequest` it called the tool with, so a card UI can read
+ * them instead of parsing them out of markup.
+ *
+ * Provides two tiers: a handful of CURATED flat fields (name/measure/time_dimension/
+ * breakdown_dimensions) as the clean primary interface, plus `input` — the request's `input`
+ * echoed VERBATIM — as an escape hatch for any request field not (yet) surfaced flat, e.g. the
+ * comparison kind at `input.metric.metric_specification.comparison.comparison`. Every curated
+ * field this reads is optional in `pulseBundleRequestSchema`, so every access is defensive. Does
+ * not mutate `bundleRequest`.
+ */
+export function buildMetricContext(bundleRequest: BundleRequest): MetricContext {
+  const { input } = bundleRequest.bundle_request;
+
+  return {
+    name: input.metadata.name,
+    measure: input.metric.definition.basic_specification?.measure.field,
+    time_dimension: input.metric.definition.basic_specification?.time_dimension.field,
+    breakdown_dimensions: input.metric.extension_options?.allowed_dimensions ?? [],
+    input,
+  };
+}

--- a/src/tools/web/pulse/generateMetricValueInsightBundle/slimBundle.ts
+++ b/src/tools/web/pulse/generateMetricValueInsightBundle/slimBundle.ts
@@ -1,12 +1,4 @@
-import { z } from 'zod';
-
-import {
-  MetricContext,
-  pulseBundleRequestSchema,
-  PulseBundleResponse,
-} from '../../../../sdks/tableau/types/pulse.js';
-
-type BundleRequest = z.infer<typeof pulseBundleRequestSchema>;
+import { PulseBundleResponse } from '../../../../sdks/tableau/types/pulse.js';
 
 /**
  * Returns a slimmed-down copy of a `PulseBundleResponse` — the response a text/card UI (e.g.
@@ -46,28 +38,5 @@ export function slimBundle(bundle: PulseBundleResponse): PulseBundleResponse {
         })),
       },
     },
-  };
-}
-
-/**
- * Builds the `metric_context` surfaced alongside a slim bundle response — the agent's per-bundle
- * choices, read straight off the `bundleRequest` it called the tool with, so a card UI can read
- * them instead of parsing them out of markup.
- *
- * A handful of CURATED flat fields (name/measure/time_dimension/breakdown_dimensions). The request
- * `input` is intentionally not echoed back — a caller needing an uncurated request field already
- * holds the request it sent (carried on the `tool_use` block, correlated to this result by id), so
- * re-emitting it here would just bloat a response the `slim` param exists to shrink. Every curated
- * field this reads is optional in `pulseBundleRequestSchema`, so every access is defensive. Does
- * not mutate `bundleRequest`.
- */
-export function buildMetricContext(bundleRequest: BundleRequest): MetricContext {
-  const { input } = bundleRequest.bundle_request;
-
-  return {
-    name: input.metadata.name,
-    measure: input.metric.definition.basic_specification?.measure.field,
-    time_dimension: input.metric.definition.basic_specification?.time_dimension.field,
-    breakdown_dimensions: input.metric.extension_options?.allowed_dimensions ?? [],
   };
 }

--- a/src/tools/web/pulse/generateMetricValueInsightBundle/slimBundle.ts
+++ b/src/tools/web/pulse/generateMetricValueInsightBundle/slimBundle.ts
@@ -54,10 +54,10 @@ export function slimBundle(bundle: PulseBundleResponse): PulseBundleResponse {
  * choices, read straight off the `bundleRequest` it called the tool with, so a card UI can read
  * them instead of parsing them out of markup.
  *
- * Provides two tiers: a handful of CURATED flat fields (name/measure/time_dimension/
- * breakdown_dimensions) as the clean primary interface, plus `input` — the request's `input`
- * echoed VERBATIM — as an escape hatch for any request field not (yet) surfaced flat, e.g. the
- * comparison kind at `input.metric.metric_specification.comparison.comparison`. Every curated
+ * A handful of CURATED flat fields (name/measure/time_dimension/breakdown_dimensions). The request
+ * `input` is intentionally not echoed back — a caller needing an uncurated request field already
+ * holds the request it sent (carried on the `tool_use` block, correlated to this result by id), so
+ * re-emitting it here would just bloat a response the `slim` param exists to shrink. Every curated
  * field this reads is optional in `pulseBundleRequestSchema`, so every access is defensive. Does
  * not mutate `bundleRequest`.
  */
@@ -69,6 +69,5 @@ export function buildMetricContext(bundleRequest: BundleRequest): MetricContext 
     measure: input.metric.definition.basic_specification?.measure.field,
     time_dimension: input.metric.definition.basic_specification?.time_dimension.field,
     breakdown_dimensions: input.metric.extension_options?.allowed_dimensions ?? [],
-    input,
   };
 }


### PR DESCRIPTION
Adds an optional **`slim`** boolean to `generate-pulse-metric-value-insight-bundle`.

When `slim: true`, return the bundle **without the `viz` (Vega chart-spec) blobs** — a text/card UI renders from `facts`/`markup` alone, so this strips the heaviest part of the payload. Defaults to `false` (response returned verbatim, including `viz`), so existing callers are unaffected.

**Why:** dependency for the tab-agent-south-ui viz-canvas insight bundles (W-23447550) — without `slim` the Vega blobs bloat the headless agent's context.

**Testing:** 17/17 tests green · `tsc --noEmit` + `eslint` clean.
