### PR TITLE
fix: read single sheets/dashboards as fragments and apply them without pruning siblings

### DIFF
--- a/src/desktop/commands/workbook/getDashboardXml.test.ts
+++ b/src/desktop/commands/workbook/getDashboardXml.test.ts
@@ -2,7 +2,7 @@ import { Err, Ok } from 'ts-results-es';
 
 import { ExternalApiToolExecutor } from '../../externalApi/externalApiToolExecutor.js';
 import { ExecuteCommandError } from '../../toolExecutor/toolExecutor.js';
-import { getDashboardXml } from './getDashboardXml.js';
+import { getDashboardFragment, getDashboardXml } from './getDashboardXml.js';
 
 describe('getDashboardXml', () => {
   it('resolves dashboard name to id and fetches the per-item document', async () => {
@@ -118,5 +118,63 @@ describe('getDashboardXml', () => {
     expect(result.isOk()).toBe(true);
     expect(result.unwrap()).toContain('<dashboard name="Sales">');
     expect(executor.getWorkbookDocument).toHaveBeenCalledWith(signal);
+  });
+});
+
+describe('getDashboardFragment', () => {
+  it('slices the requested dashboard out of a whole-workbook /document response', async () => {
+    const signal = new AbortController().signal;
+    const executor = {
+      listDashboards: vi.fn().mockResolvedValue(
+        Ok({
+          dashboards: [
+            { id: 'dashboard-1', name: 'Executive Overview' },
+            { id: 'dashboard-2', name: 'Sales' },
+          ],
+        }),
+      ),
+      getDashboardDocument: vi.fn().mockResolvedValue(
+        Ok({
+          xml: `<workbook><dashboards>
+            <dashboard name="Executive Overview"><zone /></dashboard>
+            <dashboard name="Sales"><zone /></dashboard>
+          </dashboards></workbook>`,
+        }),
+      ),
+    } as unknown as ExternalApiToolExecutor;
+
+    const result = await getDashboardFragment({
+      executor,
+      signal,
+      dashboardName: 'Sales',
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toContain('<dashboard name="Sales"');
+      expect(result.value).not.toContain('<workbook');
+      expect(result.value).not.toContain('Executive Overview');
+    }
+  });
+
+  it('returns a bare dashboard fragment unchanged', async () => {
+    const signal = new AbortController().signal;
+    const executor = {
+      listDashboards: vi.fn().mockResolvedValue(
+        Ok({
+          dashboards: [{ id: 'dashboard-1', name: 'Sales' }],
+        }),
+      ),
+      getDashboardDocument: vi.fn().mockResolvedValue(Ok({ xml: '<dashboard name="Sales" />' })),
+    } as unknown as ExternalApiToolExecutor;
+
+    const result = await getDashboardFragment({
+      executor,
+      signal,
+      dashboardName: 'Sales',
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(result.unwrap()).toBe('<dashboard name="Sales" />');
   });
 });

--- a/src/desktop/commands/workbook/getDashboardXml.ts
+++ b/src/desktop/commands/workbook/getDashboardXml.ts
@@ -1,3 +1,6 @@
+import { Err, Ok } from 'ts-results-es';
+
+import { dashboardDocumentToFragment } from '../../metadata/dashboards.js';
 import { WithExecutorAndAbortSignal } from '../../toolExecutor/toolExecutor.js';
 import {
   type GetDashboardXmlError,
@@ -12,4 +15,32 @@ export async function getDashboardXml(
   args: { dashboardName: string } & WithExecutorAndAbortSignal,
 ): Promise<GetDashboardXmlResult> {
   return await new WorkbookReadGateway(args).getDashboardXml(args.dashboardName);
+}
+
+/**
+ * Like {@link getDashboardXml}, but always resolves to a single `<dashboard>` fragment. The
+ * External Client API per-dashboard `/document` route returns a whole `<workbook>` scoped to the
+ * dashboard; callers that feed the XML to apply-dashboard need the fragment. The other transports
+ * already return a fragment, so this is a no-op slice for them.
+ */
+export async function getDashboardFragment(
+  args: { dashboardName: string } & WithExecutorAndAbortSignal,
+): Promise<GetDashboardXmlResult> {
+  const result = await getDashboardXml(args);
+  if (result.isErr()) {
+    return result;
+  }
+
+  const fragment = dashboardDocumentToFragment(result.value, args.dashboardName);
+  if (fragment === null) {
+    return Err({
+      type: 'get-dashboard-xml-error',
+      error: {
+        type: 'no-dashboard-found',
+        message: `No dashboard found for "${args.dashboardName}".`,
+      },
+    });
+  }
+
+  return Ok(fragment);
 }

--- a/src/desktop/commands/workbook/getWorksheetXml.test.ts
+++ b/src/desktop/commands/workbook/getWorksheetXml.test.ts
@@ -2,7 +2,7 @@ import { Err, Ok } from 'ts-results-es';
 
 import { ExternalApiToolExecutor } from '../../externalApi/externalApiToolExecutor.js';
 import { ExecuteCommandError } from '../../toolExecutor/toolExecutor.js';
-import { getWorksheetXml } from './getWorksheetXml.js';
+import { getWorksheetFragment, getWorksheetXml } from './getWorksheetXml.js';
 
 describe('getWorksheetXml', () => {
   it('resolves worksheet name to id and fetches the per-item document', async () => {
@@ -109,5 +109,63 @@ describe('getWorksheetXml', () => {
     expect(result.isOk()).toBe(true);
     expect(result.unwrap()).toContain('<worksheet name="Profit">');
     expect(executor.getWorkbookDocument).toHaveBeenCalledWith(signal);
+  });
+});
+
+describe('getWorksheetFragment', () => {
+  it('slices the requested sheet out of a whole-workbook /document response', async () => {
+    const signal = new AbortController().signal;
+    const executor = {
+      listWorksheets: vi.fn().mockResolvedValue(
+        Ok({
+          worksheets: [
+            { id: 'sheet-1', name: 'Sales by Region' },
+            { id: 'sheet-2', name: 'Profit by Category' },
+          ],
+        }),
+      ),
+      getWorksheetDocument: vi.fn().mockResolvedValue(
+        Ok({
+          xml: `<workbook><worksheets>
+            <worksheet name="Sales by Region"><table><view /></table></worksheet>
+            <worksheet name="Profit by Category"><table><view /></table></worksheet>
+          </worksheets></workbook>`,
+        }),
+      ),
+    } as unknown as ExternalApiToolExecutor;
+
+    const result = await getWorksheetFragment({
+      executor,
+      signal,
+      worksheetName: 'Sales by Region',
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toContain('<worksheet name="Sales by Region"');
+      expect(result.value).not.toContain('<workbook');
+      expect(result.value).not.toContain('Profit by Category');
+    }
+  });
+
+  it('returns a bare worksheet fragment unchanged', async () => {
+    const signal = new AbortController().signal;
+    const executor = {
+      listWorksheets: vi.fn().mockResolvedValue(
+        Ok({
+          worksheets: [{ id: 'sheet-1', name: 'Sales' }],
+        }),
+      ),
+      getWorksheetDocument: vi.fn().mockResolvedValue(Ok({ xml: '<worksheet name="Sales" />' })),
+    } as unknown as ExternalApiToolExecutor;
+
+    const result = await getWorksheetFragment({
+      executor,
+      signal,
+      worksheetName: 'Sales',
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(result.unwrap()).toBe('<worksheet name="Sales" />');
   });
 });

--- a/src/desktop/commands/workbook/getWorksheetXml.ts
+++ b/src/desktop/commands/workbook/getWorksheetXml.ts
@@ -1,3 +1,6 @@
+import { Err, Ok } from 'ts-results-es';
+
+import { worksheetDocumentToFragment } from '../../metadata/sheets.js';
 import { WithExecutorAndAbortSignal } from '../../toolExecutor/toolExecutor.js';
 import {
   type GetWorksheetXmlError,
@@ -12,4 +15,32 @@ export async function getWorksheetXml(
   args: { worksheetName: string } & WithExecutorAndAbortSignal,
 ): Promise<GetWorksheetXmlResult> {
   return await new WorkbookReadGateway(args).getWorksheetXml(args.worksheetName);
+}
+
+/**
+ * Like {@link getWorksheetXml}, but always resolves to a single `<worksheet>` fragment. The
+ * External Client API per-sheet `/document` route returns a whole `<workbook>` scoped to the
+ * sheet; callers that feed the XML to apply-worksheet or a readback verifier need the fragment.
+ * The other transports already return a fragment, so this is a no-op slice for them.
+ */
+export async function getWorksheetFragment(
+  args: { worksheetName: string } & WithExecutorAndAbortSignal,
+): Promise<GetWorksheetXmlResult> {
+  const result = await getWorksheetXml(args);
+  if (result.isErr()) {
+    return result;
+  }
+
+  const fragment = worksheetDocumentToFragment(result.value, args.worksheetName);
+  if (fragment === null) {
+    return Err({
+      type: 'get-worksheet-xml-error',
+      error: {
+        type: 'no-worksheet-found',
+        message: `No worksheet found for ${args.worksheetName}.`,
+      },
+    });
+  }
+
+  return Ok(fragment);
 }

--- a/src/desktop/commands/workbook/loadDashboardXml.test.ts
+++ b/src/desktop/commands/workbook/loadDashboardXml.test.ts
@@ -79,7 +79,7 @@ describe('loadDashboardXml (External Client API transport)', () => {
     vi.restoreAllMocks();
   });
 
-  it('should apply a minimal document that upserts the dashboard and omits worksheets', async () => {
+  it('upserts the dashboard into the whole live workbook, preserving siblings and worksheets', async () => {
     const { executor, calls } = dispatchingExecutor(
       liveWorkbook(['Sales Dashboard', 'Other DB'], ['Sheet 1']),
     );
@@ -97,11 +97,13 @@ describe('loadDashboardXml (External Client API transport)', () => {
     const applyCall = calls.find((c) => c.kind === 'apply');
     const applied = applyCall?.xml as string;
     expect(applied).toContain('name="Sales Dashboard"');
-    expect(applied).not.toContain('Other DB');
-    expect(applied).not.toContain('<worksheet');
+    // The POST replaces the open workbook wholesale, so the sibling dashboard and the live
+    // worksheet MUST survive in the posted doc — omitting them would prune them from Desktop.
+    expect(applied).toContain('name="Other DB"');
+    expect(applied).toContain('name="Sheet 1"');
   });
 
-  it('focuses the dashboard after a successful minimal-doc apply', async () => {
+  it('focuses the dashboard after a successful apply', async () => {
     const { executor, calls } = dispatchingExecutor(
       liveWorkbook(['Sales Dashboard', 'Other DB'], ['Sheet 1']),
     );
@@ -119,7 +121,7 @@ describe('loadDashboardXml (External Client API transport)', () => {
     );
   });
 
-  it('does not reject a per-dashboard apply whose minimal document omits live worksheets referenced by zones', async () => {
+  it('keeps live worksheets referenced by the dashboard zones in the posted document', async () => {
     const dashboardXml = `<dashboard name='${dashboardName}'><zones><zone name='Sheet 1' /></zones></dashboard>`;
     const { executor, calls } = dispatchingExecutor(
       liveWorkbook(['Sales Dashboard', 'Other DB'], ['Sheet 1']),
@@ -134,11 +136,11 @@ describe('loadDashboardXml (External Client API transport)', () => {
 
     expect(result.isOk()).toBe(true);
     const applyCall = calls.find((c) => c.kind === 'apply');
+    expect(applyCall?.xml).toContain('<worksheet');
     expect(applyCall?.xml).toContain('name="Sheet 1"');
-    expect(applyCall?.xml).not.toContain('<worksheet');
   });
 
-  it('should apply a minimal document for a brand-new dashboard', async () => {
+  it('appends a brand-new dashboard while preserving the existing one', async () => {
     const { executor, calls } = dispatchingExecutor(liveWorkbook(['Some Other DB']));
 
     const result = await loadDashboardXml({
@@ -150,7 +152,9 @@ describe('loadDashboardXml (External Client API transport)', () => {
 
     expect(result.isOk()).toBe(true);
     expect(calls.find((c) => c.command === 'delete-sheet')).toBeUndefined();
-    expect(calls.find((c) => c.kind === 'apply')).toBeDefined();
+    const applyCall = calls.find((c) => c.kind === 'apply');
+    expect(applyCall?.xml).toContain('name="Sales Dashboard"');
+    expect(applyCall?.xml).toContain('name="Some Other DB"');
   });
 
   it('should return invalid-xml error when xml is empty', async () => {

--- a/src/desktop/commands/workbook/loadDashboardXml.ts
+++ b/src/desktop/commands/workbook/loadDashboardXml.ts
@@ -2,7 +2,7 @@ import { Err, Ok, Result } from 'ts-results-es';
 
 import { log } from '../../../logging/logger.js';
 import { sanitizeValue } from '../../../logging/sanitize.js';
-import { buildMinimalDashboardDoc } from '../../metadata/dashboards.js';
+import { upsertDashboardIntoWorkbook } from '../../metadata/dashboards.js';
 import { normalizeArray, parseXML } from '../../metadata/parser.js';
 import type { ParsedDashboard } from '../../metadata/types.js';
 import {
@@ -53,10 +53,10 @@ type LoadDashboardHelperResult = Result<
  * identical NFD/NFC spellings do not false-mismatch. Returns the validated canonical name — the
  * name exactly as authored in the XML (trimmed), which is what Tableau stores when it applies the
  * raw XML — for the load and the post-apply goto-sheet, so focus can never target a stale/default
- * sheet (e.g. "Sheet 1"), and so buildMinimalDashboardDoc's own name check still matches.
+ * sheet (e.g. "Sheet 1"), and so upsertDashboardIntoWorkbook's own name check still matches.
  *
  * Only a single top-level `<dashboard>` fragment is a legal payload here (the same fragment
- * get-dashboard-xml returns and buildMinimalDashboardDoc requires). A `<workbook>`-wrapped document
+ * get-dashboard-xml returns and upsertDashboardIntoWorkbook requires). A `<workbook>`-wrapped document
  * has no top-level identity to gate on, so it is rejected before apply with a recovery hint rather
  * than failing as a misleading mismatch against an empty XML name.
  */
@@ -166,8 +166,8 @@ export async function loadDashboardXml({
   const canonicalName = canonicalNameResult.value;
 
   // External Client API ("Athena V0") exposes no per-dashboard apply route, so applying a single
-  // dashboard re-posts a minimal whole-workbook document.
-  // The POST upserts by name: it overwrites the colliding dashboard in place and leaves the rest live.
+  // dashboard re-posts the whole live workbook with just this dashboard swapped in (the POST
+  // replaces the open workbook wholesale, so anything omitted would be pruned).
   const result = await loadDashboardXmlViaExternalApi({
     dashboardName: canonicalName,
     xml,
@@ -197,14 +197,14 @@ async function loadDashboardXmlViaExternalApi({
       return Err({ type: 'execute-command-error', error: workbookResult.error });
     }
 
-    let minimalDoc: string;
+    let workbookDoc: string;
     try {
-      minimalDoc = buildMinimalDashboardDoc(workbookResult.value, dashboardName, xml);
+      workbookDoc = upsertDashboardIntoWorkbook(workbookResult.value, dashboardName, xml);
     } catch (error) {
       return Err({ type: 'execute-command-error', error: { type: 'invalid-response', error } });
     }
 
-    const applyResult = await applyWorkbookText({ xml: minimalDoc, executor, signal });
+    const applyResult = await applyWorkbookText({ xml: workbookDoc, executor, signal });
     if (applyResult.isErr()) {
       return Err({ type: 'execute-command-error', error: applyResult.error });
     }

--- a/src/desktop/commands/workbook/loadWorksheetXml.test.ts
+++ b/src/desktop/commands/workbook/loadWorksheetXml.test.ts
@@ -13,14 +13,18 @@ describe('loadWorksheetXml (External Client API transport)', () => {
   const worksheetName = 'Sheet 1';
   const validXml = `<worksheet name='${worksheetName}'><table><rows /></table></worksheet>`;
 
-  function liveWorkbook(worksheetNames: string[]): string {
+  function liveWorkbook(worksheetNames: string[], dashboardNames: string[] = []): string {
     const worksheets = worksheetNames
       .map((name) => `<worksheet name='${name}'><table /></worksheet>`)
+      .join('');
+    const dashboards = dashboardNames
+      .map((name) => `<dashboard name='${name}'><zones /></dashboard>`)
       .join('');
     const windows = worksheetNames
       .map((name) => `<window class='worksheet' name='${name}' />`)
       .join('');
-    return `<?xml version='1.0'?><workbook><worksheets>${worksheets}</worksheets><windows>${windows}</windows></workbook>`;
+    const dashboardsBlock = dashboards ? `<dashboards>${dashboards}</dashboards>` : '';
+    return `<?xml version='1.0'?><workbook><worksheets>${worksheets}</worksheets>${dashboardsBlock}<windows>${windows}</windows></workbook>`;
   }
 
   function dispatchingExecutor(workbookXml: string): {
@@ -81,8 +85,10 @@ describe('loadWorksheetXml (External Client API transport)', () => {
     vi.restoreAllMocks();
   });
 
-  it('should apply a minimal document that upserts the edited sheet without deleting first', async () => {
-    const { executor, calls } = dispatchingExecutor(liveWorkbook(['Sheet 1', 'Other']));
+  it('upserts the edited sheet into the whole live workbook, preserving siblings and dashboards', async () => {
+    const { executor, calls } = dispatchingExecutor(
+      liveWorkbook(['Sheet 1', 'Other'], ['Dashboard 1']),
+    );
 
     const result = await loadWorksheetXml({
       worksheetName,
@@ -97,10 +103,13 @@ describe('loadWorksheetXml (External Client API transport)', () => {
     const applyCall = calls.find((c) => c.kind === 'apply');
     expect(typeof applyCall?.xml).toBe('string');
     expect(applyCall?.xml).toContain('name="Sheet 1"');
-    expect(applyCall?.xml).not.toContain('Other');
+    // The POST replaces the open workbook wholesale, so the sibling sheet and the live dashboard
+    // MUST survive in the posted doc — omitting them would prune them from Desktop.
+    expect(applyCall?.xml).toContain('name="Other"');
+    expect(applyCall?.xml).toContain('name="Dashboard 1"');
   });
 
-  it('focuses the worksheet after a successful minimal-doc apply', async () => {
+  it('focuses the worksheet after a successful apply', async () => {
     const { executor, calls } = dispatchingExecutor(liveWorkbook(['Sheet 1', 'Other']));
 
     const result = await loadWorksheetXml({
@@ -116,7 +125,7 @@ describe('loadWorksheetXml (External Client API transport)', () => {
     );
   });
 
-  it('should apply a minimal document for a brand-new sheet', async () => {
+  it('appends a brand-new sheet while preserving the existing one', async () => {
     const { executor, calls } = dispatchingExecutor(liveWorkbook(['Some Other Sheet']));
 
     const result = await loadWorksheetXml({
@@ -128,7 +137,9 @@ describe('loadWorksheetXml (External Client API transport)', () => {
 
     expect(result.isOk()).toBe(true);
     expect(calls.find((c) => c.command === 'delete-sheet')).toBeUndefined();
-    expect(calls.find((c) => c.kind === 'apply')).toBeDefined();
+    const applyCall = calls.find((c) => c.kind === 'apply');
+    expect(applyCall?.xml).toContain('name="Sheet 1"');
+    expect(applyCall?.xml).toContain('name="Some Other Sheet"');
   });
 
   it('should return error when XML is invalid', async () => {

--- a/src/desktop/commands/workbook/loadWorksheetXml.ts
+++ b/src/desktop/commands/workbook/loadWorksheetXml.ts
@@ -3,7 +3,7 @@ import { Err, Ok, Result } from 'ts-results-es';
 import { log } from '../../../logging/logger.js';
 import { sanitizeValue } from '../../../logging/sanitize.js';
 import { normalizeArray, parseXML } from '../../metadata/parser.js';
-import { buildMinimalSheetDoc } from '../../metadata/sheets.js';
+import { upsertSheetIntoWorkbook } from '../../metadata/sheets.js';
 import type { ParsedWorksheet } from '../../metadata/types.js';
 import {
   ExecuteCommandError,
@@ -146,10 +146,10 @@ function readbackOutcome(
  * identical NFD/NFC spellings do not false-mismatch. Returns the validated canonical name — the
  * name exactly as authored in the XML (trimmed), which is what Tableau stores when it applies the
  * raw XML — for the load, the readback, and the post-apply goto-sheet, so focus can never target a
- * stale/default sheet (e.g. "Sheet 1"), and so buildMinimalSheetDoc's own name check still matches.
+ * stale/default sheet (e.g. "Sheet 1"), and so upsertSheetIntoWorkbook's own name check still matches.
  *
  * Only a single top-level `<worksheet>` fragment is a legal payload here (the same fragment
- * get-worksheet-xml returns and buildMinimalSheetDoc requires). A `<workbook>`-wrapped document has
+ * get-worksheet-xml returns and upsertSheetIntoWorkbook requires). A `<workbook>`-wrapped document has
  * no top-level identity to gate on, so it is rejected before apply with a recovery hint rather than
  * failing as a misleading mismatch against an empty XML name.
  */
@@ -265,9 +265,9 @@ export async function loadWorksheetXml({
   }
   const canonicalName = canonicalNameResult.value;
 
-  // External Client API ("Athena V0") exposes no per-sheet apply route, so applying a single
-  // sheet re-posts a minimal whole-workbook document.
-  // The POST upserts by name: it overwrites the colliding sheet in place and leaves the rest live.
+  // External Client API ("Athena V0") exposes no per-sheet apply route, so applying a single sheet
+  // re-posts the whole live workbook with just this sheet swapped in (the POST replaces the open
+  // workbook wholesale, so anything omitted would be pruned).
   const result = await loadWorksheetXmlViaExternalApi({
     worksheetName: canonicalName,
     xml,
@@ -303,14 +303,14 @@ async function loadWorksheetXmlViaExternalApi({
       return Err({ type: 'execute-command-error', error: workbookResult.error });
     }
 
-    let minimalDoc: string;
+    let workbookDoc: string;
     try {
-      minimalDoc = buildMinimalSheetDoc(workbookResult.value, worksheetName, xml);
+      workbookDoc = upsertSheetIntoWorkbook(workbookResult.value, worksheetName, xml);
     } catch (error) {
       return Err({ type: 'execute-command-error', error: { type: 'invalid-response', error } });
     }
 
-    const applyResult = await applyWorkbookText({ xml: minimalDoc, executor, signal });
+    const applyResult = await applyWorkbookText({ xml: workbookDoc, executor, signal });
     if (applyResult.isErr()) {
       return Err({ type: 'execute-command-error', error: applyResult.error });
     }

--- a/src/desktop/commands/workbook/loadWorksheetXml.ts
+++ b/src/desktop/commands/workbook/loadWorksheetXml.ts
@@ -21,7 +21,7 @@ import { xmlNamesEqual } from '../../xmlElement.js';
 import { withApplyLock } from './applyMutex.js';
 import { focusAppliedSheetBestEffort } from './focusAppliedSheet.js';
 import { getWorkbookXml } from './getWorkbookXml.js';
-import { getWorksheetXml } from './getWorksheetXml.js';
+import { getWorksheetFragment } from './getWorksheetXml.js';
 import { applyWorkbookText } from './loadWorkbookXml.js';
 
 export type LoadWorksheetXmlError =
@@ -79,7 +79,7 @@ async function verifyPostApplyWorksheetReadback(
   signal: WithExecutorAndAbortSignal['signal'],
 ): Promise<PostApplyWorksheetReadbackVerification> {
   try {
-    const reread = await getWorksheetXml({ worksheetName, executor, signal });
+    const reread = await getWorksheetFragment({ worksheetName, executor, signal });
     if (reread.isErr()) {
       const message =
         reread.error.type === 'get-worksheet-xml-error'

--- a/src/desktop/externalApi/mockExternalApiServer.ts
+++ b/src/desktop/externalApi/mockExternalApiServer.ts
@@ -41,10 +41,18 @@ export type MockExternalApiServer = {
 
 const DEFAULT_TOKEN = 'valid-token';
 const DEFAULT_WORKBOOK_XML = '<?xml version="1.0"?><workbook><worksheets /></workbook>';
-const DEFAULT_WORKSHEET_XML =
-  '<worksheet name="Sales by Region"><table><rows /></table></worksheet>';
-const DEFAULT_DASHBOARD_XML =
-  '<dashboard name="Executive Dashboard"><zones><zone name="Sales by Region" /></zones></dashboard>';
+// The live per-item /document routes return a whole <workbook> scoped to the requested item, NOT a
+// bare fragment (verified against Desktop 0.1.1). The mock mirrors that so the read paths' slice is
+// exercised: the worksheet document carries a sibling sheet the slice must exclude by name.
+const DEFAULT_WORKSHEET_DOCUMENT_XML =
+  '<?xml version="1.0"?><workbook><worksheets>' +
+  '<worksheet name="Sales by Region"><table><rows /></table></worksheet>' +
+  '<worksheet name="Profit by Category"><table><rows /></table></worksheet>' +
+  '</worksheets></workbook>';
+const DEFAULT_DASHBOARD_DOCUMENT_XML =
+  '<?xml version="1.0"?><workbook><dashboards>' +
+  '<dashboard name="Executive Dashboard"><zones><zone name="Sales by Region" /></zones></dashboard>' +
+  '</dashboards></workbook>';
 const DEFAULT_STORYBOARD_XML = '<storyboard name="QBR Story"><story-points /></storyboard>';
 const DEFAULT_WORKSHEETS = [
   {
@@ -308,7 +316,7 @@ export async function startMockExternalApiServer(
         sendProblem(res, 404, 'sheet-not-found', `Worksheet not found: ${worksheetId}`);
         return;
       }
-      sendXml(res, 200, DEFAULT_WORKSHEET_XML);
+      sendXml(res, 200, DEFAULT_WORKSHEET_DOCUMENT_XML);
       return;
     }
 
@@ -319,7 +327,7 @@ export async function startMockExternalApiServer(
         sendProblem(res, 404, 'sheet-not-found', `Dashboard not found: ${dashboardId}`);
         return;
       }
-      sendXml(res, 200, DEFAULT_DASHBOARD_XML);
+      sendXml(res, 200, DEFAULT_DASHBOARD_DOCUMENT_XML);
       return;
     }
 

--- a/src/desktop/metadata/dashboards.test.ts
+++ b/src/desktop/metadata/dashboards.test.ts
@@ -3,6 +3,7 @@ import {
   dashboardDocumentToFragment,
   extractDashboardXml,
   listWorkbookDashboards,
+  upsertDashboardIntoWorkbook,
 } from './dashboards.js';
 
 // Same shape as the worksheet regression (sheets.test.ts): the <workbook> root declares
@@ -85,6 +86,46 @@ describe('dashboardDocumentToFragment', () => {
     expect(
       dashboardDocumentToFragment('<workbook><dashboards /></workbook>', 'Missing'),
     ).toBeNull();
+  });
+});
+
+describe('upsertDashboardIntoWorkbook', () => {
+  // The POST replaces the open workbook wholesale, so the posted doc must carry the entire live
+  // workbook — worksheets included (the dashboard's zones reference them by name) — with only the
+  // target dashboard swapped in.
+  const LIVE_WORKBOOK = `<?xml version='1.0' encoding='utf-8' ?>
+<workbook xmlns:user='http://www.tableausoftware.com/xml/user'>
+  <worksheets>
+    <worksheet name='Sheet 1'><table /></worksheet>
+  </worksheets>
+  <dashboards>
+    <dashboard name='Dashboard 1'><zones><old /></zones></dashboard>
+    <dashboard name='Dashboard 2'><zones /></dashboard>
+  </dashboards>
+</workbook>`;
+
+  it('replaces the target dashboard while preserving siblings and worksheets', () => {
+    const edited = "<dashboard name='Dashboard 1'><zones><new /></zones></dashboard>";
+    const doc = upsertDashboardIntoWorkbook(LIVE_WORKBOOK, 'Dashboard 1', edited);
+
+    expect(doc).toContain('<new');
+    expect(doc).not.toContain('<old');
+    expect(doc).toContain('name="Dashboard 2"');
+    expect(doc).toContain('name="Sheet 1"');
+    expect(listWorkbookDashboards(doc)).toEqual(['Dashboard 1', 'Dashboard 2']);
+  });
+
+  it('appends a brand-new dashboard, keeping the existing ones and worksheets', () => {
+    const edited = "<dashboard name='Dashboard 3'><zones /></dashboard>";
+    const doc = upsertDashboardIntoWorkbook(LIVE_WORKBOOK, 'Dashboard 3', edited);
+
+    expect(listWorkbookDashboards(doc)).toEqual(['Dashboard 1', 'Dashboard 2', 'Dashboard 3']);
+    expect(doc).toContain('name="Sheet 1"');
+  });
+
+  it('throws when the edited XML does not carry a <dashboard> with the given name', () => {
+    const edited = "<dashboard name='Wrong'><zones /></dashboard>";
+    expect(() => upsertDashboardIntoWorkbook(LIVE_WORKBOOK, 'Dashboard 1', edited)).toThrow();
   });
 });
 

--- a/src/desktop/metadata/dashboards.test.ts
+++ b/src/desktop/metadata/dashboards.test.ts
@@ -127,6 +127,25 @@ describe('upsertDashboardIntoWorkbook', () => {
     const edited = "<dashboard name='Wrong'><zones /></dashboard>";
     expect(() => upsertDashboardIntoWorkbook(LIVE_WORKBOOK, 'Dashboard 1', edited)).toThrow();
   });
+
+  it('preserves whitespace-significant run text on an untouched sibling worksheet', () => {
+    // A dashboard apply re-serializes the whole workbook, worksheets included. A worksheet's
+    // formatted <run> text with significant spaces must survive verbatim.
+    const workbook = `<?xml version='1.0' encoding='utf-8' ?>
+<workbook>
+  <worksheets>
+    <worksheet name='Sheet 1'><table><formatted-text><run>Sales: </run><run>  $1.2M</run></formatted-text></table></worksheet>
+  </worksheets>
+  <dashboards>
+    <dashboard name='Dashboard 1'><zones><old /></zones></dashboard>
+  </dashboards>
+</workbook>`;
+    const edited = "<dashboard name='Dashboard 1'><zones><new /></zones></dashboard>";
+    const doc = upsertDashboardIntoWorkbook(workbook, 'Dashboard 1', edited);
+
+    expect(doc).toContain('<run>Sales: </run>');
+    expect(doc).toContain('<run>  $1.2M</run>');
+  });
 });
 
 describe('listWorkbookDashboards', () => {

--- a/src/desktop/metadata/dashboards.test.ts
+++ b/src/desktop/metadata/dashboards.test.ts
@@ -1,5 +1,9 @@
 import { wellFormedXmlRule } from '../validation/rules/wellFormedXml.js';
-import { extractDashboardXml, listWorkbookDashboards } from './dashboards.js';
+import {
+  dashboardDocumentToFragment,
+  extractDashboardXml,
+  listWorkbookDashboards,
+} from './dashboards.js';
 
 // Same shape as the worksheet regression (sheets.test.ts): the <workbook> root declares
 // xmlns:user, and a zone's filter carries a user:-prefixed attribute. The declaration lives on
@@ -53,6 +57,34 @@ describe('extractDashboardXml', () => {
     const xml = extractDashboardXml(workbookWithConflict, 'q');
     expect(xml).toContain('http://example.com/already-declared');
     expect(xml).not.toContain('http://www.tableausoftware.com/xml/user');
+  });
+});
+
+describe('dashboardDocumentToFragment', () => {
+  // The live per-dashboard /document route returns a whole <workbook>, not a bare fragment.
+  const WORKBOOK_WITH_DASHBOARD = `<?xml version='1.0' encoding='utf-8' ?>
+<workbook xmlns:user='http://www.tableausoftware.com/xml/user'>
+  <dashboards>
+    <dashboard name='Executive Dashboard'><zones /></dashboard>
+  </dashboards>
+</workbook>`;
+
+  it('slices the requested dashboard out of a whole-workbook document', () => {
+    const xml = dashboardDocumentToFragment(WORKBOOK_WITH_DASHBOARD, 'Executive Dashboard');
+    expect(xml).not.toBeNull();
+    expect(xml).toContain('name="Executive Dashboard"');
+    expect(xml).not.toContain('<workbook');
+  });
+
+  it('returns a document that is already a bare <dashboard> fragment unchanged', () => {
+    const fragment = '<dashboard name="Solo"><zones /></dashboard>';
+    expect(dashboardDocumentToFragment(fragment, 'Solo')).toBe(fragment);
+  });
+
+  it('returns null when the document contains no dashboard', () => {
+    expect(
+      dashboardDocumentToFragment('<workbook><dashboards /></workbook>', 'Missing'),
+    ).toBeNull();
   });
 });
 

--- a/src/desktop/metadata/dashboards.ts
+++ b/src/desktop/metadata/dashboards.ts
@@ -178,6 +178,20 @@ export function extractDashboardXml(workbookXml: string, dashboardName: string):
   return serializeXML({ dashboard });
 }
 
+// The External Client API per-dashboard `/document` route returns a whole `<workbook>` scoped to
+// the requested dashboard, but callers require a single `<dashboard>` fragment. Slice it out. A
+// document that is already a bare `<dashboard>` fragment is returned unchanged; null if absent.
+export function dashboardDocumentToFragment(
+  documentXml: string,
+  dashboardName: string,
+): string | null {
+  const fragment = extractDashboardXml(documentXml, dashboardName);
+  if (fragment !== null) {
+    return fragment;
+  }
+  return parseXML(documentXml).dashboard ? documentXml : null;
+}
+
 // Builds a whole-workbook document carrying only the one edited dashboard (and its window).
 // The workbook POST upserts by name: it overwrites the colliding live dashboard and leaves the
 // rest of the live workbook untouched. Worksheets are stripped from the doc — they stay live and

--- a/src/desktop/metadata/dashboards.ts
+++ b/src/desktop/metadata/dashboards.ts
@@ -192,11 +192,12 @@ export function dashboardDocumentToFragment(
   return parseXML(documentXml).dashboard ? documentXml : null;
 }
 
-// Builds a whole-workbook document carrying only the one edited dashboard (and its window).
-// The workbook POST upserts by name: it overwrites the colliding live dashboard and leaves the
-// rest of the live workbook untouched. Worksheets are stripped from the doc — they stay live and
-// the dashboard's zones still reference them by name — so the POST does not touch them at all.
-export function buildMinimalDashboardDoc(
+// The External Client API has no per-dashboard write route — applying one dashboard re-POSTs the
+// whole document, which Desktop treats as authoritative and replaces the open workbook with. So the
+// doc must carry the ENTIRE live workbook (worksheets included — the dashboard's zones reference
+// them by name) with only this dashboard swapped in; anything omitted would be pruned. Upsert by
+// name: replace the matching dashboard, or append it if absent. Windows are left intact.
+export function upsertDashboardIntoWorkbook(
   workbookXml: string,
   dashboardName: string,
   editedDashboardXml: string,
@@ -208,23 +209,17 @@ export function buildMinimalDashboardDoc(
     throw new Error(`Edited XML does not contain a <dashboard name="${dashboardName}">`);
   }
 
-  if (workbook.workbook?.dashboards) {
-    workbook.workbook.dashboards.dashboard = editedDashboard;
-  }
+  if (!workbook.workbook) workbook.workbook = {};
+  if (!workbook.workbook.dashboards) workbook.workbook.dashboards = {};
 
-  if (workbook.workbook?.windows) {
-    const windows = normalizeArray(workbook.workbook.windows.window);
-    const targetWindow = windows.find(
-      (win) => win['@_class'] === 'dashboard' && win['@_name'] === dashboardName,
-    );
-    if (targetWindow) {
-      workbook.workbook.windows.window = targetWindow;
-    } else {
-      delete workbook.workbook.windows.window;
-    }
+  const dashboards = normalizeArray(workbook.workbook.dashboards.dashboard);
+  const index = dashboards.findIndex((db) => db['@_name'] === dashboardName);
+  if (index === -1) {
+    dashboards.push(editedDashboard);
+  } else {
+    dashboards[index] = editedDashboard;
   }
-
-  delete workbook.workbook?.worksheets;
+  workbook.workbook.dashboards.dashboard = dashboards.length === 1 ? dashboards[0] : dashboards;
 
   return serializeXML(workbook);
 }

--- a/src/desktop/metadata/parser.ts
+++ b/src/desktop/metadata/parser.ts
@@ -12,7 +12,10 @@ const parserOptions = {
   removeNSPrefix: false,
   parseTagValue: false,
   parseNodeValue: false,
-  trimValues: true,
+  // Preserve text whitespace: workbook <run> nodes (formatted titles/tooltips) carry
+  // significant leading/trailing spaces, and a single-sheet apply re-serializes the whole
+  // workbook — trimming would silently corrupt that text on untouched sibling sheets.
+  trimValues: false,
   parseTrueNumberOnly: false,
   arrayMode: false,
   alwaysCreateTextNode: false,

--- a/src/desktop/metadata/sheets.test.ts
+++ b/src/desktop/metadata/sheets.test.ts
@@ -136,6 +136,23 @@ describe('upsertSheetIntoWorkbook', () => {
     const edited = "<worksheet name='Wrong'><table /></worksheet>";
     expect(() => upsertSheetIntoWorkbook(LIVE_WORKBOOK, 'Sheet 1', edited)).toThrow();
   });
+
+  it('preserves whitespace-significant run text on an untouched sibling sheet', () => {
+    // A single-sheet apply re-serializes the whole workbook. A sibling's formatted <run> text with
+    // significant leading/trailing spaces must survive verbatim — trimming corrupts titles/tooltips.
+    const workbook = `<?xml version='1.0' encoding='utf-8' ?>
+<workbook>
+  <worksheets>
+    <worksheet name='Edited'><table><old /></table></worksheet>
+    <worksheet name='Sibling'><table><formatted-text><run>Sales: </run><run>  $1.2M</run></formatted-text></table></worksheet>
+  </worksheets>
+</workbook>`;
+    const edited = "<worksheet name='Edited'><table><new /></table></worksheet>";
+    const doc = upsertSheetIntoWorkbook(workbook, 'Edited', edited);
+
+    expect(doc).toContain('<run>Sales: </run>');
+    expect(doc).toContain('<run>  $1.2M</run>');
+  });
 });
 
 describe('listSheets', () => {

--- a/src/desktop/metadata/sheets.test.ts
+++ b/src/desktop/metadata/sheets.test.ts
@@ -1,5 +1,11 @@
 import { wellFormedXmlRule } from '../validation/rules/wellFormedXml.js';
-import { addSheet, deleteSheet, extractSheetXml, listSheets } from './sheets.js';
+import {
+  addSheet,
+  deleteSheet,
+  extractSheetXml,
+  listSheets,
+  worksheetDocumentToFragment,
+} from './sheets.js';
 
 // Real-world shape: the <workbook> root declares xmlns:user, and a worksheet's level-members
 // filter carries a user:-prefixed attribute (confirmed pattern, see refineWorksheet.test.ts).
@@ -58,6 +64,35 @@ describe('extractSheetXml', () => {
     const xml = extractSheetXml(workbookWithConflict, 'q');
     expect(xml).toContain('http://example.com/already-declared');
     expect(xml).not.toContain('http://www.tableausoftware.com/xml/user');
+  });
+});
+
+describe('worksheetDocumentToFragment', () => {
+  // The live per-sheet /document route returns a whole <workbook> carrying every sheet, not a bare
+  // fragment. The helper must slice out only the requested sheet.
+  const WORKBOOK_WITH_TWO_SHEETS = `<?xml version='1.0' encoding='utf-8' ?>
+<workbook xmlns:user='http://www.tableausoftware.com/xml/user'>
+  <worksheets>
+    <worksheet name='Sales by Region'><table /></worksheet>
+    <worksheet name='Profit by Category'><table /></worksheet>
+  </worksheets>
+</workbook>`;
+
+  it('slices the requested sheet out of a whole-workbook document, excluding siblings', () => {
+    const xml = worksheetDocumentToFragment(WORKBOOK_WITH_TWO_SHEETS, 'Sales by Region');
+    expect(xml).not.toBeNull();
+    expect(xml).toContain('name="Sales by Region"');
+    expect(xml).not.toContain('<workbook');
+    expect(xml).not.toContain('Profit by Category');
+  });
+
+  it('returns a document that is already a bare <worksheet> fragment unchanged', () => {
+    const fragment = '<worksheet name="Solo"><table /></worksheet>';
+    expect(worksheetDocumentToFragment(fragment, 'Solo')).toBe(fragment);
+  });
+
+  it('returns null when the document contains no worksheet', () => {
+    expect(worksheetDocumentToFragment('<workbook><worksheets /></workbook>', 'Missing')).toBeNull();
   });
 });
 

--- a/src/desktop/metadata/sheets.test.ts
+++ b/src/desktop/metadata/sheets.test.ts
@@ -4,6 +4,7 @@ import {
   deleteSheet,
   extractSheetXml,
   listSheets,
+  upsertSheetIntoWorkbook,
   worksheetDocumentToFragment,
 } from './sheets.js';
 
@@ -92,7 +93,48 @@ describe('worksheetDocumentToFragment', () => {
   });
 
   it('returns null when the document contains no worksheet', () => {
-    expect(worksheetDocumentToFragment('<workbook><worksheets /></workbook>', 'Missing')).toBeNull();
+    expect(
+      worksheetDocumentToFragment('<workbook><worksheets /></workbook>', 'Missing'),
+    ).toBeNull();
+  });
+});
+
+describe('upsertSheetIntoWorkbook', () => {
+  // The External Client API POST replaces the open workbook wholesale, so the posted doc must carry
+  // the entire live workbook with only the target sheet swapped in — siblings and dashboards intact.
+  const LIVE_WORKBOOK = `<?xml version='1.0' encoding='utf-8' ?>
+<workbook xmlns:user='http://www.tableausoftware.com/xml/user'>
+  <worksheets>
+    <worksheet name='Sheet 1'><table><old /></table></worksheet>
+    <worksheet name='Sheet 2'><table /></worksheet>
+  </worksheets>
+  <dashboards>
+    <dashboard name='Dashboard 1'><zones /></dashboard>
+  </dashboards>
+</workbook>`;
+
+  it('replaces the target sheet while preserving siblings and dashboards', () => {
+    const edited = "<worksheet name='Sheet 1'><table><new /></table></worksheet>";
+    const doc = upsertSheetIntoWorkbook(LIVE_WORKBOOK, 'Sheet 1', edited);
+
+    expect(doc).toContain('<new');
+    expect(doc).not.toContain('<old');
+    expect(doc).toContain('name="Sheet 2"');
+    expect(doc).toContain('name="Dashboard 1"');
+    expect(listSheets(doc)).toEqual(['Sheet 1', 'Sheet 2']);
+  });
+
+  it('appends a brand-new sheet, keeping the existing ones', () => {
+    const edited = "<worksheet name='Sheet 3'><table /></worksheet>";
+    const doc = upsertSheetIntoWorkbook(LIVE_WORKBOOK, 'Sheet 3', edited);
+
+    expect(listSheets(doc)).toEqual(['Sheet 1', 'Sheet 2', 'Sheet 3']);
+    expect(doc).toContain('name="Dashboard 1"');
+  });
+
+  it('throws when the edited XML does not carry a <worksheet> with the given name', () => {
+    const edited = "<worksheet name='Wrong'><table /></worksheet>";
+    expect(() => upsertSheetIntoWorkbook(LIVE_WORKBOOK, 'Sheet 1', edited)).toThrow();
   });
 });
 

--- a/src/desktop/metadata/sheets.ts
+++ b/src/desktop/metadata/sheets.ts
@@ -142,10 +142,12 @@ export function worksheetDocumentToFragment(documentXml: string, sheetName: stri
   return parseXML(documentXml).worksheet ? documentXml : null;
 }
 
-// Builds a whole-workbook document carrying only the one edited worksheet (and its window).
-// The workbook POST upserts by name: it overwrites the colliding live sheet and, because the
-// doc carries no other sheets, leaves the rest of the live workbook untouched.
-export function buildMinimalSheetDoc(
+// The External Client API has no per-sheet write route — applying one sheet re-POSTs the whole
+// document, which Desktop treats as authoritative and replaces the open workbook with. So the doc
+// must carry the ENTIRE live workbook with only this sheet swapped in; anything omitted (sibling
+// sheets, dashboards) would be pruned. Upsert by name: replace the matching worksheet, or append
+// it if absent (a new sheet). Windows are left intact so every sheet keeps its own.
+export function upsertSheetIntoWorkbook(
   workbookXml: string,
   sheetName: string,
   editedWorksheetXml: string,
@@ -157,23 +159,17 @@ export function buildMinimalSheetDoc(
     throw new Error(`Edited XML does not contain a <worksheet name="${sheetName}">`);
   }
 
-  if (workbook.workbook?.worksheets) {
-    workbook.workbook.worksheets.worksheet = editedWorksheet;
-  }
+  if (!workbook.workbook) workbook.workbook = {};
+  if (!workbook.workbook.worksheets) workbook.workbook.worksheets = {};
 
-  if (workbook.workbook?.windows) {
-    const windows = normalizeArray(workbook.workbook.windows.window);
-    const targetWindow = windows.find(
-      (win) => win['@_class'] === 'worksheet' && win['@_name'] === sheetName,
-    );
-    if (targetWindow) {
-      workbook.workbook.windows.window = targetWindow;
-    } else {
-      delete workbook.workbook.windows.window;
-    }
+  const worksheets = normalizeArray(workbook.workbook.worksheets.worksheet);
+  const index = worksheets.findIndex((ws) => ws['@_name'] === sheetName);
+  if (index === -1) {
+    worksheets.push(editedWorksheet);
+  } else {
+    worksheets[index] = editedWorksheet;
   }
-
-  delete workbook.workbook?.dashboards;
+  workbook.workbook.worksheets.worksheet = worksheets.length === 1 ? worksheets[0] : worksheets;
 
   return serializeXML(workbook);
 }

--- a/src/desktop/metadata/sheets.ts
+++ b/src/desktop/metadata/sheets.ts
@@ -131,6 +131,17 @@ export function extractSheetXml(workbookXml: string, sheetName: string): string 
   return serializeXML({ worksheet });
 }
 
+// The External Client API per-sheet `/document` route returns a whole `<workbook>` scoped to the
+// requested sheet, but callers require a single `<worksheet>` fragment. Slice it out. A document
+// that is already a bare `<worksheet>` fragment is returned unchanged; null if no worksheet exists.
+export function worksheetDocumentToFragment(documentXml: string, sheetName: string): string | null {
+  const fragment = extractSheetXml(documentXml, sheetName);
+  if (fragment !== null) {
+    return fragment;
+  }
+  return parseXML(documentXml).worksheet ? documentXml : null;
+}
+
 // Builds a whole-workbook document carrying only the one edited worksheet (and its window).
 // The workbook POST upserts by name: it overwrites the colliding live sheet and, because the
 // doc carries no other sheets, leaves the rest of the live workbook untouched.

--- a/src/tools/desktop/coordination/batchCreateAndCacheSheets.test.ts
+++ b/src/tools/desktop/coordination/batchCreateAndCacheSheets.test.ts
@@ -16,9 +16,9 @@ vi.mock('fs');
 
 import { writeFileSync } from 'fs';
 
-import { getDashboardXml } from '../../../desktop/commands/workbook/getDashboardXml.js';
+import { getDashboardFragment } from '../../../desktop/commands/workbook/getDashboardXml.js';
 import { getWorkbookXml } from '../../../desktop/commands/workbook/getWorkbookXml.js';
-import { getWorksheetXml } from '../../../desktop/commands/workbook/getWorksheetXml.js';
+import { getWorksheetFragment } from '../../../desktop/commands/workbook/getWorksheetXml.js';
 import { loadWorkbookXml } from '../../../desktop/commands/workbook/loadWorkbookXml.js';
 import { addDashboard, addSheet } from '../../../desktop/metadata/index.js';
 import { deflectionText } from '../../../desktop/route/route-gate.js';
@@ -40,8 +40,8 @@ function makeExtra(): TableauDesktopRequestHandlerExtra {
   vi.mocked(addSheet).mockReturnValue(WORKBOOK_XML);
   vi.mocked(addDashboard).mockReturnValue(WORKBOOK_XML);
   vi.mocked(loadWorkbookXml).mockResolvedValue(new Ok({ validationWarnings: [] }));
-  vi.mocked(getWorksheetXml).mockResolvedValue(new Ok(WORKSHEET_XML));
-  vi.mocked(getDashboardXml).mockResolvedValue(new Ok(DASHBOARD_XML));
+  vi.mocked(getWorksheetFragment).mockResolvedValue(new Ok(WORKSHEET_XML));
+  vi.mocked(getDashboardFragment).mockResolvedValue(new Ok(DASHBOARD_XML));
   vi.mocked(writeFileSync).mockImplementation(() => {});
   return extra;
 }
@@ -127,7 +127,7 @@ describe('batchCreateAndCacheSheetsTool', () => {
 
   it('should include warnings in the result when worksheet fetch fails', async () => {
     const extra = makeExtra();
-    vi.mocked(getWorksheetXml).mockResolvedValue(
+    vi.mocked(getWorksheetFragment).mockResolvedValue(
       new Err({
         type: 'get-worksheet-xml-error',
         error: { type: 'no-worksheet-found' as const, message: 'Not found' },

--- a/src/tools/desktop/coordination/batchCreateAndCacheSheets.ts
+++ b/src/tools/desktop/coordination/batchCreateAndCacheSheets.ts
@@ -5,9 +5,9 @@ import { z } from 'zod';
 
 import { DesktopCache } from '../../../desktop/cache.js';
 import { writeSidecar } from '../../../desktop/commands/workbook/cacheFingerprint.js';
-import { getDashboardXml } from '../../../desktop/commands/workbook/getDashboardXml.js';
+import { getDashboardFragment } from '../../../desktop/commands/workbook/getDashboardXml.js';
 import { getWorkbookXml } from '../../../desktop/commands/workbook/getWorkbookXml.js';
-import { getWorksheetXml } from '../../../desktop/commands/workbook/getWorksheetXml.js';
+import { getWorksheetFragment } from '../../../desktop/commands/workbook/getWorksheetXml.js';
 import { loadWorkbookXml } from '../../../desktop/commands/workbook/loadWorkbookXml.js';
 import { currentEpisodeId, emitEpisodeEvent } from '../../../desktop/episode-events.js';
 import { addDashboard, addSheet } from '../../../desktop/metadata/index.js';
@@ -133,7 +133,7 @@ export const getBatchCreateAndCacheSheetsTool = (
           const worksheetFiles: Record<string, string> = {};
           const worksheetWarnings: string[] = [];
           for (const name of worksheetNames) {
-            const wsResult = await getWorksheetXml({ worksheetName: name, executor, signal });
+            const wsResult = await getWorksheetFragment({ worksheetName: name, executor, signal });
             if (wsResult.isErr()) {
               const { type, error } = wsResult.error;
               if (type === 'get-worksheet-xml-error') {
@@ -152,7 +152,7 @@ export const getBatchCreateAndCacheSheetsTool = (
 
           // Fetch and cache the dashboard working copy.
           let dashboardFile: string | null = null;
-          const dashResult = await getDashboardXml({ dashboardName, executor, signal });
+          const dashResult = await getDashboardFragment({ dashboardName, executor, signal });
           if (dashResult.isErr()) {
             const { type, error } = dashResult.error;
             if (type === 'get-dashboard-xml-error') {

--- a/src/tools/desktop/dashboard/getDashboardXml.test.ts
+++ b/src/tools/desktop/dashboard/getDashboardXml.test.ts
@@ -52,7 +52,7 @@ describe('getDashboardXmlTool', () => {
 
   it('should return dashboard XML inline when mode is inline', async () => {
     const mockXml = '<dashboard name="Sales Dashboard"><zones></zones></dashboard>';
-    vi.spyOn(getDashboardXmlModule, 'getDashboardXml').mockResolvedValue(Ok(mockXml));
+    vi.spyOn(getDashboardXmlModule, 'getDashboardFragment').mockResolvedValue(Ok(mockXml));
 
     const result = await getToolResult({ dashboardName: 'Sales Dashboard', mode: 'inline' });
 
@@ -67,7 +67,7 @@ describe('getDashboardXmlTool', () => {
 
   it('should write to file and return path when mode is file', async () => {
     const mockXml = '<dashboard name="Sales Dashboard"><zones></zones></dashboard>';
-    vi.spyOn(getDashboardXmlModule, 'getDashboardXml').mockResolvedValue(Ok(mockXml));
+    vi.spyOn(getDashboardXmlModule, 'getDashboardFragment').mockResolvedValue(Ok(mockXml));
 
     const result = await getToolResult({ dashboardName: 'Sales Dashboard', mode: 'file' });
 
@@ -88,7 +88,7 @@ describe('getDashboardXmlTool', () => {
         error: { code: 'ERROR', message: 'Network error', recoverable: false },
       },
     };
-    vi.spyOn(getDashboardXmlModule, 'getDashboardXml').mockResolvedValue(Err(error));
+    vi.spyOn(getDashboardXmlModule, 'getDashboardFragment').mockResolvedValue(Err(error));
 
     const result = await getToolResult({ dashboardName: 'Sales Dashboard', mode: 'inline' });
 
@@ -105,7 +105,7 @@ describe('getDashboardXmlTool', () => {
         message: 'No dashboard found for "Sales Dashboard".',
       },
     };
-    vi.spyOn(getDashboardXmlModule, 'getDashboardXml').mockResolvedValue(Err(error));
+    vi.spyOn(getDashboardXmlModule, 'getDashboardFragment').mockResolvedValue(Err(error));
 
     const result = await getToolResult({ dashboardName: 'Sales Dashboard', mode: 'inline' });
 
@@ -122,7 +122,7 @@ describe('getDashboardXmlTool', () => {
         message: '2 dashboards found instead of 1.',
       },
     };
-    vi.spyOn(getDashboardXmlModule, 'getDashboardXml').mockResolvedValue(Err(error));
+    vi.spyOn(getDashboardXmlModule, 'getDashboardFragment').mockResolvedValue(Err(error));
 
     const result = await getToolResult({ dashboardName: 'Sales Dashboard', mode: 'inline' });
 
@@ -131,9 +131,9 @@ describe('getDashboardXmlTool', () => {
     expect(result.content[0].text).toBe(new GetDashboardXmlFailedError(error.error).message);
   });
 
-  it('should pass the abort signal to getDashboardXml command', async () => {
+  it('should pass the abort signal to getDashboardFragment', async () => {
     const mockGetDashboardXml = vi
-      .spyOn(getDashboardXmlModule, 'getDashboardXml')
+      .spyOn(getDashboardXmlModule, 'getDashboardFragment')
       .mockResolvedValue(Ok('<dashboard name="Sales Dashboard"/>'));
 
     const customSignal = new AbortController().signal;
@@ -147,7 +147,7 @@ describe('getDashboardXmlTool', () => {
   it('forces file mode when inline XML exceeds the cap, regardless of requested mode', async () => {
     const overCapXml =
       '<dashboard name="Sales Dashboard"><zones>' + 'x'.repeat(20000) + '</zones></dashboard>';
-    vi.spyOn(getDashboardXmlModule, 'getDashboardXml').mockResolvedValue(Ok(overCapXml));
+    vi.spyOn(getDashboardXmlModule, 'getDashboardFragment').mockResolvedValue(Ok(overCapXml));
 
     const result = await getToolResult({ dashboardName: 'Sales Dashboard', mode: 'inline' });
 
@@ -165,7 +165,7 @@ describe('getDashboardXmlTool', () => {
   it('logs a cap-hit receipt when the cap fires', async () => {
     const logSpy = vi.spyOn(loggerModule, 'log').mockImplementation(() => {});
     const overCapXml = '<dashboard name="D"><zones>' + 'x'.repeat(20000) + '</zones></dashboard>';
-    vi.spyOn(getDashboardXmlModule, 'getDashboardXml').mockResolvedValue(Ok(overCapXml));
+    vi.spyOn(getDashboardXmlModule, 'getDashboardFragment').mockResolvedValue(Ok(overCapXml));
 
     await getToolResult({ dashboardName: 'D', mode: 'inline' });
 
@@ -179,7 +179,7 @@ describe('getDashboardXmlTool', () => {
 
   it('respects a smaller cap overridden via config', async () => {
     const smallXml = '<dashboard name="D"><zones/></dashboard>';
-    vi.spyOn(getDashboardXmlModule, 'getDashboardXml').mockResolvedValue(Ok(smallXml));
+    vi.spyOn(getDashboardXmlModule, 'getDashboardFragment').mockResolvedValue(Ok(smallXml));
 
     const result = await getToolResult({ dashboardName: 'D', mode: 'inline', capBytes: 8 });
 

--- a/src/tools/desktop/dashboard/getDashboardXml.ts
+++ b/src/tools/desktop/dashboard/getDashboardXml.ts
@@ -7,7 +7,7 @@ import { formatArtifactSummary } from '../../../desktop/artifactSummary.js';
 import { DesktopCache } from '../../../desktop/cache.js';
 import { writeSidecar } from '../../../desktop/commands/workbook/cacheFingerprint.js';
 import {
-  getDashboardXml,
+  getDashboardFragment,
   isRouteMissing,
 } from '../../../desktop/commands/workbook/getDashboardXml.js';
 import {
@@ -65,7 +65,11 @@ export const getGetDashboardXmlTool = (
           }
           const resolvedSession = sessionResult.value;
           const executor = await extra.getExecutor(resolvedSession);
-          const result = await getDashboardXml({ dashboardName, executor, signal: extra.signal });
+          const result = await getDashboardFragment({
+            dashboardName,
+            executor,
+            signal: extra.signal,
+          });
 
           if (result.isErr()) {
             const { type, error } = result.error;

--- a/src/tools/desktop/worksheet/getWorksheetXml.test.ts
+++ b/src/tools/desktop/worksheet/getWorksheetXml.test.ts
@@ -52,7 +52,7 @@ describe('getWorksheetXmlTool', () => {
 
   it('should return worksheet XML inline when mode is inline', async () => {
     const mockXml = '<worksheet name="Sheet 1"><table></table></worksheet>';
-    vi.spyOn(getWorksheetXmlModule, 'getWorksheetXml').mockResolvedValue(Ok(mockXml));
+    vi.spyOn(getWorksheetXmlModule, 'getWorksheetFragment').mockResolvedValue(Ok(mockXml));
 
     const result = await getToolResult({
       session: '12345',
@@ -71,7 +71,7 @@ describe('getWorksheetXmlTool', () => {
 
   it('should write to file and return path when mode is file', async () => {
     const mockXml = '<worksheet name="Sheet 1"><table></table></worksheet>';
-    vi.spyOn(getWorksheetXmlModule, 'getWorksheetXml').mockResolvedValue(Ok(mockXml));
+    vi.spyOn(getWorksheetXmlModule, 'getWorksheetFragment').mockResolvedValue(Ok(mockXml));
 
     const result = await getToolResult({
       session: '12345',
@@ -96,7 +96,7 @@ describe('getWorksheetXmlTool', () => {
         error: { code: 'ERROR', message: 'Network error', recoverable: false },
       },
     };
-    vi.spyOn(getWorksheetXmlModule, 'getWorksheetXml').mockResolvedValue(Err(error));
+    vi.spyOn(getWorksheetXmlModule, 'getWorksheetFragment').mockResolvedValue(Err(error));
 
     const result = await getToolResult({
       session: '12345',
@@ -114,7 +114,7 @@ describe('getWorksheetXmlTool', () => {
       type: 'get-worksheet-xml-error' as const,
       error: { type: 'no-worksheet-found' as const, message: 'No worksheet found for Sheet 1.' },
     };
-    vi.spyOn(getWorksheetXmlModule, 'getWorksheetXml').mockResolvedValue(Err(error));
+    vi.spyOn(getWorksheetXmlModule, 'getWorksheetFragment').mockResolvedValue(Err(error));
 
     const result = await getToolResult({
       session: '12345',
@@ -135,7 +135,7 @@ describe('getWorksheetXmlTool', () => {
         message: '3 worksheets found instead of 1.',
       },
     };
-    vi.spyOn(getWorksheetXmlModule, 'getWorksheetXml').mockResolvedValue(Err(error));
+    vi.spyOn(getWorksheetXmlModule, 'getWorksheetFragment').mockResolvedValue(Err(error));
 
     const result = await getToolResult({
       session: '12345',
@@ -148,9 +148,9 @@ describe('getWorksheetXmlTool', () => {
     expect(result.content[0].text).toBe(new GetWorksheetXmlFailedError(error.error).message);
   });
 
-  it('should pass the abort signal to getWorksheetXml command', async () => {
+  it('should pass the abort signal to getWorksheetFragment', async () => {
     const mockGetWorksheetXml = vi
-      .spyOn(getWorksheetXmlModule, 'getWorksheetXml')
+      .spyOn(getWorksheetXmlModule, 'getWorksheetFragment')
       .mockResolvedValue(Ok('<worksheet name="Sheet 1"/>'));
 
     const customSignal = new AbortController().signal;
@@ -172,7 +172,7 @@ describe('getWorksheetXmlTool', () => {
 
   it('forces file mode when inline XML exceeds the cap, regardless of requested mode', async () => {
     const overCapXml = '<worksheet name="Sales">' + 'x'.repeat(20000) + '</worksheet>';
-    vi.spyOn(getWorksheetXmlModule, 'getWorksheetXml').mockResolvedValue(Ok(overCapXml));
+    vi.spyOn(getWorksheetXmlModule, 'getWorksheetFragment').mockResolvedValue(Ok(overCapXml));
 
     const result = await getToolResult({
       session: '12345',
@@ -194,7 +194,7 @@ describe('getWorksheetXmlTool', () => {
   it('logs a cap-hit receipt when the cap fires', async () => {
     const logSpy = vi.spyOn(loggerModule, 'log').mockImplementation(() => {});
     const overCapXml = '<worksheet name="Sales">' + 'x'.repeat(20000) + '</worksheet>';
-    vi.spyOn(getWorksheetXmlModule, 'getWorksheetXml').mockResolvedValue(Ok(overCapXml));
+    vi.spyOn(getWorksheetXmlModule, 'getWorksheetFragment').mockResolvedValue(Ok(overCapXml));
 
     await getToolResult({ session: '12345', worksheetName: 'Sales', mode: 'inline' });
 
@@ -208,7 +208,7 @@ describe('getWorksheetXmlTool', () => {
 
   it('respects a smaller cap overridden via config', async () => {
     const smallXml = '<worksheet name="Sales"><a/></worksheet>';
-    vi.spyOn(getWorksheetXmlModule, 'getWorksheetXml').mockResolvedValue(Ok(smallXml));
+    vi.spyOn(getWorksheetXmlModule, 'getWorksheetFragment').mockResolvedValue(Ok(smallXml));
 
     const result = await getToolResult({
       session: '12345',

--- a/src/tools/desktop/worksheet/getWorksheetXml.ts
+++ b/src/tools/desktop/worksheet/getWorksheetXml.ts
@@ -7,7 +7,7 @@ import { formatArtifactSummary } from '../../../desktop/artifactSummary.js';
 import { DesktopCache } from '../../../desktop/cache.js';
 import { writeSidecar } from '../../../desktop/commands/workbook/cacheFingerprint.js';
 import {
-  getWorksheetXml,
+  getWorksheetFragment,
   isRouteMissing,
 } from '../../../desktop/commands/workbook/getWorksheetXml.js';
 import {
@@ -72,7 +72,11 @@ export const getGetWorksheetXmlTool = (
           }
           const resolvedSession = sessionResult.value;
           const executor = await extra.getExecutor(resolvedSession);
-          const result = await getWorksheetXml({ worksheetName, executor, signal: extra.signal });
+          const result = await getWorksheetFragment({
+            worksheetName,
+            executor,
+            signal: extra.signal,
+          });
 
           if (result.isErr()) {
             const { type, error } = result.error;

--- a/src/tools/desktop/worksheet/refineWorksheet.test.ts
+++ b/src/tools/desktop/worksheet/refineWorksheet.test.ts
@@ -104,8 +104,9 @@ interface MockOpts {
   readback?: 'echo' | 'source' | number;
 }
 
-const getMock = (): ReturnType<typeof vi.mocked<typeof getWorksheetXmlModule.getWorksheetXml>> =>
-  vi.mocked(getWorksheetXmlModule.getWorksheetXml);
+const getMock = (): ReturnType<
+  typeof vi.mocked<typeof getWorksheetXmlModule.getWorksheetFragment>
+> => vi.mocked(getWorksheetXmlModule.getWorksheetFragment);
 const loadMock = (): ReturnType<typeof vi.mocked<typeof loadWorksheetXmlModule.loadWorksheetXml>> =>
   vi.mocked(loadWorksheetXmlModule.loadWorksheetXml);
 

--- a/src/tools/desktop/worksheet/refineWorksheet.ts
+++ b/src/tools/desktop/worksheet/refineWorksheet.ts
@@ -15,7 +15,7 @@ import { setTimeout as setTimeoutPromise } from 'timers/promises';
 import { Ok } from 'ts-results-es';
 import { z } from 'zod';
 
-import { getWorksheetXml } from '../../../desktop/commands/workbook/getWorksheetXml.js';
+import { getWorksheetFragment } from '../../../desktop/commands/workbook/getWorksheetXml.js';
 import { loadWorksheetXml } from '../../../desktop/commands/workbook/loadWorksheetXml.js';
 import {
   confirmSortByFieldApplied,
@@ -155,7 +155,7 @@ export const getRefineWorksheetTool = (
           const executor = await extra.getExecutor(resolvedSession);
 
           // 1. ONE fetch of the target worksheet.
-          const fetched = await getWorksheetXml({
+          const fetched = await getWorksheetFragment({
             worksheetName,
             executor,
             signal: extra.signal,
@@ -264,7 +264,7 @@ export const getRefineWorksheetTool = (
           // after SUCCEEDED, so poll rather than trusting one immediate readback — the
           // first read can race the settle and still show pre-apply XML.
           for (let attempt = 1; attempt <= READBACK_POLL_MAX_ATTEMPTS; attempt++) {
-            const readback = await getWorksheetXml({
+            const readback = await getWorksheetFragment({
               worksheetName: canonicalWorksheetName,
               executor,
               signal: extra.signal,


### PR DESCRIPTION
Two related fixes for how the desktop server reads and writes single sheets/dashboards over the External Client API ("Athena V0"), whose only write route is the authoritative whole-workbook `POST /v0/workbook/document` (there is no per-sheet/per-dashboard write route).

## 1. Slice per-sheet/dashboard document reads to a fragment

The per-sheet and per-dashboard `GET .../document` routes return a whole `<workbook>` scoped to the requested item, not a bare fragment. Callers that feed that XML to apply-worksheet/apply-dashboard or a readback verifier need a single `<worksheet>`/`<dashboard>` fragment.

- **`getWorksheetFragment` / `getDashboardFragment`** — wrappers over the read gateway that slice the result to a single fragment (no-op for transports that already return one).
- **`worksheetDocumentToFragment` / `dashboardDocumentToFragment`** (`metadata/sheets.ts`, `metadata/dashboards.ts`) — slice a `<worksheet>`/`<dashboard>` out of a whole-workbook document; a bare fragment is returned unchanged, `null` if absent.
- Callers switched to the fragment getters: `loadWorksheetXml` readback, `batchCreateAndCacheSheets`, `refineWorksheet`, and the get-xml tools.

## 2. Apply by upserting into the whole live workbook (sibling-loss fix)

**Bug:** Applying one sheet/dashboard built a *minimal* whole-workbook doc — one element, siblings and the other type deleted — on the assumption the POST would "upsert by name and leave the rest live." That server-side upsert is gone: the POST now **replaces the open workbook wholesale**, so everything omitted from the minimal doc was pruned. Editing a worksheet wiped sibling sheets and all dashboards; editing a dashboard would have wiped every worksheet.

**Fix:** We already GET the whole live workbook before applying. Splice the edited element into that full document (replace-by-name, or append if new) and POST it, preserving everything else.

- `buildMinimalSheetDoc` → **`upsertSheetIntoWorkbook`**; `buildMinimalDashboardDoc` → **`upsertDashboardIntoWorkbook`**.
- Updated both callers (`loadWorksheetXml`, `loadDashboardXml`) and the tests that encoded the old "omits siblings" contract; added direct unit tests for both new functions.

## Testing

- Unit tests for both fragment getters and both upsert functions; affected suites green. `tsc --noEmit` and `eslint` clean.
- Verified live against Tableau Desktop (External Client API): refining a sheet with a sibling present, adding a new sheet, and refining a sheet with a dashboard + 2 other sheets present all preserve every sheet and the dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
