### PR TITLE
feat: surface invokeCommand output — consume the 0.1.1 result envelope

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "2.31.0",
+  "version": "2.32.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "2.31.0",
+      "version": "2.32.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.7.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "2.31.0",
+  "version": "2.32.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/src/desktop/data/tableau-desktop-commands-reference.json
+++ b/src/desktop/data/tableau-desktop-commands-reference.json
@@ -23508,7 +23508,7 @@
       "source_file": "AnalyticsAssistantDesktopPaneCommand",
       "editor_type": "D",
       "server_permission": "UNRESTRICTED",
-      "description": "Generate a NotionalSpec from the current viz — BUT the /v0 External Client API does NOT return this command's output (write-blind envelope: state SUCCEEDED, no result). Do not rely on it to read the current spec. To inspect current state, use tabui:save-underlying-metadata (whole-document readback) or the list tools, then author a fresh v0.2 spec for tabdoc:generate-viz-from-notional-spec.",
+      "description": "Generate a NotionalSpec from the current viz — BUT on External Client API apiVersion <=0.1.0 the /v0 External Client API did not return this command's output (write-blind envelope: state SUCCEEDED, no result). On apiVersion >=0.1.1, SUCCEEDED invokeCommand envelopes may carry serialized command output in result. Do not rely on <=0.1.0 to read the current spec. To inspect current state, use tabui:save-underlying-metadata (whole-document readback) or the list tools, then author a fresh v0.2 spec for tabdoc:generate-viz-from-notional-spec.",
       "classification": "user_initiated",
       "usage_count": 0,
       "is_user_initiated": true,

--- a/src/desktop/externalApi/externalApiClient.ts
+++ b/src/desktop/externalApi/externalApiClient.ts
@@ -94,6 +94,10 @@ export class ExternalApiClient {
     return this.instance.instanceId;
   }
 
+  get apiVersion(): string | undefined {
+    return this.instance.apiVersion;
+  }
+
   async health(signal?: AbortSignal): Promise<Result<{ healthy: boolean }, ExternalApiError>> {
     const response = await this.request('GET', EXTERNAL_API_ROUTES.health, { signal });
     if (response.isErr()) {

--- a/src/desktop/externalApi/externalApiContract.test.ts
+++ b/src/desktop/externalApi/externalApiContract.test.ts
@@ -76,11 +76,12 @@ describe('external client API contract (captured openapi fixture)', () => {
       expect(missing).toEqual([]);
     });
 
-    it('only carries `result` beyond the spec (kept until Ask-1(b) output-param behavior is confirmed)', () => {
+    it('documents `result` as expected from apiVersion 0.1.1 even if the captured 0.1.0 spec omits it', () => {
       const extras = declaredKeys(operationEnvelopeSchema).filter(
         (key) => !(key in (operation.properties ?? {})),
       );
-      expect(extras).toEqual(['result']);
+      const expectedExtras = operation.properties?.result ? [] : ['result'];
+      expect(extras).toEqual(expectedExtras);
     });
 
     it('matches the spec required set exactly', () => {
@@ -203,6 +204,23 @@ describe('external client API contract (captured openapi fixture)', () => {
         completedAt: '2026-07-20T10:00:01Z',
         error: { code: 'operation-failed', message: 'nope' },
         warnings: [{ code: 'partial', message: 'one sheet skipped' }],
+      });
+      expect(parsed.success).toBe(true);
+    });
+
+    it('parses a 0.1.1 SUCCEEDED Operation result object and serialize-degradation warning', () => {
+      const parsed = operationEnvelopeSchema.safeParse({
+        id: 'op-1',
+        kind: 'command.invoke',
+        state: 'SUCCEEDED',
+        result: { outputParam: 'value' },
+        warnings: [
+          {
+            code: 'output-serialization-failed',
+            message: 'Command output could not be serialized.',
+            target: 'result',
+          },
+        ],
       });
       expect(parsed.success).toBe(true);
     });

--- a/src/desktop/externalApi/externalApiToolExecutor.test.ts
+++ b/src/desktop/externalApi/externalApiToolExecutor.test.ts
@@ -10,12 +10,13 @@ vi.mock('../../logging/logger.js');
 const instanceFor = (
   server: MockExternalApiServer,
   token = 'valid-token',
+  apiVersion = '0.1.1',
 ): ExternalApiInstance => ({
   baseUrl: server.baseUrl,
   token,
   pid: 999,
   instanceId: 'inst-exec',
-  apiVersion: '1.0',
+  apiVersion,
 });
 
 describe('ExternalApiToolExecutor', () => {
@@ -164,6 +165,100 @@ describe('ExternalApiToolExecutor', () => {
       if (error.type === 'command-failed') {
         expect(error.error?.code).toBe('operation-failed');
       }
+    });
+
+    it('carries Operation warnings from a succeeded invokeCommand envelope', async () => {
+      server.setOverride('POST /v0/app:invokeCommand', {
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          id: 'op-warn-1',
+          kind: 'command.invoke',
+          state: 'SUCCEEDED',
+          result: { ok: true },
+          warnings: [
+            {
+              code: 'output-serialization-failed',
+              message: 'Command output could not be serialized.',
+            },
+          ],
+        }),
+      });
+      const executor = new ExternalApiToolExecutor({ discover: () => [instanceFor(server)] });
+      await executor.start();
+
+      const result = await executor.executeCommand({
+        namespace: 'tabdoc',
+        command: 'undo',
+        signal,
+      });
+
+      expect(result.isOk()).toBe(true);
+      expect(result.unwrap().warnings).toEqual([
+        {
+          code: 'output-serialization-failed',
+          message: 'Command output could not be serialized.',
+        },
+      ]);
+    });
+
+    it('preserves failed Operation message and tableau-error-code extension', async () => {
+      server.setOverride('POST /v0/app:invokeCommand', {
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          id: 'op-fail-1',
+          kind: 'command.invoke',
+          state: 'FAILED',
+          error: {
+            code: 'operation-failed',
+            message: 'Desktop reported the real failure',
+            'tableau-error-code': '0x1234',
+          },
+        }),
+      });
+      const executor = new ExternalApiToolExecutor({ discover: () => [instanceFor(server)] });
+      await executor.start();
+
+      const result = await executor.executeCommand({
+        namespace: 'tabdoc',
+        command: 'undo',
+        signal,
+      });
+
+      expect(result.isErr()).toBe(true);
+      const error = result.unwrapErr();
+      expect(error.type).toBe('command-failed');
+      if (error.type === 'command-failed') {
+        expect(error.error?.message).toBe('Desktop reported the real failure');
+        expect((error.error as Record<string, unknown>)['tableau-error-code']).toBe('0x1234');
+      }
+    });
+
+    it('treats missing result on a 0.1.0 succeeded invokeCommand as silent success', async () => {
+      server.setOverride('POST /v0/app:invokeCommand', {
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          id: 'op-010-1',
+          kind: 'command.invoke',
+          state: 'SUCCEEDED',
+        }),
+      });
+      const executor = new ExternalApiToolExecutor({
+        discover: () => [instanceFor(server, 'valid-token', '0.1.0')],
+      });
+      await executor.start();
+
+      const result = await executor.executeCommand({
+        namespace: 'tabdoc',
+        command: 'undo',
+        signal,
+      });
+
+      expect(result.isOk()).toBe(true);
+      expect(result.unwrap().result).toBeUndefined();
+      expect(result.unwrap().warnings).toBeUndefined();
     });
 
     it('maps a command-not-found problem to a command-failed error', async () => {

--- a/src/desktop/externalApi/externalApiToolExecutor.ts
+++ b/src/desktop/externalApi/externalApiToolExecutor.ts
@@ -26,6 +26,7 @@ import {
   ExternalApiInstance,
   OperationEnvelope,
   OperationError,
+  OperationWarning,
   Site,
   SiteDatasourceList,
   SiteWorkbookList,
@@ -66,9 +67,11 @@ type RawOutcome = {
   result: Record<string, unknown> | undefined;
   state: string | undefined;
   envelopeError: OperationError | undefined;
+  warnings: OperationWarning[] | undefined;
   createdAt: string | undefined;
   completedAt: string | undefined;
   operationId: string | undefined;
+  apiVersion: string | undefined;
 };
 
 /**
@@ -435,9 +438,11 @@ export class ExternalApiToolExecutor extends ToolExecutor {
         result: { text: result.value.xml },
         state: 'succeeded',
         envelopeError: undefined,
+        warnings: undefined,
         createdAt: undefined,
         completedAt: undefined,
         operationId: undefined,
+        apiVersion: client.apiVersion,
       });
     }
 
@@ -450,25 +455,27 @@ export class ExternalApiToolExecutor extends ToolExecutor {
       if (result.isErr()) {
         return Err(result.error);
       }
-      return Ok(normalizeEnvelope(result.value));
+      return Ok(normalizeEnvelope(result.value, client.apiVersion));
     }
 
     const result = await client.invokeCommand(namespace, command, args, signal);
     if (result.isErr()) {
       return Err(result.error);
     }
-    return Ok(normalizeEnvelope(result.value));
+    return Ok(normalizeEnvelope(result.value, client.apiVersion));
   }
 }
 
-function normalizeEnvelope(envelope: OperationEnvelope): RawOutcome {
+function normalizeEnvelope(envelope: OperationEnvelope, apiVersion?: string): RawOutcome {
   return {
     result: isRecord(envelope.result) ? envelope.result : undefined,
     state: envelope.state,
     envelopeError: envelope.error,
+    warnings: envelope.warnings,
     createdAt: envelope.createdAt,
     completedAt: envelope.completedAt,
     operationId: envelope.id,
+    apiVersion,
   };
 }
 
@@ -480,25 +487,45 @@ function buildCommandStatus(
   const failed = state === 'failed' || state === 'error' || outcome.envelopeError !== undefined;
 
   if (failed) {
+    const tableauErrorCode = getTableauErrorCode(outcome.envelopeError);
     return Err({
       type: 'command-failed',
       error: {
         code: outcome.envelopeError?.code ?? 'operation-failed',
         message: outcome.envelopeError?.message ?? `Command ${namespace}:${command} failed`,
         recoverable: false,
+        ...(tableauErrorCode ? { 'tableau-error-code': tableauErrorCode } : {}),
       },
     });
   }
 
   const now = new Date().toISOString();
+  const resultPayload =
+    outcome.result !== undefined || supportsOperationResult(outcome.apiVersion)
+      ? { result: outcome.result }
+      : {};
   return Ok({
     command_id: outcome.operationId ?? `ext_${namespace}:${command}_${Date.now()}`,
     status: 'completed',
     submitted_at: outcome.createdAt ?? now,
     started_at: outcome.createdAt ?? now,
     completed_at: outcome.completedAt ?? now,
-    result: outcome.result,
+    ...resultPayload,
+    ...(outcome.warnings ? { warnings: outcome.warnings } : {}),
   });
+}
+
+function getTableauErrorCode(error: OperationError | undefined): string | undefined {
+  const value = error?.['tableau-error-code'];
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function supportsOperationResult(apiVersion: string | undefined): boolean {
+  const [major = 0, minor = 0, patch = 0] = (apiVersion ?? '')
+    .split('.')
+    .map((part) => Number.parseInt(part, 10))
+    .map((part) => (Number.isFinite(part) ? part : 0));
+  return major > 0 || (major === 0 && (minor > 1 || (minor === 1 && patch >= 1)));
 }
 
 function mapClientError(error: ExternalApiError | NoInstance): ExecuteCommandError {

--- a/src/desktop/externalApi/types.ts
+++ b/src/desktop/externalApi/types.ts
@@ -168,16 +168,16 @@ export type OperationWarning = z.infer<typeof operationWarningSchema>;
 /**
  * Operation envelope returned by `POST /v0/workbook/document` and
  * `POST /v0/app:invokeCommand`. `id`/`kind`/`state` are required per the spec.
- * `result` is ABSENT from the spec's Operation schema but kept optional here until
- * output-param behavior is confirmed with the API owner (Ask 1(b)) — do not tighten
- * it out, and do not rely on it being populated.
+ * `result` is present only on SUCCEEDED envelopes with non-null command output as of
+ * External Client API apiVersion 0.1.1 (monolith #60596); 0.1.0 instances legitimately
+ * omit it on success.
  */
 export const operationEnvelopeSchema = z
   .object({
     id: z.string(),
     kind: z.string(),
     state: z.string(),
-    result: z.unknown().optional(),
+    result: z.record(z.string(), z.unknown()).optional(),
     error: operationErrorSchema.optional(),
     warnings: z.array(operationWarningSchema).optional(),
     createdAt: z.string().optional(),

--- a/src/desktop/toolExecutor/toolExecutor.ts
+++ b/src/desktop/toolExecutor/toolExecutor.ts
@@ -34,10 +34,12 @@ export type ExecuteCommandError =
   | { type: 'invalid-response'; error: unknown }
   | { type: 'unknown'; error: unknown };
 
+export type ExecuteCommandWarning = { code: string; message: string };
+
 export type ExecuteCommandResult<Z extends z.ZodTypeAny | undefined = undefined> =
   Z extends z.ZodTypeAny
-    ? GetCommandStatusResponse & { parsedResult: z.infer<Z> }
-    : GetCommandStatusResponse;
+    ? GetCommandStatusResponse & { parsedResult: z.infer<Z>; warnings?: ExecuteCommandWarning[] }
+    : GetCommandStatusResponse & { warnings?: ExecuteCommandWarning[] };
 
 export abstract class ToolExecutor {
   abstract start(): Promise<void>;

--- a/src/errors/mcpToolError.ts
+++ b/src/errors/mcpToolError.ts
@@ -264,12 +264,30 @@ export class AdminInsightsUnavailableError extends McpToolError {
 
 export class DesktopCommandExecutionError extends McpToolError {
   constructor(error: ExecuteCommandError, fix?: string) {
+    const message = formatDesktopCommandExecutionError(error);
     super({
       type: 'desktop-command-execution-error',
-      message: fix ? `${JSON.stringify(error)}\n${fix}` : JSON.stringify(error),
+      message: fix ? `${message}\n${fix}` : message,
       statusCode: 500,
     });
   }
+}
+
+function formatDesktopCommandExecutionError(error: ExecuteCommandError): string {
+  if (error.type !== 'command-failed') {
+    return JSON.stringify(error);
+  }
+
+  const commandError = error.error;
+  const message = commandError?.message;
+  if (!message) {
+    return JSON.stringify(error);
+  }
+
+  const tableauErrorCode = commandError['tableau-error-code'];
+  return typeof tableauErrorCode === 'string' && tableauErrorCode.length > 0
+    ? `${message}\ntableau-error-code: ${tableauErrorCode}`
+    : message;
 }
 
 export class WorkbookXmlLoadFailedError extends McpToolError {

--- a/src/sdks/desktop/agentApi/types.ts
+++ b/src/sdks/desktop/agentApi/types.ts
@@ -24,7 +24,10 @@ export const executeCommandResponseSchema = z.object({
   status: z.enum(['queued', 'running', 'completed', 'failed']),
   submitted_at: z.string(),
   status_url: z.string(),
-  error: z.object({ code: z.string(), message: z.string(), recoverable: z.boolean() }).optional(),
+  error: z
+    .object({ code: z.string(), message: z.string(), recoverable: z.boolean() })
+    .passthrough()
+    .optional(),
 });
 export type ExecuteCommandResponse = z.infer<typeof executeCommandResponseSchema>;
 export type ExecuteCommandResponseError = ExecuteCommandResponse['error'];

--- a/src/server.desktop.ts
+++ b/src/server.desktop.ts
@@ -59,9 +59,10 @@ export const DEMO_TOOL_PROFILE: ReadonlySet<DesktopToolName> = new Set<DesktopTo
  * for calcs, both dispatched through execute-tableau-command on the /v0 External
  * API — is sufficient on its own, with NO XML tools, NO templates, NO bind-template.
  * Everything a chart/calc/dashboard ask needs routes through execute-tableau-command;
- * the rest is discovery + readback (the /v0 generic route is write-blind, so the
- * list-* tools are how the model observes state). Proven by hand 2026-07-19: a full
- * analytics workbook (calcs + charts + dashboard) authored live in seconds, zero XML.
+ * the rest is discovery + readback (on apiVersion <=0.1.0 the /v0 generic route was
+ * write-blind, so the list-* tools were how the model observed state). Proven by hand
+ * 2026-07-19: a full analytics workbook (calcs + charts + dashboard) authored live in
+ * seconds, zero XML.
  * The known-command guard (from #542) makes the single execute-tableau-command tool
  * safe against hallucinated verbs.
  */

--- a/src/tools/desktop/commands/executeTableauCommand.test.ts
+++ b/src/tools/desktop/commands/executeTableauCommand.test.ts
@@ -188,11 +188,61 @@ describe('executeTableauCommandTool', () => {
 
     expect(result.isError).toBeFalsy();
     invariant(result.content[0].type === 'text');
-    expect(result.content[0].text).toContain('Command executed successfully');
-    expect(result.content[0].text).toContain('some_value');
+    const payload = JSON.parse(result.content[0].text);
+    expect(payload.message).toContain('Command executed successfully');
+    expect(payload.result).toEqual(commandResult);
   });
 
-  it('should return success with fallback message when result is null', async () => {
+  it('truncates oversized command result payloads with an honest byte-count note', async () => {
+    const largeValue = 'x'.repeat(20 * 1024);
+    const executeCommand = vi
+      .fn()
+      .mockResolvedValue(new Ok({ command_id: 'c1', result: { largeValue } }));
+    const extra = makeExtra(executeCommand);
+
+    const result = await getResult({ session: SESSION, command: 'tabdoc:save' }, extra);
+
+    expect(result.isError).toBeFalsy();
+    invariant(result.content[0].type === 'text');
+    const payload = JSON.parse(result.content[0].text);
+    expect(payload.message).toContain('result truncated:');
+    expect(payload.message).toContain('re-run with a narrower command if you need the rest');
+    expect(payload.result).not.toContain(largeValue);
+    expect(Buffer.byteLength(result.content[0].text, 'utf-8')).toBeLessThan(18 * 1024);
+  });
+
+  it('renders envelope warnings as visible warning lines on success', async () => {
+    const executeCommand = vi.fn().mockResolvedValue(
+      new Ok({
+        command_id: 'c1',
+        result: { ok: true },
+        warnings: [
+          {
+            code: 'output-serialization-failed',
+            message: 'Command output could not be serialized.',
+          },
+        ],
+      }),
+    );
+    const extra = makeExtra(executeCommand);
+
+    const result = await getResult({ session: SESSION, command: 'tabdoc:save' }, extra);
+
+    expect(result.isError).toBeFalsy();
+    invariant(result.content[0].type === 'text');
+    const payload = JSON.parse(result.content[0].text);
+    expect(payload.message).toContain(
+      'WARNING: output-serialization-failed - Command output could not be serialized.',
+    );
+    expect(payload.warnings).toEqual([
+      {
+        code: 'output-serialization-failed',
+        message: 'Command output could not be serialized.',
+      },
+    ]);
+  });
+
+  it('is silent about missing output when a command succeeds without result data', async () => {
     const executeCommand = vi.fn().mockResolvedValue(new Ok({ command_id: 'c1', result: null }));
     const extra = makeExtra(executeCommand);
 
@@ -200,13 +250,21 @@ describe('executeTableauCommandTool', () => {
 
     expect(result.isError).toBeFalsy();
     invariant(result.content[0].type === 'text');
-    expect(result.content[0].text).toContain('no result data');
+    const payload = JSON.parse(result.content[0].text);
+    expect(payload.message).toBe('Command executed successfully.');
+    expect(payload.result).toBeUndefined();
+    expect(payload.message).not.toContain('no result data');
   });
 
-  it('keeps unmapped executeCommand failure text unchanged', async () => {
+  it('surfaces command failure message and tableau-error-code extension', async () => {
     const commandError = {
       type: 'command-failed' as const,
-      error: { code: 'ERR', message: 'fail', recoverable: false },
+      error: {
+        code: 'ERR',
+        message: 'Desktop reported the real failure',
+        recoverable: false,
+        'tableau-error-code': '0x1234',
+      },
     };
     const executeCommand = vi.fn().mockResolvedValue({ isErr: () => true, error: commandError });
     const extra = makeExtra(executeCommand);
@@ -220,7 +278,10 @@ describe('executeTableauCommandTool', () => {
 
     expect(result.isError).toBe(true);
     invariant(result.content[0].type === 'text');
-    expect(result.content[0].text).toBe(new DesktopCommandExecutionError(commandError).message);
+    expect(result.content[0].text).toBe(
+      'Desktop reported the real failure\ntableau-error-code: 0x1234',
+    );
+    expect(result.content[0].text).not.toContain('Command execution failed');
   });
 
   it('appends the known-live failure fix when mapped command execution fails', async () => {
@@ -517,9 +578,7 @@ describe('executeTableauCommandTool', () => {
 
       expect(result.isError).toBeFalsy();
       invariant(result.content[0].type === 'text');
-      expect(JSON.parse(result.content[0].text).message).toBe(
-        'Command executed successfully:\n\nCommand completed successfully (no result data)',
-      );
+      expect(JSON.parse(result.content[0].text).message).toBe('Command executed successfully.');
     });
 
     it('leaves an arbitrary valid command call untouched', async () => {

--- a/src/tools/desktop/commands/executeTableauCommand.ts
+++ b/src/tools/desktop/commands/executeTableauCommand.ts
@@ -28,7 +28,10 @@ import type {
 import { validateNotionalSpecArgs } from '../../../desktop/notionalSpecGuard.js';
 import { validateCommandParams } from '../../../desktop/paramContractGuard.js';
 import { resolveSession } from '../../../desktop/sessionResolution.js';
-import type { ToolExecutor } from '../../../desktop/toolExecutor/toolExecutor.js';
+import type {
+  ExecuteCommandWarning,
+  ToolExecutor,
+} from '../../../desktop/toolExecutor/toolExecutor.js';
 import { validateUnderlyingMetadataLoad } from '../../../desktop/underlyingMetadataGuard.js';
 import { ArgsValidationError, DesktopCommandExecutionError } from '../../../errors/mcpToolError.js';
 import { DesktopMcpServer } from '../../../server.desktop.js';
@@ -37,6 +40,7 @@ import { DesktopTool } from '../tool.js';
 const LOAD_UNDERLYING_METADATA_COMMAND = 'tabui:load-underlying-metadata';
 const GENERATE_VIZ_FROM_NOTIONAL_SPEC_COMMAND = 'tabdoc:generate-viz-from-notional-spec';
 const CONTEXT_FILLED_PARAM_TYPES = new Set(['UPI_Workspace', 'UPI_IWorkspace']);
+const MAX_RESULT_BYTES = 16 * 1024;
 
 const paramsSchema = {
   session: z.string().optional().describe('Session ID; optional if pinned or unique.'),
@@ -174,20 +178,20 @@ export const getExecuteTableauCommandTool = (
             ).toErr();
           }
 
-          const resultText = result.value.result
-            ? JSON.stringify(result.value.result, null, 2)
-            : 'Command completed successfully (no result data)';
-          let message = `Command executed successfully:\n\n${resultText}`;
+          const payload = buildSuccessPayload({
+            result: result.value.result,
+            envelopeWarnings: result.value.warnings ?? [],
+            registryWarnings: externalApiRegistryWarnings,
+          });
           if (command === GENERATE_VIZ_FROM_NOTIONAL_SPEC_COMMAND) {
-            message = await appendGenerateVizReadback({ message, executor, signal: extra.signal });
-          }
-          if (externalApiRegistryWarnings.length > 0) {
-            message = `${message}\n\n${externalApiRegistryWarnings.join('\n')}`;
+            payload.message = await appendGenerateVizReadback({
+              message: payload.message,
+              executor,
+              signal: extra.signal,
+            });
           }
 
-          return new Ok({
-            message,
-          });
+          return new Ok(payload);
         },
       });
     },
@@ -203,6 +207,54 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 type ExternalApiGuardResult =
   | { ok: true; args: Record<string, unknown>; warnings: string[] }
   | { ok: false; message: string };
+
+type ExecuteTableauCommandSuccess = {
+  message: string;
+  result?: Record<string, unknown> | string;
+  warnings?: ExecuteCommandWarning[];
+};
+
+function buildSuccessPayload({
+  result,
+  envelopeWarnings,
+  registryWarnings,
+}: {
+  result: Record<string, unknown> | null | undefined;
+  envelopeWarnings: ExecuteCommandWarning[];
+  registryWarnings: string[];
+}): ExecuteTableauCommandSuccess {
+  const payload: ExecuteTableauCommandSuccess = {
+    message: 'Command executed successfully.',
+  };
+
+  if (result !== undefined && result !== null) {
+    const serialized = JSON.stringify(result, null, 2);
+    const totalBytes = Buffer.byteLength(serialized, 'utf-8');
+    if (totalBytes > MAX_RESULT_BYTES) {
+      const preview = Buffer.from(serialized, 'utf-8').subarray(0, MAX_RESULT_BYTES).toString();
+      const previewBytes = Buffer.byteLength(preview, 'utf-8');
+      payload.result = `${preview}\n...`;
+      payload.message =
+        `Command executed successfully. result truncated: ${previewBytes} of ${totalBytes} bytes - ` +
+        're-run with a narrower command if you need the rest.';
+    } else {
+      payload.result = result;
+    }
+  }
+
+  const warningLines = [
+    ...envelopeWarnings.map((warning) => `WARNING: ${warning.code} - ${warning.message}`),
+    ...registryWarnings,
+  ];
+  if (warningLines.length > 0) {
+    payload.message = `${payload.message}\n\n${warningLines.join('\n')}`;
+  }
+  if (envelopeWarnings.length > 0) {
+    payload.warnings = envelopeWarnings;
+  }
+
+  return payload;
+}
 
 function validateExternalApiCommandRegistry({
   command,
@@ -238,6 +290,8 @@ function validateExternalApiCommandRegistry({
     const param = findExternalApiParam(registry, key);
     if (!param) {
       rewrittenArgs[key] = value;
+      // Non-goal for monolith #60596: unknown params can still surface as bare 500s;
+      // the command-registry guard remains the client-side defense.
       warnings.push(
         `WARNING: key "${key}" is not in the command registry - a wrong name surfaces as a bare 500.`,
       );


### PR DESCRIPTION
Consumes monolith #60596: `Operation.result` (command output params, serialized on SUCCEEDED as of apiVersion 0.1.1) flows to the agent — `execute-tableau-command` success payloads carry structured `result` + warnings with honest 16KB truncation; FAILED surfaces the real error text + `tableau-error-code`; 0.1.0 builds feature-detect and stay silent. Write-blind doc claims corrected (scoped to ≤0.1.0). a2td gets the doc-correction port separately.

Validated firsthand: full suite 4994 passed / 1 skipped, tsc + eslint clean. Live proof rides the post-#60211/0.1.1 Desktop build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)