### PR TITLE
chore: scrub internal references; retire NotionalSpec readback + instructional prose

### DIFF
--- a/src/desktop/data/tableau-desktop-commands-reference.json
+++ b/src/desktop/data/tableau-desktop-commands-reference.json
@@ -23508,7 +23508,7 @@
       "source_file": "AnalyticsAssistantDesktopPaneCommand",
       "editor_type": "D",
       "server_permission": "UNRESTRICTED",
-      "description": "Generate a NotionalSpec from the current viz — BUT on External Client API apiVersion <=0.1.0 the /v0 External Client API did not return this command's output (write-blind envelope: state SUCCEEDED, no result). On apiVersion >=0.1.1, SUCCEEDED invokeCommand envelopes may carry serialized command output in result. Do not rely on <=0.1.0 to read the current spec. To inspect current state, use tabui:save-underlying-metadata (whole-document readback) or the list tools, then author a fresh v0.2 spec for tabdoc:generate-viz-from-notional-spec.",
+      "description": "Generate a NotionalSpec from the current viz. On External Client API apiVersion <=0.1.0, the /v0 External Client API does not return this command's output (write-blind envelope: state SUCCEEDED, no result). On apiVersion >=0.1.1, SUCCEEDED invokeCommand envelopes may carry serialized command output in result. The output is constrained to the serialized command result when Desktop supplies it.",
       "classification": "user_initiated",
       "usage_count": 0,
       "is_user_initiated": true,
@@ -23544,7 +23544,7 @@
       "source_file": "AnalyticsAssistantDesktopPaneCommand",
       "editor_type": "D",
       "server_permission": "UNRESTRICTED",
-      "description": "Generate a viz from a NotionalSpec v0.2 JSON. Args: NotionalSpecJson (REQUIRED, a JSON STRING), ClearSheet (optional boolean; true=fresh build, false=refinement). NO WorksheetId — target the sheet with tabdoc:goto-sheet first. Spec shape: {version:'0.2.0', chart?: one of text|heatmap|bar|stackedbar|line|area|gantt|scatterplot|histogram|symbolmap|filledmap|treemap|pie|dualline|boxplot|bullet|bubble, fields:[{caption, data: number|string|date|boolean|geographic|set, type: discrete|continuous, role: dimension|measure, aggregation: default|count|countd|sum|avg|max|min|median|year|qtr|month|week|day|hour|minute|second, encoding: x|y|color|size|text|shape}], categoricalFilters?:[{type:'categorical',field,values?,exclude?,limit?,condition?}], rangeFilters?:[{field,start?,end?,includeNull?}] (start/end, NOT min/max), relativeDateFilters?:[{type:'relative-date',field,amount,period: days|weeks|months|quarters|years (PLURAL),direction: next|previous}], sort?:{field, by, aggregation?, direction: asc|desc}}. CALCULATED FIELDS: create with author-calc FIRST, then reference by caption with aggregation 'default' (never 'none' — not v0.2 vocabulary). STRING DATES ('YYYY-MM' columns): author-calc a DATE() conversion (e.g. DATE([month] + \"-01\")) before a line chart — a line over a discrete string is a false trend. WRITE-BLIND: the /v0 API returns NO VizGenerationStatusList/VizCoherenceResult — a success envelope can hide an empty sheet. ALWAYS verify after apply: read the sheet back (tabui:save-underlying-metadata) and confirm rows/cols landed.",
+      "description": "Generate a viz from a NotionalSpec v0.2 JSON. Args: NotionalSpecJson (required JSON string), ClearSheet (optional boolean; true=fresh build, false=refinement). The route is constrained to the current worksheet; WorksheetId is not accepted. The output is constrained to the invokeCommand envelope and does not include a post-apply workbook readback.",
       "classification": "user_initiated",
       "usage_count": 0,
       "is_user_initiated": true,
@@ -23573,7 +23573,7 @@
           "local_name": "VizGenerationStatusList",
           "type_id": "",
           "required": false,
-          "comment": "NOT returned by the /v0 External Client API, but execute-tableau-command appends a compact post-apply readback to successful tabdoc:generate-viz-from-notional-spec results. Trust that line; use tabui:save-underlying-metadata only for deeper inspection.",
+          "comment": "The /v0 External Client API does not return a post-apply workbook readback for this command. The invokeCommand envelope may include serialized command output only when Desktop supplies it.",
           "cannot_provide_from_mcp": false
         }
       ],

--- a/src/desktop/externalApi/types.ts
+++ b/src/desktop/externalApi/types.ts
@@ -3,9 +3,9 @@ import { z } from 'zod';
 /**
  * Types and schemas for the Tableau Desktop "External Client API" (Athena V0).
  *
- * Contract originally derived from monolith PRs #57536 → #59383, then tightened
- * against the live `/openapi.json` (OpenAPI 3.1, `info.version` 0.1.0, captured
- * 2026-07-20) plus live probes against the running 0.1.0 build. Envelope fields the
+ * Contract derived from the External Client API rollout, then tightened against the
+ * live `/openapi.json` (OpenAPI 3.1, `info.version` 0.1.0, captured 2026-07-20)
+ * plus live probes against the running 0.1.0 build. Envelope fields the
  * spec marks required are required here; everything else stays permissive
  * (`.passthrough()` / optional) because the spec is read-complete but write-thin.
  */
@@ -169,7 +169,7 @@ export type OperationWarning = z.infer<typeof operationWarningSchema>;
  * Operation envelope returned by `POST /v0/workbook/document` and
  * `POST /v0/app:invokeCommand`. `id`/`kind`/`state` are required per the spec.
  * `result` is present only on SUCCEEDED envelopes with non-null command output as of
- * External Client API apiVersion 0.1.1 (monolith #60596); 0.1.0 instances legitimately
+ * External Client API apiVersion 0.1.1; 0.1.0 instances legitimately
  * omit it on success.
  */
 export const operationEnvelopeSchema = z

--- a/src/tools/desktop/commands/executeTableauCommand.test.ts
+++ b/src/tools/desktop/commands/executeTableauCommand.test.ts
@@ -1,7 +1,7 @@
 import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { mkdtempSync, rmSync, writeFileSync } from 'fs';
 import { join } from 'path';
-import { Err, Ok } from 'ts-results-es';
+import { Ok } from 'ts-results-es';
 
 import { _resetExternalApiCommandRegistryForTest } from '../../../desktop/externalApi/commandRegistry.js';
 import { ArgsValidationError, DesktopCommandExecutionError } from '../../../errors/mcpToolError.js';
@@ -19,25 +19,6 @@ const LIVE_UNDERLYING_METADATA_XML = `<workbook>
 const STALE_UNDERLYING_METADATA_XML = `<workbook>
   <datasources><datasource name='ds' /></datasources>
   <worksheets><worksheet name='A' /></worksheets>
-</workbook>`;
-const GENERATED_VIZ_READBACK_XML = `<workbook>
-  <worksheets>
-    <worksheet name="Revenue by Region">
-      <table>
-        <panes>
-          <pane>
-            <mark class="Bar"/>
-          </pane>
-        </panes>
-        <rows>[Region]</rows>
-        <cols>SUM([Revenue])</cols>
-        <sort class="computed" column="[Region]" direction="desc" using="SUM([Revenue])"/>
-      </table>
-    </worksheet>
-  </worksheets>
-  <windows>
-    <window class="worksheet" name="Revenue by Region" active="true"/>
-  </windows>
 </workbook>`;
 const SORT_NESTED_LIVE_500_FIX =
   'FIX: tabdoc:sort-nested is known to fail (HTTP 500) on current Desktop builds regardless of parameters — do not retry it. Sort instead via the bind-template sort proposal (preferred for template-bound sheets) or the document round-trip (tabui:save-underlying-metadata → edit the computed-sort → tabui:load-underlying-metadata).';
@@ -515,52 +496,10 @@ describe('executeTableauCommandTool', () => {
       );
     });
 
-    it('appends compact readback after generate-viz-from-notional-spec succeeds', async () => {
-      const executeCommand = vi.fn(async (params: any) => {
-        if (params.command === 'save-underlying-metadata') {
-          return new Ok({
-            command_id: 'save-1',
-            parsedResult: { text: GENERATED_VIZ_READBACK_XML },
-          });
-        }
-        return new Ok({ command_id: 'generate-1', result: null });
-      });
-      const extra = makeExtra(executeCommand);
-
-      const result = await getResult(
-        {
-          session: SESSION,
-          command: 'tabdoc:generate-viz-from-notional-spec',
-          args: {
-            NotionalSpecJson:
-              '{"version":"0.2.0","chart":"bar","fields":[{"caption":"Region","data":"string","type":"discrete","role":"dimension","encoding":"x"},{"caption":"Revenue","data":"number","type":"continuous","role":"measure","aggregation":"sum","encoding":"y"}]}',
-            ClearSheet: true,
-          },
-        },
-        extra,
-      );
-
-      expect(result.isError).toBeFalsy();
-      invariant(result.content[0].type === 'text');
-      expect(JSON.parse(result.content[0].text).message).toContain(
-        'readback: sheet "Revenue by Region" - Rows: [Region]; Cols: SUM([Revenue]); mark: Bar; sort: [Region] desc by SUM([Revenue]).',
-      );
-      expect(executeCommand).toHaveBeenCalledWith(
-        expect.objectContaining({
-          namespace: 'tabui',
-          command: 'save-underlying-metadata',
-          args: { 'is-json': false },
-        }),
-      );
-    });
-
-    it('keeps generate-viz-from-notional-spec success unchanged when readback fails', async () => {
-      const executeCommand = vi.fn(async (params: any) => {
-        if (params.command === 'save-underlying-metadata') {
-          return Err({ type: 'command-timed-out' as const, error: 'Timeout' });
-        }
-        return new Ok({ command_id: 'generate-1', result: null });
-      });
+    it('does not append a readback after generate-viz-from-notional-spec succeeds', async () => {
+      const executeCommand = vi
+        .fn()
+        .mockResolvedValue(new Ok({ command_id: 'generate-1', result: null }));
       const extra = makeExtra(executeCommand);
 
       const result = await getResult(
@@ -579,6 +518,13 @@ describe('executeTableauCommandTool', () => {
       expect(result.isError).toBeFalsy();
       invariant(result.content[0].type === 'text');
       expect(JSON.parse(result.content[0].text).message).toBe('Command executed successfully.');
+      expect(executeCommand).toHaveBeenCalledTimes(1);
+      expect(executeCommand).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          namespace: 'tabui',
+          command: 'save-underlying-metadata',
+        }),
+      );
     });
 
     it('leaves an arbitrary valid command call untouched', async () => {

--- a/src/tools/desktop/commands/executeTableauCommand.ts
+++ b/src/tools/desktop/commands/executeTableauCommand.ts
@@ -7,38 +7,21 @@ import {
   knownLiveFailureFixFor,
 } from '../../../desktop/commandPolicy.js';
 import { validateKnownCommand } from '../../../desktop/commandRegistry.js';
-import { getWorkbookXml } from '../../../desktop/commands/workbook/getWorkbookXml.js';
 import {
   ExternalApiCommandRegistryEntry,
   ExternalApiRegistryParam,
   lookupExternalApiCommandRegistry,
 } from '../../../desktop/externalApi/commandRegistry.js';
-import {
-  findAllWorksheets,
-  findWorksheet,
-  normalizeArray,
-  parseXML,
-} from '../../../desktop/metadata/parser.js';
-import type {
-  ParsedPane,
-  ParsedWindow,
-  ParsedWorkbook,
-  ParsedWorksheet,
-} from '../../../desktop/metadata/types.js';
 import { validateNotionalSpecArgs } from '../../../desktop/notionalSpecGuard.js';
 import { validateCommandParams } from '../../../desktop/paramContractGuard.js';
 import { resolveSession } from '../../../desktop/sessionResolution.js';
-import type {
-  ExecuteCommandWarning,
-  ToolExecutor,
-} from '../../../desktop/toolExecutor/toolExecutor.js';
+import type { ExecuteCommandWarning } from '../../../desktop/toolExecutor/toolExecutor.js';
 import { validateUnderlyingMetadataLoad } from '../../../desktop/underlyingMetadataGuard.js';
 import { ArgsValidationError, DesktopCommandExecutionError } from '../../../errors/mcpToolError.js';
 import { DesktopMcpServer } from '../../../server.desktop.js';
 import { DesktopTool } from '../tool.js';
 
 const LOAD_UNDERLYING_METADATA_COMMAND = 'tabui:load-underlying-metadata';
-const GENERATE_VIZ_FROM_NOTIONAL_SPEC_COMMAND = 'tabdoc:generate-viz-from-notional-spec';
 const CONTEXT_FILLED_PARAM_TYPES = new Set(['UPI_Workspace', 'UPI_IWorkspace']);
 const MAX_RESULT_BYTES = 16 * 1024;
 
@@ -183,13 +166,6 @@ export const getExecuteTableauCommandTool = (
             envelopeWarnings: result.value.warnings ?? [],
             registryWarnings: externalApiRegistryWarnings,
           });
-          if (command === GENERATE_VIZ_FROM_NOTIONAL_SPEC_COMMAND) {
-            payload.message = await appendGenerateVizReadback({
-              message: payload.message,
-              executor,
-              signal: extra.signal,
-            });
-          }
 
           return new Ok(payload);
         },
@@ -290,7 +266,7 @@ function validateExternalApiCommandRegistry({
     const param = findExternalApiParam(registry, key);
     if (!param) {
       rewrittenArgs[key] = value;
-      // Non-goal for monolith #60596: unknown params can still surface as bare 500s;
+      // The External Client API still surfaces some unknown command params as bare 500s;
       // the command-registry guard remains the client-side defense.
       warnings.push(
         `WARNING: key "${key}" is not in the command registry - a wrong name surfaces as a bare 500.`,
@@ -392,145 +368,4 @@ function extractDocumentText(value: unknown): string | null {
   }
 
   return typeof result === 'string' ? result : null;
-}
-
-async function appendGenerateVizReadback({
-  message,
-  executor,
-  signal,
-}: {
-  message: string;
-  executor: ToolExecutor;
-  signal: AbortSignal;
-}): Promise<string> {
-  try {
-    const workbookXml = await getWorkbookXml({ executor, signal });
-    if (workbookXml.isErr()) {
-      return message;
-    }
-    const readback = formatCurrentWorksheetReadback(workbookXml.value);
-    return readback ? `${message}\n\n${readback}` : message;
-  } catch {
-    return message;
-  }
-}
-
-function formatCurrentWorksheetReadback(workbookXml: string): string | null {
-  const workbook = parseXML(workbookXml);
-  const worksheet = pickCurrentWorksheet(workbook);
-  if (!worksheet) {
-    return null;
-  }
-
-  const rows = formatShelf(worksheet.table?.rows);
-  const cols = formatShelf(worksheet.table?.cols);
-  const markClass = getMarkClass(worksheet);
-  const sort = getSortSummary(worksheet);
-  const pieces = [
-    `readback: sheet "${worksheet['@_name']}" - Rows: ${rows}; Cols: ${cols}`,
-    markClass ? `mark: ${markClass}` : undefined,
-    sort ? `sort: ${sort}` : undefined,
-  ].filter(Boolean);
-
-  return `${pieces.join('; ')}.`;
-}
-
-function pickCurrentWorksheet(workbook: ParsedWorkbook): ParsedWorksheet | null {
-  const worksheets = findAllWorksheets(workbook);
-  if (worksheets.length === 0) {
-    return null;
-  }
-
-  const worksheetWindows = normalizeArray<ParsedWindow>(workbook.workbook?.windows?.window).filter(
-    (window) => (window['@_class'] ?? 'worksheet') === 'worksheet',
-  );
-  const activeWindow = worksheetWindows.find((window) =>
-    ['true', '1'].includes(String(window['@_active'] ?? '').toLowerCase()),
-  );
-  if (activeWindow?.['@_name']) {
-    return findWorksheet(workbook, activeWindow['@_name']);
-  }
-
-  const maximizedWindow = worksheetWindows.find((window) =>
-    ['true', '1'].includes(String(window['@_maximized'] ?? '').toLowerCase()),
-  );
-  if (maximizedWindow?.['@_name']) {
-    return findWorksheet(workbook, maximizedWindow['@_name']);
-  }
-
-  if (worksheets.length === 1) {
-    return worksheets[0];
-  }
-  if (worksheetWindows.length === 1 && worksheetWindows[0]['@_name']) {
-    return findWorksheet(workbook, worksheetWindows[0]['@_name']);
-  }
-
-  return null;
-}
-
-function formatShelf(value: unknown): string {
-  const parts = normalizeArray(value)
-    .map((entry) => textValue(entry))
-    .filter((entry): entry is string => Boolean(entry));
-  return parts.length > 0 ? parts.join(', ') : '[]';
-}
-
-function getMarkClass(worksheet: ParsedWorksheet): string | null {
-  const panes = normalizeArray<ParsedPane>(worksheet.table?.panes?.pane);
-  const paneWithMark = panes.find((pane) => typeof pane.mark?.['@_class'] === 'string');
-  return paneWithMark?.mark?.['@_class'] ?? null;
-}
-
-function getSortSummary(worksheet: ParsedWorksheet): string | null {
-  const sort = findFirstSort(worksheet.table);
-  if (!isRecord(sort)) {
-    return null;
-  }
-
-  const column = stringAttr(sort, '@_column');
-  const direction = stringAttr(sort, '@_direction')?.toLowerCase();
-  const using = stringAttr(sort, '@_using');
-  if (!column && !direction && !using) {
-    return null;
-  }
-
-  return [column, direction, using ? `by ${using}` : undefined].filter(Boolean).join(' ');
-}
-
-function findFirstSort(value: unknown): unknown {
-  if (!isRecord(value)) {
-    return null;
-  }
-  for (const [key, child] of Object.entries(value)) {
-    if (key.toLowerCase().endsWith('sort')) {
-      return Array.isArray(child) ? child[0] : child;
-    }
-  }
-  for (const child of Object.values(value)) {
-    if (Array.isArray(child)) {
-      for (const item of child) {
-        const sort = findFirstSort(item);
-        if (sort) return sort;
-      }
-      continue;
-    }
-    const sort = findFirstSort(child);
-    if (sort) return sort;
-  }
-  return null;
-}
-
-function textValue(value: unknown): string | null {
-  if (typeof value === 'string') {
-    return value;
-  }
-  if (isRecord(value) && typeof value['#text'] === 'string') {
-    return value['#text'];
-  }
-  return null;
-}
-
-function stringAttr(value: Record<string, unknown>, key: string): string | null {
-  const attr = value[key];
-  return typeof attr === 'string' && attr.length > 0 ? attr : null;
 }

--- a/src/tools/desktop/data-source/getSummaryData.test.ts
+++ b/src/tools/desktop/data-source/getSummaryData.test.ts
@@ -258,7 +258,7 @@ function parseResult(result: CallToolResult): z.infer<typeof resultSchema> {
 }
 
 describe('isRouteMissing', () => {
-  it('detects the pre-#60211 Desktop route miss', () => {
+  it('detects the Desktop route miss before summary data support is available', () => {
     expect(
       isRouteMissing({
         type: 'command-failed',


### PR DESCRIPTION
Small cleanup PR (owner directive + @lauren-jacksonSFDC's #576 comments):

- **Internal references scrubbed repo-wide**: every internal PR/repo pointer in comments, strings, and tool messages reworded to neutral public-safe phrasing (apiVersion-scoped where the fact matters). Post-sweep grep: zero hits.
- **NotionalSpec**: the commands-reference entries no longer instruct spec authoring (retired path — constraints stated, nothing taught); the readback special case + helper removed from `execute-tableau-command`. The containment guard (`validateNotionalSpecArgs`) stays.

Validated firsthand: tsc clean, full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)