### PR TITLE
Resync main → feature/desktop (id_type, MCP-Apps folders, stale-content hardening)

### DIFF
--- a/src/sdks/tableau/types/pulse.ts
+++ b/src/sdks/tableau/types/pulse.ts
@@ -361,6 +361,7 @@ export const pulseBundleRequestSchema = z.object({
         definition: z.object({
           datasource: z.object({
             id: z.string(),
+            id_type: z.enum(['DATASOURCE_ID_TYPE_WORKBOOK_DATASOURCE']).optional(),
           }),
           basic_specification: pulseBasicSpecificationSchema,
           is_running_total: z.boolean(),

--- a/src/tools/web/pulse/generateMetricValueInsightBundle/generatePulseMetricValueInsightBundleTool.ts
+++ b/src/tools/web/pulse/generateMetricValueInsightBundle/generatePulseMetricValueInsightBundleTool.ts
@@ -41,6 +41,9 @@ Generate an insight bundle for the current aggregated value for Pulse Metric usi
     - time_zone: 'UTC'
     - language: 'LANGUAGE_EN_US'
     - locale: 'LOCALE_EN_US'
+    - The \`datasource\` field under \`metric.definition\` requires an \`id\` (datasource LUID) and accepts an optional \`id_type\`:
+      - Omit \`id_type\` for standard published datasources (default behavior).
+      - Use \`'DATASOURCE_ID_TYPE_WORKBOOK_DATASOURCE'\` when the metric is based on an embedded workbook datasource rather than a published datasource.
 - \`bundleType\` (optional): The type of bundle to generate.  The default is 'ban'.
   - 'ban' - Return a basic insight bundle with the current aggregated value for the Pulse Metric, period over period change, and the highest ranked insight for each filterable dimension of the metric.
   - 'springboard' - Return a springboard insight bundle with the current value, period over period change, and the highest ranked insight for the metric.


### PR DESCRIPTION
Second same-day resync: 23 main commits, notably **#528's optional `datasource id_type` on the insight bundle request** (Pulse blocker-3 adjacent) and #553's Admin Insights LUID-cache hardening. Same conflict-resolution pattern as #570 (version line ours + lock regenerated; publish.yml composed; server.web.ts absorbed into the lazy-registration structure). Full suite 4988 passed post-resolution, verified firsthand.

Ready to merge whenever you want main's latest in — no rush dependency on the in-flight work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)