### PR TITLE
@W-23541903: Improve performance of list-workbooks when bounded context is applied

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "3.5.4",
+  "version": "3.5.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "3.5.4",
+      "version": "3.5.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.7.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "3.5.3",
+  "version": "3.5.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "3.5.3",
+      "version": "3.5.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.7.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "3.5.4",
+  "version": "3.5.6",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "3.5.3",
+  "version": "3.5.4",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/src/tools/web/workbooks/listWorkbooks.test.ts
+++ b/src/tools/web/workbooks/listWorkbooks.test.ts
@@ -1,6 +1,7 @@
 import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 
 import { WebMcpServer } from '../../../server.web.js';
+import { stubDefaultEnvVars } from '../../../testShared.js';
 import { getCombinationsOfBoundedContextInputs } from '../../../utils/getCombinationsOfBoundedContextInputs.js';
 import invariant from '../../../utils/invariant.js';
 import { Provider } from '../../../utils/provider.js';
@@ -19,6 +20,7 @@ const mockWorkbooksResponse = {
 
 const mocks = vi.hoisted(() => ({
   mockQueryWorkbooksForSite: vi.fn(),
+  mockGetWorkbook: vi.fn(),
 }));
 
 vi.mock('../../../restApiInstance.js', () => ({
@@ -26,6 +28,7 @@ vi.mock('../../../restApiInstance.js', () => ({
     callback({
       workbooksMethods: {
         queryWorkbooksForSite: mocks.mockQueryWorkbooksForSite,
+        getWorkbook: mocks.mockGetWorkbook,
       },
       siteId: 'test-site-id',
     }),
@@ -35,6 +38,12 @@ vi.mock('../../../restApiInstance.js', () => ({
 describe('listWorkbooksTool', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.unstubAllEnvs();
+    stubDefaultEnvVars();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
   });
 
   it('should create a tool instance with correct properties', () => {
@@ -67,6 +76,119 @@ describe('listWorkbooksTool', () => {
     expect(result.isError).toBe(true);
     invariant(result.content[0].type === 'text');
     expect(result.content[0].text).toContain(errorMessage);
+  });
+
+  describe('INCLUDE_WORKBOOK_IDS fast path (fetch by ID)', () => {
+    function makeAxiosError(status: number): Error {
+      return Object.assign(new Error(`Request failed with status code ${status}`), {
+        isAxiosError: true,
+        response: { status },
+      });
+    }
+
+    it('should fetch workbooks by ID when INCLUDE_WORKBOOK_IDS is set and no filter is provided', async () => {
+      vi.stubEnv('INCLUDE_WORKBOOK_IDS', `${mockWorkbook.id},${mockWorkbook2.id}`);
+      mocks.mockGetWorkbook.mockImplementation(async ({ workbookId }: { workbookId: string }) =>
+        workbookId === mockWorkbook.id ? mockWorkbook : mockWorkbook2,
+      );
+
+      const result = await getToolResult({});
+
+      expect(result.isError).toBe(false);
+      expect(mocks.mockGetWorkbook).toHaveBeenCalledTimes(2);
+      expect(mocks.mockGetWorkbook).toHaveBeenCalledWith({
+        siteId: 'test-site-id',
+        workbookId: mockWorkbook.id,
+      });
+      expect(mocks.mockQueryWorkbooksForSite).not.toHaveBeenCalled();
+
+      invariant(result.content[0].type === 'text');
+      const workbooks = JSON.parse(`${result.content[0].text}`);
+      expect(workbooks.map((w: { id: string }) => w.id).sort()).toEqual(
+        [mockWorkbook.id, mockWorkbook2.id].sort(),
+      );
+    });
+
+    it('should silently omit workbooks that return 403 or 404', async () => {
+      vi.stubEnv('INCLUDE_WORKBOOK_IDS', `${mockWorkbook.id},not-allowed,missing`);
+      mocks.mockGetWorkbook.mockImplementation(async ({ workbookId }: { workbookId: string }) => {
+        if (workbookId === 'not-allowed') {
+          throw makeAxiosError(403);
+        }
+        if (workbookId === 'missing') {
+          throw makeAxiosError(404);
+        }
+        return mockWorkbook;
+      });
+
+      const result = await getToolResult({});
+
+      expect(result.isError).toBe(false);
+      invariant(result.content[0].type === 'text');
+      const workbooks = JSON.parse(`${result.content[0].text}`);
+      expect(workbooks).toHaveLength(1);
+      expect(workbooks[0].id).toBe(mockWorkbook.id);
+    });
+
+    it('should propagate non-403/404 errors', async () => {
+      vi.stubEnv('INCLUDE_WORKBOOK_IDS', `${mockWorkbook.id},boom`);
+      mocks.mockGetWorkbook.mockImplementation(async ({ workbookId }: { workbookId: string }) => {
+        if (workbookId === 'boom') {
+          throw makeAxiosError(500);
+        }
+        return mockWorkbook;
+      });
+
+      const result = await getToolResult({});
+
+      expect(result.isError).toBe(true);
+      invariant(result.content[0].type === 'text');
+      expect(result.content[0].text).toContain('500');
+    });
+
+    it('should use the slow path when a filter is provided alongside INCLUDE_WORKBOOK_IDS', async () => {
+      vi.stubEnv('INCLUDE_WORKBOOK_IDS', mockWorkbook.id);
+      mocks.mockQueryWorkbooksForSite.mockResolvedValue(mockWorkbooksResponse);
+
+      const result = await getToolResult({ filter: 'name:eq:Superstore' });
+
+      expect(result.isError).toBe(false);
+      expect(mocks.mockQueryWorkbooksForSite).toHaveBeenCalledTimes(1);
+      expect(mocks.mockGetWorkbook).not.toHaveBeenCalled();
+    });
+
+    it('should still apply coexisting bounds (e.g. project) to fetched workbooks', async () => {
+      vi.stubEnv('INCLUDE_WORKBOOK_IDS', `${mockWorkbook.id},${mockWorkbook2.id}`);
+      // Only mockWorkbook's project is allowed; mockWorkbook2 must be filtered out by constrainWorkbooks.
+      vi.stubEnv('INCLUDE_PROJECT_IDS', mockWorkbook.project.id);
+      mocks.mockGetWorkbook.mockImplementation(async ({ workbookId }: { workbookId: string }) =>
+        workbookId === mockWorkbook.id ? mockWorkbook : mockWorkbook2,
+      );
+
+      const result = await getToolResult({});
+
+      expect(result.isError).toBe(false);
+      invariant(result.content[0].type === 'text');
+      const workbooks = JSON.parse(`${result.content[0].text}`);
+      expect(workbooks).toHaveLength(1);
+      expect(workbooks[0].id).toBe(mockWorkbook.id);
+    });
+
+    it('should slice fetched workbooks to the effective limit', async () => {
+      vi.stubEnv('INCLUDE_WORKBOOK_IDS', `${mockWorkbook.id},${mockWorkbook2.id}`);
+      mocks.mockGetWorkbook.mockImplementation(async ({ workbookId }: { workbookId: string }) =>
+        workbookId === mockWorkbook.id ? mockWorkbook : mockWorkbook2,
+      );
+
+      const result = await getToolResult({ limit: 1 });
+
+      expect(result.isError).toBe(false);
+      // All allowed workbooks are fetched before slicing, then trimmed to the limit.
+      expect(mocks.mockGetWorkbook).toHaveBeenCalledTimes(2);
+      invariant(result.content[0].type === 'text');
+      const workbooks = JSON.parse(`${result.content[0].text}`);
+      expect(workbooks).toHaveLength(1);
+    });
   });
 
   describe('constrainWorkbooks', () => {
@@ -142,11 +264,11 @@ describe('listWorkbooksTool', () => {
   });
 });
 
-async function getToolResult(params: { filter: string }): Promise<CallToolResult> {
+async function getToolResult(params: { filter?: string; limit?: number }): Promise<CallToolResult> {
   const listWorkbooksTool = getListWorkbooksTool(new WebMcpServer());
   const callback = await Provider.from(listWorkbooksTool.callback);
   return await callback(
-    { filter: params.filter, pageSize: undefined, limit: undefined },
+    { filter: params.filter, pageSize: undefined, limit: params.limit },
     getMockRequestHandlerExtra(),
   );
 }

--- a/src/tools/web/workbooks/listWorkbooks.ts
+++ b/src/tools/web/workbooks/listWorkbooks.ts
@@ -10,8 +10,10 @@ import {
   getWorkbookLineageQuery,
   mergeWorkbookLineage,
 } from '../../../sdks/tableau/methods/lineageUtils.js';
+import { RestApi } from '../../../sdks/tableau/restApi.js';
 import { Workbook } from '../../../sdks/tableau/types/workbook.js';
 import { WebMcpServer } from '../../../server.web.js';
+import { isAxiosError } from '../../../utils/axios.js';
 import { getExceptionMessage } from '../../../utils/getExceptionMessage.js';
 import { paginate } from '../../../utils/paginate.js';
 import { genericFilterDescription } from '../genericFilterDescription.js';
@@ -87,26 +89,40 @@ export const getListWorkbooksTool = (server: WebMcpServer): WebTool<typeof param
                 const maxResultLimit = configWithOverrides.getMaxResultLimit(
                   listWorkbooksTool.name,
                 );
+                const effectiveLimit = maxResultLimit
+                  ? Math.min(maxResultLimit, limit ?? Number.MAX_SAFE_INTEGER)
+                  : limit;
 
-                const workbooks = await paginate({
-                  pageConfig: {
-                    pageSize,
-                    limit: maxResultLimit
-                      ? Math.min(maxResultLimit, limit ?? Number.MAX_SAFE_INTEGER)
-                      : limit,
-                  },
-                  getDataFn: async (pageConfig) => {
-                    const { pagination, workbooks: data } =
-                      await restApi.workbooksMethods.queryWorkbooksForSite({
-                        siteId: restApi.siteId,
-                        filter: validatedFilter ?? '',
-                        pageSize: pageConfig.pageSize,
-                        pageNumber: pageConfig.pageNumber,
+                // Fast path: when results are scoped to a specific set of workbook IDs and the user
+                // hasn't supplied a filter, fetch those workbooks directly instead of paging the
+                // whole site. Query Workbooks for Site has no workbook-ID filter, so the slow path
+                // would fetch every workbook only to discard all but the allowed ones. A user filter
+                // forces the slow path since Query Workbook can't apply server-side filtering.
+                const workbookIds = configWithOverrides.boundedContext.workbookIds;
+                const workbooks =
+                  workbookIds !== null && !filter
+                    ? await fetchAllowedWorkbooksById({
+                        restApi,
+                        workbookIds,
+                        limit: effectiveLimit,
+                      })
+                    : await paginate({
+                        pageConfig: {
+                          pageSize,
+                          limit: effectiveLimit,
+                        },
+                        getDataFn: async (pageConfig) => {
+                          const { pagination, workbooks: data } =
+                            await restApi.workbooksMethods.queryWorkbooksForSite({
+                              siteId: restApi.siteId,
+                              filter: validatedFilter ?? '',
+                              pageSize: pageConfig.pageSize,
+                              pageNumber: pageConfig.pageNumber,
+                            });
+
+                          return { pagination, data };
+                        },
                       });
-
-                    return { pagination, data };
-                  },
-                });
 
                 if (configWithOverrides.disableMetadataApiRequests || workbooks.length === 0) {
                   return workbooks;
@@ -142,6 +158,59 @@ export const getListWorkbooksTool = (server: WebMcpServer): WebTool<typeof param
 
   return listWorkbooksTool;
 };
+
+/**
+ * Fetches the allowed workbooks directly via Query Workbook, one request per ID. Used when the
+ * results are scoped by `INCLUDE_WORKBOOK_IDS` and no user filter is present.
+ *
+ * Workbooks that return 403 (no permission) or 404 (deleted / not found) are silently omitted so the
+ * result matches the slow path, where such workbooks simply never appear in Query Workbooks for
+ * Site. Any other failure (5xx, network, etc.) propagates so genuine errors aren't hidden.
+ *
+ * All workbooks are fetched before slicing to `limit` so that omitted (403/404) workbooks are
+ * backfilled by other allowed workbooks rather than leaving the result short.
+ */
+async function fetchAllowedWorkbooksById({
+  restApi,
+  workbookIds,
+  limit,
+}: {
+  restApi: RestApi;
+  workbookIds: Set<string>;
+  limit: number | undefined;
+}): Promise<Array<Workbook>> {
+  const ids = [...workbookIds];
+  const results = await Promise.allSettled(
+    ids.map((workbookId) =>
+      restApi.workbooksMethods.getWorkbook({
+        siteId: restApi.siteId,
+        workbookId,
+      }),
+    ),
+  );
+
+  const workbooks: Array<Workbook> = [];
+  results.forEach((result, i) => {
+    if (result.status === 'fulfilled') {
+      workbooks.push(result.value);
+      return;
+    }
+
+    const status = isAxiosError(result.reason) ? result.reason.response?.status : undefined;
+    if (status === 403 || status === 404) {
+      log({
+        message: `Skipping workbook ${ids[i]} from INCLUDE_WORKBOOK_IDS: not accessible (HTTP ${status})`,
+        level: 'warning',
+        logger: 'list-workbooks',
+      });
+      return;
+    }
+
+    throw result.reason;
+  });
+
+  return limit !== undefined ? workbooks.slice(0, limit) : workbooks;
+}
 
 export function constrainWorkbooks({
   workbooks,


### PR DESCRIPTION




# Pull Request Template

<!-- Thank you for your contribution! Please fill out the following template to help us review your pull
request! -->

## Description
When bounded context is applied through INCLUDE_WORKBOOK_IDS, Adds a fast path to `list-workbooks`. In this fast path, each allowed workbook is fetched directly via [QueryWorkbook](https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref_workbooks_and_views.htm#query_workbook) API rather than paging the whole site and filtering in memory. 

A user filter still forces the regular path since [QueryWorkbook](https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref_workbooks_and_views.htm#query_workbook) doesn't provide input params to send in filters.

## Motivation and Context
Imagine the use case of site having tens of thousands of workbooks with allowed workbookIds(small in number) applied through INCLUDE_WORKBOOK_IDS. Current mechanism for `list-workbooks` fetches all of the workbooks through pagination into memory and then applies filtering. This approach is not scalable. This MR addresses the scalability issue.


## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [X] Other (please describe):

## How Has This Been Tested?

<!-- Please describe the tests that you performed to verify your changes. -->

## Related Issues

<!-- List any related issues, pull requests, or discussions. -->

## Checklist

- [X] I have updated the version in the package.json file by using `npm run version`. For example,
      use `npm run version:patch` for a patch version bump.
- [ ] I have made any necessary changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have documented any breaking changes in the PR description. For example, renaming a config
      environment variable or changing its default value.

## Contributor Agreement

By submitting this pull request, I confirm that:

- [X] I have read the [CONTRIBUTING guidelines](../../CONTRIBUTING.md) for this project and followed
      its Contribution Checklist.
