### PR TITLE
feat(desktop): pinned session is a default, not an invariant

### DIFF
--- a/src/desktop/desktopDiscoverer.ts
+++ b/src/desktop/desktopDiscoverer.ts
@@ -12,19 +12,6 @@ const manifestSchema = z.object({
 
 export type DesktopInstanceManifest = z.infer<typeof manifestSchema>;
 
-/**
- * Agent-actionable recovery text for a stale session (Desktop quit/restarted, or a
- * cache file produced by a different Desktop instance). Shared by SessionManager's
- * freshness gate and the cache-fingerprint bleed guard so both speak the same recovery.
- */
-export function staleSessionRecoveryMessage(sessionId: string | number): string {
-  return (
-    `Session ${sessionId} is stale: that Tableau Desktop process is no longer reachable or was restarted. ` +
-    'Call list-instances and retry with the current session id. ' +
-    'Cached XML files from the old session may not match the current workbook — re-read before applying.'
-  );
-}
-
 export class DesktopDiscoverer {
   private readonly isPidAlive: (pid: number) => boolean;
 

--- a/src/desktop/routeTable.test.ts
+++ b/src/desktop/routeTable.test.ts
@@ -6,6 +6,8 @@ import {
   generateDesktopInstructions,
   renderInstructionEntry,
   SESSION_RESOLUTION_ID,
+  SESSION_RESOLUTION_TEXT_PINNED,
+  SESSION_RESOLUTION_TEXT_UNPINNED,
 } from './routeTable.js';
 
 const routes = DESKTOP_ROUTE_TABLE.filter(
@@ -121,24 +123,25 @@ describe('generateDesktopInstructions', () => {
 });
 
 describe('buildDesktopInstructions', () => {
-  const sessionResolutionText = DESKTOP_ROUTE_TABLE.find(
+  const sessionResolutionEntry = DESKTOP_ROUTE_TABLE.find(
     (entry) => entry.id === SESSION_RESOLUTION_ID && entry.kind === 'prose',
   );
 
-  it('keeps the session-resolution guidance when no session is pinned', () => {
+  it('keeps the unpinned session-resolution guidance when no session is pinned', () => {
     const unpinned = buildDesktopInstructions({ sessionPinned: false });
     expect(unpinned).toBe(generateDesktopInstructions(DESKTOP_ROUTE_TABLE));
+    expect(unpinned).toContain(SESSION_RESOLUTION_TEXT_UNPINNED);
     expect(unpinned).toContain('list-instances');
   });
 
-  it('drops the session-resolution guidance when a session is pinned', () => {
+  it('swaps in pin-aware session guidance when a session is pinned', () => {
     const pinned = buildDesktopInstructions({ sessionPinned: true });
-    expect(sessionResolutionText?.kind).toBe('prose');
-    if (sessionResolutionText?.kind === 'prose') {
-      expect(pinned).not.toContain(sessionResolutionText.text);
-    }
-    expect(pinned).not.toContain('list-instances');
-    // The other routes must survive the filter untouched.
+    expect(sessionResolutionEntry?.kind).toBe('prose');
+    expect(pinned).toContain(SESSION_RESOLUTION_TEXT_PINNED);
+    // Still names list-instances — the pin is a default, and the agent may target another Desktop.
+    expect(pinned).toContain('list-instances');
+    expect(pinned).not.toContain(SESSION_RESOLUTION_TEXT_UNPINNED);
+    // The other routes must survive untouched.
     expect(pinned).toContain('You control Tableau Desktop.');
   });
 });

--- a/src/desktop/routeTable.ts
+++ b/src/desktop/routeTable.ts
@@ -21,10 +21,16 @@ export type DesktopInstructionProse = {
 
 export type DesktopInstructionEntry = DesktopInstructionRoute | DesktopInstructionProse;
 
-// The session-resolution prose points the agent at list-instances. When the launching
-// Desktop pins a session, that tool is unregistered, so this entry is dropped from the
-// instructions to avoid naming a tool the client cannot call.
+// The session-resolution prose points the agent at list-instances. The pin is a default,
+// not an invariant, so the pinned variant still names list-instances (the tool stays
+// registered) and tells the agent it may target another open Desktop.
 export const SESSION_RESOLUTION_ID = 'session-resolution';
+
+export const SESSION_RESOLUTION_TEXT_UNPINNED =
+  'Omit session for one Desktop; use list-instances when multiple are open.';
+
+export const SESSION_RESOLUTION_TEXT_PINNED =
+  'Session defaults to the current Tableau Desktop; use list-instances to see all open Desktops and pass session to target another.';
 
 export const DESKTOP_ROUTE_TABLE: readonly DesktopInstructionEntry[] = [
   {
@@ -130,7 +136,7 @@ export const DESKTOP_ROUTE_TABLE: readonly DesktopInstructionEntry[] = [
   {
     kind: 'prose',
     id: SESSION_RESOLUTION_ID,
-    text: 'Omit session for one Desktop; use list-instances when multiple are open.',
+    text: SESSION_RESOLUTION_TEXT_UNPINNED,
   },
   {
     kind: 'prose',
@@ -148,12 +154,17 @@ export function generateDesktopInstructions(table: readonly DesktopInstructionEn
 }
 
 /**
- * Instructions for a given session-pinning state. When a session is pinned the
- * agent never calls list-instances, so the session-resolution guidance is dropped.
+ * Instructions for a given session-pinning state. When pinned, the session-resolution
+ * prose switches to the pinned variant (pin is the default; the agent can still target
+ * another open Desktop via list-instances) rather than being dropped.
  */
 export function buildDesktopInstructions({ sessionPinned }: { sessionPinned: boolean }): string {
   const table = sessionPinned
-    ? DESKTOP_ROUTE_TABLE.filter((entry) => entry.id !== SESSION_RESOLUTION_ID)
+    ? DESKTOP_ROUTE_TABLE.map((entry) =>
+        entry.id === SESSION_RESOLUTION_ID
+          ? { ...entry, text: SESSION_RESOLUTION_TEXT_PINNED }
+          : entry,
+      )
     : DESKTOP_ROUTE_TABLE;
   return generateDesktopInstructions(table);
 }

--- a/src/desktop/sessionManager.externalApi.test.ts
+++ b/src/desktop/sessionManager.externalApi.test.ts
@@ -49,4 +49,35 @@ describe('SessionManager executor selection', () => {
       'The pinned Tableau Desktop is no longer reachable — it was closed or restarted. Relaunch the agent from Tableau Desktop to reconnect.',
     );
   });
+
+  it('throws a stale-session error when an unpinned session is gone but other instances are running', async () => {
+    mocks.discoverInstances.mockReturnValue([
+      {
+        baseUrl: 'http://127.0.0.1:8765',
+        token: 'token',
+        pid: 999,
+        instanceId: 'inst',
+      },
+    ] as never);
+
+    await expect(new SessionManager().getExecutor('12345')).rejects.toThrow(
+      'The requested Tableau Desktop session is no longer running — it was closed. Call list-instances and retry with a current session.',
+    );
+  });
+
+  it('throws a stale-session error when a pinned config targets a different, still-running Desktop', async () => {
+    vi.stubEnv('TABLEAU_DESKTOP_SESSION_ID', '999');
+    mocks.discoverInstances.mockReturnValue([
+      {
+        baseUrl: 'http://127.0.0.1:8765',
+        token: 'token',
+        pid: 999,
+        instanceId: 'inst',
+      },
+    ] as never);
+
+    await expect(new SessionManager().getExecutor('12345')).rejects.toThrow(
+      'The requested Tableau Desktop session is no longer running — it was closed. Call list-instances and retry with a current session.',
+    );
+  });
 });

--- a/src/desktop/sessionManager.externalApi.test.ts
+++ b/src/desktop/sessionManager.externalApi.test.ts
@@ -33,11 +33,20 @@ describe('SessionManager executor selection', () => {
     expect(executor).toBeInstanceOf(ExternalApiToolExecutor);
   });
 
-  it('throws an honest update-required error when Desktop does not serve the External Client API', async () => {
+  it('throws an honest update-required error when an unpinned Desktop does not serve the External Client API', async () => {
     mocks.discoverInstances.mockReturnValue([]);
 
     await expect(new SessionManager().getExecutor('12345')).rejects.toThrow(
       'This Tableau Desktop build does not serve the External Client API — update Desktop.',
+    );
+  });
+
+  it('throws a restart-recovery error when the pinned Desktop is no longer reachable', async () => {
+    vi.stubEnv('TABLEAU_DESKTOP_SESSION_ID', '12345');
+    mocks.discoverInstances.mockReturnValue([]);
+
+    await expect(new SessionManager().getExecutor('12345')).rejects.toThrow(
+      'The pinned Tableau Desktop is no longer reachable — it was closed or restarted. Relaunch the agent from Tableau Desktop to reconnect.',
     );
   });
 });

--- a/src/desktop/sessionManager.ts
+++ b/src/desktop/sessionManager.ts
@@ -17,14 +17,26 @@ export const EXTERNAL_API_UNAVAILABLE_MESSAGE =
 export const PINNED_DESKTOP_UNREACHABLE_MESSAGE =
   'The pinned Tableau Desktop is no longer reachable — it was closed or restarted. Relaunch the agent from Tableau Desktop to reconnect.';
 
+export const STALE_SESSION_MESSAGE =
+  'The requested Tableau Desktop session is no longer running — it was closed. Call list-instances and retry with a current session.';
+
+export type DesktopUnavailableReason = 'pinned-unreachable' | 'stale-session' | 'no-api';
+
 export class ExternalClientApiUnavailableError extends Error {
-  constructor(sessionId: string | number, { pinned = false }: { pinned?: boolean } = {}) {
-    super(
-      pinned
-        ? `${PINNED_DESKTOP_UNREACHABLE_MESSAGE} Session: ${sessionId}.`
-        : `${EXTERNAL_API_UNAVAILABLE_MESSAGE} Requested session: ${sessionId}.`,
-    );
+  constructor(sessionId: string | number, reason: DesktopUnavailableReason = 'no-api') {
+    super(ExternalClientApiUnavailableError.messageFor(sessionId, reason));
     this.name = 'ExternalClientApiUnavailableError';
+  }
+
+  private static messageFor(sessionId: string | number, reason: DesktopUnavailableReason): string {
+    switch (reason) {
+      case 'pinned-unreachable':
+        return `${PINNED_DESKTOP_UNREACHABLE_MESSAGE} Session: ${sessionId}.`;
+      case 'stale-session':
+        return `${STALE_SESSION_MESSAGE} Session: ${sessionId}.`;
+      case 'no-api':
+        return `${EXTERNAL_API_UNAVAILABLE_MESSAGE} Requested session: ${sessionId}.`;
+    }
   }
 }
 
@@ -42,15 +54,15 @@ export class SessionManager {
 
       const pid = sessionIdResult.value;
       const config = getDesktopConfig();
-      const executor = new ExternalApiToolExecutor({
-        pid,
-        discover: () => discoverInstances({ discoveryDir: config.externalApiDiscoveryDir }),
-      });
+      const discover = (): ReturnType<typeof discoverInstances> =>
+        discoverInstances({ discoveryDir: config.externalApiDiscoveryDir });
+      const executor = new ExternalApiToolExecutor({ pid, discover });
       await executor.start();
       if (!executor.isAvailable()) {
-        throw new ExternalClientApiUnavailableError(sessionId, {
-          pinned: config.desktopSessionId === sessionId,
-        });
+        throw new ExternalClientApiUnavailableError(
+          sessionId,
+          resolveUnavailableReason(sessionId, config.desktopSessionId, discover()),
+        );
       }
 
       session = {
@@ -75,6 +87,18 @@ export class SessionManager {
     session.lastAccess = Date.now();
     return session.executor;
   }
+}
+
+function resolveUnavailableReason(
+  sessionId: string,
+  pinnedSessionId: string | undefined,
+  runningInstances: ReturnType<typeof discoverInstances>,
+): DesktopUnavailableReason {
+  if (pinnedSessionId === sessionId) {
+    return 'pinned-unreachable';
+  }
+  const others = runningInstances.filter((instance) => String(instance.pid) !== sessionId);
+  return others.length > 0 ? 'stale-session' : 'no-api';
 }
 
 function parseSessionId(sessionId: string): Result<number, void> {

--- a/src/desktop/sessionManager.ts
+++ b/src/desktop/sessionManager.ts
@@ -14,9 +14,16 @@ export type DesktopConnection = {
 export const EXTERNAL_API_UNAVAILABLE_MESSAGE =
   'This Tableau Desktop build does not serve the External Client API — update Desktop.';
 
+export const PINNED_DESKTOP_UNREACHABLE_MESSAGE =
+  'The pinned Tableau Desktop is no longer reachable — it was closed or restarted. Relaunch the agent from Tableau Desktop to reconnect.';
+
 export class ExternalClientApiUnavailableError extends Error {
-  constructor(sessionId: string | number) {
-    super(`${EXTERNAL_API_UNAVAILABLE_MESSAGE} Requested session: ${sessionId}.`);
+  constructor(sessionId: string | number, { pinned = false }: { pinned?: boolean } = {}) {
+    super(
+      pinned
+        ? `${PINNED_DESKTOP_UNREACHABLE_MESSAGE} Session: ${sessionId}.`
+        : `${EXTERNAL_API_UNAVAILABLE_MESSAGE} Requested session: ${sessionId}.`,
+    );
     this.name = 'ExternalClientApiUnavailableError';
   }
 }
@@ -41,7 +48,9 @@ export class SessionManager {
       });
       await executor.start();
       if (!executor.isAvailable()) {
-        throw new ExternalClientApiUnavailableError(sessionId);
+        throw new ExternalClientApiUnavailableError(sessionId, {
+          pinned: config.desktopSessionId === sessionId,
+        });
       }
 
       session = {

--- a/src/desktop/sessionResolution.test.ts
+++ b/src/desktop/sessionResolution.test.ts
@@ -95,6 +95,22 @@ describe('resolveSession', () => {
     expect(text).toContain('list-instances');
   });
 
+  it('accepts an explicit session when discovery is empty and nothing is pinned (deliberate fail-open)', () => {
+    mockConfig({ desktopSessionId: undefined });
+    mockExternalApiInstances([]);
+    const result = resolveSession('7');
+    expect(result.isOk()).toBe(true);
+    expect(result.unwrap()).toBe('7');
+  });
+
+  it('accepts an explicit session that differs from the pin when discovery is empty', () => {
+    mockConfig({ desktopSessionId: '4242' });
+    mockExternalApiInstances([]);
+    const result = resolveSession('7');
+    expect(result.isOk()).toBe(true);
+    expect(result.unwrap()).toBe('7');
+  });
+
   it('auto-resolves the unique External API instance when nothing is pinned', () => {
     mockConfig({ desktopSessionId: undefined });
     mockExternalApiInstances([99]);

--- a/src/desktop/sessionResolution.test.ts
+++ b/src/desktop/sessionResolution.test.ts
@@ -27,13 +27,22 @@ describe('resolveSession', () => {
     vi.restoreAllMocks();
   });
 
-  it('rejects an explicit session that conflicts with the pin', () => {
+  it('honors an explicit live session that differs from the pin', () => {
     mockConfig({ desktopSessionId: '4242' });
+    mockExternalApiInstances([4242, 7]);
+    const result = resolveSession('7');
+    expect(result.isOk()).toBe(true);
+    expect(result.unwrap()).toBe('7');
+  });
+
+  it('rejects an explicit session that is not a running instance (pinned)', () => {
+    mockConfig({ desktopSessionId: '4242' });
+    mockExternalApiInstances([4242]);
     const result = resolveSession('7');
     expect(result.isErr()).toBe(true);
     const text = result.unwrapErr().getErrorText();
-    expect(text).toContain('4242');
     expect(text).toContain('7');
+    expect(text).toContain('list-instances');
   });
 
   it('honors an explicit session that matches the pin', () => {
@@ -68,11 +77,22 @@ describe('resolveSession', () => {
     }
   });
 
-  it('returns an explicit session id verbatim when nothing is pinned', () => {
+  it('returns an explicit live session id when nothing is pinned', () => {
     mockConfig({ desktopSessionId: undefined });
+    mockExternalApiInstances([7]);
     const result = resolveSession('7');
     expect(result.isOk()).toBe(true);
     expect(result.unwrap()).toBe('7');
+  });
+
+  it('rejects an explicit session that is not a running instance when unpinned', () => {
+    mockConfig({ desktopSessionId: undefined });
+    mockExternalApiInstances([99]);
+    const result = resolveSession('7');
+    expect(result.isErr()).toBe(true);
+    const text = result.unwrapErr().getErrorText();
+    expect(text).toContain('7');
+    expect(text).toContain('list-instances');
   });
 
   it('auto-resolves the unique External API instance when nothing is pinned', () => {

--- a/src/desktop/sessionResolution.ts
+++ b/src/desktop/sessionResolution.ts
@@ -14,56 +14,64 @@ const LIST_INSTANCES_TOOL: DesktopToolName = 'list-instances';
 /**
  * Resolve which Tableau Desktop session (pid) a session-scoped tool should target.
  *
+ * The pin (`config.desktopSessionId`, set when the launching Desktop passes
+ * `TABLEAU_DESKTOP_SESSION_ID`) is a DEFAULT, not an invariant: it is used when no
+ * `session` is given, but the caller may still target another running Desktop by passing
+ * its pid explicitly.
+ *
  * Precedence:
- *   1. `config.desktopSessionId` — when the launching Desktop pinned itself via
- *      `TABLEAU_DESKTOP_SESSION_ID`, the pin is an invariant: it always wins, and an
- *      explicit `session` naming a different Desktop is rejected rather than honored.
- *      (list-instances is hidden when pinned, so any conflicting explicit session can
- *      only be stale model context.)
- *   2. Explicit `session` arg — when unpinned, the caller chooses.
- *   3. Auto-resolve when exactly one Desktop instance is running. 0 or 2+ instances
- *      fail closed with an instance-listing error rather than guessing.
+ *   1. No explicit `session` (or the sentinel "default") — use the pin if set, else
+ *      auto-resolve when exactly one Desktop is running (0 or 2+ fail closed).
+ *   2. Explicit `session` equal to the pin — use the pin (no discovery needed).
+ *   3. Explicit `session` naming another Desktop — honored if that pid is a running
+ *      instance. Rejected only when discovery lists other running instances that exclude
+ *      it; if discovery is empty we cannot confirm, so we proceed and let the executor's
+ *      unreachable handling report a truly dead pid (never block blind — same posture as
+ *      the cache-fingerprint guard).
  *
  * Uses the External Client API discovery files written by Tableau Desktop.
  */
 export function resolveSession(session: string | undefined): Result<string, McpToolError> {
   // Treat empty/whitespace AND the sentinel "default" as ABSENT. Some clients inject
-  // session:"default" as a placeholder; when the agent is pinned to a Desktop pid that
-  // literal is not the pid, so it used to fail closed with a spurious "pinned to pid X but
-  // session 'default' requested" error on every session-scoped call (add-field, apply, …).
-  // "default" means "use whatever session is resolved", i.e. the pin — never a real id.
+  // session:"default" as a placeholder; that literal is never a real pid, so it means
+  // "use whatever session is resolved" (the pin, or the sole running instance).
   const trimmed = session?.trim();
   const requestedSession = trimmed && trimmed.toLowerCase() !== 'default' ? trimmed : undefined;
   const config = getDesktopConfig();
-  if (config.desktopSessionId !== undefined) {
-    if (requestedSession !== undefined && requestedSession !== config.desktopSessionId) {
+
+  if (requestedSession === undefined || requestedSession === config.desktopSessionId) {
+    if (config.desktopSessionId !== undefined) {
+      return Ok(config.desktopSessionId);
+    }
+
+    const pids = discoverInstances({ discoveryDir: config.externalApiDiscoveryDir }).map(
+      (i) => i.pid,
+    );
+
+    if (pids.length === 0) {
+      return Err(new NoDesktopInstancesFoundError());
+    }
+    if (pids.length > 1) {
       return Err(
         new ArgsValidationError(
-          `This agent is pinned to Tableau Desktop (pid ${config.desktopSessionId}), but session '${requestedSession}' was requested. Omit the 'session' parameter — the pinned Desktop is used automatically.`,
+          `Multiple Tableau Desktop instances are running (session IDs: ${pids.join(', ')}). Specify which one to use via the 'session' parameter (see ${LIST_INSTANCES_TOOL} for details).`,
         ),
       );
     }
-    return Ok(config.desktopSessionId);
+
+    return Ok(String(pids[0]));
   }
 
-  if (requestedSession !== undefined) {
-    return Ok(requestedSession);
-  }
-
-  const pids = discoverInstances({ discoveryDir: config.externalApiDiscoveryDir }).map(
-    (i) => i.pid,
+  const runningPids = discoverInstances({ discoveryDir: config.externalApiDiscoveryDir }).map((i) =>
+    String(i.pid),
   );
-
-  if (pids.length === 0) {
-    return Err(new NoDesktopInstancesFoundError());
-  }
-  if (pids.length > 1) {
+  if (runningPids.length > 0 && !runningPids.includes(requestedSession)) {
     return Err(
       new ArgsValidationError(
-        `Multiple Tableau Desktop instances are running (session IDs: ${pids.join(', ')}). Specify which one to use via the 'session' parameter (see ${LIST_INSTANCES_TOOL} for details).`,
+        `Tableau Desktop session '${requestedSession}' is not a running instance (running: ${runningPids.join(', ')}). See ${LIST_INSTANCES_TOOL} for the current instances.`,
       ),
     );
   }
 
-  return Ok(String(pids[0]));
+  return Ok(requestedSession);
 }

--- a/src/server.desktop.test.ts
+++ b/src/server.desktop.test.ts
@@ -2,6 +2,11 @@ import { normalizeObjectSchema } from '@modelcontextprotocol/sdk/server/zod-comp
 import { toJsonSchemaCompat } from '@modelcontextprotocol/sdk/server/zod-json-schema-compat.js';
 
 import * as configModule from './config.desktop.js';
+import {
+  buildDesktopInstructions,
+  SESSION_RESOLUTION_TEXT_PINNED,
+  SESSION_RESOLUTION_TEXT_UNPINNED,
+} from './desktop/routeTable.js';
 import * as loggerModule from './logging/logger.js';
 import {
   DEMO_TOOL_PROFILE,
@@ -56,7 +61,7 @@ describe('DesktopMcpServer', () => {
     expect(registeredNames).toContain('list-worksheets');
   });
 
-  it('does not register list-instances when a Desktop session is pinned', async () => {
+  it('registers list-instances even when a Desktop session is pinned', async () => {
     const base = configModule.getDesktopConfig();
     const spy = vi
       .spyOn(configModule, 'getDesktopConfig')
@@ -69,7 +74,7 @@ describe('DesktopMcpServer', () => {
       const registeredNames = (
         vi.mocked(server.mcpServer.registerTool).mock.calls as Array<[string, ...unknown[]]>
       ).map(([name]) => name);
-      expect(registeredNames).not.toContain('list-instances');
+      expect(registeredNames).toContain('list-instances');
       expect(registeredNames).toContain('list-worksheets');
     } finally {
       spy.mockRestore();
@@ -119,6 +124,13 @@ If preflight rejects apply, fix per FIX lines. Prefer file mode`,
 
   it('tells agents to narrate with Tableau vocabulary', () => {
     expect(DESKTOP_INSTRUCTIONS).toContain('Use Tableau terms: workbook/viz/sheet/field');
+  });
+
+  it('keeps pin-aware session guidance (list-instances, target another) when pinned', () => {
+    const pinned = buildDesktopInstructions({ sessionPinned: true });
+    expect(pinned).toContain(SESSION_RESOLUTION_TEXT_PINNED);
+    expect(pinned).toContain('list-instances');
+    expect(pinned).not.toContain(SESSION_RESOLUTION_TEXT_UNPINNED);
   });
 });
 

--- a/src/server.desktop.ts
+++ b/src/server.desktop.ts
@@ -16,7 +16,6 @@ import { SessionManager } from './desktop/sessionManager.js';
 import { log } from './logging/logger.js';
 import { ClientInfo, Server } from './server.js';
 import { getCheckForUserChangesTool } from './tools/desktop/session/checkForUserChanges.js';
-import { getListInstancesTool } from './tools/desktop/session/listInstances.js';
 import { DesktopTool } from './tools/desktop/tool.js';
 import { TableauDesktopRequestHandlerExtra } from './tools/desktop/toolContext.js';
 import { DesktopToolName } from './tools/desktop/toolName.js';
@@ -253,13 +252,6 @@ export class DesktopMcpServer extends Server {
     // check-for-user-changes needs the legacy events endpoint, which the External Client API does
     // not expose; don't advertise a tool that can only return an error.
     excluded.add(getCheckForUserChangesTool);
-
-    // When the launching Desktop pinned a session, every tool defaults to it, so
-    // list-instances has nothing to add — dropping it keeps the agent from ever
-    // spending a turn discovering which instance to control.
-    if (config.desktopSessionId !== undefined) {
-      excluded.add(getListInstancesTool);
-    }
 
     const factories = [
       ...desktopToolFactories,

--- a/src/tools/desktop/binder/bindTemplate.test.ts
+++ b/src/tools/desktop/binder/bindTemplate.test.ts
@@ -324,6 +324,7 @@ const badSortFieldEscalateResult: BinderResult = {
 describe('bindTemplateTool', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(externalDiscovery.discoverInstances).mockReturnValue([]);
   });
 
   it('should create a tool instance with correct properties', () => {
@@ -660,6 +661,7 @@ function setupAutoApplyMocks({
 describe('bindTemplateTool auto_apply gate', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(externalDiscovery.discoverInstances).mockReturnValue([]);
   });
 
   it('auto_apply=false leaves today’s read-only bound result byte-compatible (no apply)', async () => {
@@ -1373,6 +1375,7 @@ describe('bindTemplateTool auto_apply gate', () => {
 describe('bindTemplateTool auto_apply graceful fallback', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(externalDiscovery.discoverInstances).mockReturnValue([]);
   });
 
   it('inject failure returns the bound args intact with applied:false + apply_error', async () => {
@@ -1450,6 +1453,7 @@ describe('bindTemplateTool auto_apply graceful fallback', () => {
 describe('bindTemplateTool session-default-when-unique', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(externalDiscovery.discoverInstances).mockReturnValue([]);
   });
 
   function mockInstances(pids: number[]): void {
@@ -1503,11 +1507,24 @@ describe('bindTemplateTool session-default-when-unique', () => {
     expect(binderModule.bindTemplate).not.toHaveBeenCalled();
   });
 
-  it('an explicit session always wins (discovery is never consulted)', async () => {
-    // Even with 2+ instances running, an explicit session bypasses discovery.
+  it('targets an explicit session that is one of the running instances', async () => {
     mockInstances([11, 22]);
     vi.spyOn(getWorkbookXmlModule, 'getWorkbookXml').mockResolvedValue(Ok(XML));
     vi.mocked(binderModule.bindTemplate).mockResolvedValue(boundResult);
+    const getExecutor = vi.fn().mockResolvedValue({});
+
+    const result = await getToolResult({
+      session: '22',
+      ask: 'bar chart of Sales by Region',
+      getExecutor,
+    });
+
+    expect(result.isError).toBe(false);
+    expect(getExecutor).toHaveBeenCalledWith('22');
+  });
+
+  it('rejects an explicit session that is not a running instance, naming the running pids', async () => {
+    mockInstances([11, 22]);
     const getExecutor = vi.fn().mockResolvedValue({});
 
     const result = await getToolResult({
@@ -1516,15 +1533,19 @@ describe('bindTemplateTool session-default-when-unique', () => {
       getExecutor,
     });
 
-    expect(result.isError).toBe(false);
-    expect(getExecutor).toHaveBeenCalledWith('7');
-    expect(externalDiscovery.discoverInstances).not.toHaveBeenCalled();
+    expect(result.isError).toBe(true);
+    invariant(result.content[0].type === 'text');
+    expect(result.content[0].text).toContain('7');
+    expect(result.content[0].text).toContain('list-instances');
+    expect(getExecutor).not.toHaveBeenCalled();
+    expect(binderModule.bindTemplate).not.toHaveBeenCalled();
   });
 });
 
 describe('bindTemplateTool auto_apply target_worksheet (e1/s7 stray-sheet class)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(externalDiscovery.discoverInstances).mockReturnValue([]);
   });
 
   it('applies onto the named existing sheet: inject titled with the target, sheet_name reports it', async () => {
@@ -1631,6 +1652,7 @@ describe('bindTemplateTool auto_apply target_worksheet (e1/s7 stray-sheet class)
 describe('bindTemplateTool auto_apply — events-clean gate (W60 blind-spot #1)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(externalDiscovery.discoverInstances).mockReturnValue([]);
   });
 
   it('refuses to auto-apply over a workbook the user touched mid-bind (falls back, bind intact)', async () => {
@@ -1724,6 +1746,7 @@ describe('bindTemplateTool auto_apply — events-clean gate (W60 blind-spot #1)'
 describe('bindTemplateTool route-state recording', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(externalDiscovery.discoverInstances).mockReturnValue([]);
     sessionRouteState.clear();
     vi.spyOn(bundledIntelligenceProvider, 'listTemplateManifests').mockReturnValue([
       ...loadManifests().values(),

--- a/src/tools/desktop/cache/writeCachedXml.test.ts
+++ b/src/tools/desktop/cache/writeCachedXml.test.ts
@@ -10,12 +10,14 @@ import { getWriteCachedXmlTool } from './writeCachedXml.js';
 
 vi.mock('../../../desktop/cache.js');
 vi.mock('../../../desktop/commands/workbook/cacheFingerprint.js');
+vi.mock('../../../desktop/externalApi/discovery.js');
 vi.mock('fs');
 
 import { existsSync, readFileSync, writeFileSync } from 'fs';
 
 import { DesktopCache } from '../../../desktop/cache.js';
 import * as cacheFingerprintModule from '../../../desktop/commands/workbook/cacheFingerprint.js';
+import * as discoveryModule from '../../../desktop/externalApi/discovery.js';
 
 const CACHE_DIR = resolve('/tmp/test-cache');
 const CACHED_FILE = `${CACHE_DIR}/worksheet-session-1.xml`;
@@ -46,6 +48,7 @@ describe('writeCachedXmlTool', () => {
     vi.clearAllMocks();
     setupCacheMock();
     mockPinnedSession(undefined);
+    vi.mocked(discoveryModule.discoverInstances).mockReturnValue([]);
     vi.mocked(writeFileSync).mockImplementation(() => {});
   });
 
@@ -89,14 +92,18 @@ describe('writeCachedXmlTool', () => {
     expect(cacheFingerprintModule.writeSidecar).toHaveBeenCalledWith(resolve(CACHED_FILE), SESSION);
   });
 
-  it('rejects and writes no sidecar when the requested session conflicts with the pin', async () => {
+  it('rejects and writes no sidecar when the requested session is not a running instance', async () => {
     mockPinnedSession('99999');
+    vi.mocked(discoveryModule.discoverInstances).mockReturnValue([
+      { pid: 99999 } as ReturnType<typeof discoveryModule.discoverInstances>[number],
+    ]);
 
     const result = await getResult(CACHED_FILE, VALID_XML, {}, SESSION);
 
     expect(result.isError).toBe(true);
     invariant(result.content[0].type === 'text');
-    expect(result.content[0].text).toContain('99999');
+    expect(result.content[0].text).toContain(SESSION);
+    expect(result.content[0].text).toContain('list-instances');
     expect(cacheFingerprintModule.writeSidecar).not.toHaveBeenCalled();
     expect(writeFileSync).not.toHaveBeenCalled();
   });

--- a/src/tools/desktop/cache/writeCachedXml.ts
+++ b/src/tools/desktop/cache/writeCachedXml.ts
@@ -18,7 +18,7 @@ import { DesktopTool } from '../tool.js';
 import { getCacheDir, isWithinCacheDir } from './cachePath.js';
 
 const paramsSchema = {
-  session: z.string(),
+  session: z.string().optional(),
   filePath: z.string(),
   xmlContent: z.string(),
   worksheet: z.string().optional(),

--- a/src/tools/desktop/dashboard/dashboardAutoApply.test.ts
+++ b/src/tools/desktop/dashboard/dashboardAutoApply.test.ts
@@ -96,6 +96,7 @@ const escalateResult: BinderResult = {
 describe('dashboardAutoApplyTool', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(externalDiscovery.discoverInstances).mockReturnValue([]);
   });
 
   it('should create a tool instance with correct properties', () => {
@@ -261,6 +262,7 @@ async function getToolResult({
 describe('dashboardAutoApplyTool happy path', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(externalDiscovery.discoverInstances).mockReturnValue([]);
   });
 
   it('applies exactly once (one read, one dispatch) and returns the trimmed success shape', async () => {
@@ -391,6 +393,7 @@ describe('dashboardAutoApplyTool happy path', () => {
 describe('dashboardAutoApplyTool all-or-nothing gate matrix', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(externalDiscovery.discoverInstances).mockReturnValue([]);
   });
 
   it('any ask "propose" refuses the whole batch — zero dispatches, every outcome intact', async () => {
@@ -641,6 +644,7 @@ describe('dashboardAutoApplyTool all-or-nothing gate matrix', () => {
 describe('dashboardAutoApplyTool session-default-when-unique', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(externalDiscovery.discoverInstances).mockReturnValue([]);
   });
 
   function mockInstances(pids: number[]): void {
@@ -696,9 +700,23 @@ describe('dashboardAutoApplyTool session-default-when-unique', () => {
     expect(getExecutor).not.toHaveBeenCalled();
   });
 
-  it('an explicit session always wins (discovery is never consulted)', async () => {
+  it('targets an explicit session that is one of the running instances', async () => {
     mockInstances([11, 22]);
     const { getExecutor } = setupMocks();
+
+    const result = await getToolResult({
+      session: '22',
+      asks: [{ ask: 'bar chart of Sales by Region' }, { ask: 'line chart of Profit by Month' }],
+      getExecutor,
+    });
+
+    expect(result.isError).toBe(false);
+    expect(getExecutor).toHaveBeenCalledWith('22');
+  });
+
+  it('rejects an explicit session that is not a running instance, naming the running pids', async () => {
+    mockInstances([11, 22]);
+    const getExecutor = vi.fn().mockResolvedValue({});
 
     const result = await getToolResult({
       session: '7',
@@ -706,8 +724,10 @@ describe('dashboardAutoApplyTool session-default-when-unique', () => {
       getExecutor,
     });
 
-    expect(result.isError).toBe(false);
-    expect(getExecutor).toHaveBeenCalledWith('7');
-    expect(externalDiscovery.discoverInstances).not.toHaveBeenCalled();
+    expect(result.isError).toBe(true);
+    invariant(result.content[0].type === 'text');
+    expect(result.content[0].text).toContain('7');
+    expect(result.content[0].text).toContain('list-instances');
+    expect(getExecutor).not.toHaveBeenCalled();
   });
 });

--- a/src/tools/desktop/fields/addField.test.ts
+++ b/src/tools/desktop/fields/addField.test.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 
 import * as configModule from '../../../config.desktop.js';
 import * as cacheFingerprintModule from '../../../desktop/commands/workbook/cacheFingerprint.js';
+import * as discoveryModule from '../../../desktop/externalApi/discovery.js';
 import * as metadataModule from '../../../desktop/metadata/index.js';
 import {
   ArgsValidationError,
@@ -19,6 +20,7 @@ import { getAddFieldTool } from './addField.js';
 
 vi.mock('../../../desktop/metadata/index.js');
 vi.mock('../../../desktop/commands/workbook/cacheFingerprint.js');
+vi.mock('../../../desktop/externalApi/discovery.js');
 vi.mock('fs');
 
 type EncodingType = 'color' | 'size' | 'lod' | 'detail' | 'text' | 'tooltip' | 'path' | 'angle';
@@ -47,6 +49,7 @@ describe('addFieldTool', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockPinnedSession(undefined);
+    vi.mocked(discoveryModule.discoverInstances).mockReturnValue([]);
   });
 
   it('should create a tool instance with correct properties', () => {
@@ -166,8 +169,11 @@ describe('addFieldTool', () => {
     expect(cacheFingerprintModule.writeSidecar).toHaveBeenCalledWith(WORKSHEET_FILE, SESSION);
   });
 
-  it('rejects and writes no sidecar when the requested session conflicts with the pin', async () => {
+  it('rejects and writes no sidecar when the requested session is not a running instance', async () => {
     mockPinnedSession('99999');
+    vi.mocked(discoveryModule.discoverInstances).mockReturnValue([
+      { pid: 99999 } as ReturnType<typeof discoveryModule.discoverInstances>[number],
+    ]);
     vi.mocked(existsSync).mockReturnValue(true);
     vi.mocked(readFileSync).mockReturnValue('<worksheet/>');
     vi.mocked(metadataModule.addFieldToRows).mockReturnValue(MODIFIED_XML);
@@ -182,7 +188,8 @@ describe('addFieldTool', () => {
 
     expect(result.isError).toBe(true);
     invariant(result.content[0].type === 'text');
-    expect(result.content[0].text).toContain('99999');
+    expect(result.content[0].text).toContain(SESSION);
+    expect(result.content[0].text).toContain('list-instances');
     expect(cacheFingerprintModule.writeSidecar).not.toHaveBeenCalled();
     expect(writeFileSync).not.toHaveBeenCalled();
   });

--- a/src/tools/desktop/fields/addField.ts
+++ b/src/tools/desktop/fields/addField.ts
@@ -36,7 +36,7 @@ const ENCODING_TYPES = [
 const FIELD_TARGETS = ['rows', 'cols', 'encoding'] as const;
 
 const paramsSchema = {
-  session: z.string(),
+  session: z.string().optional(),
   worksheetFile: z.string(),
   target: z.enum(FIELD_TARGETS),
   columnRef: z.string(),

--- a/src/tools/desktop/fields/removeField.test.ts
+++ b/src/tools/desktop/fields/removeField.test.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 
 import * as configModule from '../../../config.desktop.js';
 import * as cacheFingerprintModule from '../../../desktop/commands/workbook/cacheFingerprint.js';
+import * as discoveryModule from '../../../desktop/externalApi/discovery.js';
 import * as metadataModule from '../../../desktop/metadata/index.js';
 import {
   ArgsValidationError,
@@ -19,6 +20,7 @@ import { getRemoveFieldTool } from './removeField.js';
 
 vi.mock('../../../desktop/metadata/index.js');
 vi.mock('../../../desktop/commands/workbook/cacheFingerprint.js');
+vi.mock('../../../desktop/externalApi/discovery.js');
 vi.mock('fs');
 
 type EncodingType = 'color' | 'size' | 'lod' | 'detail' | 'text' | 'tooltip' | 'path' | 'angle';
@@ -46,6 +48,7 @@ describe('removeFieldTool', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockPinnedSession(undefined);
+    vi.mocked(discoveryModule.discoverInstances).mockReturnValue([]);
   });
 
   it('should create a tool instance with correct properties', () => {
@@ -166,8 +169,11 @@ describe('removeFieldTool', () => {
     expect(cacheFingerprintModule.writeSidecar).toHaveBeenCalledWith(WORKSHEET_FILE, SESSION);
   });
 
-  it('rejects and writes no sidecar when the requested session conflicts with the pin', async () => {
+  it('rejects and writes no sidecar when the requested session is not a running instance', async () => {
     mockPinnedSession('99999');
+    vi.mocked(discoveryModule.discoverInstances).mockReturnValue([
+      { pid: 99999 } as ReturnType<typeof discoveryModule.discoverInstances>[number],
+    ]);
     vi.mocked(existsSync).mockReturnValue(true);
     vi.mocked(readFileSync).mockReturnValue('<worksheet/>');
     vi.mocked(metadataModule.removeFieldFromRows).mockReturnValue(MODIFIED_XML);
@@ -182,7 +188,8 @@ describe('removeFieldTool', () => {
 
     expect(result.isError).toBe(true);
     invariant(result.content[0].type === 'text');
-    expect(result.content[0].text).toContain('99999');
+    expect(result.content[0].text).toContain(SESSION);
+    expect(result.content[0].text).toContain('list-instances');
     expect(cacheFingerprintModule.writeSidecar).not.toHaveBeenCalled();
     expect(writeFileSync).not.toHaveBeenCalled();
   });

--- a/src/tools/desktop/fields/removeField.ts
+++ b/src/tools/desktop/fields/removeField.ts
@@ -36,7 +36,7 @@ const ENCODING_TYPES = [
 const FIELD_TARGETS = ['rows', 'cols', 'encoding'] as const;
 
 const paramsSchema = {
-  session: z.string(),
+  session: z.string().optional(),
   worksheetFile: z.string(),
   target: z.enum(FIELD_TARGETS),
   columnRef: z.string(),

--- a/src/tools/desktop/template/injectTemplate.test.ts
+++ b/src/tools/desktop/template/injectTemplate.test.ts
@@ -14,10 +14,12 @@ vi.mock('../../../desktop/templates/injectTemplate.js');
 vi.mock('../../../desktop/templates/fieldReferenceRewriter.js');
 vi.mock('../../../desktop/templates/templatePath.js');
 vi.mock('../../../desktop/commands/workbook/cacheFingerprint.js');
+vi.mock('../../../desktop/externalApi/discovery.js');
 vi.mock('fs');
 
 import { existsSync, readFileSync, writeFileSync } from 'fs';
 
+import * as discoveryModule from '../../../desktop/externalApi/discovery.js';
 import { rewriteFieldReferences } from '../../../desktop/templates/fieldReferenceRewriter.js';
 import { injectTemplate } from '../../../desktop/templates/injectTemplate.js';
 import { listTemplateNames, readTemplate } from '../../../desktop/templates/templatePath.js';
@@ -70,6 +72,7 @@ describe('injectTemplateTool', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockPinnedSession(undefined);
+    vi.mocked(discoveryModule.discoverInstances).mockReturnValue([]);
   });
 
   it('should create a tool instance with correct properties', () => {
@@ -121,14 +124,18 @@ describe('injectTemplateTool', () => {
     );
   });
 
-  it('rejects and writes no sidecar when the requested session conflicts with the pin', async () => {
+  it('rejects and writes no sidecar when the requested session is not a running instance', async () => {
     mockPinnedSession('99999');
+    vi.mocked(discoveryModule.discoverInstances).mockReturnValue([
+      { pid: 99999 } as ReturnType<typeof discoveryModule.discoverInstances>[number],
+    ]);
 
     const result = await getResult(BASE_PARAMS);
 
     expect(result.isError).toBe(true);
     invariant(result.content[0].type === 'text');
-    expect(result.content[0].text).toContain('99999');
+    expect(result.content[0].text).toContain(SESSION);
+    expect(result.content[0].text).toContain('list-instances');
     expect(cacheFingerprintModule.writeSidecar).not.toHaveBeenCalled();
     expect(writeFileSync).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## What changed

This PR now goes the **opposite** direction from where it started. Instead of hiding the `session` param when a Desktop is pinned, we make the pin a **default the agent can override**, so the MCP can still talk to other running Desktop instances while knowing which one is current.

## Why

The pinned session was an invariant: `session` was stripped from every tool schema when pinned, and an explicit `session` that differed from the pin was rejected. But the PM wants the MCP to be able to target other open Desktops too. The pin should be a default, not a lock.

The original bug that #599 worked around was smaller than the fix: only **3** tools (`add-field`, `remove-field`, `write-cached-xml`) made `session` **required**, which forced the model to jam worksheet names like `"Sheet 1"` into it. Every other tool already had it optional.

## How

1. **Revert the original #599 commit** (the 49-tool schema-stripping mechanism).
2. **Fix the real bug**: make `session` optional on the 3 tools that were required.
3. **Unwind the invariant** so the pin is a default:
   - `resolveSession` uses the pin when `session` is omitted; an explicit `session` is validated against live instances and only rejected if it is not a running pid (fails open when discovery is empty).
   - `list-instances` is no longer hidden when pinned.
   - Session-resolution guidance is now pin-aware instead of dropped.

```mermaid
flowchart TD
    A[session param] --> B{omitted or == pin?}
    B -- yes --> C{pin set?}
    C -- yes --> D[use pin]
    C -- no --> E{how many Desktops running?}
    E -- exactly 1 --> F[use it]
    E -- 0 or 2+ --> G[fail closed]
    B -- "no (explicit other pid)" --> H{is it a running instance?}
    H -- yes --> I[target it]
    H -- "no (and discovery non-empty)" --> J[reject, hint list-instances]
    H -- discovery empty --> I
```

## Testing

- `npm test`: 335 files, 4929 pass, 0 errors
- `npm run lint`: clean
- `npm run build:desktop`: clean
