### PR TITLE
feat: regrow the singable surface — shelf placement + dashboard composition in the dynamic profile

### DIFF
--- a/src/desktop/binder/explicit-bind.ts
+++ b/src/desktop/binder/explicit-bind.ts
@@ -463,7 +463,7 @@ function fixForBlocker(b: Blocker): string {
     case 'calc-dependency-unmet':
       return 'Bind every manifest slot required by the template-owned calculation.';
     default:
-      return 'Fall back to plan-dashboard-creation and the general worksheet build tools.';
+      return 'Fall back to plan-dashboard-creation, placing fields per sheet with add-field.';
   }
 }
 

--- a/src/server.desktop.test.ts
+++ b/src/server.desktop.test.ts
@@ -346,10 +346,10 @@ describe('selectToolsForProfile (TOOL_PROFILE, W60 spike lever 1 / preamble P1)'
     expect(selected.map((t) => t.name)).toContain('execute-tableau-command');
   });
 
-  it('TOOL_PROFILE=dynamic-authoring registers exactly the 21-tool data-first singable surface — existing native authoring plus first-class workbook reads, no XML/cache tools', () => {
+  it('TOOL_PROFILE=dynamic-authoring registers exactly the 27-tool data-first singable surface — existing native authoring plus first-class workbook reads, no XML/cache tools', () => {
     const selected = selectToolsForProfile(allTools(), 'dynamic-authoring');
     expect(new Set(selected.map((t) => t.name))).toEqual(DYNAMIC_AUTHORING_TOOL_PROFILE);
-    expect(selected).toHaveLength(21);
+    expect(selected).toHaveLength(27);
     // The full dynamic dialect, semantically named — every author-* verb present,
     // plus the ask-for-help, command-discovery, deterministic fast-path, and the three
     // knowledge doors the system prompt's "consult the expertise library" law routes to.
@@ -363,6 +363,12 @@ describe('selectToolsForProfile (TOOL_PROFILE, W60 spike lever 1 / preamble P1)'
       'search-commands',
       'bind-template',
       'refine-worksheet',
+      'add-field',
+      'remove-field',
+      'dashboard-auto-apply',
+      'plan-dashboard-creation',
+      'batch-create-and-cache-sheets',
+      'build-and-apply-dashboard',
       'list-knowledge-resources',
       'read-knowledge-resource',
       'search-knowledge',

--- a/src/server.desktop.ts
+++ b/src/server.desktop.ts
@@ -103,6 +103,12 @@ export const DYNAMIC_AUTHORING_TOOL_PROFILE: ReadonlySet<DesktopToolName> =
   new Set<DesktopToolName>([
     'bind-template',
     'refine-worksheet',
+    'add-field',
+    'remove-field',
+    'dashboard-auto-apply',
+    'plan-dashboard-creation',
+    'batch-create-and-cache-sheets',
+    'build-and-apply-dashboard',
     'execute-tableau-command',
     'search-commands',
     'ask-user',

--- a/src/tools/desktop/binder/bindTemplate.ts
+++ b/src/tools/desktop/binder/bindTemplate.ts
@@ -152,8 +152,8 @@ function nextActionForEscalation(reason: EscalateReason): NextAction {
     );
   }
   return prefillNextAction(
-      'Build manually: place fields with add-field (rows/cols/encodings), then refine-worksheet',
-    );
+    'Build manually: place fields with add-field (rows/cols/encodings), then refine-worksheet',
+  );
 }
 
 function renderBlockers(blockers: Blocker[]): string {

--- a/src/tools/desktop/binder/bindTemplate.ts
+++ b/src/tools/desktop/binder/bindTemplate.ts
@@ -147,9 +147,13 @@ function nextActionForEscalation(reason: EscalateReason): NextAction {
     return prefillNextAction('Pick a higher-confidence proposal');
   }
   if (TIER2_REASONS.has(reason)) {
-    return prefillNextAction('Use the general worksheet build tools');
+    return prefillNextAction(
+      'Build manually: place fields with add-field (rows/cols/encodings), then refine-worksheet',
+    );
   }
-  return prefillNextAction('Build the worksheet manually');
+  return prefillNextAction(
+      'Build manually: place fields with add-field (rows/cols/encodings), then refine-worksheet',
+    );
 }
 
 function renderBlockers(blockers: Blocker[]): string {

--- a/src/tools/desktop/fields/addField.test.ts
+++ b/src/tools/desktop/fields/addField.test.ts
@@ -52,7 +52,7 @@ describe('addFieldTool', () => {
   it('should create a tool instance with correct properties', () => {
     const tool = getAddFieldTool(new DesktopMcpServer());
     expect(tool.name).toBe('add-field');
-    expect(tool.description).toBe('Add a field.');
+    expect(tool.description).toBe('Place a field on a shelf (rows/cols/encoding) — the manual build path when no template binds.');
     expect(tool.paramsSchema).toMatchObject({
       session: expect.any(Object),
       worksheetFile: expect.any(Object),

--- a/src/tools/desktop/fields/addField.test.ts
+++ b/src/tools/desktop/fields/addField.test.ts
@@ -52,7 +52,9 @@ describe('addFieldTool', () => {
   it('should create a tool instance with correct properties', () => {
     const tool = getAddFieldTool(new DesktopMcpServer());
     expect(tool.name).toBe('add-field');
-    expect(tool.description).toBe('Place a field on a shelf (rows/cols/encoding) — the manual build path when no template binds.');
+    expect(tool.description).toBe(
+      'Place a field on a shelf (rows/cols/encoding) — the manual build path when no template binds.',
+    );
     expect(tool.paramsSchema).toMatchObject({
       session: expect.any(Object),
       worksheetFile: expect.any(Object),

--- a/src/tools/desktop/fields/addField.ts
+++ b/src/tools/desktop/fields/addField.ts
@@ -51,7 +51,7 @@ export const getAddFieldTool = (server: DesktopMcpServer): DesktopTool<typeof pa
     server,
     name: 'add-field',
     title,
-    description: 'Add a field.',
+    description: 'Place a field on a shelf (rows/cols/encoding) — the manual build path when no template binds.',
     paramsSchema,
     annotations: {
       title,

--- a/src/tools/desktop/fields/addField.ts
+++ b/src/tools/desktop/fields/addField.ts
@@ -51,7 +51,8 @@ export const getAddFieldTool = (server: DesktopMcpServer): DesktopTool<typeof pa
     server,
     name: 'add-field',
     title,
-    description: 'Place a field on a shelf (rows/cols/encoding) — the manual build path when no template binds.',
+    description:
+      'Place a field on a shelf (rows/cols/encoding) — the manual build path when no template binds.',
     paramsSchema,
     annotations: {
       title,


### PR DESCRIPTION
Two field-proven over-cuts from the lean-surface era, fixed now that the 46k cliff is retired:

1. **add-field / remove-field** join the profile — a live-debugged Studio session showed bind-template rejecting (flat geography vs required geo-hierarchy slots) and its escalation copy pointing at 'general worksheet build tools' that didn't exist in the profile, sending the model fishing in the command census. All rejection messages now name the real path (add-field → refine-worksheet).
2. **dashboard-auto-apply / plan-dashboard-creation / batch-create-and-cache-sheets / build-and-apply-dashboard** join — the same session's logs caught the model *guessing* `tabdoc:create-and-cache-sheets` as a raw command: it reached for a tool that existed only in the full set.

21 → 27 tools; XML/cache tools deliberately stay out. **Gate before gospel: this profile change should be validated with an eval sing** (the knowledge-tools A/B precedent). Validated: tsc + eslint clean, full suite green firsthand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)