### PR TITLE
refactor: converge slim vocabulary — verbosity enum on the Pulse bundle, slim deprecated

### DIFF
--- a/src/tools/web/pulse/generateMetricValueInsightBundle/generatePulseMetricValueInsightBundleTool.test.ts
+++ b/src/tools/web/pulse/generateMetricValueInsightBundle/generatePulseMetricValueInsightBundleTool.test.ts
@@ -220,13 +220,25 @@ describe('getGeneratePulseMetricValueInsightBundleTool', () => {
     },
   );
 
-  it('should have correct tool properties', () => {
+  it('should have correct tool properties', async () => {
     const tool = getGeneratePulseMetricValueInsightBundleTool(new WebMcpServer());
+    const paramsSchema = await Provider.from(tool.paramsSchema);
     expect(tool.name).toBe('generate-pulse-metric-value-insight-bundle');
     expect(tool.description).toContain(
       'Generate an insight bundle for the current aggregated value',
     );
-    expect(tool.paramsSchema).toMatchObject({ bundleRequest: expect.any(Object) });
+    expect(paramsSchema).toMatchObject({
+      bundleRequest: expect.any(Object),
+      slim: expect.any(Object),
+      verbosity: expect.any(Object),
+    });
+    expect(paramsSchema.slim.description).toContain('Deprecated: use verbosity=slim.');
+    expect(paramsSchema.verbosity.description).toContain(
+      'strips the large viz (Vega chart-spec) blobs',
+    );
+    expect(paramsSchema.verbosity.safeParse('slim').success).toBe(true);
+    expect(paramsSchema.verbosity.safeParse('full').success).toBe(true);
+    expect(paramsSchema.verbosity.safeParse('verbose').success).toBe(false);
   });
 
   it('should handle API errors gracefully', async () => {
@@ -338,6 +350,32 @@ describe('getGeneratePulseMetricValueInsightBundleTool', () => {
     expect(parsed).not.toHaveProperty('metric_context');
   });
 
+  it('returns byte-identical output for verbosity slim and deprecated slim alias', async () => {
+    mocks.mockGeneratePulseMetricValueInsightBundle.mockResolvedValue(
+      new Ok(mockPopulatedResponse),
+    );
+
+    const verbositySlimResult = await getToolResult('ban', undefined, 'slim');
+    const deprecatedSlimResult = await getToolResult('ban', true);
+
+    invariant(verbositySlimResult.content[0].type === 'text');
+    invariant(deprecatedSlimResult.content[0].type === 'text');
+    expect(verbositySlimResult.content[0].text).toBe(deprecatedSlimResult.content[0].text);
+  });
+
+  it('uses verbosity when both verbosity and deprecated slim alias are supplied', async () => {
+    mocks.mockGeneratePulseMetricValueInsightBundle.mockResolvedValue(
+      new Ok(mockPopulatedResponse),
+    );
+
+    const result = await getToolResult('ban', true, 'full');
+
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed).toEqual(mockPopulatedResponse);
+  });
+
   it('returns viz verbatim when slim is omitted or false', async () => {
     mocks.mockGeneratePulseMetricValueInsightBundle.mockResolvedValue(
       new Ok(mockPopulatedResponse),
@@ -359,9 +397,13 @@ describe('getGeneratePulseMetricValueInsightBundleTool', () => {
   async function getToolResult(
     bundleType?: PulseInsightBundleType,
     slim?: boolean,
+    verbosity?: 'slim' | 'full',
   ): Promise<CallToolResult> {
     const tool = getGeneratePulseMetricValueInsightBundleTool(new WebMcpServer());
     const callback = await Provider.from(tool.callback);
-    return await callback({ bundleRequest, bundleType, slim }, getMockRequestHandlerExtra());
+    return await callback(
+      { bundleRequest, bundleType, slim, verbosity },
+      getMockRequestHandlerExtra(),
+    );
   }
 });

--- a/src/tools/web/pulse/generateMetricValueInsightBundle/generatePulseMetricValueInsightBundleTool.ts
+++ b/src/tools/web/pulse/generateMetricValueInsightBundle/generatePulseMetricValueInsightBundleTool.ts
@@ -16,14 +16,14 @@ import { slimBundle } from './slimBundle.js';
 const paramsSchema = {
   bundleRequest: pulseBundleRequestSchema,
   bundleType: z.optional(z.enum(pulseInsightBundleTypeEnum)),
-  slim: z
-    .optional(z.boolean())
+  verbosity: z
+    .enum(['full', 'slim'])
+    .optional()
     .describe(
-      'When true, strips the large viz (Vega chart-spec) blobs from every insight and summary ' +
-        'result, returning only the facts/markup fields a text/card UI renders — use this to ' +
-        'reduce payload size when the caller does not need chart specs. Defaults to false, which ' +
-        'returns the response verbatim, including viz.',
+      'full (default): returns the response verbatim, including viz. slim: strips the large viz ' +
+        '(Vega chart-spec) blobs from every insight and summary result.',
     ),
+  slim: z.optional(z.boolean()).describe('Deprecated: use verbosity=slim.'),
 };
 
 export const getGeneratePulseMetricValueInsightBundleTool = (
@@ -46,7 +46,8 @@ Generate an insight bundle for the current aggregated value for Pulse Metric usi
   - 'springboard' - Return a springboard insight bundle with the current value, period over period change, and the highest ranked insight for the metric.
   - 'basic' - Similar to a springboard insight, but data is focused on the dimensions of a metric that are low bandwidth because they have small value sets. It shows the current value, period over period change, and the highest ranked insight for the metric for that data.
   - 'detail' - Shows insights on performance over time of the metric, a summary visualization of metric highs and lows and trends, breakdowns of top contributors for each filterable dimension of the metric, and followup insights based on the top ranked insights not already presented.
-- \`slim\` (optional): When true, strips the large \`viz\` (Vega chart-spec) blobs from every insight and summary result, returning only the \`facts\`/\`markup\` fields a text/card UI renders. Use this to reduce payload size when chart specs are not needed. Defaults to false, which returns the response verbatim, including \`viz\`.
+- \`verbosity\` (optional): 'full' returns the response verbatim, including \`viz\`. 'slim' strips the large \`viz\` (Vega chart-spec) blobs from every insight and summary result. Defaults to 'full'.
+- \`slim\` (optional): Deprecated: use \`verbosity=slim\`.
 
 **Example Usage:**
 - Generate the default insight bundle for the Pulse metric:
@@ -149,10 +150,14 @@ Generate an insight bundle for the current aggregated value for Pulse Metric usi
       idempotentHint: true,
       openWorldHint: false,
     },
-    callback: async ({ bundleRequest, bundleType, slim }, extra): Promise<CallToolResult> => {
+    callback: async (
+      { bundleRequest, bundleType, verbosity, slim },
+      extra,
+    ): Promise<CallToolResult> => {
+      const useSlim = verbosity ? verbosity === 'slim' : Boolean(slim);
       return await generatePulseMetricValueInsightBundleTool.logAndExecute<PulseBundleResponse>({
         extra,
-        args: { bundleRequest, bundleType, slim },
+        args: { bundleRequest, bundleType, verbosity, slim },
         callback: async () => {
           const validationError = validateBundleRequest(bundleRequest);
           if (validationError) {
@@ -188,7 +193,7 @@ Generate an insight bundle for the current aggregated value for Pulse Metric usi
         constrainSuccessResult: (insightBundle) => {
           return {
             type: 'success',
-            result: slim ? slimBundle(insightBundle) : insightBundle,
+            result: useSlim ? slimBundle(insightBundle) : insightBundle,
           };
         },
       });


### PR DESCRIPTION
Review finding 8 (architectural pass over today's merges): #535 and #571 introduced two 'slim' dialects the same week. The Pulse bundle tool now takes `verbosity: 'full'|'slim'` (the #535 canonical vocabulary) with identical strip-the-viz-blobs semantics; boolean `slim` stays as a deprecated alias (verbosity wins on conflict) so existing UI callers are unbroken. Parity + precedence + default tests included.

@nawartamawi FYI — no action needed on your side now; when convenient, switch callers to `verbosity: 'slim'` and we retire the boolean later.

Validated firsthand: full suite 4990 passed / 1 skipped, tsc + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)