### PR TITLE
fix(binder): honest bind-template annotations — not read-only, not idempotent (thrash-fix slice 1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "2.36.0",
+  "version": "2.37.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/src/tools/desktop/binder/bindTemplate.test.ts
+++ b/src/tools/desktop/binder/bindTemplate.test.ts
@@ -321,7 +321,7 @@ describe('bindTemplateTool', () => {
   it('should create a tool instance with correct properties', () => {
     const tool = getBindTemplateTool(new DesktopMcpServer());
     expect(tool.name).toBe('bind-template');
-    expect(tool.description).toBe('Bind/apply template; calcs[] first.');
+    expect(tool.description).toBe('Bind/apply template; calcs first.');
     expect(tool.paramsSchema).toMatchObject({
       session: expect.any(Object),
       ask: expect.any(Object),
@@ -331,7 +331,9 @@ describe('bindTemplateTool', () => {
     });
     expect(tool.annotations).toMatchObject({
       title: 'Bind Template',
-      readOnlyHint: true,
+      // NOT read-only / NOT idempotent: auto_apply + calcs[] mutate the live workbook.
+      readOnlyHint: false,
+      idempotentHint: false,
       openWorldHint: false,
     });
   });

--- a/src/tools/desktop/binder/bindTemplate.ts
+++ b/src/tools/desktop/binder/bindTemplate.ts
@@ -727,14 +727,19 @@ export const getBindTemplateTool = (server: DesktopMcpServer): DesktopTool<typeo
     server,
     name: 'bind-template',
     title,
-    description: 'Bind/apply template; calcs[] first.',
+    description: 'Bind/apply template; calcs first.',
     paramsSchema,
     annotations: {
       title,
-      readOnlyHint: true, // Reads the live workbook and computes; never mutates it.
+      // NOT read-only and NOT idempotent: auto_apply:true mutates the live workbook via
+      // loadWorkbookXml, and calcs[] author (mutate) even without auto-apply. The old
+      // readOnly/idempotent hints told the host/model that retrying a bind is free — a
+      // direct incentive for the blind-retry thrash (a completed apply re-run is a real
+      // re-mutation, not a no-op). Honest hints let the host treat repeats as consequential.
+      readOnlyHint: false,
       openWorldHint: false,
       destructiveHint: false,
-      idempotentHint: true,
+      idempotentHint: false,
     },
     callback: async (
       { session, ask, proposal, minConfidence, auto_apply, target_worksheet, calcs },


### PR DESCRIPTION
## The incentive bug behind Blake's thrash
bind-template was annotated `readOnlyHint:true` + `idempotentHint:true`, but `auto_apply:true` mutates the live workbook (loadWorkbookXml:666-671) and `calcs[]` author before binding (authorCalcCore). The hints told the host/model that **retrying a bind is free** — a direct incentive for the blind-retry spiral Blake reported (bind succeeds in ~50ms, agent re-binds + searches for 90-136s).

## Fix
`readOnlyHint:false` + `idempotentHint:false`. Funded the +2 tools/list surface bytes by trimming the description (`'calcs[] first'`→`'calcs first'`) so bind-template stays under its grandfathered byte cap (ledger rule: shrink, don't raise). Updated the 2 tests that pinned the old annotation/description.

## Context
This is **slice 1** of the systemic thrash fix (Sol-diagnosed: the real cause is a control-flow gap — bind failures say 'retry', never 'diagnose'; no attempt budget). The larger follow-up is the bind-recovery state machine (one-bind + one-evidence-backed-retry-max, dup-suppression) — separate PR, plan verified to preserve the designed Call-1-propose→Call-2 flow. This slice is the small, safe, obviously-correct piece.

## Verified
tsc 0 · binder + server.desktop suites 121 pass · eslint 0 · under byte cap · v2.36.0→2.37.0. Diagnosed by GPT-5.6-Sol, firsthand-verified.