### PR TITLE
@W-12345678 Pulse description update for chatgpt plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "3.5.3",
+  "version": "3.5.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "3.5.3",
+      "version": "3.5.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.7.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "3.5.3",
+  "version": "3.5.4",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/src/tools/web/pulse/generateInsightBrief/generatePulseInsightBriefTool.ts
+++ b/src/tools/web/pulse/generateInsightBrief/generatePulseInsightBriefTool.ts
@@ -48,7 +48,7 @@ An insight brief is an AI-generated response to questions about Pulse metrics. I
    - \`insights_options.settings\` with all insight types and their enabled/disabled state
    - Incomplete data will cause API errors even if it passes schema validation
 
-3. **Multi-Turn Conversations**: you can optionally include previous conversation context in the \`messages\` array. This can help the API to generate more accurate and relevant responses.
+3. **Multi-Turn Conversations**: you can optionally provide a concise summary of the directly relevant conversation history in the \`messages\` array. This can help the API to generate more accurate and relevant responses. Do not include full conversation history or arrays of prior conversation context.
    history in the \`messages\` array:
    - Add the initial user question with \`role: 'ROLE_USER'\`
    - Add the assistant's response with \`role: 'ROLE_ASSISTANT'\` and \`content\` containing the previous response text

--- a/src/tools/web/pulse/generateInsightBrief/generatePulseInsightBriefTool.ts
+++ b/src/tools/web/pulse/generateInsightBrief/generatePulseInsightBriefTool.ts
@@ -36,7 +36,7 @@ An insight brief is an AI-generated response to questions about Pulse metrics. I
 - **Ban**: Current value with period-over-period change and top dimensional insights
 - **Breakdown**: Emphasizes categorical dimension analysis and distributions
 
-**IMPORTANT Requirements:**
+**IMPORTANT Details:**
 
 1. **Same Datasource Recommendation**: The API works best when all metrics in \`metric_group_context\` come from the same datasource,
    as this allows the backend to apply consistent filters across metrics. While the API may accept metrics from different datasources,
@@ -48,7 +48,7 @@ An insight brief is an AI-generated response to questions about Pulse metrics. I
    - \`insights_options.settings\` with all insight types and their enabled/disabled state
    - Incomplete data will cause API errors even if it passes schema validation
 
-3. **Multi-Turn Conversations**: To enable follow-up questions and conversational analysis, include the full conversation
+3. **Multi-Turn Conversations**: you can optionally include previous conversation context in the \`messages\` array. This can help the API to generate more accurate and relevant responses.
    history in the \`messages\` array:
    - Add the initial user question with \`role: 'ROLE_USER'\`
    - Add the assistant's response with \`role: 'ROLE_ASSISTANT'\` and \`content\` containing the previous response text


### PR DESCRIPTION
From OpenAI: "generate-pulse-insight-briefrequires a messages array and explicitly instructs the model to include the full conversation history for follow-up questions, including prior user and assistant turns. This is prohibited bulk ChatGPT conversation-history collection under the conversation-minimization rule." 

This change fixes this.
