### PR TITLE
fix(binder): terminal signal on complete auto-apply bind (Blake spiral, wall 1/2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "2.33.0",
+  "version": "2.34.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/src/tools/desktop/binder/bindTemplate.test.ts
+++ b/src/tools/desktop/binder/bindTemplate.test.ts
@@ -737,6 +737,37 @@ describe('bindTemplateTool auto_apply gate', () => {
     expect((body.guidance as string).length).toBeLessThan(200);
   });
 
+  it('applied:true non-waterfall bind is terminal: guidance says done and nextAction.kind is "done"', async () => {
+    // Blake's spiral: a completed auto-apply (symbol map, no unfilled re-bind slot) must
+    // carry a terminal marker so the agent stops instead of burning 100s on search-commands
+    // over an already-rendered chart. The prose stop-clause works with today's host; the
+    // structuredContent.nextAction{kind:'done'} is the durable machine contract.
+    const { getExecutor } = setupAutoApplyMocks();
+
+    const result = await getToolResult({
+      session: '1',
+      ask: 'symbol map of Sales by State',
+      auto_apply: true,
+      getExecutor,
+    });
+
+    invariant(result.content[0].type === 'text');
+    const body = JSON.parse(result.content[0].text);
+    expect(body.guidance).toContain('no further tool calls');
+    expect(result.structuredContent).toEqual({
+      nextAction: { label: 'Chart complete — no further calls needed', kind: 'done' },
+    });
+    // structuredContent lives on the envelope, not in the JSON body.
+    expect(Object.keys(body).sort()).toEqual([
+      'applied',
+      'guidance',
+      'phase_ms',
+      'sheet_name',
+      'status',
+    ]);
+    expect((body.guidance as string).length).toBeLessThan(200);
+  });
+
   it('auto_apply=true applies a validated Call-2 proposal bind with the events anchor', async () => {
     const { applyWorkbookDocument, getEvents, getExecutor } = setupAutoApplyMocks({
       bind: boundViaProposalResult,
@@ -950,6 +981,31 @@ describe('bindTemplateTool auto_apply gate', () => {
     const body = JSON.parse(result.content[0].text);
     expect(body.guidance).not.toContain('anchor_category');
     expect(body.guidance).not.toContain('Waterfall default sort');
+  });
+
+  it('applied waterfall with an unfilled order slot still steers a re-bind and is NOT terminal', async () => {
+    // WATERFALL GUARD (non-negotiable): the m1 demo. A genuine unfilled sequence slot MUST
+    // still emit the imperative re-bind steer and MUST NOT carry the terminal marker. A naive
+    // blanket-terminate of every applied:true fails this test.
+    const { getExecutor } = setupAutoApplyMocks({
+      bind: boundWaterfallResult,
+      inject: { ok: true, xml: INJECTED_WATERFALL_WORKBOOK_XML },
+      workbookReads: [P_AND_L_WORKBOOK_XML],
+    });
+
+    const result = await getToolResult({
+      session: '1',
+      ask: 'P&L waterfall',
+      auto_apply: true,
+      getExecutor,
+    });
+
+    invariant(result.content[0].type === 'text');
+    const body = JSON.parse(result.content[0].text);
+    expect(body.guidance).toContain('Waterfall step order: schema has display_order');
+    expect(body.guidance).toContain('proposal.sort:{by:"display_order",direction:"asc"}');
+    expect(body.guidance).not.toContain('no further tool calls');
+    expect(result.structuredContent).toBeUndefined();
   });
 
   it('adds waterfall discovery guidance to propose results', async () => {

--- a/src/tools/desktop/binder/bindTemplate.ts
+++ b/src/tools/desktop/binder/bindTemplate.ts
@@ -48,6 +48,7 @@ import {
   authorCalculationsInWorkbook,
 } from '../data-source/authorCalcCore.js';
 import {
+  doneNextAction,
   jsonToolResult,
   type NextAction,
   prefillNextAction,
@@ -147,6 +148,11 @@ const WATERFALL_ANCHOR_MAPPING_KEY = 'Anchor Category';
 // in the ORIGINAL bind (proposal.sort) instead of giving up on refine or falling to XML surgery.
 const WATERFALL_SORT_HINT =
   'Waterfall default sort is DESC by the bound measure; override with proposal.sort:{by:<field>,direction:"asc"|"desc"} IN THE BIND — refine-worksheet cannot sort by a field that is not on the view.';
+// Terminal stop-clause appended to the applied:true receipt when NO re-bind slot is unfilled
+// (Blake's spiral): the model reads guidance verbatim, so this directly contradicts the
+// bundled skill's "adapt fields/formatting" + the ambient "search-commands available" pulls.
+// Paired with structuredContent.nextAction{kind:'done'} for a future route-gate/host.
+const TERMINAL_GUIDANCE = 'Done — no further tool calls needed.';
 
 function nextActionForEscalation(reason: EscalateReason): NextAction {
   if (reason === 'ambiguous-field' || reason === 'field-not-found') {
@@ -309,6 +315,25 @@ function appendWaterfallDiscoveryGuidance(
 ): string {
   const additions = buildWaterfallDiscoveryGuidance(res, schemaSummary, proposal);
   return additions.length > 0 ? `${guidance} ${additions.join(' ')}` : guidance;
+}
+
+/**
+ * True iff this applied waterfall bind still has a NAMED, fillable re-bind slot (an anchor
+ * category candidate or an explicit order column) — the m1 genuine-unfilled case that MUST
+ * keep steering a re-bind. It is the exact complement of "terminal": the applied:true receipt
+ * is only marked done when this is false. Built from the SAME four helpers the steer uses so
+ * the two sides cannot drift. The gray-zone waterfall whose only emission would be the bare
+ * WATERFALL_SORT_HINT (no named order column) is deliberately NOT unfilled here — matching the
+ * cartographer's boundary: steer ⟺ a named candidate field is actually fillable.
+ */
+function waterfallReBindSlotUnfilled(res: BinderResult, schemaSummary?: SchemaSummary): boolean {
+  if (!isWaterfallResult(res)) {
+    return false;
+  }
+  const anchorUnfilled =
+    !hasAnchorCategoryBinding(res) && waterfallAnchorCandidates(schemaSummary).length > 0;
+  const orderUnfilled = !hasSortOverride(res) && waterfallOrderCandidates(schemaSummary).length > 0;
+  return anchorUnfilled || orderUnfilled;
 }
 
 function buildGuidance(
@@ -568,7 +593,7 @@ async function performAutoApply({
   bindMs: number;
   eventsAnchor?: number;
   schemaSummary: SchemaSummary;
-}): Promise<BindTemplateToolResult> {
+}): Promise<StructuredBindTemplateToolResult> {
   const { args } = res;
 
   // ── Events-clean gate (W60 blind-spot #1) ────────────────────────
@@ -651,12 +676,16 @@ async function performAutoApply({
   // enable a manual second call that never happens once the apply succeeds.
   const calcPrefix = renderAuthoredCalcPrefix(base.authored_calcs, res.status);
   const literalTitle = decodeXmlEntities(args.title);
-  const guidance = appendWaterfallDiscoveryGuidance(
-    `${calcPrefix}Applied "${literalTitle}" to the live workbook (bind ${bindMs}ms, inject ${injectMs}ms, apply ${applyMs}ms).`,
-    res,
-    schemaSummary,
-  );
-  return {
+  const receipt = `${calcPrefix}Applied "${literalTitle}" to the live workbook (bind ${bindMs}ms, inject ${injectMs}ms, apply ${applyMs}ms).`;
+  // Blake's spiral fix: the applied:true receipt is TERMINAL unless a genuine, named re-bind
+  // slot is still unfilled (the m1 waterfall case). On INCOMPLETE we keep today's steer and
+  // attach NO structuredContent (byte-for-byte identical to the pre-fix code). On COMPLETE we
+  // append the stop-clause AND the machine-readable done marker so nothing re-asserts "keep going".
+  const incomplete = waterfallReBindSlotUnfilled(res, schemaSummary);
+  const guidance = incomplete
+    ? appendWaterfallDiscoveryGuidance(receipt, res, schemaSummary)
+    : `${receipt} ${TERMINAL_GUIDANCE}`;
+  const applied: AppliedFastPathResult = {
     status: res.status,
     ...(base.authored_calcs ? { authored_calcs: base.authored_calcs } : {}),
     ...(base.warnings && base.warnings.length > 0 ? { warnings: base.warnings } : {}),
@@ -665,6 +694,7 @@ async function performAutoApply({
     sheet_name: literalTitle,
     phase_ms: { bind: bindMs, inject: injectMs, apply: applyMs },
   };
+  return incomplete ? applied : withNextAction(applied, doneNextAction());
 }
 
 function renderAuthoredCalcPrefix(

--- a/src/tools/desktop/structuredContent.test.ts
+++ b/src/tools/desktop/structuredContent.test.ts
@@ -1,4 +1,5 @@
 import {
+  doneNextAction,
   jsonToolResult,
   prefillNextAction,
   textToolResult,
@@ -29,5 +30,12 @@ describe('structuredContent helpers', () => {
 
   it('rejects labels over 60 characters', () => {
     expect(() => prefillNextAction('x'.repeat(61))).toThrow('nextAction label');
+  });
+
+  it('doneNextAction returns a done-kind action within the label brand limit', () => {
+    expect(doneNextAction()).toEqual({
+      label: 'Chart complete — no further calls needed',
+      kind: 'done',
+    });
   });
 });

--- a/src/tools/desktop/structuredContent.ts
+++ b/src/tools/desktop/structuredContent.ts
@@ -4,7 +4,7 @@ const MAX_NEXT_ACTION_LABEL_LENGTH = 60;
 
 declare const nextActionLabelBrand: unique symbol;
 
-export type NextActionKind = 'execute' | 'prefill';
+export type NextActionKind = 'execute' | 'prefill' | 'done';
 
 export type NextActionLabel = string & { readonly [nextActionLabelBrand]: true };
 
@@ -25,6 +25,10 @@ export type StructuredResult<T extends object> = T & StructuredContentCarrier;
 
 export function prefillNextAction(label: string): NextAction {
   return { label: nextActionLabel(label), kind: 'prefill' };
+}
+
+export function doneNextAction(): NextAction {
+  return { label: nextActionLabel('Chart complete — no further calls needed'), kind: 'done' };
 }
 
 function nextActionLabel(label: string): NextActionLabel {


### PR DESCRIPTION
## Blake's spiral (wall 1 of 2)
Real user (Blake) + eval s7 both show: bind-template auto_apply SUCCEEDS (~50ms) and renders the viz, then the agent keeps working — Blake 90-136s / 7+ search-commands; s7 route `BIND->XMLAPPLY->BIND->BIND->BIND->BIND`, 420s timeout, no result frame. Root cause: the success return hard-codes `status:'bound'` with an 'Applied…' receipt and NO stop signal. Blake's 4 prose-based attempts (CLAUDE.md, disable-model-invocation, perms, profile) all failed — **the fix must be structural, in the tool return.**

## Fix
On `applied:true` with NO genuinely-unfilled re-bind slot: append `Done — no further tool calls needed.` **and** attach `structuredContent.nextAction{kind:'done'}` (the durable machine contract). On a genuine unfilled waterfall anchor/order slot (**m1**): keep today's imperative re-bind steer, **byte-for-byte identical**, no terminal marker. Predicate `waterfallReBindSlotUnfilled()===false`, built from the same four helpers the steer uses so the two sides cannot drift.

Dropped the route-table companion (blew the 46k tools/list cliff; prose is the weakest lever). Runtime signal only.

## Verified
tsc 0 · full binder + structuredContent + server.desktop suites green (125/125) · eslint 0 · surface budget under 46k · v2.33.0→2.34.0.

**Wall 2/2** (measure-free lat/long map so s7 confidently auto-applies in the first place) is a separate PR. Both needed for Blake's map <20s.

Diagnosed by GPT-5.6-Sol + a 6-agent design/build/verify workflow; verified firsthand.