### PR TITLE
fix(binder): two demo-blockers — session:'default' sentinel + build-apply dead required fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "2.36.0",
+  "version": "2.38.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/src/desktop/sessionResolution.test.ts
+++ b/src/desktop/sessionResolution.test.ts
@@ -57,6 +57,17 @@ describe('resolveSession', () => {
     expect(result.unwrap()).toBe('4242');
   });
 
+  it('treats the sentinel "default" as absent when pinned (no spurious pin-mismatch)', () => {
+    // Some clients inject session:"default" as a placeholder; before the fix that literal
+    // was compared against the pinned pid and failed closed on every session-scoped call.
+    mockConfig({ desktopSessionId: '4242' });
+    for (const sentinel of ['default', 'Default', ' DEFAULT ']) {
+      const result = resolveSession(sentinel);
+      expect(result.isOk(), `"${sentinel}" should resolve to the pin`).toBe(true);
+      expect(result.unwrap()).toBe('4242');
+    }
+  });
+
   it('returns an explicit session id verbatim when nothing is pinned', () => {
     mockConfig({ desktopSessionId: undefined });
     const result = resolveSession('7');

--- a/src/desktop/sessionResolution.ts
+++ b/src/desktop/sessionResolution.ts
@@ -27,7 +27,13 @@ const LIST_INSTANCES_TOOL: DesktopToolName = 'list-instances';
  * Uses the External Client API discovery files written by Tableau Desktop.
  */
 export function resolveSession(session: string | undefined): Result<string, McpToolError> {
-  const requestedSession = session?.trim() ? session : undefined;
+  // Treat empty/whitespace AND the sentinel "default" as ABSENT. Some clients inject
+  // session:"default" as a placeholder; when the agent is pinned to a Desktop pid that
+  // literal is not the pid, so it used to fail closed with a spurious "pinned to pid X but
+  // session 'default' requested" error on every session-scoped call (add-field, apply, …).
+  // "default" means "use whatever session is resolved", i.e. the pin — never a real id.
+  const trimmed = session?.trim();
+  const requestedSession = trimmed && trimmed.toLowerCase() !== 'default' ? trimmed : undefined;
   const config = getDesktopConfig();
   if (config.desktopSessionId !== undefined) {
     if (requestedSession !== undefined && requestedSession !== config.desktopSessionId) {

--- a/src/tools/desktop/coordination/buildAndApplyWorksheet.ts
+++ b/src/tools/desktop/coordination/buildAndApplyWorksheet.ts
@@ -95,8 +95,12 @@ const paramsSchema = {
   session: z.string().optional(),
   taskSpec: z.object({
     worksheetName: z.string(),
-    worksheetFile: z.string(),
-    type: z.enum(['kpi', 'chart']),
+    // worksheetFile + type are DEAD (never destructured/used at the callback — the impl reads
+    // { worksheetName, workbookFile, template, fields }). They were REQUIRED in the schema, so
+    // an agent that (reasonably) omitted them hit a Zod invalid_type and fell into a retry
+    // spiral. Made optional so a minimal, correct taskSpec validates; kept for back-compat.
+    worksheetFile: z.string().optional(),
+    type: z.enum(['kpi', 'chart']).optional(),
     template: z.string().optional(),
     fields: z.array(z.string()),
     workbookFile: z.string(),


### PR DESCRIPTION
Two deterministic demo-blockers from Blake's ask-ledger (newest builds), both make calls fail closed and spiral.

## 1. session:'default' (sessionResolution.ts) — BLOCKING
Clients inject `session:"default"` as a placeholder. When the agent is pinned to a Desktop pid, that literal ≠ the pid, so EVERY session-scoped call (add-field, apply, …) failed with a spurious *"pinned to pid X but session 'default' requested"* error (seen 3× in the ledger). Now the `default` sentinel (case-insensitive) is treated as ABSENT — same as empty — and resolves to the pin. +test (default / Default / ' DEFAULT ').

## 2. build-and-apply-worksheet taskSpec — BLOCKING on fallback
`worksheetFile` + `type` were REQUIRED in the Zod schema but DEAD (never destructured — the impl reads `{worksheetName, workbookFile, template, fields}`). An agent that omitted them hit a Zod `invalid_type` and fell into a retry spiral (3× in the ledger). Made both optional (kept for back-compat). *(Live-read fallback when `workbookFile` is omitted = separate follow-up.)*

## Verified
Diagnosed by GPT-5.6-Sol from the ledger analysis, firsthand-verified (session?.trim() logic; the dead-field destructure). 2715 binder/desktop tests green, eslint 0, v2.37.0→2.38.0.

Part of the demo gap-closing plan (vault demo-gap-closing-plan-2026-07-22.md) — Sol ranked these the top-2 deterministic BLOCKERS for a solid demo.