### PR TITLE
refactor: one command-policy table — collapse five scattered special-command maps

### DIFF
--- a/src/desktop/commandPolicy.test.ts
+++ b/src/desktop/commandPolicy.test.ts
@@ -1,0 +1,25 @@
+describe('commandPolicy', () => {
+  it('keeps sort-nested as one policy record with both live params and the do-not-retry hint', async () => {
+    const { checkCommandPolicy } = await import('./commandPolicy.js');
+
+    const policy = checkCommandPolicy('tabdoc:sort-nested');
+
+    expect(policy).toMatchObject({
+      action: 'hint',
+      reason: 'known-live-failure',
+    });
+    expect(policy?.fix).toContain('known to fail');
+    expect(policy?.fix).toContain('do not retry');
+    expect(policy?.fix).toContain('bind-template sort proposal');
+    expect(policy?.params?.required).toEqual(
+      new Set(['DimensionToSort', 'Worksheet', 'MeasureName', 'ShelfType']),
+    );
+    expect(policy?.params?.allowed).toContain('KeepFieldFilters');
+  });
+
+  it('removes the old exported crash-prone table from commandRegistry', async () => {
+    const commandRegistry = await import('./commandRegistry.js');
+
+    expect(commandRegistry).not.toHaveProperty('CRASH_PRONE_COMMANDS');
+  });
+});

--- a/src/desktop/commandPolicy.ts
+++ b/src/desktop/commandPolicy.ts
@@ -1,0 +1,118 @@
+export type CommandParamPolicy = { allowed: Set<string>; required: Set<string> };
+
+export type CommandPolicy = {
+  action: 'refuse' | 'hint' | 'param-override';
+  reason?: string;
+  fix?: string;
+  params?: CommandParamPolicy;
+};
+
+const CRASH_PRONE_REASON = 'crash-prone';
+const LIVE_DIALOG_REASON = 'live-dialog';
+const EXTERNAL_API_DIALOG_REASON = 'external-api-dialog';
+const KNOWN_LIVE_FAILURE_REASON = 'known-live-failure';
+const FILTER_FIX = 'express filters in the NotionalSpec (categoricalFilters/rangeFilters/...)';
+const SORT_FIX =
+  'tabdoc:sort drives a UI dialog and blocks the screen. Use refine-worksheet with operation sort_by_field (sort a dimension by a field/measure), or the bind-template sort proposal/document round-trip for nested sorts';
+const SORT_NESTED_FIX =
+  'FIX: tabdoc:sort-nested is known to fail (HTTP 500) on current Desktop builds regardless of parameters — do not retry it. Sort instead via the bind-template sort proposal (preferred for template-bound sheets) or the document round-trip (tabui:save-underlying-metadata → edit the computed-sort → tabui:load-underlying-metadata).';
+const SORT_NESTED_ALLOWED =
+  'DimensionToSort Worksheet MeasureName ShelfType Direction ClearSort Dashboard LevelNames MemberValues KeepFieldFilters';
+const SORT_NESTED_REQUIRED = 'DimensionToSort Worksheet MeasureName ShelfType';
+const REVERT_FIX =
+  'there is no headless revert — author forward instead (a wrong node is corrected by a follow-up author-* call or document round-trip)';
+const SITE_FIX =
+  'changing sites is fine, but this command opens a dialog - ask the user to switch sites in Desktop instead';
+const TABLE_CALC_FIX = 'author table calculations through supported calculation tools';
+const PAGE_FIX = 'use a page navigation call with exactly one of page-number or page-name';
+
+function refuse(reason: string, fix?: string): CommandPolicy {
+  return { action: 'refuse', reason, fix };
+}
+
+const keySet = (keys: string): Set<string> => new Set(keys.split(' '));
+const liveDialog = (fix: string): CommandPolicy => refuse(LIVE_DIALOG_REASON, fix);
+const externalDialog = (fix: string): CommandPolicy => refuse(EXTERNAL_API_DIALOG_REASON, fix);
+const paramOverride = (allowed: string, required: string): CommandPolicy => ({
+  action: 'param-override',
+  reason: 'live-param-override',
+  params: { allowed: keySet(allowed), required: keySet(required) },
+});
+const hintWithParams = (fix: string, allowed: string, required: string): CommandPolicy => ({
+  action: 'hint',
+  reason: KNOWN_LIVE_FAILURE_REASON,
+  fix,
+  params: { allowed: keySet(allowed), required: keySet(required) },
+});
+
+export const COMMAND_POLICIES: Map<string, CommandPolicy> = new Map([
+  ['tabdoc:show-parameter-controls', refuse(CRASH_PRONE_REASON)], // commandRegistry crash guard: crash-prone headlessly.
+  ['tabdoc:show-parameter-controls-range', refuse(CRASH_PRONE_REASON)], // commandRegistry crash guard: crash-prone headlessly.
+  ['tabdoc:goto-sheet', paramOverride('Sheet', 'Sheet')], // 2026-07-19 live /v0 receipts: WindowLocator fails 500 + modal; Sheet succeeds.
+  [
+    'tabdoc:sort-nested',
+    hintWithParams(SORT_NESTED_FIX, SORT_NESTED_ALLOWED, SORT_NESTED_REQUIRED),
+  ], // 2026-07-19 live receipts: contract is validation-only; execution still 500s.
+  ['tabdoc:launch-map-service-edit-dialog', liveDialog('no headless alternative')], // 2026-07-19 dialog sweep: map service edit dialog.
+  ['tabdoc:show-goto-sheet-dialog', liveDialog('use tabdoc:goto-sheet with {"Sheet": name}')], // 2026-07-19 dialog sweep: goto-sheet dialog.
+  ['tabui:show-feature-flag-dialog', liveDialog('no headless alternative')], // 2026-07-19 dialog sweep: feature flag dialog.
+  ['tabdoc:edit-filter-dialog', liveDialog(FILTER_FIX)], // 2026-07-19 dialog sweep: filter edit dialog.
+  ['tabdoc:launch-shared-filter-dialog', liveDialog('express filters in the NotionalSpec')], // 2026-07-19 dialog sweep: shared filter dialog.
+  ['tabdoc:launch-map-services-dialog', liveDialog('no headless alternative')], // 2026-07-19 dialog sweep: map services dialog.
+  ['tabdoc:get-button-config-dialog', liveDialog('no headless alternative')], // 2026-07-19 dialog sweep: button config dialog.
+  ['tabui:launch-accelerator-data-mapper-dialog', liveDialog('no headless alternative')], // 2026-07-19 dialog sweep: accelerator mapper dialog.
+  ['tabdoc:launch-custom-sql-dialog', liveDialog('no headless alternative')], // 2026-07-19 dialog sweep: custom SQL dialog.
+  ['tabdoc:launch-web-url-dialog', liveDialog('no headless alternative')], // 2026-07-19 dialog sweep: web URL dialog.
+  ['tabdoc:show-action-list-dialog-for-dashboard', liveDialog('use author-action')], // 2026-07-19 dialog sweep: dashboard action list.
+  ['tabdoc:show-action-list-dialog-for-worksheet', liveDialog('use author-action')], // 2026-07-19 dialog sweep: worksheet action list.
+  ['tabdoc:show-sort-dialog', liveDialog("express sort in the NotionalSpec's sort key")], // 2026-07-19 dialog sweep: sort dialog.
+  ['tabdoc:sort', liveDialog(SORT_FIX)], // 2026-07-19 live sort sweep: sort drives dialog; sort-nested now fails live.
+  ['tabdoc:create-new-parameter', liveDialog('use author-parameter')], // 2026-07-19 dialog sweep: new parameter dialog.
+  ['tabdoc:edit-existing-parameter', liveDialog('use author-parameter for new parameters')], // 2026-07-19 dialog sweep: edit parameter dialog.
+  ['tabdoc:revert-workbook-ui', liveDialog(REVERT_FIX)], // 2026-07-19 live modal receipts: Error 47BF7751 twice.
+  ['tabui:workgroup-change-site', externalDialog(SITE_FIX)], // Live External API dialog sweep: site change blocks.
+  [
+    'tabdoc:toggle-ind-join-semantics',
+    externalDialog('no headless relationship-semantics alternative'),
+  ], // Live External API dialog sweep: join semantics blocks.
+  [
+    'tabdoc:toggle-referential-integrity',
+    externalDialog('no headless referential-integrity alternative'),
+  ], // Live External API dialog sweep: referential integrity blocks.
+  ['tabdoc:table-calc-add', externalDialog(TABLE_CALC_FIX)], // Live External API dialog sweep: table calc add blocks.
+  ['tabdoc:table-calc-edit', externalDialog(TABLE_CALC_FIX)], // Live External API dialog sweep: table calc edit blocks.
+  ['tabdoc:change-page', externalDialog(PAGE_FIX)], // Live External API dialog sweep: page change blocks.
+  ['tabdoc:hide-unused-fields', externalDialog('no headless hide-unused-fields alternative')], // Live External API dialog sweep: hide unused fields blocks.
+]);
+
+export function checkCommandPolicy(command: string): CommandPolicy | undefined {
+  return COMMAND_POLICIES.get(command);
+}
+
+function policyForReason(command: string, reason: string): CommandPolicy | undefined {
+  const policy = checkCommandPolicy(command);
+  return policy?.action === 'refuse' && policy.reason === reason ? policy : undefined;
+}
+
+export function crashPronePolicyFor(command: string): CommandPolicy | undefined {
+  return policyForReason(command, CRASH_PRONE_REASON);
+}
+
+export function liveDialogPolicyFor(command: string): CommandPolicy | undefined {
+  return policyForReason(command, LIVE_DIALOG_REASON);
+}
+
+export function externalApiDialogPolicyFor(command: string): CommandPolicy | undefined {
+  return policyForReason(command, EXTERNAL_API_DIALOG_REASON);
+}
+
+export function knownLiveFailureFixFor(command: string): string | undefined {
+  const policy = checkCommandPolicy(command);
+  return policy?.action === 'hint' && policy.reason === KNOWN_LIVE_FAILURE_REASON
+    ? policy.fix
+    : undefined;
+}
+
+export function liveParamOverrideFor(command: string): CommandParamPolicy | undefined {
+  return checkCommandPolicy(command)?.params;
+}

--- a/src/desktop/commandRegistry.ts
+++ b/src/desktop/commandRegistry.ts
@@ -1,14 +1,10 @@
 import levenshtein from 'fast-levenshtein';
 
 import { readDataAsset } from './assets.js';
+import { crashPronePolicyFor } from './commandPolicy.js';
 
 const COMMANDS_REFERENCE_ASSET = 'tableau-desktop-commands-reference.json';
 const MAX_SUGGESTIONS = 3;
-
-export const CRASH_PRONE_COMMANDS = new Set([
-  'tabdoc:show-parameter-controls',
-  'tabdoc:show-parameter-controls-range',
-]);
 
 type CommandReferenceEntry = {
   fully_qualified_serialized_name?: unknown;
@@ -53,7 +49,7 @@ export function knownCommands(): Set<string> | null {
 }
 
 export function validateKnownCommand(command: string): CommandValidationResult {
-  if (CRASH_PRONE_COMMANDS.has(command)) {
+  if (crashPronePolicyFor(command)) {
     return {
       ok: false,
       message: `Refusing to execute crash-prone Tableau command "${command}".`,

--- a/src/desktop/paramContractGuard.test.ts
+++ b/src/desktop/paramContractGuard.test.ts
@@ -227,7 +227,7 @@ describe('live param overrides (runtime truth beats the reference)', () => {
   });
 });
 
-describe('LIVE_DIALOG_BLOCKLIST', () => {
+describe('live dialog policy refusals', () => {
   it('refuses tabdoc:sort outright with the headless sort FIX', async () => {
     const { validateCommandParams } = await import('./paramContractGuard.js');
     const result = validateCommandParams('tabdoc:sort', {
@@ -238,7 +238,7 @@ describe('LIVE_DIALOG_BLOCKLIST', () => {
     if (!result.ok) {
       expect(result.message).toContain('tabdoc:sort drives a UI dialog and blocks the screen');
       expect(result.message).toContain('refine-worksheet with operation sort_by_field');
-      expect(result.message).toContain('tabdoc:sort-nested');
+      expect(result.message).toContain('bind-template sort proposal/document round-trip');
     }
   });
 
@@ -285,11 +285,13 @@ describe('live param overrides for sort commands', () => {
       expect(result.message).toContain(
         'Missing required parameter(s) for Tableau command "tabdoc:sort-nested": MeasureName, ShelfType',
       );
-      expect(result.message).toContain('FIX: provide "MeasureName", "ShelfType"');
+      expect(result.message).toContain('Live-verified /v0 contract requires');
+      expect(result.message).toContain('known to fail');
+      expect(result.message).toContain('do not retry');
     }
   });
 
-  it('accepts sort-nested with its required live contract params', async () => {
+  it('keeps sort-nested validation-only params when its live contract is complete', async () => {
     const { validateCommandParams } = await import('./paramContractGuard.js');
     expect(
       validateCommandParams('tabdoc:sort-nested', {

--- a/src/desktop/paramContractGuard.ts
+++ b/src/desktop/paramContractGuard.ts
@@ -25,6 +25,7 @@
 // validates that command's actual shape.
 
 import { readDataAsset } from './assets.js';
+import { checkCommandPolicy, liveDialogPolicyFor, liveParamOverrideFor } from './commandPolicy.js';
 import type { CommandValidationResult } from './commandRegistry.js';
 
 const COMMANDS_REFERENCE_ASSET = 'tableau-desktop-commands-reference.json';
@@ -111,105 +112,24 @@ function blockingDialogNote(entry: CommandReferenceEntry): string {
     : '';
 }
 
-/**
- * Validates a known command's `args` against its bundled parameter contract.
- * Call AFTER validateKnownCommand() confirms the verb is real. Fails open
- * (returns ok: true) when the reference can't be loaded, the command has no
- * entry in it, or its contract declares zero "in" params (nothing to check
- * unknown keys against — see the module doc for generate-viz-from-notional-spec).
- */
-/**
- * Live-verified runtime contracts that OVERRIDE the commands-reference where the
- * reference's declared params are wrong at the /v0 runtime. Evidence anchors are
- * mandatory per entry. First occupant (2026-07-19, three live receipts each way):
- * tabdoc:goto-sheet — the reference declares WindowLocator (required:true) as the
- * only "in" param, but at the /v0 External API runtime {"WindowLocator": name}
- * fails 500 AND pops a blocking modal (Error 47BF7751) on the user's screen,
- * while {"Sheet": name} — absent from the reference — SUCCEEDS and activates the
- * sheet. Until the reference generator learns the /v0 dialect, this table is
- * where live-verified corrections accumulate.
- */
-const LIVE_PARAM_OVERRIDES: Map<string, { allowed: Set<string>; required: Set<string> }> = new Map([
-  ['tabdoc:goto-sheet', { allowed: new Set(['Sheet']), required: new Set(['Sheet']) }],
-  [
-    'tabdoc:sort-nested',
-    {
-      allowed: new Set([
-        'DimensionToSort',
-        'Worksheet',
-        'MeasureName',
-        'ShelfType',
-        'Direction',
-        'ClearSort',
-        'Dashboard',
-        'LevelNames',
-        'MemberValues',
-        'KeepFieldFilters',
-      ]),
-      required: new Set(['DimensionToSort', 'Worksheet', 'MeasureName', 'ShelfType']),
-    },
-  ],
-]);
-
-/**
- * Commands live-proven to open a blocking dialog (or modal error) headlessly, which the
- * reference misclassifies as safely invocable — the `*DialogCommand`-sourced entries
- * from the dialog-command-misclassification knowledge doc, plus revert-workbook-ui
- * (probed modal 2026-07-19; it fired Error 47BF7751 on a live user's screen TWICE in one
- * session before this blocklist existed) and tabdoc:sort (dialog-notification-based sort UI).
- * Refused outright with a redirect to the
- * sanctioned alternative: the modal never reaches a human again.
- */
-const LIVE_DIALOG_BLOCKLIST: Map<string, string> = new Map(
-  (
-    [
-      ['tabdoc:launch-map-service-edit-dialog', 'no headless alternative'],
-      ['tabdoc:show-goto-sheet-dialog', 'use tabdoc:goto-sheet with {"Sheet": name}'],
-      ['tabui:show-feature-flag-dialog', 'no headless alternative'],
-      [
-        'tabdoc:edit-filter-dialog',
-        'express filters in the NotionalSpec (categoricalFilters/rangeFilters/...)',
-      ],
-      ['tabdoc:launch-shared-filter-dialog', 'express filters in the NotionalSpec'],
-      ['tabdoc:launch-map-services-dialog', 'no headless alternative'],
-      ['tabdoc:get-button-config-dialog', 'no headless alternative'],
-      ['tabui:launch-accelerator-data-mapper-dialog', 'no headless alternative'],
-      ['tabdoc:launch-custom-sql-dialog', 'no headless alternative'],
-      ['tabdoc:launch-web-url-dialog', 'no headless alternative'],
-      ['tabdoc:show-action-list-dialog-for-dashboard', 'use author-action'],
-      ['tabdoc:show-action-list-dialog-for-worksheet', 'use author-action'],
-      ['tabdoc:show-sort-dialog', "express sort in the NotionalSpec's sort key"],
-      [
-        'tabdoc:sort',
-        'tabdoc:sort drives a UI dialog and blocks the screen. Use refine-worksheet with operation sort_by_field (sort a dimension by a field/measure), or tabdoc:sort-nested',
-      ],
-      ['tabdoc:create-new-parameter', 'use author-parameter'],
-      ['tabdoc:edit-existing-parameter', 'use author-parameter for new parameters'],
-      [
-        'tabdoc:revert-workbook-ui',
-        'there is no headless revert — author forward instead (a wrong node is corrected by a follow-up author-* call or document round-trip)',
-      ],
-    ] as const
-  ).map(([name, fix]) => [name, fix]),
-);
-
 export function validateCommandParams(
   command: string,
   args: Record<string, unknown> | undefined,
 ): CommandValidationResult {
-  const dialogFix = LIVE_DIALOG_BLOCKLIST.get(command);
-  if (dialogFix !== undefined) {
+  const dialogPolicy = liveDialogPolicyFor(command);
+  if (dialogPolicy?.fix !== undefined) {
     return {
       ok: false,
       message:
         `Tableau command "${command}" opens a BLOCKING dialog/modal on the user's screen when called ` +
         'headlessly (live-proven; the reference misclassifies it as safe). NOT sent. ' +
-        `FIX: ${dialogFix}.`,
+        `FIX: ${dialogPolicy.fix}.`,
     };
   }
 
-  const override = LIVE_PARAM_OVERRIDES.get(command);
+  const override = liveParamOverrideFor(command);
   if (override) {
+    const policy = checkCommandPolicy(command);
     const providedArgs = args && typeof args === 'object' ? args : {};
     const providedKeys = Object.keys(providedArgs);
     const unknownKeys = providedKeys.filter((key) => !override.allowed.has(key));
@@ -219,8 +139,7 @@ export function validateCommandParams(
         message:
           `Unknown parameter(s) for Tableau command "${command}": ${unknownKeys.join(', ')}. NOT sent — ` +
           "a wrong parameter for this command pops a blocking error dialog on the user's screen " +
-          `(live-verified 2026-07-19). FIX: use exactly ${[...override.allowed].map((k) => `"${k}"`).join(', ')} ` +
-          "(the live-verified /v0 contract; the bundled reference's declared params are wrong for this command).",
+          `(live-verified 2026-07-19).${formatUnknownOverrideFix(policy, override)}`,
       };
     }
     const missing = [...override.required].filter((key) => !(key in providedArgs));
@@ -229,7 +148,7 @@ export function validateCommandParams(
         ok: false,
         message:
           `Missing required parameter(s) for Tableau command "${command}": ${missing.join(', ')}. ` +
-          `FIX: provide ${missing.map((k) => `"${k}"`).join(', ')} (live-verified /v0 contract).`,
+          formatMissingOverrideFix(policy, missing),
       };
     }
     return { ok: true };
@@ -285,4 +204,32 @@ export function validateCommandParams(
   }
 
   return { ok: true };
+}
+
+function formatUnknownOverrideFix(
+  policy: ReturnType<typeof checkCommandPolicy>,
+  override: { allowed: Set<string> },
+): string {
+  const allowed = [...override.allowed].map((key) => `"${key}"`).join(', ');
+  if (policy?.action === 'hint' && policy.fix) {
+    return (
+      ` Live-verified /v0 contract allows exactly ${allowed}; ` +
+      `the bundled reference's declared params are wrong for this command. ${policy.fix}`
+    );
+  }
+  return (
+    ` FIX: use exactly ${allowed} ` +
+    "(the live-verified /v0 contract; the bundled reference's declared params are wrong for this command)."
+  );
+}
+
+function formatMissingOverrideFix(
+  policy: ReturnType<typeof checkCommandPolicy>,
+  missing: string[],
+): string {
+  const missingParams = missing.map((key) => `"${key}"`).join(', ');
+  if (policy?.action === 'hint' && policy.fix) {
+    return `Live-verified /v0 contract requires ${missingParams}. ${policy.fix}`;
+  }
+  return `FIX: provide ${missingParams} (live-verified /v0 contract).`;
 }

--- a/src/tools/desktop/commands/executeTableauCommand.test.ts
+++ b/src/tools/desktop/commands/executeTableauCommand.test.ts
@@ -395,7 +395,7 @@ describe('executeTableauCommandTool', () => {
         'tabdoc:sort drives a UI dialog and blocks the screen',
       );
       expect(result.content[0].text).toContain('refine-worksheet with operation sort_by_field');
-      expect(result.content[0].text).toContain('tabdoc:sort-nested');
+      expect(result.content[0].text).toContain('bind-template sort proposal/document round-trip');
       expect(extra.getExecutor).not.toHaveBeenCalled();
     });
 

--- a/src/tools/desktop/commands/executeTableauCommand.ts
+++ b/src/tools/desktop/commands/executeTableauCommand.ts
@@ -2,6 +2,10 @@ import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { Ok } from 'ts-results-es';
 import { z } from 'zod';
 
+import {
+  externalApiDialogPolicyFor,
+  knownLiveFailureFixFor,
+} from '../../../desktop/commandPolicy.js';
 import { validateKnownCommand } from '../../../desktop/commandRegistry.js';
 import { getWorkbookXml } from '../../../desktop/commands/workbook/getWorkbookXml.js';
 import {
@@ -33,25 +37,6 @@ import { DesktopTool } from '../tool.js';
 const LOAD_UNDERLYING_METADATA_COMMAND = 'tabui:load-underlying-metadata';
 const GENERATE_VIZ_FROM_NOTIONAL_SPEC_COMMAND = 'tabdoc:generate-viz-from-notional-spec';
 const CONTEXT_FILLED_PARAM_TYPES = new Set(['UPI_Workspace', 'UPI_IWorkspace']);
-const KNOWN_LIVE_FAILURE_FIXES = new Map<string, string>([
-  [
-    'tabdoc:sort-nested',
-    'FIX: tabdoc:sort-nested is known to fail (HTTP 500) on current Desktop builds regardless of parameters — do not retry it. Sort instead via the bind-template sort proposal (preferred for template-bound sheets) or the document round-trip (tabui:save-underlying-metadata → edit the computed-sort → tabui:load-underlying-metadata).',
-  ],
-]);
-// Live-swept dialog poppers misclassified as callable: never let the External API open these headlessly.
-const LIVE_EXTERNAL_API_DIALOG_BLOCKLIST = new Map<string, string>([
-  [
-    'tabui:workgroup-change-site',
-    'changing sites is fine, but this command opens a dialog - ask the user to switch sites in Desktop instead',
-  ],
-  ['tabdoc:toggle-ind-join-semantics', 'no headless relationship-semantics alternative'],
-  ['tabdoc:toggle-referential-integrity', 'no headless referential-integrity alternative'],
-  ['tabdoc:table-calc-add', 'author table calculations through supported calculation tools'],
-  ['tabdoc:table-calc-edit', 'author table calculations through supported calculation tools'],
-  ['tabdoc:change-page', 'use a page navigation call with exactly one of page-number or page-name'],
-  ['tabdoc:hide-unused-fields', 'no headless hide-unused-fields alternative'],
-]);
 
 const paramsSchema = {
   session: z.string().optional().describe('Session ID; optional if pinned or unique.'),
@@ -114,12 +99,13 @@ export const getExecuteTableauCommandTool = (
           // Unconditional: these hang the UI thread headlessly on EVERY deployment
           // (live-observed dialog-poppers that pass the static safety flags), so the
           // refusal cannot depend on the optional registry being installed.
-          if (LIVE_EXTERNAL_API_DIALOG_BLOCKLIST.has(command)) {
+          const externalApiDialogPolicy = externalApiDialogPolicyFor(command);
+          if (externalApiDialogPolicy) {
             return new ArgsValidationError(
               formatExternalApiRefusalMessage({
                 command,
                 reasons: ['live-observed dialog-popper'],
-                fix: LIVE_EXTERNAL_API_DIALOG_BLOCKLIST.get(command),
+                fix: externalApiDialogPolicy.fix,
               }),
             ).toErr();
           }
@@ -188,7 +174,7 @@ export const getExecuteTableauCommandTool = (
           if (result.isErr()) {
             return new DesktopCommandExecutionError(
               result.error,
-              KNOWN_LIVE_FAILURE_FIXES.get(command),
+              knownLiveFailureFixFor(command),
             ).toErr();
           }
 
@@ -231,16 +217,20 @@ function validateExternalApiCommandRegistry({
   args: Record<string, unknown>;
   registry: ExternalApiCommandRegistryEntry;
 }): ExternalApiGuardResult {
-  const blocklistFix = LIVE_EXTERNAL_API_DIALOG_BLOCKLIST.get(command);
-  if (blocklistFix !== undefined || !registry.invocable || registry.blockingDialog) {
+  const externalApiDialogPolicy = externalApiDialogPolicyFor(command);
+  if (externalApiDialogPolicy || !registry.invocable || registry.blockingDialog) {
     const reasons = [
-      blocklistFix !== undefined ? 'live-observed dialog-popper' : undefined,
+      externalApiDialogPolicy ? 'live-observed dialog-popper' : undefined,
       !registry.invocable ? 'agent_can_invoke=false' : undefined,
       registry.blockingDialog ? 'opens_blocking_dialog=true' : undefined,
     ].filter((reason): reason is string => reason !== undefined);
     return {
       ok: false,
-      message: formatExternalApiRefusalMessage({ command, reasons, fix: blocklistFix }),
+      message: formatExternalApiRefusalMessage({
+        command,
+        reasons,
+        fix: externalApiDialogPolicy?.fix,
+      }),
     };
   }
 


### PR DESCRIPTION
Stacked on #572. Five independent special-command tables across three files collapse into one `commandPolicy.ts` (refuse / hint / param-override semantics, per-entry origin comments); every call site reads from it. Fixes the `tabdoc:sort-nested` contradiction (param contract kept for validation messages; do-not-retry hint authoritative). Carries Lauren's #572 corrections into the unified table. Validated: tsc clean, full suite 4871 passed (post-rebase reconcile, firsthand).

🤖 Generated with [Claude Code](https://claude.com/claude-code)