### PR TITLE
fix(binder): latlon resolver binds WIDE real map schemas (best detail dim), not fail-closed on 3+ dims

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "2.38.0",
+  "version": "2.40.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/src/desktop/binder/binder.test.ts
+++ b/src/desktop/binder/binder.test.ts
@@ -307,26 +307,57 @@ describe('binder/classifyNoLlm — measure-free lat/long symbol map (Blake wall 
     expect(classifyNoLlm('Build me a Tableau map of the office locations', forced, s)).toBeNull();
   });
 
-  it('BACK-DOOR CLOSED: with 3+ dimensions the resolver declines AND the generic keyword loop must NOT bind latlon (no axis-swap/dropped-dim escape hatch)', () => {
-    // latlon carries generic map keywords ('map'/'symbol-map'/'spatial'); if it were left
-    // in the generic scoring loop, a resolver-declined ask could still win latlon by keyword
-    // and role-greedy-bind it — swapping axes or dropping a detail dim. The resolver fails
-    // closed on 3+ non-coordinate dims; classification as a whole MUST also fail closed here.
-    const threeDimCoordXml = `<?xml version='1.0' encoding='utf-8'?>
+  it('WIDE REAL SCHEMA: 3+ dims → binds coords + the single BEST detail dim (Blake World Cup), not fail-closed', () => {
+    // Blake's real teams.csv is WIDE (team_id/team_api_id/group_name/country_code/team_name +
+    // coords + flag/color/source) — 5 categoricals. The mark identity is ONE label (team_name),
+    // not every attribute. pickBestDetailDim scores team_name up (+ 'team' overlaps the ask,
+    // '+name'), and penalizes id/code/source, so it wins uniquely → confident single bind with
+    // team_name on detail, coords on axes. (Before: 3+ → fail closed → thrash on real map data.)
+    const wideXml = `<?xml version='1.0' encoding='utf-8'?>
 <workbook>
   <datasources>
-    <datasource name='Offices'>
-      <column name='[pm_name]' role='dimension' type='nominal' datatype='string' />
-      <column name='[city]' role='dimension' type='nominal' datatype='string' />
-      <column name='[region]' role='dimension' type='nominal' datatype='string' />
+    <datasource name='Teams'>
+      <column name='[team_id]' role='dimension' type='nominal' datatype='string' />
+      <column name='[team_api_id]' role='dimension' type='nominal' datatype='string' />
+      <column name='[group_name]' role='dimension' type='nominal' datatype='string' />
+      <column name='[country_code]' role='dimension' type='nominal' datatype='string' />
+      <column name='[team_name]' role='dimension' type='nominal' datatype='string' />
       <column name='[latitude]' role='measure' type='quantitative' datatype='real' />
       <column name='[longitude]' role='measure' type='quantitative' datatype='real' />
     </datasource>
   </datasources>
 </workbook>`;
     const forced = withForcedEligible([LATLON]);
-    const s = summarizeSchema(threeDimCoordXml);
-    expect(classifyNoLlm('Build me a Tableau map of the office locations', forced, s)).toBeNull();
+    const s = summarizeSchema(wideXml);
+    const cls = classifyNoLlm('Build me a map of the World Cup team locations', forced, s);
+    expect(cls).not.toBeNull();
+    expect(cls!.template).toBe(LATLON);
+    const bySlot = Object.fromEntries(cls!.bindings.map((b) => [b.slot_id, b.field]));
+    expect(bySlot['longitude']).toBe('longitude');
+    expect(bySlot['latitude']).toBe('latitude');
+    const detailFields = cls!.bindings.filter((b) => b.slot_id.startsWith('detail')).map((b) => b.field);
+    // exactly ONE detail dim, and it is the label (team_name) — not id/code/group noise.
+    expect(detailFields).toEqual(['team_name']);
+  });
+
+  it('AMBIGUOUS wide schema (3+ dims, no clear best) still FAILS CLOSED — a wrong grain is worse than a propose', () => {
+    // Three generic-noun dims none of which overlaps the ask or is a 'name' label → a genuine
+    // scoring tie → pickBestDetailDim returns null → classification fails closed (propose).
+    const tieXml = `<?xml version='1.0' encoding='utf-8'?>
+<workbook>
+  <datasources>
+    <datasource name='Sites'>
+      <column name='[alpha]' role='dimension' type='nominal' datatype='string' />
+      <column name='[beta]' role='dimension' type='nominal' datatype='string' />
+      <column name='[gamma]' role='dimension' type='nominal' datatype='string' />
+      <column name='[latitude]' role='measure' type='quantitative' datatype='real' />
+      <column name='[longitude]' role='measure' type='quantitative' datatype='real' />
+    </datasource>
+  </datasources>
+</workbook>`;
+    const forced = withForcedEligible([LATLON]);
+    const s = summarizeSchema(tieXml);
+    expect(classifyNoLlm('Build me a map of the site locations', forced, s)).toBeNull();
   });
 
   it('is LIVE in production: the committed manifest is render-stamped eligible and binds the office-map ask', () => {

--- a/src/desktop/binder/binder.test.ts
+++ b/src/desktop/binder/binder.test.ts
@@ -370,6 +370,33 @@ describe('binder/classifyNoLlm — measure-free lat/long symbol map (Blake wall 
     expect(detailFields).toEqual(['venue_name']);
   });
 
+  it('UNLISTED coarse token cannot stack ask-overlap to beat the fine label (ask-overlap capped +2/field)', () => {
+    // Sol #598 re-review: a multi-token coarse field like 'tournament_round' ('round' is not
+    // in COARSE_GRAIN_TOKENS) could stack ask-overlap (tournament +2, round +2 = 4) and beat
+    // venue_name (3) → collapse. The per-FIELD +2 cap (not per-token) prevents it: both fields
+    // get at most +2 overlap, so venue_name's +1 'name' label breaks the tie for the fine grain.
+    const roundXml = `<?xml version='1.0' encoding='utf-8'?>
+<workbook>
+  <datasources>
+    <datasource name='Venues'>
+      <column name='[venue_name]' role='dimension' type='nominal' datatype='string' />
+      <column name='[tournament_round]' role='dimension' type='nominal' datatype='string' />
+      <column name='[host_city]' role='dimension' type='nominal' datatype='string' />
+      <column name='[latitude]' role='measure' type='quantitative' datatype='real' />
+      <column name='[longitude]' role='measure' type='quantitative' datatype='real' />
+    </datasource>
+  </datasources>
+</workbook>`;
+    const forced = withForcedEligible([LATLON]);
+    const s = summarizeSchema(roundXml);
+    const cls = classifyNoLlm('map tournament round venue locations', forced, s);
+    expect(cls).not.toBeNull();
+    const detailFields = cls!.bindings
+      .filter((b) => b.slot_id.startsWith('detail'))
+      .map((b) => b.field);
+    expect(detailFields).toEqual(['venue_name']);
+  });
+
   it('AMBIGUOUS wide schema (3+ dims, no clear best) still FAILS CLOSED — a wrong grain is worse than a propose', () => {
     // Three generic-noun dims none of which overlaps the ask or is a 'name' label → a genuine
     // scoring tie → pickBestDetailDim returns null → classification fails closed (propose).

--- a/src/desktop/binder/binder.test.ts
+++ b/src/desktop/binder/binder.test.ts
@@ -342,6 +342,34 @@ describe('binder/classifyNoLlm — measure-free lat/long symbol map (Blake wall 
     expect(detailFields).toEqual(['team_name']);
   });
 
+  it('COARSE dim named in the ask does NOT win detail over the fine label (no centroid collapse)', () => {
+    // Sol counterexample: ask "map tournament stage venue locations" mentions BOTH 'stage'
+    // (coarse — many venues share a stage) and 'venue'. A naive ask-overlap scorer would put
+    // tournament_stage on detail → venues collapse to per-stage AVG centroids. The coarse
+    // penalty must keep venue_name (fine label) as the detail grain.
+    const venueXml = `<?xml version='1.0' encoding='utf-8'?>
+<workbook>
+  <datasources>
+    <datasource name='Venues'>
+      <column name='[venue_id]' role='dimension' type='nominal' datatype='string' />
+      <column name='[venue_name]' role='dimension' type='nominal' datatype='string' />
+      <column name='[tournament_stage]' role='dimension' type='nominal' datatype='string' />
+      <column name='[latitude]' role='measure' type='quantitative' datatype='real' />
+      <column name='[longitude]' role='measure' type='quantitative' datatype='real' />
+    </datasource>
+  </datasources>
+</workbook>`;
+    const forced = withForcedEligible([LATLON]);
+    const s = summarizeSchema(venueXml);
+    const cls = classifyNoLlm('map tournament stage venue locations', forced, s);
+    expect(cls).not.toBeNull();
+    const detailFields = cls!.bindings
+      .filter((b) => b.slot_id.startsWith('detail'))
+      .map((b) => b.field);
+    // venue_name (fine) wins over tournament_stage (coarse) despite 'stage' being in the ask.
+    expect(detailFields).toEqual(['venue_name']);
+  });
+
   it('AMBIGUOUS wide schema (3+ dims, no clear best) still FAILS CLOSED — a wrong grain is worse than a propose', () => {
     // Three generic-noun dims none of which overlaps the ask or is a 'name' label → a genuine
     // scoring tie → pickBestDetailDim returns null → classification fails closed (propose).

--- a/src/desktop/binder/binder.test.ts
+++ b/src/desktop/binder/binder.test.ts
@@ -335,7 +335,9 @@ describe('binder/classifyNoLlm — measure-free lat/long symbol map (Blake wall 
     const bySlot = Object.fromEntries(cls!.bindings.map((b) => [b.slot_id, b.field]));
     expect(bySlot['longitude']).toBe('longitude');
     expect(bySlot['latitude']).toBe('latitude');
-    const detailFields = cls!.bindings.filter((b) => b.slot_id.startsWith('detail')).map((b) => b.field);
+    const detailFields = cls!.bindings
+      .filter((b) => b.slot_id.startsWith('detail'))
+      .map((b) => b.field);
     // exactly ONE detail dim, and it is the label (team_name) — not id/code/group noise.
     expect(detailFields).toEqual(['team_name']);
   });

--- a/src/desktop/binder/classify.ts
+++ b/src/desktop/binder/classify.ts
@@ -695,16 +695,44 @@ const NON_LABEL_DETAIL_TOKENS: ReadonlySet<string> = new Set([
 ]);
 
 /**
+ * COARSE-grain grouping tokens: dimensions that bucket MANY marks together (a group, a
+ * stage, a category…). On a coordinate map these are the WRONG detail grain — putting only
+ * a coarse dim on detail collapses every mark sharing that bucket into one AVG centroid.
+ * A coarse token is penalized so it can never outrank a fine per-mark label, even when the
+ * ASK mentions it (Sol's venue counterexample: "map tournament STAGE venue locations" must
+ * still grain by venue_name, not tournament_stage). Kept small + conservative.
+ */
+const COARSE_GRAIN_TOKENS: ReadonlySet<string> = new Set([
+  'group',
+  'stage',
+  'category',
+  'region',
+  'type',
+  'class',
+  'status',
+  'segment',
+  'tier',
+  'division',
+  'conference',
+  'bucket',
+  'band',
+]);
+
+/**
  * Pick the single best DETAIL (mark-identity) dimension from a WIDE schema's categoricals
  * (3+), so a real-world map (team_id, team_api_id, group_name, country_code, team_name, …)
- * binds a confident single map gained by ONE label rather than failing closed. The mark
- * identity is one label dimension, not every descriptive attribute. Scoring (Sol-specced):
- *   +2  a token overlaps the ask (e.g. "team" in "World Cup team locations" ↔ team_name)
+ * binds a confident single map grained by ONE label rather than failing closed. The mark
+ * identity is one FINE label dimension, not every descriptive attribute and NOT a coarse
+ * bucket. Scoring:
+ *   +2  a token overlaps the ask (names the intended subject — but NOT if the field is coarse)
  *   +1  a label-like `name` token
- *   −2  per technical token (id/code/hex/url/emoji/source/…) — these are not the grain
- * Returns the unique top scorer; null on a TIE (ambiguous grain → caller fails closed —
- * a wrong grain is worse than an honest propose). Never returns a coordinate field (the
- * caller passes categoricals only, and coords are measures).
+ *   −2  per technical token (id/code/hex/url/emoji/source/…) — not the grain
+ *   −3  per COARSE grouping token (group/stage/category/region/…) — the wrong grain; a
+ *       coarse dim on detail collapses marks (Sol: ask-overlap ≠ finest grain).
+ * Returns the unique top scorer with a POSITIVE score; null on a tie OR when the best is not
+ * positive (no clear fine label → ambiguous grain → caller fails closed; a wrong grain that
+ * silently centroid-collapses is worse than an honest propose). Coords never reach here
+ * (caller passes categoricals only).
  */
 function pickBestDetailDim(
   categoricals: SchemaField[],
@@ -713,11 +741,16 @@ function pickBestDetailDim(
 ): SchemaField | null {
   const scoreOf = (f: SchemaField): number => {
     const toks = new Set([...nameTokens(f.name), ...nameTokens(bareName(f.columnName))]);
+    const isCoarse = [...toks].some((t) => COARSE_GRAIN_TOKENS.has(t));
     let score = 0;
     for (const t of toks) {
       if (NON_LABEL_DETAIL_TOKENS.has(t)) score -= 2;
+      if (COARSE_GRAIN_TOKENS.has(t)) score -= 3;
       if (t === 'name') score += 1;
-      // token appears in the ask (raw or masked) → strong signal it names the intended grain
+      // token appears in the ask (raw or masked) → names the subject — but a COARSE field
+      // (group/stage/…) is still the wrong GRAIN even when the ask mentions it, so ask-overlap
+      // does NOT rescue a coarse dim (prevents the "map tournament stage venues" collapse).
+      if (isCoarse) continue;
       if (phraseIndexInAsk(rawAsk, t) >= 0 || phraseIndexInAsk(maskedAsk, t) >= 0) score += 2;
     }
     return score;
@@ -725,8 +758,14 @@ function pickBestDetailDim(
   const ranked = categoricals
     .map((f) => ({ f, score: scoreOf(f) }))
     .sort((a, b) => b.score - a.score);
-  if (ranked.length < 2) return ranked[0]?.f ?? null;
-  if (ranked[0].score === ranked[1].score) return null; // tie → ambiguous → fail closed
+  if (ranked.length === 0) return null;
+  // The winner must be a POSITIVE, UNIQUE fine label. A non-positive top means no field
+  // read as a clean per-mark label (all coarse/technical/neutral) → ambiguous grain → fail
+  // closed. A tie at the top → can't tell which is the mark identity → fail closed. Only a
+  // clear, positive, single winner binds (a wrong grain silently centroid-collapses; propose
+  // is safer).
+  if (ranked[0].score <= 0) return null;
+  if (ranked.length > 1 && ranked[0].score === ranked[1].score) return null;
   return ranked[0].f;
 }
 

--- a/src/desktop/binder/classify.ts
+++ b/src/desktop/binder/classify.ts
@@ -672,11 +672,64 @@ function uniqueCoordinateField(
  *   - the ask carries coordinate/point-location intent (askHasCoordinateOrPointIntent);
  *   - EXACTLY ONE latitude-affine quantitative field AND EXACTLY ONE longitude-affine one,
  *     and they are DISTINCT (a field named "lat_long" that matched both → ambiguous → null);
- *   - EXACTLY ONE categorical dimension for the detail slot (0 → nothing to grain by;
- *     2+ → ambiguous which detail, fail closed).
+ *   - AT LEAST ONE categorical for detail (0 → nothing to grain by → fail closed). 1–2
+ *     categoricals bind all (clean schema, no collapse). 3+ (a real WIDE schema) → narrow to
+ *     the single best label dim via pickBestDetailDim; a scoring tie → fail closed.
  * The axis assignment is by NAME (longitude→cols, latitude→rows), never schema order, so a
  * reversed-order schema binds identically — the axis-swap regression is impossible here.
  */
+
+/** Technical/attribute tokens that mark a field as NOT the map's identifying label. */
+const NON_LABEL_DETAIL_TOKENS: ReadonlySet<string> = new Set([
+  'id',
+  'code',
+  'hex',
+  'url',
+  'uri',
+  'emoji',
+  'source',
+  'key',
+  'guid',
+  'uuid',
+  'api',
+]);
+
+/**
+ * Pick the single best DETAIL (mark-identity) dimension from a WIDE schema's categoricals
+ * (3+), so a real-world map (team_id, team_api_id, group_name, country_code, team_name, …)
+ * binds a confident single map gained by ONE label rather than failing closed. The mark
+ * identity is one label dimension, not every descriptive attribute. Scoring (Sol-specced):
+ *   +2  a token overlaps the ask (e.g. "team" in "World Cup team locations" ↔ team_name)
+ *   +1  a label-like `name` token
+ *   −2  per technical token (id/code/hex/url/emoji/source/…) — these are not the grain
+ * Returns the unique top scorer; null on a TIE (ambiguous grain → caller fails closed —
+ * a wrong grain is worse than an honest propose). Never returns a coordinate field (the
+ * caller passes categoricals only, and coords are measures).
+ */
+function pickBestDetailDim(
+  categoricals: SchemaField[],
+  rawAsk: string,
+  maskedAsk: string,
+): SchemaField | null {
+  const scoreOf = (f: SchemaField): number => {
+    const toks = new Set([...nameTokens(f.name), ...nameTokens(bareName(f.columnName))]);
+    let score = 0;
+    for (const t of toks) {
+      if (NON_LABEL_DETAIL_TOKENS.has(t)) score -= 2;
+      if (t === 'name') score += 1;
+      // token appears in the ask (raw or masked) → strong signal it names the intended grain
+      if (phraseIndexInAsk(rawAsk, t) >= 0 || phraseIndexInAsk(maskedAsk, t) >= 0) score += 2;
+    }
+    return score;
+  };
+  const ranked = categoricals
+    .map((f) => ({ f, score: scoreOf(f) }))
+    .sort((a, b) => b.score - a.score);
+  if (ranked.length < 2) return ranked[0]?.f ?? null;
+  if (ranked[0].score === ranked[1].score) return null; // tie → ambiguous → fail closed
+  return ranked[0].f;
+}
+
 function resolveLatLonSymbolMap(
   m: TemplateManifest,
   rawAsk: string,
@@ -689,15 +742,24 @@ function resolveLatLonSymbolMap(
   const lon = uniqueCoordinateField(summary.fields, LONGITUDE_TOKENS);
   if (!lat || !lon || lat === lon) return null; // 0/2+/collision → fail closed
 
-  // GRAIN: bind EVERY non-coordinate dimension to a detail slot, in deterministic schema
-  // order. The template AVG-aggregates the coordinates, so a mark collapses to a per-member
-  // centroid for any dimension NOT on detail — binding one of two dimensions (e.g. city but
-  // not pm_name) would blob every office in a city onto one AVG point (the blank-centroid
-  // wrong-bind). One dimension → detail1 only (detail2 pruned). Two → both. Zero → nothing
-  // to grain by. THREE+ exceeds this template's two-slot capacity, and dropping any dim
-  // re-introduces the collapse, so fail closed to propose rather than silently under-grain.
-  const detailDims = summary.fields.filter(isCategorical);
-  if (detailDims.length < 1 || detailDims.length > 2) return null; // 0 or 3+ → fail closed
+  // GRAIN: bind the identifying non-coordinate dimension(s) to detail. The template
+  // AVG-aggregates the coordinates, so a mark collapses to a per-member centroid for any
+  // grain dimension NOT on detail. Zero categoricals → nothing to grain by → fail closed.
+  const categoricals = summary.fields.filter(isCategorical);
+  if (categoricals.length < 1) return null;
+  // 1–2 categoricals: bind them all (a clean map schema — pm_name+city — must keep both so
+  // no mark collapses). 3+ (a REAL wide schema — team_id/team_api_id/group_name/country_code/
+  // team_name): the mark identity is ONE label dimension, not every descriptive attribute;
+  // narrow to the single best detail dim rather than fail closed (real map data is always
+  // wide). Ties (no clear winner) still fail closed — a wrong grain is worse than a propose.
+  let detailDims: SchemaField[];
+  if (categoricals.length <= 2) {
+    detailDims = categoricals;
+  } else {
+    const best = pickBestDetailDim(categoricals, rawAsk, maskedAsk);
+    if (!best) return null; // ambiguous grain (tie) → fail closed
+    detailDims = [best];
+  }
 
   // Map by SLOT ROLE/ID, not slot order: longitude→the cols slot, latitude→the rows slot,
   // and the non-coordinate dims → the detail slots in order. Guards against a manifest

--- a/src/desktop/binder/classify.ts
+++ b/src/desktop/binder/classify.ts
@@ -743,16 +743,21 @@ function pickBestDetailDim(
     const toks = new Set([...nameTokens(f.name), ...nameTokens(bareName(f.columnName))]);
     const isCoarse = [...toks].some((t) => COARSE_GRAIN_TOKENS.has(t));
     let score = 0;
+    let askOverlap = false;
     for (const t of toks) {
       if (NON_LABEL_DETAIL_TOKENS.has(t)) score -= 2;
       if (COARSE_GRAIN_TOKENS.has(t)) score -= 3;
       if (t === 'name') score += 1;
-      // token appears in the ask (raw or masked) → names the subject — but a COARSE field
-      // (group/stage/…) is still the wrong GRAIN even when the ask mentions it, so ask-overlap
-      // does NOT rescue a coarse dim (prevents the "map tournament stage venues" collapse).
-      if (isCoarse) continue;
-      if (phraseIndexInAsk(rawAsk, t) >= 0 || phraseIndexInAsk(maskedAsk, t) >= 0) score += 2;
+      // ask-overlap is a per-FIELD signal, capped at +2 TOTAL (not per-token): a multi-token
+      // coarse field ("tournament_round") must NOT stack overlap points (tournament + round)
+      // to outrank a fine label ("venue_name"). And a COARSE field earns NO overlap credit at
+      // all — even when the ask names it — because it's the wrong GRAIN regardless (a coarse
+      // dim on detail centroid-collapses the finer marks). Sol #598 re-review: cap-not-list.
+      if (!isCoarse && (phraseIndexInAsk(rawAsk, t) >= 0 || phraseIndexInAsk(maskedAsk, t) >= 0)) {
+        askOverlap = true;
+      }
     }
+    if (askOverlap) score += 2;
     return score;
   };
   const ranked = categoricals


### PR DESCRIPTION
## Live-caught on Blake's REAL data
Blake's actual World Cup workbook (teams.csv: team_id/team_api_id/group_name/country_code/team_name + lat/long + flag/color/source — 11 cols, 5 categoricals) **THRASHED** (route `BIND→BIND→BIND`, 29.6s, FAIL) where the clean synthetic s7 proxy binds single-BIND <20s. **The proxy was too clean; real map data is always wide.**

## Root cause (Sol-diagnosed, firsthand-verified)
resolveLatLonSymbolMap failed closed on 3+ categorical dims (the detail-selection guard) — but the mark identity is ONE label dimension (team_name), not every descriptive attribute. So the confident bind never fired → propose → the model thrashed across the 3 map templates.

## Fix
For 3+ categoricals, `pickBestDetailDim` scores: +2 ask-token overlap (team↔'World Cup team'), +1 'name' label, −2 per technical token (id/code/hex/url/emoji/source). Binds the unique top scorer to detail, coords to axes. **1–2 dims unchanged** (bind all — no collapse). A scoring **tie still fails closed** (a wrong grain is worse than a propose). Blake's schema → team_name on detail, noise ignored → confident single map.

## Tests
Replaced the old '3+ dims → fail closed' test with two: (a) wide World Cup schema → confident bind with team_name detail; (b) genuine tie (alpha/beta/gamma) → still fail closed. Full binder suite 718 green (invariants intact), tsc 0, eslint 0. v2.39.0→2.40.0.

This is the fix for why Blake sees inconsistency on his REAL data even post-#591 — s7 was the unrealistic case.