### PR TITLE
fix: enum linkage accepts tuple-shaped type_of_param (the shipped registry shape)

### DIFF
--- a/src/desktop/externalApi/commandRegistry.test.ts
+++ b/src/desktop/externalApi/commandRegistry.test.ts
@@ -83,6 +83,7 @@ describe('externalApi commandRegistry', () => {
       },
       typeOfParam: {
         DPI_ShowMeCommandType: { enum_name: 'ShowMeCommandType' },
+        DPI_TupleEnumType: ['TupleEnum', 'enum'],
       },
       enumVals: {
         ShowMeCommandType: ['bars', 'lines'],
@@ -103,6 +104,33 @@ describe('externalApi commandRegistry', () => {
     expect(entry?.paramWireByLocal.get('ShowMeType')).toBe('show-me-command-type');
     expect(entry?.paramWireByCamelToDashed.get('show-me-type')).toBe('show-me-command-type');
     expect(entry?.enumValuesForParamType.get('DPI_ShowMeCommandType')).toEqual(['bars', 'lines']);
+  });
+
+  it('resolves enum names from tuple-shaped type_of_param entries (the shipped registry shape)', async () => {
+    const dir = writeRegistry({
+      commands: {
+        'tabdoc:show-me': {
+          agent_can_invoke: true,
+          opens_blocking_dialog: false,
+          in_params: [
+            {
+              local: 'ShowMeType',
+              type: 'DPI_TupleEnumType',
+              required: true,
+              wire: 'show-me-command-type',
+            },
+          ],
+        },
+      },
+      typeOfParam: { DPI_TupleEnumType: ['TupleEnum', 'enum'] },
+      enumVals: { TupleEnum: ['bar-horiz', 'text'] },
+    });
+    vi.stubEnv('EXTERNAL_API_REGISTRY_DIR', dir);
+
+    const { lookupExternalApiCommandRegistry } = await import('./commandRegistry.js');
+    const entry = lookupExternalApiCommandRegistry('tabdoc', 'show-me');
+
+    expect(entry?.enumValuesForParamType.get('DPI_TupleEnumType')).toEqual(['bar-horiz', 'text']);
   });
 
   it('parses the files once for a stable env dir', async () => {

--- a/src/desktop/externalApi/commandRegistry.ts
+++ b/src/desktop/externalApi/commandRegistry.ts
@@ -206,6 +206,12 @@ function enumNameFrom(value: unknown): string | null {
   if (typeof value === 'string' && value.length > 0) {
     return value;
   }
+  // The codegen registry's type_of_param values are tuples like
+  // ["ShowMeCommandType", "enum"] — the first element is the enum name.
+  if (Array.isArray(value)) {
+    const [first] = value;
+    return typeof first === 'string' && first.length > 0 ? first : null;
+  }
   if (!isRecord(value)) {
     return null;
   }


### PR DESCRIPTION
A cross-repo compatibility check (tab-agent-south !66's shipped registries vs this repo's guard) found the enum-name lookup silently inert for the actual shipped `type_of_param` shape — tuple entries like `["ShowMeCommandType", "enum"]`. `enumNameFrom` accepted only strings/objects, so enum validation quietly skipped exactly the mismatch class the guard exists for (`DPI_ShowMeType` → `ShowMeCommandType`). Fail-open masked it: no crash, just a weaker guard.

Five-line fix + a regression test using the shipped shape. Full suite 4997 passed / 1 skipped, verified firsthand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)