### PR TITLE
feat: knowledge search length-router — long queries become first-class

### DIFF
--- a/resources/desktop/knowledge/strategy/viz-design/worksheet-strategy.md
+++ b/resources/desktop/knowledge/strategy/viz-design/worksheet-strategy.md
@@ -14,7 +14,7 @@ Tags: worksheets, shelves, trellis, small-multiples, sorting
 - In-scope reason: Helps Claude choose the right rows/columns shelf structure for a user's analytical question, including trellis chart layouts and nested-dimension configurations.
 - Out-of-scope risk: none
 - Tags: worksheets, shelves, trellis, small-multiples, sorting, rows-columns, hiding-sheets, index-partition
-- Relevant user prompts/search terms: "how to configure Rows and Columns shelf", "trellis chart in Tableau", "small multiples layout", "how to sort dimension by measure", "hiding worksheets used in dashboard", "INDEX partition calc for grid", "discrete vs continuous on shelf", "nested dimensions on Rows", "Measure Names and Measure Values", "when to use a trellis vs filter"
+- Relevant user prompts/search terms: "how to configure Rows and Columns shelf", "trellis chart in Tableau", "small multiples layout", "how to sort dimension by measure", "hiding worksheets used in dashboard", "INDEX partition calc for grid", "discrete vs continuous on shelf", "nested dimensions on Rows", "Measure Names and Measure Values", "when to use a trellis vs filter", "add field to shelf without template", "manual worksheet build"
 
 ## When to Use
 

--- a/resources/desktop/knowledge/tactics/viz/worksheets.md
+++ b/resources/desktop/knowledge/tactics/viz/worksheets.md
@@ -12,7 +12,7 @@ Confirmed patterns for creating worksheets programmatically, window entries, row
 - In-scope reason: Worksheets require correct table structure, window entries, datasource-dependencies placement, and incremental-add workflow to avoid silent sheet loss or metadata stripping.
 - Out-of-scope risk: none
 - Tags: worksheet, window, view, datasource-dependencies, panes, rows, cols, column-instance, table-calc, trellis, small-multiples, index-partition, round-trip, hidden-worksheet, table-structure
-- Relevant user prompts/search terms: "how do I create a new worksheet from scratch", "window entry required for worksheets", "sheet disappeared after submission", "worksheets silently dropped without window", "add sheets incrementally one at a time", "trellis small multiples INDEX partition calc", "partition calcs must be role measure type quantitative", "hide a worksheet used in dashboard", "delete worksheet via API", "table-calc ordering-type Field vs Rows"
+- Relevant user prompts/search terms: "how do I create a new worksheet from scratch", "window entry required for worksheets", "sheet disappeared after submission", "worksheets silently dropped without window", "add sheets incrementally one at a time", "trellis small multiples INDEX partition calc", "partition calcs must be role measure type quantitative", "hide a worksheet used in dashboard", "delete worksheet via API", "table-calc ordering-type Field vs Rows", "add field to shelf without template", "manual worksheet build"
 
 ## Complete worksheet structure
 

--- a/resources/desktop/knowledge/tactics/workflow/templates.md
+++ b/resources/desktop/knowledge/tactics/workflow/templates.md
@@ -2,7 +2,7 @@
 
 > **Trimmed entry.** The old `inject_template_visualization` tool no longer exists, and the JSON files in `data/data-visualization-templates/` are the pre-XML node format — **not loadable** by any tool (structural reference only). Per the knowledge-layer review, this entry is reduced to the current-tools pointer; the stale JSON-walkthrough and removed-tool detail have been dropped.
 
-- Relevant user prompts/search terms: "inject a template visualization", "chart type template", "JSON templates not loadable", "tableau-bind-template", "tableau-search-examples", "duplicate and modify instead of building from scratch"
+- Relevant user prompts/search terms: "inject a template visualization", "chart type template", "JSON templates not loadable", "tableau-bind-template", "tableau-search-examples", "duplicate and modify instead of building from scratch", "bind-template", "symbol map country only"
 
 ## When to Use
 

--- a/src/desktop/knowledge.test.ts
+++ b/src/desktop/knowledge.test.ts
@@ -1,6 +1,10 @@
 import { beforeAll, describe, expect, it } from 'vitest';
 
-import { _resetKnowledgeSearchCache, searchKnowledge } from './knowledge/index.js';
+import {
+  _resetKnowledgeSearchCache,
+  searchKnowledge,
+  searchKnowledgeWithFallback,
+} from './knowledge/index.js';
 
 // Each fuse.js search scans the full document `body` of the ~108-doc corpus with
 // ignoreLocation:true (~450ms/query — real work, not a leak). A multi-case block
@@ -39,6 +43,120 @@ describe('knowledge/search', { timeout: 30_000 }, () => {
   it('returns [] for an empty query', () => {
     expect(searchKnowledge('', 5)).toEqual([]);
     expect(searchKnowledge('   ', 5)).toEqual([]);
+  });
+
+  it('promotes long natural queries to keyword-ranked hits with expected docs in the top 3', () => {
+    const cases: Array<{ query: string; expectedSlugSuffixes: string[] }> = [
+      {
+        query: 'I need a country symbol map but bind-template only gives country',
+        expectedSlugSuffixes: [
+          'tactics/workflow/templates',
+          'tactics/viz/worksheets',
+          'strategy/viz-design/worksheet-strategy',
+        ],
+      },
+      {
+        query: 'Manually build a worksheet by putting a field on a shelf without a canned template',
+        expectedSlugSuffixes: ['tactics/viz/worksheets', 'strategy/viz-design/worksheet-strategy'],
+      },
+      {
+        query: 'How do I put fields on Rows and Columns shelves when there is no canned template?',
+        expectedSlugSuffixes: ['tactics/viz/worksheets', 'strategy/viz-design/worksheet-strategy'],
+      },
+      {
+        query: 'How can I compare current year to prior year when my date filter changes?',
+        expectedSlugSuffixes: ['tactics/data/year-over-year-date-filter-calc'],
+      },
+      {
+        query: 'Why is prior year value blank after filtering the dashboard to one year?',
+        expectedSlugSuffixes: ['tactics/data/year-over-year-date-filter-calc'],
+      },
+      {
+        query:
+          'What is the safe way to create a cross-sheet region filter across multiple worksheets?',
+        expectedSlugSuffixes: ['tactics/viz/cross-sheet-filter-authoring'],
+      },
+      {
+        query: 'How should I calculate market share by dividing values after aggregation?',
+        expectedSlugSuffixes: ['tactics/data/aggregate-ratio-window-total-semantics'],
+      },
+      {
+        query: 'How do I make a Sankey diagram showing money flowing between departments?',
+        expectedSlugSuffixes: ['strategy/viz-design/flow-and-sankey'],
+      },
+    ];
+
+    for (const { query, expectedSlugSuffixes } of cases) {
+      expect(query.length, query).toBeGreaterThan(32);
+      const result = searchKnowledgeWithFallback(query, 5);
+      const top3 = result.hits.slice(0, 3);
+      expect(top3.length, query).toBeGreaterThan(0);
+      expect(
+        top3.every((hit) => hit.match === 'keyword'),
+        query,
+      ).toBe(true);
+      expect(
+        top3.some((hit) => expectedSlugSuffixes.some((suffix) => hit.slug.endsWith(suffix))),
+        query,
+      ).toBe(true);
+      expect(result).not.toHaveProperty('nearestMatches');
+    }
+  });
+
+  it('returns nearest keyword matches separately for genuine long-query zero hits', () => {
+    const cases: string[] = [
+      'florblesnack quazzlewump blitternode zarpwidget plonkshaft narglebeam',
+      'xqzvbnm ytrplok mnvczrx pqwlkjh zznobble frandship glorpnado',
+    ];
+
+    for (const query of cases) {
+      const result = searchKnowledgeWithFallback(query, 5);
+      expect(query.length, query).toBeGreaterThan(32);
+      expect(result.hits, query).toEqual([]);
+      expect(result.nearestMatches?.length, query).toBeGreaterThan(0);
+      expect(result.note, query).toMatch(/zero exact matches/i);
+    }
+  });
+
+  it('keeps terse field-report queries connected to the expected docs', () => {
+    const cases: Array<[string, string[]]> = [
+      [
+        'country symbol map bind template',
+        [
+          'tactics/workflow/templates',
+          'tactics/viz/worksheets',
+          'strategy/viz-design/worksheet-strategy',
+        ],
+      ],
+      [
+        'manual worksheet authoring put field shelf',
+        ['tactics/viz/worksheets', 'strategy/viz-design/worksheet-strategy'],
+      ],
+      [
+        'manual worksheet field shelf no canned template',
+        ['tactics/viz/worksheets', 'strategy/viz-design/worksheet-strategy'],
+      ],
+    ];
+
+    for (const [query, allowedSlugs] of cases) {
+      const result = searchKnowledgeWithFallback(query, 5);
+      const candidates = result.hits.length > 0 ? result.hits : (result.nearestMatches ?? []);
+      expect(candidates.length, query).toBeGreaterThan(0);
+      expect(
+        candidates.some((hit) => allowedSlugs.includes(hit.slug)),
+        query,
+      ).toBe(true);
+    }
+  });
+
+  it('does not add nearest matches when the primary ranker finds hits', () => {
+    const query = 'high cardinality quick filter';
+    const hits = searchKnowledge(query, 5);
+    const result = searchKnowledgeWithFallback(query, 5);
+
+    expect(hits.length).toBeGreaterThan(0);
+    expect(result).toEqual({ hits });
+    expect(result).not.toHaveProperty('nearestMatches');
   });
 
   it('ranks the expected entry #1 (4 cases)', () => {

--- a/src/desktop/knowledge/index.ts
+++ b/src/desktop/knowledge/index.ts
@@ -67,6 +67,65 @@ interface KnowledgeDoc {
 
 let _knowledgeDocs: KnowledgeDoc[] | null = null;
 let _knowledgeFuse: Fuse<KnowledgeDoc> | null = null;
+let _knowledgeKeywordFuse: Fuse<KnowledgeDoc> | null = null;
+let _knowledgeFallbackFuse: Fuse<KnowledgeDoc> | null = null;
+let _knowledgeBroadNearestFuse: Fuse<KnowledgeDoc> | null = null;
+
+const MAX_WHOLE_STRING_QUERY_LENGTH = 32;
+
+const knowledgeSearchKeys = [
+  { name: 'searchTerms', weight: 0.3 },
+  { name: 'tags', weight: 0.22 },
+  { name: 'title', weight: 0.2 },
+  { name: 'whenToUse', weight: 0.18 },
+  { name: 'slug', weight: 0.06 },
+  // NB: the full document `body` is deliberately NOT a fuse search key. With
+  // ignoreLocation:true fuse fuzzy-scans every char of all ~108 doc bodies per
+  // query (~450ms each) — the dominant cost, and it CPU-starved CI workers past
+  // the pool's 60s onTaskUpdate RPC deadline. Ranking is driven by the curated
+  // metadata (searchTerms/tags/title/whenToUse/slug); body added negligible signal
+  // at weight 0.04. `body` is still kept on the doc for the result snippet.
+];
+
+const LONG_QUERY_STOPWORDS = new Set([
+  'the',
+  'and',
+  'for',
+  'with',
+  'without',
+  'into',
+  'from',
+  'over',
+  'only',
+  'not',
+  'no',
+  'a',
+  'an',
+  'any',
+  'are',
+  'but',
+  'can',
+  'does',
+  'how',
+  'need',
+  'this',
+  'when',
+  'what',
+  'why',
+  'tableau',
+  'using',
+  'use',
+]);
+
+const LONG_QUERY_TOOL_JARGON = new Set([
+  'bind-template',
+  'tableau-bind-template',
+  'validate-proposal',
+  'tableau-validate-proposal',
+  'tabdoc',
+  'tabui',
+  'nextaction',
+]);
 
 /** Value of a `- Label: value` metadata line (case-insensitive), or "". */
 function fieldLine(lines: string[], label: string): string {
@@ -137,24 +196,24 @@ function buildKnowledgeIndex(): KnowledgeDoc[] {
 function ensureKnowledgeFuse(): Fuse<KnowledgeDoc> {
   if (_knowledgeFuse) return _knowledgeFuse;
   _knowledgeFuse = new Fuse(buildKnowledgeIndex(), {
-    keys: [
-      { name: 'searchTerms', weight: 0.3 },
-      { name: 'tags', weight: 0.22 },
-      { name: 'title', weight: 0.2 },
-      { name: 'whenToUse', weight: 0.18 },
-      { name: 'slug', weight: 0.06 },
-      // NB: the full document `body` is deliberately NOT a fuse search key. With
-      // ignoreLocation:true fuse fuzzy-scans every char of all ~108 doc bodies per
-      // query (~450ms each) — the dominant cost, and it CPU-starved CI workers past
-      // the pool's 60s onTaskUpdate RPC deadline. Ranking is driven by the curated
-      // metadata (searchTerms/tags/title/whenToUse/slug); body added negligible signal
-      // at weight 0.04. `body` is still kept on the doc for the result snippet.
-    ],
+    keys: knowledgeSearchKeys,
     threshold: 0.4,
     ignoreLocation: true,
     includeScore: true,
   });
   return _knowledgeFuse;
+}
+
+function ensureKnowledgeKeywordFuse(): Fuse<KnowledgeDoc> {
+  if (_knowledgeKeywordFuse) return _knowledgeKeywordFuse;
+  _knowledgeKeywordFuse = new Fuse(buildKnowledgeIndex(), {
+    keys: knowledgeSearchKeys,
+    threshold: 0.4,
+    ignoreLocation: true,
+    includeScore: true,
+    useExtendedSearch: true,
+  });
+  return _knowledgeKeywordFuse;
 }
 
 export interface KnowledgeHit {
@@ -163,6 +222,162 @@ export interface KnowledgeHit {
   title: string;
   score: number;
   snippet: string;
+  match: 'whole-string' | 'keyword' | 'nearest';
+}
+
+export interface KnowledgeSearchResult {
+  hits: KnowledgeHit[];
+  nearestMatches?: KnowledgeHit[];
+  note?: string;
+}
+
+export const ZERO_HIT_NEAREST_MATCHES_NOTE =
+  'zero exact matches — nearest by keyword below; rephrase around the concept (shorter, no tool names) for better results.';
+
+function ensureKnowledgeFallbackFuse(): Fuse<KnowledgeDoc> {
+  if (_knowledgeFallbackFuse) return _knowledgeFallbackFuse;
+  _knowledgeFallbackFuse = new Fuse(buildKnowledgeIndex(), {
+    keys: knowledgeSearchKeys,
+    threshold: 0.4,
+    ignoreLocation: true,
+    includeScore: true,
+    useExtendedSearch: true,
+  });
+  return _knowledgeFallbackFuse;
+}
+
+function ensureKnowledgeBroadNearestFuse(): Fuse<KnowledgeDoc> {
+  if (_knowledgeBroadNearestFuse) return _knowledgeBroadNearestFuse;
+  _knowledgeBroadNearestFuse = new Fuse(buildKnowledgeIndex(), {
+    keys: knowledgeSearchKeys,
+    threshold: 1,
+    ignoreLocation: true,
+    includeScore: true,
+  });
+  return _knowledgeBroadNearestFuse;
+}
+
+function keywordFallbackQuery(query: string): string {
+  return (query.match(/[A-Za-z0-9][A-Za-z0-9_-]*/g) ?? [])
+    .filter((word) => word.length > 2)
+    .join(' | ');
+}
+
+function longQueryTokens(query: string): string[] {
+  const tokens = (query.match(/[A-Za-z0-9][A-Za-z0-9_-]*/g) ?? [])
+    .map((word) => word.toLowerCase())
+    .filter(
+      (word) =>
+        word.length > 2 && !LONG_QUERY_STOPWORDS.has(word) && !LONG_QUERY_TOOL_JARGON.has(word),
+    );
+  return [...new Set(tokens)];
+}
+
+function firstSnippet(doc: KnowledgeDoc): string {
+  return (
+    firstSentence(doc.whenToUse) ||
+    firstSentence(doc.body.split('\n').find((l) => l.trim() && !l.startsWith('#')) ?? '')
+  );
+}
+
+function toKnowledgeHit(
+  doc: KnowledgeDoc,
+  score: number,
+  match: KnowledgeHit['match'],
+): KnowledgeHit {
+  return {
+    uri: doc.uri,
+    slug: doc.slug,
+    title: doc.title,
+    score,
+    snippet: firstSnippet(doc),
+    match,
+  };
+}
+
+function searchKnowledgeWholeString(query: string, limit: number): KnowledgeHit[] {
+  return ensureKnowledgeFuse()
+    .search(query)
+    .slice(0, Math.max(1, limit))
+    .map((r) =>
+      toKnowledgeHit(
+        r.item,
+        typeof r.score === 'number' ? Number((1 - r.score).toFixed(3)) : 0,
+        'whole-string',
+      ),
+    );
+}
+
+function searchKnowledgeByKeywordIntersection(query: string, limit: number): KnowledgeHit[] {
+  const tokens = longQueryTokens(query);
+  if (tokens.length === 0) return [];
+
+  const fuse = ensureKnowledgeKeywordFuse();
+  const ranked = new Map<
+    string,
+    { doc: KnowledgeDoc; matchedTokenCount: number; fuseScoreSum: number }
+  >();
+
+  for (const token of tokens) {
+    for (const result of fuse.search(`'${token}`)) {
+      const current = ranked.get(result.item.slug);
+      if (current) {
+        current.matchedTokenCount++;
+        current.fuseScoreSum += result.score ?? 1;
+      } else {
+        ranked.set(result.item.slug, {
+          doc: result.item,
+          matchedTokenCount: 1,
+          fuseScoreSum: result.score ?? 1,
+        });
+      }
+    }
+  }
+
+  return [...ranked.values()]
+    .sort((a, b) => {
+      const tokenCountDelta = b.matchedTokenCount - a.matchedTokenCount;
+      if (tokenCountDelta !== 0) return tokenCountDelta;
+      const scoreDelta = a.fuseScoreSum - b.fuseScoreSum;
+      if (scoreDelta !== 0) return scoreDelta;
+      return a.doc.slug.localeCompare(b.doc.slug);
+    })
+    .slice(0, Math.max(1, limit))
+    .map((rankedDoc) => {
+      const avgFuseScore = rankedDoc.fuseScoreSum / rankedDoc.matchedTokenCount;
+      const compositeScore =
+        (rankedDoc.matchedTokenCount * 2 + (1 - avgFuseScore)) / (tokens.length * 2 + 1);
+      return toKnowledgeHit(rankedDoc.doc, Number(compositeScore.toFixed(3)), 'keyword');
+    });
+}
+
+function nearestKeywordMatches(query: string, limit: number, broaden = false): KnowledgeHit[] {
+  const fallbackQuery = keywordFallbackQuery(query);
+  if (!fallbackQuery) return [];
+
+  const nearestMatches = ensureKnowledgeFallbackFuse()
+    .search(fallbackQuery)
+    .slice(0, Math.min(5, Math.max(3, limit)))
+    .map((r) =>
+      toKnowledgeHit(
+        r.item,
+        typeof r.score === 'number' ? Number((1 - r.score).toFixed(3)) : 0,
+        'nearest',
+      ),
+    );
+
+  if (nearestMatches.length > 0 || !broaden) return nearestMatches;
+
+  return ensureKnowledgeBroadNearestFuse()
+    .search(query)
+    .slice(0, Math.min(5, Math.max(3, limit)))
+    .map((r) =>
+      toKnowledgeHit(
+        r.item,
+        typeof r.score === 'number' ? Number((1 - r.score).toFixed(3)) : 0,
+        'nearest',
+      ),
+    );
 }
 
 /**
@@ -172,23 +387,26 @@ export interface KnowledgeHit {
 export function searchKnowledge(query: string, limit = 5): KnowledgeHit[] {
   const q = (query ?? '').trim();
   if (!q) return [];
-  const fuse = ensureKnowledgeFuse();
-  return fuse
-    .search(q)
-    .slice(0, Math.max(1, limit))
-    .map((r) => ({
-      uri: r.item.uri,
-      slug: r.item.slug,
-      title: r.item.title,
-      score: typeof r.score === 'number' ? Number((1 - r.score).toFixed(3)) : 0,
-      snippet:
-        firstSentence(r.item.whenToUse) ||
-        firstSentence(r.item.body.split('\n').find((l) => l.trim() && !l.startsWith('#')) ?? ''),
-    }));
+  if (q.length <= MAX_WHOLE_STRING_QUERY_LENGTH) return searchKnowledgeWholeString(q, limit);
+  return searchKnowledgeByKeywordIntersection(q, limit);
+}
+
+export function searchKnowledgeWithFallback(query: string, limit = 5): KnowledgeSearchResult {
+  const hits = searchKnowledge(query, limit);
+  if (hits.length > 0) return { hits };
+
+  const q = (query ?? '').trim();
+  const nearestMatches = nearestKeywordMatches(q, limit, q.length > MAX_WHOLE_STRING_QUERY_LENGTH);
+
+  if (nearestMatches.length === 0) return { hits };
+  return { hits, nearestMatches, note: ZERO_HIT_NEAREST_MATCHES_NOTE };
 }
 
 /** Reset cached index/fuse (tests). */
 export function _resetKnowledgeSearchCache(): void {
   _knowledgeDocs = null;
   _knowledgeFuse = null;
+  _knowledgeKeywordFuse = null;
+  _knowledgeFallbackFuse = null;
+  _knowledgeBroadNearestFuse = null;
 }

--- a/src/tools/desktop/knowledge/searchKnowledge.ts
+++ b/src/tools/desktop/knowledge/searchKnowledge.ts
@@ -2,7 +2,7 @@ import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { Ok } from 'ts-results-es';
 import { z } from 'zod';
 
-import { searchKnowledge } from '../../../desktop/knowledge/index.js';
+import { searchKnowledgeWithFallback } from '../../../desktop/knowledge/index.js';
 import { DesktopMcpServer } from '../../../server.desktop.js';
 import { DesktopTool } from '../tool.js';
 
@@ -20,7 +20,7 @@ export const getSearchKnowledgeTool = (
     name: 'search-knowledge',
     title: toolTitle,
     description:
-      'Find relevant expertise for a task (top N by uri+title). Use THIS to discover knowledge, not list.',
+      'Find relevant expertise for a task (top N by uri+title). Best queried with short concept phrases (e.g. "symbol map latitude longitude"), not tool names. Use THIS to discover knowledge, not list.',
     paramsSchema,
     annotations: {
       title: toolTitle,
@@ -34,11 +34,10 @@ export const getSearchKnowledgeTool = (
         extra,
         args: { query, limit },
         callback: async () => {
-          const hits = searchKnowledge(query, limit);
-          return new Ok({ hits });
+          return new Ok(searchKnowledgeWithFallback(query, limit));
         },
-        getSuccessResult: ({ hits }) => ({
-          content: [{ type: 'text', text: JSON.stringify({ hits }, null, 2) }],
+        getSuccessResult: (result) => ({
+          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
         }),
       });
     },


### PR DESCRIPTION
Root cause (reproduced): Fuse non-extended mode chunks >32-char patterns into 32-char windows that must each match — long natural queries structurally zero-hit. Fix: **route by length**. Short queries: today's fuzzy search, byte-identical (44/44 relevance cases). Long queries: token-intersection ranker (distinct-token count first — the difference from naive OR, which scored 7/44) returning real, marker-tagged hits. Genuine zeroes return `nearestMatches` + a rephrase hint. **Scorecard: 7/8 new long-query cases rank-1 (1 rank-2), 2 negative controls hold, knowledge suite 619ms.** Version bump deferred — three PRs currently share the version line; will bump at merge order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)