### PR TITLE
@W-23146707: Loosen record-event event_type validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "3.5.3",
+  "version": "3.5.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "3.5.3",
+      "version": "3.5.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.7.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "3.5.3",
+  "version": "3.5.4",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/src/tools/web/recordEvent/recordEvent.test.ts
+++ b/src/tools/web/recordEvent/recordEvent.test.ts
@@ -88,17 +88,6 @@ describe('getRecordEventTool', () => {
     }
   });
 
-  it('rejects event_type that is too long or not SCREAMING_SNAKE_CASE', async () => {
-    const schema = z.object(
-      await Provider.from(getRecordEventTool(new WebMcpServer()).paramsSchema),
-    );
-    expect(schema.safeParse({ event_type: 'A'.repeat(65) }).success).toBe(false); // too long
-    expect(schema.safeParse({ event_type: 'tool_error' }).success).toBe(false); // lowercase
-    expect(schema.safeParse({ event_type: 'TOOL ERROR' }).success).toBe(false); // spaces
-    expect(schema.safeParse({ event_type: '1TOOL_ERROR' }).success).toBe(false); // leading digit
-    expect(schema.safeParse({ event_type: '_TOOL_ERROR' }).success).toBe(false); // leading underscore
-  });
-
   it('truncates message longer than 1024 characters in the forwarded event', async () => {
     const extra = getMockRequestHandlerExtra();
     const longMessage = 'x'.repeat(2000);

--- a/src/tools/web/recordEvent/recordEvent.ts
+++ b/src/tools/web/recordEvent/recordEvent.ts
@@ -9,12 +9,10 @@ import { WebTool } from '../tool.js';
 
 // Starting field set — the final app-supplied schema is expected to grow later.
 const paramsSchema = {
-  // Bounded free-form string rather than a hard enum: the event-type set is intentionally
-  // app-extensible (see above), so we reject malformed values but not unknown-yet-valid ones.
+  // Free-form string rather than a hard enum: the event-type set is intentionally
+  // app-extensible (see above), so we accept any value rather than reject unknown-yet-valid ones.
   event_type: z
     .string()
-    .max(64)
-    .regex(/^[A-Z][A-Z0-9_]*$/, 'event_type must be SCREAMING_SNAKE_CASE (e.g. TOOL_ERROR).')
     .describe(
       'The event type for product telemetry, e.g. TOOL_ERROR, PARSE_ERROR, AUTH_ERROR, EMBED_LOAD_ERROR, MCP_APP_CLICKED.',
     ),


### PR DESCRIPTION
## Description

Follow-up to #530. Loosens validation on the `record-event` app tool's `event_type` parameter:

- Removed the `.max(64)` length cap and the SCREAMING_SNAKE_CASE regex (`/^[A-Z][A-Z0-9_]*$/`) from `event_type` — it now accepts any string.
- Kept the `message` field's 1024-char truncation unchanged.
- Removed the now-obsolete test that asserted malformed `event_type` values are rejected; positive and message-truncation tests remain.

## Motivation and Context

The regex/length constraints on `event_type` were stricter than the telemetry pipeline needs and risked rejecting valid client events at the schema boundary. `event_type` is a free-form telemetry label; bounding it as a hard-validated field added friction without a corresponding safety benefit. The `message` truncation is retained since it protects the telemetry payload size.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## How Has This Been Tested?

- `npx vitest run src/tools/web/recordEvent` — 6 tests pass
- `npx tsc --noEmit` — clean
- `npx eslint` on the changed files — clean

## Related Issues

Follow-up to #530.

## Checklist

- [x] I have updated the version in the package.json file by using `npm run version` (3.5.3 → 3.5.4).
- [ ] I have made any necessary changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have documented any breaking changes in the PR description.