### PR TITLE
@W-23540240: Improve performance of list-views when bounded context is applied

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "3.5.3",
+  "version": "3.5.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "3.5.3",
+      "version": "3.5.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.7.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "3.5.3",
+  "version": "3.5.6",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/src/tools/web/views/listViews.test.ts
+++ b/src/tools/web/views/listViews.test.ts
@@ -1,12 +1,13 @@
 import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 
 import { WebMcpServer } from '../../../server.web.js';
+import { stubDefaultEnvVars } from '../../../testShared.js';
 import { getCombinationsOfBoundedContextInputs } from '../../../utils/getCombinationsOfBoundedContextInputs.js';
 import invariant from '../../../utils/invariant.js';
 import { Provider } from '../../../utils/provider.js';
 import { getMockRequestHandlerExtra } from '../toolContext.mock.js';
 import { constrainViews, getListViewsTool } from './listViews.js';
-import { mockView } from './mockView.js';
+import { mockView, mockView2 } from './mockView.js';
 
 const mockViews = {
   pagination: {
@@ -19,6 +20,7 @@ const mockViews = {
 
 const mocks = vi.hoisted(() => ({
   mockQueryViewsForSiteData: vi.fn(),
+  mockGetView: vi.fn(),
 }));
 
 vi.mock('../../../restApiInstance.js', () => ({
@@ -26,6 +28,7 @@ vi.mock('../../../restApiInstance.js', () => ({
     callback({
       viewsMethods: {
         queryViewsForSite: mocks.mockQueryViewsForSiteData,
+        getView: mocks.mockGetView,
       },
       siteId: 'test-site-id',
     }),
@@ -35,6 +38,12 @@ vi.mock('../../../restApiInstance.js', () => ({
 describe('listViewsTool', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.unstubAllEnvs();
+    stubDefaultEnvVars();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
   });
 
   it('should create a tool instance with correct properties', () => {
@@ -71,6 +80,120 @@ describe('listViewsTool', () => {
     expect(result.isError).toBe(true);
     invariant(result.content[0].type === 'text');
     expect(result.content[0].text).toContain(errorMessage);
+  });
+
+  describe('INCLUDE_VIEW_IDS fast path (fetch by ID)', () => {
+    function makeAxiosError(status: number): Error {
+      return Object.assign(new Error(`Request failed with status code ${status}`), {
+        isAxiosError: true,
+        response: { status },
+      });
+    }
+
+    it('should fetch views by ID when INCLUDE_VIEW_IDS is set and no filter is provided', async () => {
+      vi.stubEnv('INCLUDE_VIEW_IDS', `${mockView.id},${mockView2.id}`);
+      mocks.mockGetView.mockImplementation(async ({ viewId }: { viewId: string }) =>
+        viewId === mockView.id ? mockView : mockView2,
+      );
+
+      const result = await getToolResult({});
+
+      expect(result.isError).toBe(false);
+      expect(mocks.mockGetView).toHaveBeenCalledTimes(2);
+      expect(mocks.mockGetView).toHaveBeenCalledWith({
+        siteId: 'test-site-id',
+        viewId: mockView.id,
+        includeUsageStatistics: true,
+      });
+      expect(mocks.mockQueryViewsForSiteData).not.toHaveBeenCalled();
+
+      invariant(result.content[0].type === 'text');
+      const views = JSON.parse(`${result.content[0].text}`);
+      expect(views.map((v: { id: string }) => v.id).sort()).toEqual(
+        [mockView.id, mockView2.id].sort(),
+      );
+    });
+
+    it('should silently omit views that return 403 or 404', async () => {
+      vi.stubEnv('INCLUDE_VIEW_IDS', `${mockView.id},not-allowed,missing`);
+      mocks.mockGetView.mockImplementation(async ({ viewId }: { viewId: string }) => {
+        if (viewId === 'not-allowed') {
+          throw makeAxiosError(403);
+        }
+        if (viewId === 'missing') {
+          throw makeAxiosError(404);
+        }
+        return mockView;
+      });
+
+      const result = await getToolResult({});
+
+      expect(result.isError).toBe(false);
+      invariant(result.content[0].type === 'text');
+      const views = JSON.parse(`${result.content[0].text}`);
+      expect(views).toHaveLength(1);
+      expect(views[0].id).toBe(mockView.id);
+    });
+
+    it('should propagate non-403/404 errors', async () => {
+      vi.stubEnv('INCLUDE_VIEW_IDS', `${mockView.id},boom`);
+      mocks.mockGetView.mockImplementation(async ({ viewId }: { viewId: string }) => {
+        if (viewId === 'boom') {
+          throw makeAxiosError(500);
+        }
+        return mockView;
+      });
+
+      const result = await getToolResult({});
+
+      expect(result.isError).toBe(true);
+      invariant(result.content[0].type === 'text');
+      expect(result.content[0].text).toContain('500');
+    });
+
+    it('should use the slow path when a filter is provided alongside INCLUDE_VIEW_IDS', async () => {
+      vi.stubEnv('INCLUDE_VIEW_IDS', mockView.id);
+      mocks.mockQueryViewsForSiteData.mockResolvedValue(mockViews);
+
+      const result = await getToolResult({ filter: 'name:eq:Overview' });
+
+      expect(result.isError).toBe(false);
+      expect(mocks.mockQueryViewsForSiteData).toHaveBeenCalledTimes(1);
+      expect(mocks.mockGetView).not.toHaveBeenCalled();
+    });
+
+    it('should still apply coexisting bounds (e.g. project) to fetched views', async () => {
+      vi.stubEnv('INCLUDE_VIEW_IDS', `${mockView.id},${mockView2.id}`);
+      // Only mockView's project is allowed; mockView2 must be filtered out by constrainViews.
+      vi.stubEnv('INCLUDE_PROJECT_IDS', mockView.project.id);
+      mocks.mockGetView.mockImplementation(async ({ viewId }: { viewId: string }) =>
+        viewId === mockView.id ? mockView : mockView2,
+      );
+
+      const result = await getToolResult({});
+
+      expect(result.isError).toBe(false);
+      invariant(result.content[0].type === 'text');
+      const views = JSON.parse(`${result.content[0].text}`);
+      expect(views).toHaveLength(1);
+      expect(views[0].id).toBe(mockView.id);
+    });
+
+    it('should slice fetched views to the effective limit', async () => {
+      vi.stubEnv('INCLUDE_VIEW_IDS', `${mockView.id},${mockView2.id}`);
+      mocks.mockGetView.mockImplementation(async ({ viewId }: { viewId: string }) =>
+        viewId === mockView.id ? mockView : mockView2,
+      );
+
+      const result = await getToolResult({ limit: 1 });
+
+      expect(result.isError).toBe(false);
+      // All allowed views are fetched before slicing, then trimmed to the limit.
+      expect(mocks.mockGetView).toHaveBeenCalledTimes(2);
+      invariant(result.content[0].type === 'text');
+      const views = JSON.parse(`${result.content[0].text}`);
+      expect(views).toHaveLength(1);
+    });
   });
 
   describe('constrainViews', () => {
@@ -167,11 +290,11 @@ describe('listViewsTool', () => {
   });
 });
 
-async function getToolResult(params: { filter: string }): Promise<CallToolResult> {
+async function getToolResult(params: { filter?: string; limit?: number }): Promise<CallToolResult> {
   const listViewsTool = getListViewsTool(new WebMcpServer());
   const callback = await Provider.from(listViewsTool.callback);
   return await callback(
-    { filter: params.filter, pageSize: undefined, limit: undefined },
+    { filter: params.filter, pageSize: undefined, limit: params.limit },
     getMockRequestHandlerExtra(),
   );
 }

--- a/src/tools/web/views/listViews.ts
+++ b/src/tools/web/views/listViews.ts
@@ -10,8 +10,10 @@ import {
   getViewLineageQuery,
   mergeViewLineage,
 } from '../../../sdks/tableau/methods/lineageUtils.js';
+import { RestApi } from '../../../sdks/tableau/restApi.js';
 import { View } from '../../../sdks/tableau/types/view.js';
 import { WebMcpServer } from '../../../server.web.js';
+import { isAxiosError } from '../../../utils/axios.js';
 import { getExceptionMessage } from '../../../utils/getExceptionMessage.js';
 import { paginate } from '../../../utils/paginate.js';
 import { genericFilterDescription } from '../genericFilterDescription.js';
@@ -88,26 +90,37 @@ export const getListViewsTool = (server: WebMcpServer): WebTool<typeof paramsSch
               jwtScopes: listViewsTool.requiredApiScopes,
               callback: async (restApi) => {
                 const maxResultLimit = configWithOverrides.getMaxResultLimit(listViewsTool.name);
-                const views = await paginate({
-                  pageConfig: {
-                    pageSize,
-                    limit: maxResultLimit
-                      ? Math.min(maxResultLimit, limit ?? Number.MAX_SAFE_INTEGER)
-                      : limit,
-                  },
-                  getDataFn: async (pageConfig) => {
-                    const { pagination, views: data } =
-                      await restApi.viewsMethods.queryViewsForSite({
-                        siteId: restApi.siteId,
-                        filter: validatedFilter ?? '',
-                        includeUsageStatistics: true,
-                        pageSize: pageConfig.pageSize,
-                        pageNumber: pageConfig.pageNumber,
-                      });
+                const effectiveLimit = maxResultLimit
+                  ? Math.min(maxResultLimit, limit ?? Number.MAX_SAFE_INTEGER)
+                  : limit;
 
-                    return { pagination, data };
-                  },
-                });
+                // Fast path: when results are scoped to a specific set of view IDs and the user
+                // hasn't supplied a filter, fetch those views directly instead of paging the whole
+                // site. Query Views for Site has no view-ID filter, so the slow path would fetch
+                // every view only to discard all but the allowed ones. A user filter forces the
+                // slow path since Get View can't apply server-side filtering.
+                const viewIds = configWithOverrides.boundedContext.viewIds;
+                const views =
+                  viewIds !== null && !filter
+                    ? await fetchAllowedViewsById({ restApi, viewIds, limit: effectiveLimit })
+                    : await paginate({
+                        pageConfig: {
+                          pageSize,
+                          limit: effectiveLimit,
+                        },
+                        getDataFn: async (pageConfig) => {
+                          const { pagination, views: data } =
+                            await restApi.viewsMethods.queryViewsForSite({
+                              siteId: restApi.siteId,
+                              filter: validatedFilter ?? '',
+                              includeUsageStatistics: true,
+                              pageSize: pageConfig.pageSize,
+                              pageNumber: pageConfig.pageNumber,
+                            });
+
+                          return { pagination, data };
+                        },
+                      });
 
                 if (configWithOverrides.disableMetadataApiRequests || views.length === 0) {
                   return flattenViewUsage(views);
@@ -191,6 +204,60 @@ export function constrainViews({
     type: 'success',
     result: views,
   };
+}
+
+/**
+ * Fetches the allowed views directly via Get View, one request per ID. Used when the results are
+ * scoped by `INCLUDE_VIEW_IDS` and no user filter is present.
+ *
+ * Views that return 403 (no permission) or 404 (deleted / not found) are silently omitted so the
+ * result matches the slow path, where such views simply never appear in Query Views for Site. Any
+ * other failure (5xx, network, etc.) propagates so genuine errors aren't hidden.
+ *
+ * All views are fetched before slicing to `limit` so that omitted (403/404) views are backfilled by
+ * other allowed views rather than leaving the result short.
+ */
+async function fetchAllowedViewsById({
+  restApi,
+  viewIds,
+  limit,
+}: {
+  restApi: RestApi;
+  viewIds: Set<string>;
+  limit: number | undefined;
+}): Promise<Array<View>> {
+  const ids = [...viewIds];
+  const results = await Promise.allSettled(
+    ids.map((viewId) =>
+      restApi.viewsMethods.getView({
+        siteId: restApi.siteId,
+        viewId,
+        includeUsageStatistics: true,
+      }),
+    ),
+  );
+
+  const views: Array<View> = [];
+  results.forEach((result, i) => {
+    if (result.status === 'fulfilled') {
+      views.push(result.value);
+      return;
+    }
+
+    const status = isAxiosError(result.reason) ? result.reason.response?.status : undefined;
+    if (status === 403 || status === 404) {
+      log({
+        message: `Skipping view ${ids[i]} from INCLUDE_VIEW_IDS: not accessible (HTTP ${status})`,
+        level: 'warning',
+        logger: 'list-views',
+      });
+      return;
+    }
+
+    throw result.reason;
+  });
+
+  return limit !== undefined ? views.slice(0, limit) : views;
 }
 
 function flattenViewUsage(views: Array<View>): Array<View> {

--- a/tests/e2e/server.test.ts
+++ b/tests/e2e/server.test.ts
@@ -51,7 +51,12 @@ describe('server', () => {
         'confirm-update-cloud-extract-refresh-task',
       ];
       // flow tools are gated off by default (FLOW_TOOLS_ENABLED)
-      const flowTools: ReadonlyArray<WebToolName> = ['list-flows', 'get-flow'];
+      const flowTools: ReadonlyArray<WebToolName> = [
+        'list-flows',
+        'get-flow',
+        'list-flow-runs',
+        'list-flow-tasks',
+      ];
       // insights tools are gated off by default (INSIGHTS_TOOLS_ENABLED)
       const insightsTools: ReadonlyArray<WebToolName> = [
         'generate-insight-cards',
@@ -156,7 +161,12 @@ describe('server', () => {
         'confirm-update-cloud-extract-refresh-task',
       ];
       // flow tools are gated off by default (FLOW_TOOLS_ENABLED)
-      const flowTools: ReadonlyArray<WebToolName> = ['list-flows', 'get-flow'];
+      const flowTools: ReadonlyArray<WebToolName> = [
+        'list-flows',
+        'get-flow',
+        'list-flow-runs',
+        'list-flow-tasks',
+      ];
       // insights tools are gated off by default (INSIGHTS_TOOLS_ENABLED)
       const insightsTools: ReadonlyArray<WebToolName> = [
         'generate-insight-cards',


### PR DESCRIPTION

# Pull Request Template

<!-- Thank you for your contribution! Please fill out the following template to help us review your pull
request! -->

## Description
When bounded context is applied through INCLUDE_VIEW_IDS, Adds a fast path to `list-views`. In this fast path, each view is fetched directly via [GetView](https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref_workbooks_and_views.htm#get_view) API rather than paging through all the views and filtering in memory. 


## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [X] Other (please describe):

## How Has This Been Tested?

<!-- Please describe the tests that you performed to verify your changes. -->

## Related Issues

<!-- List any related issues, pull requests, or discussions. -->

## Checklist

- [X] I have updated the version in the package.json file by using `npm run version`. For example,
      use `npm run version:patch` for a patch version bump.
- [ ] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] I have documented any breaking changes in the PR description. For example, renaming a config
      environment variable or changing its default value.

## Contributor Agreement

By submitting this pull request, I confirm that:

- [X] I have read the [CONTRIBUTING guidelines](../../CONTRIBUTING.md) for this project and followed
      its Contribution Checklist.
