### PR TITLE
fix(binder): federated-duplicate tie-break — confident-bind survives multi-CSV join schemas

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "2.41.0",
+  "version": "2.43.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/src/desktop/binder/binder.test.ts
+++ b/src/desktop/binder/binder.test.ts
@@ -248,7 +248,76 @@ describe('binder/classifyNoLlm — measure-free lat/long symbol map (Blake wall 
   </datasources>
 </workbook>`;
 
+  const FEDERATED_WORLDCUP_WORKBOOK_XML = `<?xml version='1.0' encoding='utf-8'?>
+<workbook>
+  <datasources>
+    <datasource name='federated.114zfjw1eykx4i1auxu8o1tcqq5m'>
+      <column name='[caps]' caption='Caps' role='measure' type='quantitative' datatype='integer' />
+      <column name='[club]' caption='Club' role='dimension' type='nominal' datatype='string' />
+      <column name='[color_hex]' caption='Color Hex' role='dimension' type='nominal' datatype='string' />
+      <column name='[country_code]' caption='Country Code' role='dimension' type='nominal' datatype='string' semantic-role='[Country].[ISO3166_2]' />
+      <column name='[date_of_birth]' caption='Date Of Birth' role='dimension' type='nominal' datatype='string' />
+      <column name='[drawn]' caption='Drawn' role='measure' type='quantitative' datatype='integer' />
+      <column name='[flag_emoji]' caption='Flag Emoji' role='dimension' type='nominal' datatype='string' />
+      <column name='[flag_url]' caption='Flag Url' role='dimension' type='nominal' datatype='string' />
+      <column name='[form]' caption='Form' role='dimension' type='nominal' datatype='string' />
+      <column name='[goal_difference]' caption='Goal Difference' role='measure' type='quantitative' datatype='integer' />
+      <column name='[goals]' caption='Goals' role='measure' type='quantitative' datatype='integer' />
+      <column name='[goals_against]' caption='Goals Against' role='measure' type='quantitative' datatype='integer' />
+      <column name='[goals_for]' caption='Goals For' role='measure' type='quantitative' datatype='integer' />
+      <column name='[group_name (players.csv)]' caption='Group Name (Players.Csv)' role='dimension' type='nominal' datatype='string' />
+      <column name='[group_name (standings.csv)]' caption='Group Name (Standings.Csv)' role='dimension' type='nominal' datatype='string' />
+      <column name='[group_name]' caption='Group Name' role='dimension' type='nominal' datatype='string' />
+      <column name='[latitude]' caption='Latitude' role='measure' type='quantitative' datatype='real' semantic-role='[Geographical].[Latitude]' />
+      <column name='[longitude]' caption='Longitude' role='measure' type='quantitative' datatype='real' semantic-role='[Geographical].[Longitude]' />
+      <column name='[lost]' caption='Lost' role='measure' type='quantitative' datatype='integer' />
+      <column name='[played]' caption='Played' role='measure' type='quantitative' datatype='integer' />
+      <column name='[player_name]' caption='Player Name' role='dimension' type='nominal' datatype='string' />
+      <column name='[points]' caption='Points' role='measure' type='quantitative' datatype='integer' />
+      <column name='[position]' caption='Position' role='dimension' type='nominal' datatype='string' />
+      <column name='[qualification_status]' caption='Qualification Status' role='dimension' type='nominal' datatype='string' />
+      <column name='[rank]' caption='Rank' role='measure' type='quantitative' datatype='integer' />
+      <column name='[remaining_matches]' caption='Remaining Matches' role='measure' type='quantitative' datatype='integer' />
+      <column name='[shirt_number]' caption='Shirt Number' role='dimension' type='ordinal' datatype='integer' />
+      <column name='[snapshot_time]' caption='Snapshot Time' role='dimension' type='ordinal' datatype='datetime' />
+      <column name='[source (players.csv)]' caption='Source (Players.Csv)' role='dimension' type='nominal' datatype='string' />
+      <column name='[source (standings.csv)]' caption='Source (Standings.Csv)' role='dimension' type='nominal' datatype='string' />
+      <column name='[source]' caption='Source' role='dimension' type='nominal' datatype='string' />
+      <column name='[status]' caption='Status' role='dimension' type='nominal' datatype='string' />
+      <column name='[team_api_id (players.csv)]' caption='Team Api Id (Players.Csv)' role='dimension' type='ordinal' datatype='integer' />
+      <column name='[team_api_id (standings.csv)]' caption='Team Api Id (Standings.Csv)' role='dimension' type='ordinal' datatype='integer' />
+      <column name='[team_api_id]' caption='Team Api Id' role='dimension' type='ordinal' datatype='integer' />
+      <column name='[team_id (players.csv)]' caption='Team Id (Players.Csv)' role='dimension' type='nominal' datatype='string' />
+      <column name='[team_id (standings.csv)]' caption='Team Id (Standings.Csv)' role='dimension' type='nominal' datatype='string' />
+      <column name='[team_id]' caption='Team Id' role='dimension' type='nominal' datatype='string' />
+      <column name='[team_name (players.csv)]' caption='Team Name (Players.Csv)' role='dimension' type='nominal' datatype='string' />
+      <column name='[team_name (standings.csv)]' caption='Team Name (Standings.Csv)' role='dimension' type='nominal' datatype='string' />
+      <column name='[team_name]' caption='Team Name' role='dimension' type='nominal' datatype='string' />
+      <column name='[won]' caption='Won' role='measure' type='quantitative' datatype='integer' />
+    </datasource>
+  </datasources>
+</workbook>`;
+
   const LATLON = 'spatial-symbol-map-latlon';
+
+  function latlonWorkbookXmlWithDimensions(dimensions: string[]): string {
+    const dimensionColumns = dimensions
+      .map(
+        (name) =>
+          `      <column name='[${name}]' role='dimension' type='nominal' datatype='string' />`,
+      )
+      .join('\n');
+    return `<?xml version='1.0' encoding='utf-8'?>
+<workbook>
+  <datasources>
+    <datasource name='Sites'>
+${dimensionColumns}
+      <column name='[latitude]' role='measure' type='quantitative' datatype='real' />
+      <column name='[longitude]' role='measure' type='quantitative' datatype='real' />
+    </datasource>
+  </datasources>
+</workbook>`;
+  }
 
   it('binds spatial-symbol-map-latlon by coordinate affinity: longitude→cols, latitude→rows, ALL dims→detail, NO measure', () => {
     const forced = withForcedEligible([LATLON]);
@@ -340,6 +409,69 @@ describe('binder/classifyNoLlm — measure-free lat/long symbol map (Blake wall 
       .map((b) => b.field);
     // exactly ONE detail dim, and it is the label (team_name) — not id/code/group noise.
     expect(detailFields).toEqual(['team_name']);
+  });
+
+  it('FEDERATED REAL SCHEMA: duplicate suffixed team-name fields bind the base Team Name detail', () => {
+    const s = summarizeSchema(FEDERATED_WORLDCUP_WORKBOOK_XML);
+    expect(s.fields).toHaveLength(42);
+    const cls = classifyNoLlm('Symbol map showing team locations, one mark per team', manifests, s);
+    expect(cls).not.toBeNull();
+    expect(cls!.template).toBe(LATLON);
+    const bySlot = Object.fromEntries(cls!.bindings.map((b) => [b.slot_id, b.field]));
+    expect(bySlot['longitude']).toBe('Longitude');
+    expect(bySlot['latitude']).toBe('Latitude');
+    const detailFields = cls!.bindings
+      .filter((b) => b.slot_id.startsWith('detail'))
+      .map((b) => b.field);
+    expect(detailFields).toEqual(['Team Name']);
+  });
+
+  it('fails closed on dotted version parentheticals that are not Tableau data-file suffixes', () => {
+    const s = summarizeSchema(
+      latlonWorkbookXmlWithDimensions(['Site', 'Site (CRM.v1)', 'Site (ERP.v2)']),
+    );
+
+    expect(classifyNoLlm('map site locations', manifests, s)).toBeNull();
+  });
+
+  it('fails closed on dotted geography parentheticals that are not Tableau data-file suffixes', () => {
+    const s = summarizeSchema(
+      latlonWorkbookXmlWithDimensions(['Territory', 'Territory (U.S.)', 'Territory (E.U.)']),
+    );
+
+    expect(classifyNoLlm('map territory locations', manifests, s)).toBeNull();
+  });
+
+  it('fails closed on Region plus non-source parentheticals', () => {
+    const s = summarizeSchema(
+      latlonWorkbookXmlWithDimensions(['Region', 'Region (U.S.)', 'Region (World)']),
+    );
+
+    expect(classifyNoLlm('map region locations', manifests, s)).toBeNull();
+  });
+
+  it('fails closed when only part of a tied detail cluster collapses to one base', () => {
+    const s = summarizeSchema(
+      latlonWorkbookXmlWithDimensions([
+        'Team Name',
+        'Team Name (Players.csv)',
+        'Venue Name',
+      ]),
+    );
+
+    expect(classifyNoLlm('map team venue name locations', manifests, s)).toBeNull();
+  });
+
+  it('fails closed on suffixed federated duplicates without an unsuffixed base field', () => {
+    const s = summarizeSchema(
+      latlonWorkbookXmlWithDimensions([
+        'Team Name (Players.csv)',
+        'Team Name (Standings.csv)',
+        'team_id',
+      ]),
+    );
+
+    expect(classifyNoLlm('map team name locations', manifests, s)).toBeNull();
   });
 
   it('COARSE dim named in the ask does NOT win detail over the fine label (no centroid collapse)', () => {

--- a/src/desktop/binder/binder.test.ts
+++ b/src/desktop/binder/binder.test.ts
@@ -452,11 +452,7 @@ ${dimensionColumns}
 
   it('fails closed when only part of a tied detail cluster collapses to one base', () => {
     const s = summarizeSchema(
-      latlonWorkbookXmlWithDimensions([
-        'Team Name',
-        'Team Name (Players.csv)',
-        'Venue Name',
-      ]),
+      latlonWorkbookXmlWithDimensions(['Team Name', 'Team Name (Players.csv)', 'Venue Name']),
     );
 
     expect(classifyNoLlm('map team venue name locations', manifests, s)).toBeNull();

--- a/src/desktop/binder/classify.ts
+++ b/src/desktop/binder/classify.ts
@@ -718,6 +718,12 @@ const COARSE_GRAIN_TOKENS: ReadonlySet<string> = new Set([
   'band',
 ]);
 
+const FEDERATED_DATA_FILE_SUFFIX_RE = /\s+\([^)]+\.(?:csv|xlsx|xls|hyper|json|txt|tde)\)$/i;
+
+function federatedDuplicateBaseName(name: string): string {
+  return name.replace(FEDERATED_DATA_FILE_SUFFIX_RE, '');
+}
+
 /**
  * Pick the single best DETAIL (mark-identity) dimension from a WIDE schema's categoricals
  * (3+), so a real-world map (team_id, team_api_id, group_name, country_code, team_name, …)
@@ -766,11 +772,22 @@ function pickBestDetailDim(
   if (ranked.length === 0) return null;
   // The winner must be a POSITIVE, UNIQUE fine label. A non-positive top means no field
   // read as a clean per-mark label (all coarse/technical/neutral) → ambiguous grain → fail
-  // closed. A tie at the top → can't tell which is the mark identity → fail closed. Only a
-  // clear, positive, single winner binds (a wrong grain silently centroid-collapses; propose
-  // is safer).
+  // closed. A tie at the top → can't tell which is the mark identity → fail closed, except
+  // Tableau federated-join duplicates that differ only by a known data-file suffix
+  // (`Team Name`, `Team Name (Players.Csv)`, ...). Those are the same logical field; prefer
+  // the base unsuffixed column. Only a clear, positive, single winner binds (a wrong grain
+  // silently centroid-collapses; propose is safer).
   if (ranked[0].score <= 0) return null;
-  if (ranked.length > 1 && ranked[0].score === ranked[1].score) return null;
+  if (ranked.length > 1 && ranked[0].score === ranked[1].score) {
+    const topScore = ranked[0].score;
+    const tied = ranked.filter((r) => r.score === topScore).map((r) => r.f);
+    const bases = new Set(tied.map((f) => federatedDuplicateBaseName(f.name)));
+    if (bases.size !== 1) return null;
+    const [base] = bases;
+    const unsuffixed = tied.filter((f) => f.name === base);
+    if (unsuffixed.length !== 1) return null;
+    return unsuffixed[0];
+  }
   return ranked[0].f;
 }
 


### PR DESCRIPTION
**Live-proven decline (demo-day forensics):** on Blake's real federated workbook (3-CSV join, 42 fields), "Symbol map showing team locations" fell to the LLM propose round-trip — `pickBestDetailDim` hit a three-way top-score tie across `Team Name` / `Team Name (Players.Csv)` / `Team Name (Standings.Csv)` and failed closed. That round-trip is the bulk of the remaining 16.3s → <10s latency gap (lever `TAB_AGENT_ONE_TURN_BIND=1` already live-confirmed 36.3s → 16.3s).

**Fix:** when ALL tied top detail candidates collapse to the same base name under a known data-file federation suffix (`csv/xlsx/xls/hyper/json/txt/tde`, case-insensitive) and the unsuffixed base exists among them, bind the base — the same grain the LLM picks, minus the round-trip. Non-federation parentheticals (`(CRM.v1)`, `(U.S.)`, `(USD)`) do NOT collapse; genuine ties still fail closed.

**Verification:** repro fixture = the real extracted 42-field schema + the live ask (failing-first, now asserts the confident bind). Negative tests: versioned-source ties, non-source parentheticals, mixed clusters, missing base — all fail closed. #598's alpha/beta/gamma tie test untouched and green. Full suite 335 files / 4932 tests. Independent review found one P2 (over-broad dotted-suffix collapse) — fixed with the extension allowlist above.

**Next:** rebuild serving bundle + timed re-sing on the live stack to bank the 1-bind sub-10s number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)