### PR TITLE
feat(binder): bind-recovery state machine — thrash protection for the two-call bind protocol

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "2.43.0",
+  "version": "2.44.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/src/desktop/route/route-state.test.ts
+++ b/src/desktop/route/route-state.test.ts
@@ -6,7 +6,12 @@
 
 import { beforeEach, describe, expect, it } from 'vitest';
 
-import { type RouteDeflection, sessionRouteState, SessionRouteStateStore } from './route-state.js';
+import {
+  type RouteDeflection,
+  serializeRouteReceipt,
+  sessionRouteState,
+  SessionRouteStateStore,
+} from './route-state.js';
 
 function mkDeflection(over: Partial<RouteDeflection> = {}): RouteDeflection {
   return {
@@ -258,6 +263,332 @@ describe('SessionRouteStateStore', () => {
       expect(store.clearCurrentAsk('S1')).toBe(false);
       expect(store.clearCurrentAsk('NOPE')).toBe(false);
       expect(store.clearCurrentAsk(undefined)).toBe(false);
+    });
+  });
+
+  describe('bind recovery state', () => {
+    it('records Call 1 propose then first proposal Call 2 without consuming retry budget', () => {
+      const store = new SessionRouteStateStore();
+
+      store.recordBindRecoveryAttempt('S1', 'ask A', { outcome: 'propose' });
+      store.recordBindRecoveryAttempt('S1', 'ask A', {
+        outcome: 'escalate',
+        proposalSignature: 'signature-1',
+      });
+
+      const record = store.getBindRecovery('S1', 'ask A')!;
+      expect(record.phase).toBe('proposal-attempted');
+      expect(record.lastProposalSignature).toBe('signature-1');
+      expect(record.attempts).toHaveLength(2);
+      expect(record.attempts.map((a) => a.outcome)).toEqual(['propose', 'escalate']);
+      expect(record.attempts.map((a) => a.consumesRetryBudget)).toEqual([false, false]);
+      expect(typeof record.attempts[0].ts).toBe('string');
+    });
+
+    it('marks a semantically changed proposal after Call 2 as the single consumed retry', () => {
+      const store = new SessionRouteStateStore();
+
+      store.recordBindRecoveryAttempt('S1', 'ask A', { outcome: 'propose' });
+      store.recordBindRecoveryAttempt('S1', 'ask A', {
+        outcome: 'escalate',
+        proposalSignature: 'signature-1',
+      });
+      store.recordBindRecoveryAttempt('S1', 'ask A', {
+        outcome: 'escalate',
+        proposalSignature: 'signature-2',
+      });
+
+      const record = store.getBindRecovery('S1', 'ask A')!;
+      expect(record.phase).toBe('retry-used');
+      expect(record.lastProposalSignature).toBe('signature-2');
+      expect(record.attempts.map((a) => a.consumesRetryBudget)).toEqual([false, false, true]);
+    });
+
+    it('clears a recovery entry when the bind reaches terminal done', () => {
+      const store = new SessionRouteStateStore();
+      store.recordBindRecoveryAttempt('S1', 'ask A', { outcome: 'propose' });
+
+      store.recordBindRecoveryAttempt('S1', 'ask A', { outcome: 'bound', terminal: true });
+
+      expect(store.getBindRecovery('S1', 'ask A')).toBeUndefined();
+    });
+
+    it('keeps bind recovery separate from current_ask scratch-gate state', () => {
+      const store = new SessionRouteStateStore();
+      store.recordAskClassification('S1', {
+        ask: 'ask A',
+        route: 'bind-first',
+        shape: 'bind-first-template',
+        template: 'ranking-ordered-bar',
+      });
+
+      store.recordBindRecoveryAttempt('S1', 'ask A', { outcome: 'propose' });
+
+      expect(store.get('S1')!.current_ask).toMatchObject({
+        ask: 'ask A',
+        last_outcome: null,
+      });
+      expect(store.getBindRecovery('S1', 'ask A')?.phase).toBe('awaiting-proposal');
+    });
+
+    it('evicts terminal recovery records before active records', () => {
+      const store = new SessionRouteStateStore();
+      const cap = SessionRouteStateStore.MAX_BIND_RECOVERY_ASKS;
+
+      for (let i = 0; i < cap; i++) {
+        store.recordBindRecoveryAttempt('S1', `ask-${i}`, { outcome: 'propose' });
+      }
+      store.recordBindRecoveryTerminal('S1', 'ask-1', {
+        outcome: 'escalate',
+        proposalSignature: 'signature-1',
+      });
+      store.recordBindRecoveryAttempt('S1', `ask-${cap}`, { outcome: 'propose' });
+
+      const state = store.get('S1')!;
+      expect(state.bindRecoveryByAsk.size).toBe(cap);
+      expect(store.getBindRecovery('S1', 'ask-0')).toBeDefined();
+      expect(store.getBindRecovery('S1', 'ask-1')).toBeUndefined();
+      expect(store.getBindRecovery('S1', `ask-${cap}`)).toBeDefined();
+    });
+
+    it('refreshes bind recovery recency on read', () => {
+      const store = new SessionRouteStateStore();
+      const cap = SessionRouteStateStore.MAX_BIND_RECOVERY_ASKS;
+
+      for (let i = 0; i < cap; i++) {
+        store.recordBindRecoveryTerminal('S1', `ask-${i}`, {
+          outcome: 'escalate',
+          proposalSignature: `signature-${i}`,
+        });
+      }
+
+      expect(store.getBindRecovery('S1', 'ask-0')).toBeDefined();
+      store.recordBindRecoveryAttempt('S1', `ask-${cap}`, { outcome: 'propose' });
+
+      expect(store.getBindRecovery('S1', 'ask-0')).toBeDefined();
+      expect(store.getBindRecovery('S1', 'ask-1')).toBeUndefined();
+      expect(store.getBindRecovery('S1', `ask-${cap}`)).toBeDefined();
+    });
+
+    it('refuses to create a ninth active recovery record instead of evicting an active ask', () => {
+      const store = new SessionRouteStateStore();
+      const cap = SessionRouteStateStore.MAX_BIND_RECOVERY_ASKS;
+
+      for (let i = 0; i < cap; i++) {
+        store.recordBindRecoveryAttempt('S1', `ask-${i}`, { outcome: 'propose' });
+      }
+      store.recordBindRecoveryAttempt('S1', `ask-${cap}`, { outcome: 'propose' });
+
+      expect(store.get('S1')!.bindRecoveryByAsk.size).toBe(cap);
+      for (let i = 0; i < cap; i++) {
+        expect(store.getBindRecovery('S1', `ask-${i}`)).toBeDefined();
+      }
+      expect(store.getBindRecovery('S1', `ask-${cap}`)).toBeUndefined();
+    });
+
+    it('reserves an admitted in-flight bind and upgrades it when the outcome arrives', () => {
+      const store = new SessionRouteStateStore();
+
+      store.recordBindRecoveryAttempt('S1', 'ask A', { outcome: 'propose' });
+      const reservationId = store.reserveBindRecoveryAdmission('S1', 'ask A', {
+        proposalSignature: 'signature-1',
+      });
+
+      expect(typeof reservationId).toBe('number');
+      expect(store.getBindRecovery('S1', 'ask A')).toMatchObject({
+        phase: 'proposal-attempted',
+        lastProposalSignature: 'signature-1',
+        attempts: [
+          { outcome: 'propose', consumesRetryBudget: false },
+          { proposalSignature: 'signature-1', consumesRetryBudget: false },
+        ],
+      });
+
+      store.recordBindRecoveryAttempt('S1', 'ask A', {
+        outcome: 'escalate',
+        proposalSignature: 'signature-1',
+        reservationId,
+      });
+
+      expect(store.getBindRecovery('S1', 'ask A')?.attempts).toMatchObject([
+        { outcome: 'propose', consumesRetryBudget: false },
+        { outcome: 'escalate', proposalSignature: 'signature-1', consumesRetryBudget: false },
+      ]);
+    });
+
+    it('upgrades concurrent different-signature reservations by reservation id without phantom pending attempts', () => {
+      const store = new SessionRouteStateStore();
+      store.recordAskClassification('S1', {
+        ask: 'ask A',
+        route: 'bind-first',
+        shape: 'bind-first-template',
+        template: 'ranking-ordered-bar',
+      });
+      store.recordBindRecoveryAttempt('S1', 'ask A', { outcome: 'propose' });
+
+      const firstReservationId = store.reserveBindRecoveryAdmission('S1', 'ask A', {
+        proposalSignature: 'signature-1',
+      });
+      const secondReservationId = store.reserveBindRecoveryAdmission('S1', 'ask A', {
+        proposalSignature: 'signature-2',
+      });
+
+      store.recordBindRecoveryAttempt('S1', 'ask A', {
+        outcome: 'escalate',
+        proposalSignature: 'signature-2',
+        reservationId: secondReservationId,
+      });
+      store.recordBindRecoveryAttempt('S1', 'ask A', {
+        outcome: 'escalate',
+        proposalSignature: 'signature-1',
+        reservationId: firstReservationId,
+      });
+
+      const record = store.getBindRecovery('S1', 'ask A')!;
+      expect(record.phase).toBe('retry-used');
+      expect(record.lastProposalSignature).toBe('signature-2');
+      expect(record.attempts).toMatchObject([
+        { outcome: 'propose', consumesRetryBudget: false },
+        { outcome: 'escalate', proposalSignature: 'signature-1', consumesRetryBudget: false },
+        { outcome: 'escalate', proposalSignature: 'signature-2', consumesRetryBudget: true },
+      ]);
+      expect(record.attempts.map((attempt) => attempt.outcome)).toEqual([
+        'propose',
+        'escalate',
+        'escalate',
+      ]);
+      expect(record.attempts.some((attempt) => attempt.outcome === undefined)).toBe(false);
+      expect(serializeRouteReceipt(store.get('S1'))?.bind_attempts).toEqual({
+        count: 3,
+        outcomes: ['propose', 'escalate', 'escalate'],
+        phase: 'retry-used',
+        retry_budget_consumed: 1,
+      });
+    });
+
+    it('flags uncorrelated reservation outcomes without duplicating an already-upgraded attempt', () => {
+      const store = new SessionRouteStateStore();
+      store.recordAskClassification('S1', {
+        ask: 'ask A',
+        route: 'bind-first',
+        shape: 'bind-first-template',
+        template: 'ranking-ordered-bar',
+      });
+      store.recordBindRecoveryAttempt('S1', 'ask A', { outcome: 'propose' });
+      const reservationId = store.reserveBindRecoveryAdmission('S1', 'ask A', {
+        proposalSignature: 'signature-1',
+      });
+
+      store.recordBindRecoveryAttempt('S1', 'ask A', {
+        outcome: 'escalate',
+        proposalSignature: 'signature-1',
+        reservationId,
+      });
+      store.recordBindRecoveryAttempt('S1', 'ask A', {
+        outcome: 'escalate',
+        proposalSignature: 'signature-1',
+        reservationId,
+      });
+
+      expect(store.getBindRecovery('S1', 'ask A')?.attempts).toMatchObject([
+        { outcome: 'propose' },
+        { outcome: 'escalate', proposalSignature: 'signature-1' },
+      ]);
+      expect(serializeRouteReceipt(store.get('S1'))?.bind_attempts).toEqual({
+        count: 2,
+        outcomes: ['propose', 'escalate'],
+        phase: 'proposal-attempted',
+        retry_budget_consumed: 0,
+        uncorrelated_outcomes: 1,
+      });
+    });
+
+    it('treats a late outcome for an evicted reservation as uncorrelated after recreation', () => {
+      const store = new SessionRouteStateStore();
+      store.recordAskClassification('S1', {
+        ask: 'ask A',
+        route: 'bind-first',
+        shape: 'bind-first-template',
+        template: 'ranking-ordered-bar',
+      });
+      store.recordBindRecoveryAttempt('S1', 'ask A', { outcome: 'propose' });
+      const staleReservationId = store.reserveBindRecoveryAdmission('S1', 'ask A', {
+        proposalSignature: 'stale-signature',
+      });
+      store.recordBindRecoveryAttempt('S1', 'ask A', { outcome: 'bound', terminal: true });
+
+      store.recordBindRecoveryAttempt('S1', 'ask A', { outcome: 'propose' });
+      const freshReservationId = store.reserveBindRecoveryAdmission('S1', 'ask A', {
+        proposalSignature: 'fresh-signature',
+      });
+      store.recordBindRecoveryAttempt('S1', 'ask A', {
+        outcome: 'escalate',
+        proposalSignature: 'stale-signature',
+        reservationId: staleReservationId,
+      });
+
+      expect(freshReservationId).not.toBe(staleReservationId);
+      const record = store.getBindRecovery('S1', 'ask A')!;
+      expect(record.attempts).toMatchObject([
+        { outcome: 'propose' },
+        { proposalSignature: 'fresh-signature' },
+      ]);
+      expect(record.attempts[1].outcome).toBeUndefined();
+      expect(serializeRouteReceipt(store.get('S1'))?.bind_attempts).toEqual({
+        count: 2,
+        outcomes: ['propose'],
+        phase: 'proposal-attempted',
+        retry_budget_consumed: 0,
+        uncorrelated_outcomes: 1,
+      });
+    });
+
+    it('reports retry budget consumed when a changed retry ends in terminal fallback', () => {
+      const store = new SessionRouteStateStore();
+      store.recordAskClassification('S1', {
+        ask: 'ask A',
+        route: 'bind-first',
+        shape: 'bind-first-template',
+        template: 'ranking-ordered-bar',
+      });
+      store.recordBindRecoveryAttempt('S1', 'ask A', { outcome: 'propose' });
+      store.recordBindRecoveryAttempt('S1', 'ask A', {
+        outcome: 'escalate',
+        proposalSignature: 'signature-1',
+      });
+      store.recordBindRecoveryTerminal('S1', 'ask A', {
+        outcome: 'escalate',
+        proposalSignature: 'signature-2',
+      });
+
+      expect(serializeRouteReceipt(store.get('S1'))?.bind_attempts).toEqual({
+        count: 3,
+        outcomes: ['propose', 'escalate', 'escalate'],
+        phase: 'terminal',
+        retry_budget_consumed: 1,
+      });
+    });
+
+    it('serializes recovery attempts for the current ask instead of hard-coding one outcome', () => {
+      const store = new SessionRouteStateStore();
+      store.recordAskClassification('S1', {
+        ask: 'ask A',
+        route: 'bind-first',
+        shape: 'bind-first-template',
+        template: 'ranking-ordered-bar',
+      });
+      store.recordBindRecoveryAttempt('S1', 'ask A', { outcome: 'propose' });
+      store.recordBindRecoveryAttempt('S1', 'ask A', {
+        outcome: 'escalate',
+        proposalSignature: 'signature-1',
+      });
+
+      expect(serializeRouteReceipt(store.get('S1'))?.bind_attempts).toEqual({
+        count: 2,
+        outcomes: ['propose', 'escalate'],
+        phase: 'proposal-attempted',
+        retry_budget_consumed: 0,
+      });
     });
   });
 });

--- a/src/desktop/route/route-state.test.ts
+++ b/src/desktop/route/route-state.test.ts
@@ -386,6 +386,50 @@ describe('SessionRouteStateStore', () => {
       expect(store.getBindRecovery('S1', `ask-${cap}`)).toBeUndefined();
     });
 
+    it('records capacity-rejected admissions as bounded unprotected pass-through receipts', () => {
+      const store = new SessionRouteStateStore();
+      const cap = SessionRouteStateStore.MAX_BIND_RECOVERY_ASKS;
+
+      for (let i = 0; i < cap; i++) {
+        expect(store.reserveBindRecoveryAdmission('S1', `ask-${i}`, {})).toEqual(
+          expect.any(Number),
+        );
+      }
+      for (let i = cap; i < cap + 5; i++) {
+        expect(store.reserveBindRecoveryAdmission('S1', `ask-${i}`, {})).toBeUndefined();
+      }
+
+      expect(store.get('S1')!.bindRecoveryByAsk.size).toBe(cap);
+      expect(serializeRouteReceipt(store.get('S1'))?.unprotected_passthroughs).toEqual({
+        count: 5,
+        last_asks: [`ask-${cap + 1}`, `ask-${cap + 2}`, `ask-${cap + 3}`, `ask-${cap + 4}`],
+      });
+    });
+
+    it('omits unprotected pass-through receipts when admission is accepted', () => {
+      const store = new SessionRouteStateStore();
+      store.recordAskClassification('S1', {
+        ask: 'ask A',
+        route: 'bind-first',
+        shape: 'bind-first-template',
+        template: 'ranking-ordered-bar',
+      });
+
+      expect(store.reserveBindRecoveryAdmission('S1', 'ask A', {})).toEqual(expect.any(Number));
+
+      expect(serializeRouteReceipt(store.get('S1'))).toEqual({
+        route: 'bind-first',
+        shape: 'bind-first-template',
+        template: 'ranking-ordered-bar',
+        bind_attempts: {
+          count: 1,
+          outcomes: [],
+          phase: 'awaiting-proposal',
+          retry_budget_consumed: 0,
+        },
+      });
+    });
+
     it('reserves an admitted in-flight bind and upgrades it when the outcome arrives', () => {
       const store = new SessionRouteStateStore();
 

--- a/src/desktop/route/route-state.ts
+++ b/src/desktop/route/route-state.ts
@@ -58,6 +58,45 @@ export interface RouteOverride {
 /** Terminal dispositions a bind-template call can produce (mirrors BinderResult.status). */
 export type BindOutcome = 'bound' | 'propose' | 'escalate';
 
+export type BindRecoveryPhase =
+  | 'awaiting-proposal'
+  | 'proposal-attempted'
+  | 'retry-used'
+  | 'terminal';
+
+export interface BindAttempt {
+  /** ISO timestamp the bind recovery observation was recorded. */
+  ts: string;
+  /** Store-scoped reservation id returned by admission; outcome recording uses it to correlate concurrency. */
+  reservationId?: number;
+  /** Absent while an admitted call is still in flight or failed before a binder outcome. */
+  outcome?: BindOutcome;
+  /** Canonical semantic signature for proposal-bearing calls. */
+  proposalSignature?: string;
+  /** True only for the single changed-proposal retry after the first proposal-bearing call. */
+  consumesRetryBudget: boolean;
+}
+
+export interface BindRecoveryRecord {
+  phase: BindRecoveryPhase;
+  attempts: BindAttempt[];
+  lastProposalSignature?: string;
+  /** Outcome records that could not be correlated to a live pending reservation. */
+  uncorrelatedOutcomeCount?: number;
+}
+
+export interface BindRecoveryAttemptInput {
+  outcome: BindOutcome;
+  proposalSignature?: string;
+  reservationId?: number;
+  /** Explicit terminal-done marker; callers use this only after final bind processing concludes. */
+  terminal?: boolean;
+}
+
+export interface BindRecoveryAdmissionInput {
+  proposalSignature?: string;
+}
+
 /**
  * The MOST RECENT ask bind-template classified for this session (most-recent-ask-wins).
  * `last_outcome` is null between classification and the concluded bind-template outcome.
@@ -81,6 +120,8 @@ export interface SessionRouteState {
   deflections: RouteDeflection[];
   /** Route overrides recorded for this session (one per (session, ask) post-deflection). */
   route_overrides: RouteOverride[];
+  /** Bounded per-ask bind recovery records, keyed by the same normalized ask as current_ask. */
+  bindRecoveryByAsk: Map<string, BindRecoveryRecord>;
   /** Most recent bind-template ask classification for this session, if any. */
   current_ask?: SessionAskClassification;
 }
@@ -89,7 +130,13 @@ export interface RouteReceipt {
   route?: RouteClass;
   shape?: AskShape;
   template?: string;
-  bind_attempts?: { count: number; outcomes: BindOutcome[] };
+  bind_attempts?: {
+    count: number;
+    outcomes: BindOutcome[];
+    phase?: BindRecoveryPhase;
+    retry_budget_consumed?: number;
+    uncorrelated_outcomes?: number;
+  };
   deflections?: Array<{
     tool: string;
     ts: string;
@@ -111,13 +158,30 @@ export function serializeRouteReceipt(
   if (!state) return undefined;
   const receipt: RouteReceipt = {};
   if (state.current_ask) {
+    const bindRecovery = state.bindRecoveryByAsk.get(state.current_ask.ask);
     receipt.route = state.current_ask.route;
     receipt.shape = state.current_ask.shape;
     receipt.template = state.current_ask.template ?? undefined;
-    receipt.bind_attempts = {
-      count: state.current_ask.last_outcome === null ? 0 : 1,
-      outcomes: state.current_ask.last_outcome === null ? [] : [state.current_ask.last_outcome],
-    };
+    if (bindRecovery) {
+      receipt.bind_attempts = {
+        count: bindRecovery.attempts.length,
+        outcomes: bindRecovery.attempts.flatMap((attempt) =>
+          attempt.outcome === undefined ? [] : [attempt.outcome],
+        ),
+        phase: bindRecovery.phase,
+        retry_budget_consumed: bindRecovery.attempts.filter(
+          (attempt) => attempt.consumesRetryBudget,
+        ).length,
+        ...(bindRecovery.uncorrelatedOutcomeCount
+          ? { uncorrelated_outcomes: bindRecovery.uncorrelatedOutcomeCount }
+          : {}),
+      };
+    } else {
+      receipt.bind_attempts = {
+        count: state.current_ask.last_outcome === null ? 0 : 1,
+        outcomes: state.current_ask.last_outcome === null ? [] : [state.current_ask.last_outcome],
+      };
+    }
   }
   if (state.deflections.length > 0) {
     receipt.deflections = state.deflections.map((deflection) => ({
@@ -142,6 +206,8 @@ export function serializeRouteReceipt(
 export class SessionRouteStateStore {
   private bySession = new Map<string, SessionRouteState>();
 
+  private nextBindRecoveryReservationId = 0;
+
   /**
    * Safety cap on retained session states. A long-lived server that never sees an
    * end-of-session signal would otherwise leak; keeping only the newest ~500 states bounds
@@ -157,10 +223,18 @@ export class SessionRouteStateStore {
    */
   static readonly MAX_ENTRIES_PER_SESSION = 200;
 
+  /** Per-session LRU cap for bind recovery records. */
+  static readonly MAX_BIND_RECOVERY_ASKS = 8;
+
   private ensure(sessionId: string): SessionRouteState {
     let state = this.bySession.get(sessionId);
     if (!state) {
-      state = { session_id: sessionId, deflections: [], route_overrides: [] };
+      state = {
+        session_id: sessionId,
+        deflections: [],
+        route_overrides: [],
+        bindRecoveryByAsk: new Map(),
+      };
       this.bySession.set(sessionId, state);
       while (this.bySession.size > SessionRouteStateStore.MAX_STATES) {
         const oldest = this.bySession.keys().next().value;
@@ -169,6 +243,39 @@ export class SessionRouteStateStore {
       }
     }
     return state;
+  }
+
+  private isActiveBindRecovery(record: BindRecoveryRecord): boolean {
+    return record.phase !== 'terminal';
+  }
+
+  private touchBindRecovery(
+    state: SessionRouteState,
+    ask: string,
+    record: BindRecoveryRecord,
+  ): boolean {
+    state.bindRecoveryByAsk.delete(ask);
+    state.bindRecoveryByAsk.set(ask, record);
+    while (state.bindRecoveryByAsk.size > SessionRouteStateStore.MAX_BIND_RECOVERY_ASKS) {
+      const terminalAsk = [...state.bindRecoveryByAsk.entries()].find(
+        ([candidateAsk, candidateRecord]) =>
+          candidateAsk !== ask && !this.isActiveBindRecovery(candidateRecord),
+      )?.[0];
+      if (terminalAsk !== undefined) {
+        state.bindRecoveryByAsk.delete(terminalAsk);
+        continue;
+      }
+
+      const selfIsTerminal = !this.isActiveBindRecovery(record);
+      if (selfIsTerminal) {
+        state.bindRecoveryByAsk.delete(ask);
+        return false;
+      }
+
+      state.bindRecoveryByAsk.delete(ask);
+      return false;
+    }
+    return true;
   }
 
   /** Route state for a session, if any. Undefined for an unknown/absent id (no-op). */
@@ -190,6 +297,252 @@ export class SessionRouteStateStore {
   hasOverride(sessionId: string | undefined, ask: string): boolean {
     const state = this.get(sessionId);
     return !!state && state.route_overrides.some((o) => o.ask === ask);
+  }
+
+  /** Bind recovery record for a session/normalized-ask pair, if retained. */
+  getBindRecovery(sessionId: string | undefined, ask: string): BindRecoveryRecord | undefined {
+    const state = this.get(sessionId);
+    const record = state?.bindRecoveryByAsk.get(ask);
+    if (state && record) {
+      this.touchBindRecovery(state, ask, record);
+    }
+    return record;
+  }
+
+  private classifyBindRecoveryPhase(
+    previous: BindRecoveryRecord | undefined,
+    proposalSignature: string | undefined,
+  ): Pick<BindAttempt, 'consumesRetryBudget'> & { phase: BindRecoveryPhase } {
+    const hasProposal = proposalSignature !== undefined;
+    const priorProposalSignature = previous?.lastProposalSignature;
+    const changedProposal =
+      hasProposal &&
+      priorProposalSignature !== undefined &&
+      priorProposalSignature !== proposalSignature;
+
+    const consumesRetryBudget = previous?.phase === 'proposal-attempted' && changedProposal;
+    const phase: BindRecoveryPhase = !hasProposal
+      ? 'awaiting-proposal'
+      : consumesRetryBudget || previous?.phase === 'retry-used'
+        ? 'retry-used'
+        : 'proposal-attempted';
+
+    return { phase, consumesRetryBudget };
+  }
+
+  private withLastProposalSignature(
+    previous: BindRecoveryRecord | undefined,
+    proposalSignature: string | undefined,
+  ): Pick<BindRecoveryRecord, 'lastProposalSignature'> {
+    if (proposalSignature !== undefined) return { lastProposalSignature: proposalSignature };
+    if (previous?.lastProposalSignature !== undefined) {
+      return { lastProposalSignature: previous.lastProposalSignature };
+    }
+    return {};
+  }
+
+  private upgradesLastReservation(
+    previous: BindRecoveryRecord | undefined,
+    proposalSignature: string | undefined,
+  ): boolean {
+    const lastAttempt = previous?.attempts.at(-1);
+    return (
+      lastAttempt !== undefined &&
+      lastAttempt.outcome === undefined &&
+      lastAttempt.proposalSignature === proposalSignature
+    );
+  }
+
+  private upgradeReservedAttempt(
+    previous: BindRecoveryRecord | undefined,
+    reservationId: number,
+    bindAttempt: BindAttempt & { outcome: BindOutcome },
+  ): { attempts: BindAttempt[]; uncorrelated: boolean } {
+    const previousAttempts = previous?.attempts ?? [];
+    const reservedAttemptIndex = previousAttempts.findIndex(
+      (attempt) => attempt.reservationId === reservationId,
+    );
+    if (reservedAttemptIndex === -1) {
+      return {
+        attempts: previousAttempts,
+        uncorrelated: true,
+      };
+    }
+    const reservedAttempt = previousAttempts[reservedAttemptIndex];
+    if (reservedAttempt.outcome !== undefined) {
+      return {
+        attempts: previousAttempts,
+        uncorrelated: true,
+      };
+    }
+
+    const attempts = previousAttempts.slice();
+    attempts[reservedAttemptIndex] = {
+      ...reservedAttempt,
+      outcome: bindAttempt.outcome,
+    };
+    return { attempts, uncorrelated: false };
+  }
+
+  private upgradeOrAppendAttempt(
+    previous: BindRecoveryRecord | undefined,
+    proposalSignature: string | undefined,
+    bindAttempt: BindAttempt & { outcome: BindOutcome },
+  ): BindAttempt[] {
+    if (!this.upgradesLastReservation(previous, proposalSignature)) {
+      return [...(previous?.attempts ?? []), bindAttempt];
+    }
+    const previousAttempts = previous?.attempts ?? [];
+    const lastAttempt = previousAttempts.at(-1);
+    if (!lastAttempt) return [bindAttempt];
+    return [...previousAttempts.slice(0, -1), { ...lastAttempt, outcome: bindAttempt.outcome }];
+  }
+
+  private withUncorrelatedOutcomeCount(
+    previous: BindRecoveryRecord | undefined,
+    uncorrelated: boolean,
+  ): Pick<BindRecoveryRecord, 'uncorrelatedOutcomeCount'> {
+    const count = (previous?.uncorrelatedOutcomeCount ?? 0) + (uncorrelated ? 1 : 0);
+    return count > 0 ? { uncorrelatedOutcomeCount: count } : {};
+  }
+
+  /**
+   * Atomically admit a bind recovery call before any downstream work. The reservation itself
+   * enforces in-flight duplicate blocking; later outcome recording upgrades this reservation id.
+   */
+  reserveBindRecoveryAdmission(
+    sessionId: string | undefined,
+    ask: string,
+    admission: BindRecoveryAdmissionInput,
+  ): number | undefined {
+    if (!sessionId) return undefined;
+    const state = this.ensure(sessionId);
+    const previous = state.bindRecoveryByAsk.get(ask);
+    const { phase, consumesRetryBudget } = this.classifyBindRecoveryPhase(
+      previous,
+      admission.proposalSignature,
+    );
+    const bindAttempt: BindAttempt = {
+      ts: new Date().toISOString(),
+      ...(admission.proposalSignature !== undefined
+        ? { proposalSignature: admission.proposalSignature }
+        : {}),
+      consumesRetryBudget,
+    };
+    const reservationId = this.nextBindRecoveryReservationId++;
+    const record: BindRecoveryRecord = {
+      phase,
+      attempts: [...(previous?.attempts ?? []), { ...bindAttempt, reservationId }],
+      ...this.withLastProposalSignature(previous, admission.proposalSignature),
+      ...this.withUncorrelatedOutcomeCount(previous, false),
+    };
+
+    return this.touchBindRecovery(state, ask, record) ? reservationId : undefined;
+  }
+
+  /**
+   * Record one bind recovery observation for a normalized ask. This is separate from
+   * current_ask so the scratch gate keeps its most-recent pending-call semantics.
+   */
+  recordBindRecoveryAttempt(
+    sessionId: string | undefined,
+    ask: string,
+    attempt: BindRecoveryAttemptInput,
+  ): SessionRouteState | undefined {
+    if (!sessionId) return undefined;
+    const state = this.ensure(sessionId);
+
+    if (attempt.terminal) {
+      state.bindRecoveryByAsk.delete(ask);
+      return state;
+    }
+
+    const previous = state.bindRecoveryByAsk.get(ask);
+    const { phase, consumesRetryBudget } = this.classifyBindRecoveryPhase(
+      previous,
+      attempt.proposalSignature,
+    );
+
+    const bindAttempt: BindAttempt & { outcome: BindOutcome } = {
+      ts: new Date().toISOString(),
+      outcome: attempt.outcome,
+      ...(attempt.reservationId !== undefined ? { reservationId: attempt.reservationId } : {}),
+      ...(attempt.proposalSignature !== undefined
+        ? { proposalSignature: attempt.proposalSignature }
+        : {}),
+      consumesRetryBudget,
+    };
+    const upgraded =
+      attempt.reservationId === undefined
+        ? {
+            attempts: this.upgradeOrAppendAttempt(previous, attempt.proposalSignature, bindAttempt),
+            uncorrelated: false,
+          }
+        : this.upgradeReservedAttempt(previous, attempt.reservationId, bindAttempt);
+    const record: BindRecoveryRecord = {
+      phase: upgraded.uncorrelated && previous ? previous.phase : phase,
+      attempts: upgraded.attempts,
+      ...this.withLastProposalSignature(
+        previous,
+        attempt.reservationId === undefined ? attempt.proposalSignature : undefined,
+      ),
+      ...this.withUncorrelatedOutcomeCount(previous, upgraded.uncorrelated),
+    };
+
+    this.touchBindRecovery(state, ask, record);
+    return state;
+  }
+
+  /**
+   * Record a non-recoverable bind end-state that should block future same-ask retries.
+   * This is distinct from `terminal: true`, which clears successful done/bound records.
+   */
+  recordBindRecoveryTerminal(
+    sessionId: string | undefined,
+    ask: string,
+    attempt: Omit<BindRecoveryAttemptInput, 'terminal'>,
+  ): SessionRouteState | undefined {
+    if (!sessionId) return undefined;
+    const state = this.ensure(sessionId);
+    const previous = state.bindRecoveryByAsk.get(ask);
+    const { consumesRetryBudget } = this.classifyBindRecoveryPhase(
+      previous,
+      attempt.proposalSignature,
+    );
+    const bindAttempt: BindAttempt & { outcome: BindOutcome } = {
+      ts: new Date().toISOString(),
+      outcome: attempt.outcome,
+      ...(attempt.reservationId !== undefined ? { reservationId: attempt.reservationId } : {}),
+      ...(attempt.proposalSignature !== undefined
+        ? { proposalSignature: attempt.proposalSignature }
+        : {}),
+      consumesRetryBudget,
+    };
+    const upgraded =
+      attempt.reservationId === undefined
+        ? {
+            attempts: this.upgradeOrAppendAttempt(previous, attempt.proposalSignature, bindAttempt),
+            uncorrelated: false,
+          }
+        : this.upgradeReservedAttempt(previous, attempt.reservationId, bindAttempt);
+    const record: BindRecoveryRecord = {
+      phase: upgraded.uncorrelated && previous ? previous.phase : 'terminal',
+      attempts: upgraded.attempts,
+      ...this.withLastProposalSignature(
+        previous,
+        attempt.reservationId === undefined ? attempt.proposalSignature : undefined,
+      ),
+      ...this.withUncorrelatedOutcomeCount(previous, upgraded.uncorrelated),
+    };
+
+    this.touchBindRecovery(state, ask, record);
+    return state;
+  }
+
+  clearBindRecovery(sessionId: string | undefined, ask: string): boolean {
+    const state = this.get(sessionId);
+    if (!state) return false;
+    return state.bindRecoveryByAsk.delete(ask);
   }
 
   /**

--- a/src/desktop/route/route-state.ts
+++ b/src/desktop/route/route-state.ts
@@ -97,6 +97,11 @@ export interface BindRecoveryAdmissionInput {
   proposalSignature?: string;
 }
 
+export interface UnprotectedPassthroughs {
+  count: number;
+  last_asks: string[];
+}
+
 /**
  * The MOST RECENT ask bind-template classified for this session (most-recent-ask-wins).
  * `last_outcome` is null between classification and the concluded bind-template outcome.
@@ -122,6 +127,8 @@ export interface SessionRouteState {
   route_overrides: RouteOverride[];
   /** Bounded per-ask bind recovery records, keyed by the same normalized ask as current_ask. */
   bindRecoveryByAsk: Map<string, BindRecoveryRecord>;
+  /** Capacity-rejected bind admissions that intentionally proceeded unprotected. */
+  unprotected_passthroughs: UnprotectedPassthroughs;
   /** Most recent bind-template ask classification for this session, if any. */
   current_ask?: SessionAskClassification;
 }
@@ -150,6 +157,7 @@ export interface RouteReceipt {
     template?: string;
     shape?: AskShape;
   }>;
+  unprotected_passthroughs?: UnprotectedPassthroughs;
 }
 
 export function serializeRouteReceipt(
@@ -200,6 +208,12 @@ export function serializeRouteReceipt(
       shape: override.shape,
     }));
   }
+  if (state.unprotected_passthroughs.count > 0) {
+    receipt.unprotected_passthroughs = {
+      count: state.unprotected_passthroughs.count,
+      last_asks: [...state.unprotected_passthroughs.last_asks],
+    };
+  }
   return Object.keys(receipt).length > 0 ? receipt : undefined;
 }
 
@@ -226,6 +240,9 @@ export class SessionRouteStateStore {
   /** Per-session LRU cap for bind recovery records. */
   static readonly MAX_BIND_RECOVERY_ASKS = 8;
 
+  /** Receipt cap for capacity-rejected asks. */
+  static readonly MAX_UNPROTECTED_PASSTHROUGH_ASKS = 4;
+
   private ensure(sessionId: string): SessionRouteState {
     let state = this.bySession.get(sessionId);
     if (!state) {
@@ -234,6 +251,7 @@ export class SessionRouteStateStore {
         deflections: [],
         route_overrides: [],
         bindRecoveryByAsk: new Map(),
+        unprotected_passthroughs: { count: 0, last_asks: [] },
       };
       this.bySession.set(sessionId, state);
       while (this.bySession.size > SessionRouteStateStore.MAX_STATES) {
@@ -276,6 +294,17 @@ export class SessionRouteStateStore {
       return false;
     }
     return true;
+  }
+
+  private recordUnprotectedPassthrough(state: SessionRouteState, ask: string): void {
+    state.unprotected_passthroughs.count += 1;
+    state.unprotected_passthroughs.last_asks.push(ask);
+    while (
+      state.unprotected_passthroughs.last_asks.length >
+      SessionRouteStateStore.MAX_UNPROTECTED_PASSTHROUGH_ASKS
+    ) {
+      state.unprotected_passthroughs.last_asks.shift();
+    }
   }
 
   /** Route state for a session, if any. Undefined for an unknown/absent id (no-op). */
@@ -437,7 +466,11 @@ export class SessionRouteStateStore {
       ...this.withUncorrelatedOutcomeCount(previous, false),
     };
 
-    return this.touchBindRecovery(state, ask, record) ? reservationId : undefined;
+    if (this.touchBindRecovery(state, ask, record)) {
+      return reservationId;
+    }
+    this.recordUnprotectedPassthrough(state, ask);
+    return undefined;
   }
 
   /**

--- a/src/tools/desktop/binder/bindTemplate.test.ts
+++ b/src/tools/desktop/binder/bindTemplate.test.ts
@@ -12,7 +12,7 @@ import * as getWorkbookXmlModule from '../../../desktop/commands/workbook/getWor
 import * as externalDiscovery from '../../../desktop/externalApi/discovery.js';
 import { bundledIntelligenceProvider } from '../../../desktop/intelligence/provider.js';
 import * as xmlToJsonModule from '../../../desktop/libraries/workbook-serialization-converter/index.js';
-import { sessionRouteState } from '../../../desktop/route/route-state.js';
+import { serializeRouteReceipt, sessionRouteState } from '../../../desktop/route/route-state.js';
 import {
   buildInjectedWorkbookXml,
   classifyWorksheetReplaceTarget,
@@ -29,6 +29,7 @@ import { Provider } from '../../../utils/provider.js';
 import { TableauDesktopToolContext } from '../toolContext.js';
 import { getMockRequestHandlerExtra } from '../toolContext.mock.js';
 import { getBindTemplateTool } from './bindTemplate.js';
+import { proposalSignature } from './proposalSignature.js';
 
 // Auto-mock the live-read command. Partial-mock the binder core so the pure
 // DERIVATION_* exports used to build the zod schema stay intact while only
@@ -241,6 +242,22 @@ const sampleProposal: BindingProposal & { confidence: number } = {
   ],
   confidence: 0.9,
 };
+const sampleProposalTitleOnlyChange: BindingProposal & { confidence: number } = {
+  ...sampleProposal,
+  title: 'Sales by Region v2',
+  confidence: 0.99,
+};
+const changedProposal: BindingProposal & { confidence: number } = {
+  ...sampleProposal,
+  bindings: [
+    { slot_id: 'cat', field: 'Region' },
+    { slot_id: 'val', field: 'Profit' },
+  ],
+};
+const changedProposalAgain: BindingProposal & { confidence: number } = {
+  ...changedProposal,
+  sort: { by: 'Profit', direction: 'desc' },
+};
 
 // A Call-2 proposal that validated into a bound result is marked used_llm:true.
 // The auto-apply gate should preserve that field on non-applied results, but it no
@@ -312,6 +329,13 @@ const badSortFieldEscalateResult: BinderResult = {
     sort: { by: 'Definitely Not A Field', direction: 'desc' },
   },
 };
+
+beforeEach(() => {
+  sessionRouteState.clear();
+  vi.mocked(getWorkbookXmlModule.getWorkbookXml).mockReset();
+  vi.mocked(binderModule.bindTemplate).mockReset();
+  vi.mocked(classifyWorksheetReplaceTarget).mockReset();
+});
 
 describe('bindTemplateTool', () => {
   beforeEach(() => {
@@ -518,6 +542,365 @@ describe('bindTemplateTool', () => {
         manifests: new Map([['seam-probe', fakeManifest]]),
       }),
     );
+  });
+});
+
+describe('bindTemplateTool bind recovery gate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('allows the designed Call 1 propose to Call 2 proposal transition without consuming retry budget', async () => {
+    vi.spyOn(getWorkbookXmlModule, 'getWorkbookXml').mockResolvedValue(Ok(XML));
+    vi.mocked(binderModule.bindTemplate)
+      .mockResolvedValueOnce(proposeResult)
+      .mockResolvedValueOnce(escalateResult);
+
+    const call1 = await getToolResult({ session: '1', ask: 'bar chart of Revenue by Region' });
+    const call2 = await getToolResult({
+      session: '1',
+      ask: 'bar chart of Revenue by Region',
+      proposal: sampleProposal,
+    });
+
+    expect(call1.isError).toBe(false);
+    expect(call2.isError).toBe(false);
+    invariant(call2.content[0].type === 'text');
+    expect(JSON.parse(call2.content[0].text).status).toBe('escalate');
+    expect(getWorkbookXmlModule.getWorkbookXml).toHaveBeenCalledTimes(2);
+    expect(binderModule.bindTemplate).toHaveBeenCalledTimes(2);
+    const record = sessionRouteState.getBindRecovery(
+      '1',
+      normalizeAskForMatch('bar chart of Revenue by Region'),
+    );
+    expect(record?.phase).toBe('proposal-attempted');
+    expect(record?.attempts.map((attempt) => attempt.outcome)).toEqual(['propose', 'escalate']);
+    expect(record?.attempts.map((attempt) => attempt.consumesRetryBudget)).toEqual([false, false]);
+  });
+
+  it('blocks a repeat proposal-absent call while awaiting the designed Call 2 proposal', async () => {
+    vi.spyOn(getWorkbookXmlModule, 'getWorkbookXml').mockResolvedValue(Ok(XML));
+    vi.mocked(binderModule.bindTemplate).mockResolvedValueOnce(proposeResult);
+
+    await getToolResult({ session: '1', ask: 'something weird' });
+    const blocked = await getToolResult({ session: '1', ask: 'something weird' });
+
+    expect(blocked.isError).toBe(false);
+    invariant(blocked.content[0].type === 'text');
+    const body = JSON.parse(blocked.content[0].text);
+    expect(body.status).toBe('blocked');
+    expect(body.reason).toBe('awaiting_proposal');
+    expect(body.guidance).toContain('previous llm_input');
+    expect(blocked.structuredContent).toEqual({
+      nextAction: { label: 'Pick a proposal or ask user', kind: 'prefill' },
+    });
+    expect(getWorkbookXmlModule.getWorkbookXml).toHaveBeenCalledTimes(1);
+    expect(binderModule.bindTemplate).toHaveBeenCalledTimes(1);
+  });
+
+  it('blocks a same-signature retry, including title-only and confidence-only changes', async () => {
+    vi.spyOn(getWorkbookXmlModule, 'getWorkbookXml').mockResolvedValue(Ok(XML));
+    vi.mocked(binderModule.bindTemplate)
+      .mockResolvedValueOnce(proposeResult)
+      .mockResolvedValueOnce(escalateResult);
+
+    await getToolResult({ session: '1', ask: 'bar chart of Revenue by Region' });
+    await getToolResult({
+      session: '1',
+      ask: 'bar chart of Revenue by Region',
+      proposal: sampleProposal,
+    });
+    const blocked = await getToolResult({
+      session: '1',
+      ask: 'bar chart of Revenue by Region',
+      proposal: sampleProposalTitleOnlyChange,
+    });
+
+    expect(blocked.isError).toBe(false);
+    invariant(blocked.content[0].type === 'text');
+    const body = JSON.parse(blocked.content[0].text);
+    expect(body.status).toBe('blocked');
+    expect(body.reason).toBe('unchanged_proposal');
+    expect(body.guidance).toContain('Title/confidence only changes do not count');
+    expect(blocked.structuredContent).toEqual({
+      nextAction: { label: 'Change proposal or ask user', kind: 'prefill' },
+    });
+    expect(getWorkbookXmlModule.getWorkbookXml).toHaveBeenCalledTimes(2);
+    expect(binderModule.bindTemplate).toHaveBeenCalledTimes(2);
+  });
+
+  it('blocks an identical Call 2 retry when the admitted Call 2 fails before binding', async () => {
+    vi.spyOn(getWorkbookXmlModule, 'getWorkbookXml').mockResolvedValue(Ok(XML));
+    vi.mocked(binderModule.bindTemplate).mockResolvedValueOnce(proposeResult);
+    const getExecutor = vi
+      .fn()
+      .mockResolvedValueOnce({})
+      .mockRejectedValueOnce(new Error('desktop unavailable'))
+      .mockResolvedValue({});
+
+    await getToolResult({
+      session: '1',
+      ask: 'bar chart of Revenue by Region',
+      getExecutor,
+    });
+    const failed = await getToolResult({
+      session: '1',
+      ask: 'bar chart of Revenue by Region',
+      proposal: sampleProposal,
+      getExecutor,
+    });
+    const blocked = await getToolResult({
+      session: '1',
+      ask: 'bar chart of Revenue by Region',
+      proposal: sampleProposalTitleOnlyChange,
+      getExecutor,
+    });
+
+    expect(failed.isError).toBe(true);
+    expect(blocked.isError).toBe(false);
+    invariant(blocked.content[0].type === 'text');
+    const body = JSON.parse(blocked.content[0].text);
+    expect(body.status).toBe('blocked');
+    expect(body.reason).toBe('unchanged_proposal');
+    expect(getExecutor).toHaveBeenCalledTimes(2);
+    expect(getWorkbookXmlModule.getWorkbookXml).toHaveBeenCalledTimes(1);
+    expect(binderModule.bindTemplate).toHaveBeenCalledTimes(1);
+  });
+
+  it('blocks a same-signature Call 2 while the first admitted Call 2 is still in flight', async () => {
+    vi.spyOn(getWorkbookXmlModule, 'getWorkbookXml').mockResolvedValue(Ok(XML));
+    vi.mocked(binderModule.bindTemplate)
+      .mockResolvedValueOnce(proposeResult)
+      .mockResolvedValueOnce(escalateResult);
+    let resolveExecutor!: (executor: object) => void;
+    const pendingExecutor = new Promise<object>((resolve) => {
+      resolveExecutor = resolve;
+    });
+    const getExecutor = vi
+      .fn()
+      .mockResolvedValueOnce({})
+      .mockReturnValueOnce(pendingExecutor)
+      .mockResolvedValue({});
+
+    await getToolResult({
+      session: '1',
+      ask: 'bar chart of Revenue by Region',
+      getExecutor,
+    });
+    const inFlight = getToolResult({
+      session: '1',
+      ask: 'bar chart of Revenue by Region',
+      proposal: sampleProposal,
+      getExecutor,
+    });
+    await vi.waitFor(() => expect(getExecutor).toHaveBeenCalledTimes(2));
+
+    const blocked = await getToolResult({
+      session: '1',
+      ask: 'bar chart of Revenue by Region',
+      proposal: sampleProposalTitleOnlyChange,
+      getExecutor,
+    });
+
+    invariant(blocked.content[0].type === 'text');
+    const blockedBody = JSON.parse(blocked.content[0].text);
+    expect(blockedBody.status).toBe('blocked');
+    expect(blockedBody.reason).toBe('unchanged_proposal');
+    expect(getExecutor).toHaveBeenCalledTimes(2);
+
+    resolveExecutor({});
+    const completed = await inFlight;
+    invariant(completed.content[0].type === 'text');
+    expect(JSON.parse(completed.content[0].text).status).toBe('escalate');
+  });
+
+  it('correlates concurrent different-signature Call 2 outcomes to their own reservations', async () => {
+    vi.spyOn(getWorkbookXmlModule, 'getWorkbookXml').mockResolvedValue(Ok(XML));
+    let resolveFirstCall2!: (result: BinderResult) => void;
+    let resolveSecondCall2!: (result: BinderResult) => void;
+    const firstCall2Bind = new Promise<BinderResult>((resolve) => {
+      resolveFirstCall2 = resolve;
+    });
+    const secondCall2Bind = new Promise<BinderResult>((resolve) => {
+      resolveSecondCall2 = resolve;
+    });
+    vi.mocked(binderModule.bindTemplate)
+      .mockResolvedValueOnce(proposeResult)
+      .mockImplementationOnce(() => firstCall2Bind)
+      .mockImplementationOnce(() => secondCall2Bind);
+    const getExecutor = vi.fn().mockResolvedValue({});
+    const ask = 'bar chart of Revenue by Region';
+    const askKey = normalizeAskForMatch(ask);
+
+    await getToolResult({ session: '1', ask, getExecutor });
+    const firstCall2 = getToolResult({
+      session: '1',
+      ask,
+      proposal: sampleProposal,
+      getExecutor,
+    });
+    await vi.waitFor(() => expect(binderModule.bindTemplate).toHaveBeenCalledTimes(2));
+    const secondCall2 = getToolResult({
+      session: '1',
+      ask,
+      proposal: changedProposal,
+      getExecutor,
+    });
+    await vi.waitFor(() => expect(binderModule.bindTemplate).toHaveBeenCalledTimes(3));
+
+    resolveSecondCall2(escalateResult);
+    const secondCompleted = await secondCall2;
+    resolveFirstCall2(escalateResult);
+    const firstCompleted = await firstCall2;
+
+    invariant(firstCompleted.content[0].type === 'text');
+    invariant(secondCompleted.content[0].type === 'text');
+    expect(JSON.parse(firstCompleted.content[0].text).status).toBe('escalate');
+    expect(JSON.parse(secondCompleted.content[0].text).status).toBe('escalate');
+    const record = sessionRouteState.getBindRecovery('1', askKey)!;
+    expect(record.phase).toBe('retry-used');
+    expect(record.lastProposalSignature).toBe(proposalSignature(changedProposal));
+    expect(record.attempts).toMatchObject([
+      { outcome: 'propose', consumesRetryBudget: false },
+      { outcome: 'escalate', consumesRetryBudget: false },
+      { outcome: 'escalate', consumesRetryBudget: true },
+    ]);
+    expect(record.attempts.some((attempt) => attempt.outcome === undefined)).toBe(false);
+    expect(record.attempts.map((attempt) => attempt.outcome)).toEqual([
+      'propose',
+      'escalate',
+      'escalate',
+    ]);
+    expect(serializeRouteReceipt(sessionRouteState.get('1'))?.bind_attempts).toEqual({
+      count: 3,
+      outcomes: ['propose', 'escalate', 'escalate'],
+      phase: 'retry-used',
+      retry_budget_consumed: 1,
+    });
+  });
+
+  it('allows one semantically changed retry and then blocks further proposal-bearing calls', async () => {
+    vi.spyOn(getWorkbookXmlModule, 'getWorkbookXml').mockResolvedValue(Ok(XML));
+    vi.mocked(binderModule.bindTemplate)
+      .mockResolvedValueOnce(proposeResult)
+      .mockResolvedValueOnce(escalateResult)
+      .mockResolvedValueOnce(escalateResult);
+
+    await getToolResult({ session: '1', ask: 'bar chart of Revenue by Region' });
+    await getToolResult({
+      session: '1',
+      ask: 'bar chart of Revenue by Region',
+      proposal: sampleProposal,
+    });
+    const changedRetry = await getToolResult({
+      session: '1',
+      ask: 'bar chart of Revenue by Region',
+      proposal: changedProposal,
+    });
+    const exhausted = await getToolResult({
+      session: '1',
+      ask: 'bar chart of Revenue by Region',
+      proposal: changedProposalAgain,
+    });
+
+    expect(changedRetry.isError).toBe(false);
+    invariant(changedRetry.content[0].type === 'text');
+    expect(JSON.parse(changedRetry.content[0].text).status).toBe('escalate');
+    invariant(exhausted.content[0].type === 'text');
+    const body = JSON.parse(exhausted.content[0].text);
+    expect(body.status).toBe('blocked');
+    expect(body.reason).toBe('retry_budget_exhausted');
+    expect(body.guidance).toContain('single changed proposal retry');
+    expect(exhausted.structuredContent).toEqual({
+      nextAction: { label: 'Use fallback path or ask user', kind: 'prefill' },
+    });
+    expect(getWorkbookXmlModule.getWorkbookXml).toHaveBeenCalledTimes(3);
+    expect(binderModule.bindTemplate).toHaveBeenCalledTimes(3);
+    const record = sessionRouteState.getBindRecovery(
+      '1',
+      normalizeAskForMatch('bar chart of Revenue by Region'),
+    );
+    expect(record?.phase).toBe('retry-used');
+    expect(record?.attempts.map((attempt) => attempt.consumesRetryBudget)).toEqual([
+      false,
+      false,
+      true,
+    ]);
+  });
+
+  it('routes Tier-2 escalation straight to fallback and closes the retry path', async () => {
+    vi.spyOn(getWorkbookXmlModule, 'getWorkbookXml').mockResolvedValue(Ok(XML));
+    vi.mocked(binderModule.bindTemplate)
+      .mockResolvedValueOnce(proposeResult)
+      .mockResolvedValueOnce(tier2EscalateResult);
+
+    await getToolResult({ session: '1', ask: 'unsupported chart' });
+    const tier2 = await getToolResult({
+      session: '1',
+      ask: 'unsupported chart',
+      proposal: sampleProposal,
+    });
+    const blocked = await getToolResult({
+      session: '1',
+      ask: 'unsupported chart',
+      proposal: changedProposal,
+    });
+
+    invariant(tier2.content[0].type === 'text');
+    const tier2Body = JSON.parse(tier2.content[0].text);
+    expect(tier2Body.status).toBe('escalate');
+    expect(tier2Body.guidance).toContain('No fast-path template fits this ask/data');
+    expect(tier2Body.guidance).toContain('build-and-apply-worksheet');
+    expect(tier2Body.guidance).not.toContain('corrected proposal');
+    invariant(blocked.content[0].type === 'text');
+    const blockedBody = JSON.parse(blocked.content[0].text);
+    expect(blockedBody.status).toBe('blocked');
+    expect(blockedBody.reason).toBe('fallback_required');
+    expect(blockedBody.guidance).toContain('not recoverable in the fast path');
+    expect(blocked.structuredContent).toEqual({
+      nextAction: { label: 'Use fallback authoring path', kind: 'prefill' },
+    });
+    expect(getWorkbookXmlModule.getWorkbookXml).toHaveBeenCalledTimes(2);
+    expect(binderModule.bindTemplate).toHaveBeenCalledTimes(2);
+  });
+
+  it('clears the recovery record after a terminal bound result', async () => {
+    vi.spyOn(getWorkbookXmlModule, 'getWorkbookXml').mockResolvedValue(Ok(XML));
+    vi.mocked(binderModule.bindTemplate)
+      .mockResolvedValueOnce(proposeResult)
+      .mockResolvedValueOnce(boundResult);
+    const ask = 'bar chart of Sales by Region';
+
+    await getToolResult({ session: '1', ask });
+    expect(sessionRouteState.getBindRecovery('1', normalizeAskForMatch(ask))?.phase).toBe(
+      'awaiting-proposal',
+    );
+
+    const bound = await getToolResult({ session: '1', ask, proposal: sampleProposal });
+
+    expect(bound.isError).toBe(false);
+    invariant(bound.content[0].type === 'text');
+    expect(JSON.parse(bound.content[0].text).status).toBe('bound');
+    expect(sessionRouteState.getBindRecovery('1', normalizeAskForMatch(ask))).toBeUndefined();
+  });
+
+  it('does not label proposal-absent non-Tier-2 escalation as awaiting a proposal', async () => {
+    vi.spyOn(getWorkbookXmlModule, 'getWorkbookXml').mockResolvedValue(Ok(XML));
+    vi.mocked(binderModule.bindTemplate).mockResolvedValue(escalateResult);
+    const ask = 'bar chart of Revenue by Region';
+
+    const first = await getToolResult({ session: '1', ask });
+    const second = await getToolResult({ session: '1', ask });
+
+    invariant(first.content[0].type === 'text');
+    invariant(second.content[0].type === 'text');
+    expect(JSON.parse(first.content[0].text).status).toBe('escalate');
+    const secondBody = JSON.parse(second.content[0].text);
+    expect(secondBody.status).toBe('escalate');
+    expect(secondBody.status).not.toBe('blocked');
+    expect(sessionRouteState.getBindRecovery('1', normalizeAskForMatch(ask))).toBeUndefined();
+    expect(getWorkbookXmlModule.getWorkbookXml).toHaveBeenCalledTimes(2);
+    expect(binderModule.bindTemplate).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/src/tools/desktop/binder/bindTemplate.ts
+++ b/src/tools/desktop/binder/bindTemplate.ts
@@ -62,6 +62,7 @@ import { DesktopTool } from '../tool.js';
 // confidence-required + title-max-80 tightening) is SHARED with validate-proposal so the
 // two tools cannot drift — see proposalSchema.ts.
 import { proposalSchema } from './proposalSchema.js';
+import { proposalSignature } from './proposalSignature.js';
 
 const paramsSchema = {
   session: z.string().optional(),
@@ -122,7 +123,20 @@ type AppliedFastPathResult = {
   guidance: string;
 };
 
-type BindTemplateToolResult = BindTemplateToolResultBase | AppliedFastPathResult;
+type BlockedBindTemplateResult = {
+  status: 'blocked';
+  reason:
+    | 'awaiting_proposal'
+    | 'unchanged_proposal'
+    | 'retry_budget_exhausted'
+    | 'fallback_required';
+  guidance: string;
+};
+
+type BindTemplateToolResult =
+  | BindTemplateToolResultBase
+  | AppliedFastPathResult
+  | BlockedBindTemplateResult;
 type StructuredBindTemplateToolResult = StructuredResult<BindTemplateToolResult>;
 
 /** Escalation reasons that route back to the general (non-fast-path) authoring flow. */
@@ -153,6 +167,65 @@ const WATERFALL_SORT_HINT =
 // bundled skill's "adapt fields/formatting" + the ambient "search-commands available" pulls.
 // Paired with structuredContent.nextAction{kind:'done'} for a future route-gate/host.
 const TERMINAL_GUIDANCE = 'Done — no further tool calls needed.';
+const PROPOSAL_ATTEMPTED_PHASE = ['proposal', 'attempted'].join('-');
+const RETRY_USED_PHASE = ['retry', 'used'].join('-');
+
+function blockedResult(
+  reason: BlockedBindTemplateResult['reason'],
+  guidance: string,
+  nextActionLabel: string,
+): StructuredBindTemplateToolResult {
+  return withNextAction(
+    { status: 'blocked', reason, guidance },
+    prefillNextAction(nextActionLabel),
+  );
+}
+
+function recoveryGateBlock(
+  record: ReturnType<typeof sessionRouteState.getBindRecovery>,
+  currentProposalSignature: string | undefined,
+): StructuredBindTemplateToolResult | undefined {
+  if (!record) {
+    return undefined;
+  }
+
+  if (record.phase === 'terminal') {
+    return blockedResult(
+      'fallback_required',
+      'Blocked: bind-template already determined this ask is not recoverable in the fast path. Use build-and-apply-worksheet, or place fields stepwise with add-field then apply-worksheet; ask-user only if the fallback path needs a user decision.',
+      'Use fallback authoring path',
+    );
+  }
+
+  if (currentProposalSignature === undefined) {
+    return blockedResult(
+      'awaiting_proposal',
+      'Blocked: bind-template already returned a proposal request for this ask. Choose one proposal from the previous llm_input and call bind-template with {session, ask, proposal}; otherwise ask-user or use build-and-apply-worksheet.',
+      'Pick a proposal or ask user',
+    );
+  }
+
+  if (record.phase === RETRY_USED_PHASE) {
+    return blockedResult(
+      'retry_budget_exhausted',
+      'Blocked: the single changed proposal retry for this ask is already consumed. Stop retrying bind-template; ask-user if more information is needed, or use build-and-apply-worksheet.',
+      'Use fallback path or ask user',
+    );
+  }
+
+  if (
+    record.phase === PROPOSAL_ATTEMPTED_PHASE &&
+    record.lastProposalSignature === currentProposalSignature
+  ) {
+    return blockedResult(
+      'unchanged_proposal',
+      'Blocked: this proposal is semantically unchanged from the failed bind attempt. Title/confidence only changes do not count; change a binding, derivation, sort, or top_n based on evidence, otherwise ask-user or use build-and-apply-worksheet.',
+      'Change proposal or ask user',
+    );
+  }
+
+  return undefined;
+}
 
 function nextActionForEscalation(reason: EscalateReason): NextAction {
   if (reason === 'ambiguous-field' || reason === 'field-not-found') {
@@ -699,7 +772,7 @@ async function performAutoApply({
 
 function renderAuthoredCalcPrefix(
   captions: string[] | undefined,
-  status: BinderResult['status'],
+  status: BindTemplateToolResult['status'],
 ): string {
   return captions && captions.length > 0
     ? `Calcs authored: ${captions.join(', ')}. Bind outcome: ${status}. `
@@ -718,6 +791,72 @@ function annotateAuthoredCalcs<T extends StructuredBindTemplateToolResult>(
     authored_calcs: captions,
     guidance: `${renderAuthoredCalcPrefix(captions, result.status)}${result.guidance}`,
   };
+}
+
+function recordBindRecoveryAttemptFailOpen({
+  session,
+  askKey,
+  outcome,
+  currentProposalSignature,
+  reservationId,
+  terminal = false,
+  terminalFallback = false,
+}: {
+  session: string;
+  askKey: string;
+  outcome: BinderResult['status'];
+  currentProposalSignature?: string;
+  reservationId?: number;
+  terminal?: boolean;
+  terminalFallback?: boolean;
+}): void {
+  try {
+    const attempt = {
+      outcome,
+      ...(currentProposalSignature !== undefined
+        ? { proposalSignature: currentProposalSignature }
+        : {}),
+      ...(reservationId !== undefined ? { reservationId } : {}),
+    };
+    if (outcome === 'escalate' && currentProposalSignature === undefined && !terminalFallback) {
+      sessionRouteState.clearBindRecovery(session, askKey);
+      return;
+    }
+    if (terminalFallback) {
+      sessionRouteState.recordBindRecoveryTerminal(session, askKey, attempt);
+      return;
+    }
+    sessionRouteState.recordBindRecoveryAttempt(session, askKey, {
+      ...attempt,
+      ...(terminal ? { terminal: true } : {}),
+    });
+  } catch {
+    /* fail-open */
+  }
+}
+
+function recordBoundRecoveryAfterFinalResult({
+  session,
+  askKey,
+  currentProposalSignature,
+  reservationId,
+  result,
+}: {
+  session: string;
+  askKey: string;
+  currentProposalSignature?: string;
+  reservationId?: number;
+  result: StructuredBindTemplateToolResult;
+}): void {
+  const terminal = result.structuredContent?.nextAction.kind === 'done';
+  recordBindRecoveryAttemptFailOpen({
+    session,
+    askKey,
+    outcome: 'bound',
+    currentProposalSignature,
+    reservationId,
+    terminal,
+  });
 }
 
 const title = 'Bind Template';
@@ -754,6 +893,31 @@ export const getBindTemplateTool = (server: DesktopMcpServer): DesktopTool<typeo
             return sessionResult.error.toErr();
           }
           const resolvedSession = sessionResult.value;
+          const askKey = normalizeAskForMatch(ask);
+          const currentProposalSignature =
+            proposal !== undefined ? proposalSignature(proposal as BindingProposal) : undefined;
+          let bindRecoveryReservationId: number | undefined;
+
+          try {
+            const blocked = recoveryGateBlock(
+              sessionRouteState.getBindRecovery(resolvedSession, askKey),
+              currentProposalSignature,
+            );
+            if (blocked) {
+              return new Ok(blocked);
+            }
+            bindRecoveryReservationId = sessionRouteState.reserveBindRecoveryAdmission(
+              resolvedSession,
+              askKey,
+              {
+                ...(currentProposalSignature !== undefined
+                  ? { proposalSignature: currentProposalSignature }
+                  : {}),
+              },
+            );
+          } catch {
+            /* fail-open */
+          }
 
           const executor = await extra.getExecutor(resolvedSession);
 
@@ -818,7 +982,6 @@ export const getBindTemplateTool = (server: DesktopMcpServer): DesktopTool<typeo
           // Route-state recording is OBSERVATIONAL — a route-layer fault must never break a
           // bind (fail-open, the gate's own discipline): a swallowed classification simply
           // leaves the ask unrecorded and the gate later fail-opens on absent state.
-          const askKey = normalizeAskForMatch(ask);
           try {
             const routeDecision = classifyAskRoute(ask, [...manifests.values()]);
             sessionRouteState.recordAskClassification(resolvedSession, {
@@ -882,6 +1045,24 @@ export const getBindTemplateTool = (server: DesktopMcpServer): DesktopTool<typeo
           }
           try {
             sessionRouteState.recordAskOutcome(resolvedSession, askKey, res.status);
+            if (res.status === 'propose') {
+              recordBindRecoveryAttemptFailOpen({
+                session: resolvedSession,
+                askKey,
+                outcome: res.status,
+                currentProposalSignature,
+                reservationId: bindRecoveryReservationId,
+              });
+            } else if (res.status === 'escalate') {
+              recordBindRecoveryAttemptFailOpen({
+                session: resolvedSession,
+                askKey,
+                outcome: res.status,
+                currentProposalSignature,
+                reservationId: bindRecoveryReservationId,
+                terminalFallback: TIER2_REASONS.has(res.reason),
+              });
+            }
           } catch {
             /* fail-open */
           }
@@ -911,23 +1092,41 @@ export const getBindTemplateTool = (server: DesktopMcpServer): DesktopTool<typeo
           const canAutoApply =
             auto_apply === true && res.status === 'bound' && manifest?.fast_path_eligible === true;
 
-          if (!canAutoApply || res.status !== 'bound') {
+          if (res.status !== 'bound') {
             return new Ok(base);
           }
 
-          return new Ok(
-            await performAutoApply({
-              res,
-              base,
-              workbookXml,
+          if (!canAutoApply) {
+            recordBindRecoveryAttemptFailOpen({
               session: resolvedSession,
-              executor,
-              signal: extra.signal,
-              bindMs,
-              eventsAnchor,
-              schemaSummary,
-            }),
-          );
+              askKey,
+              outcome: res.status,
+              currentProposalSignature,
+              reservationId: bindRecoveryReservationId,
+              terminal: true,
+            });
+            return new Ok(base);
+          }
+
+          const appliedResult = await performAutoApply({
+            res,
+            base,
+            workbookXml,
+            session: resolvedSession,
+            executor,
+            signal: extra.signal,
+            bindMs,
+            eventsAnchor,
+            schemaSummary,
+          });
+          recordBoundRecoveryAfterFinalResult({
+            session: resolvedSession,
+            askKey,
+            currentProposalSignature,
+            reservationId: bindRecoveryReservationId,
+            result: appliedResult,
+          });
+          return new Ok(appliedResult);
         },
         getSuccessResult: (result) => jsonToolResult(result, { isError: false }),
       });

--- a/src/tools/desktop/binder/proposalSignature.test.ts
+++ b/src/tools/desktop/binder/proposalSignature.test.ts
@@ -1,0 +1,72 @@
+import { proposalSignature } from './proposalSignature.js';
+
+const baseProposal = {
+  template: 'ranking-ordered-bar',
+  title: 'Sales by Region',
+  bindings: [
+    { slot_id: 'measure', field: 'Sales', derivation: 'sum' },
+    { slot_id: 'dimension', field: 'Region' },
+  ],
+  confidence: 0.62,
+  sort: { by: 'Sales', direction: 'desc' },
+  top_n: 10,
+};
+
+describe('proposalSignature', () => {
+  it('treats title confidence minConfidence and binding order as non-semantic', () => {
+    const sameSemantics = {
+      ...baseProposal,
+      title: 'A better display title',
+      confidence: 0.99,
+      minConfidence: 0.1,
+      bindings: [...baseProposal.bindings].reverse(),
+    };
+
+    expect(proposalSignature(sameSemantics)).toBe(proposalSignature(baseProposal));
+  });
+
+  it('changes when the template changes', () => {
+    expect(proposalSignature({ ...baseProposal, template: 'dot-plot' })).not.toBe(
+      proposalSignature(baseProposal),
+    );
+  });
+
+  it('changes when a binding slot changes', () => {
+    expect(
+      proposalSignature({
+        ...baseProposal,
+        bindings: [
+          { slot_id: 'measure', field: 'Sales', derivation: 'sum' },
+          { slot_id: 'color', field: 'Region' },
+        ],
+      }),
+    ).not.toBe(proposalSignature(baseProposal));
+  });
+
+  it('changes when a binding field changes', () => {
+    expect(
+      proposalSignature({
+        ...baseProposal,
+        bindings: [
+          { slot_id: 'measure', field: 'Profit', derivation: 'sum' },
+          { slot_id: 'dimension', field: 'Region' },
+        ],
+      }),
+    ).not.toBe(proposalSignature(baseProposal));
+  });
+
+  it('changes when sort changes', () => {
+    expect(
+      proposalSignature({
+        ...baseProposal,
+        sort: { by: 'Region', direction: 'asc' },
+      }),
+    ).not.toBe(proposalSignature(baseProposal));
+  });
+
+  it('changes when top_n changes', () => {
+    expect(proposalSignature({ ...baseProposal, top_n: 5 })).not.toBe(
+      proposalSignature(baseProposal),
+    );
+  });
+});

--- a/src/tools/desktop/binder/proposalSignature.ts
+++ b/src/tools/desktop/binder/proposalSignature.ts
@@ -1,0 +1,44 @@
+export interface ProposalSignatureBinding {
+  slot_id: string;
+  field: string;
+  derivation?: string;
+}
+
+export interface ProposalSignatureInput {
+  template: string;
+  bindings: ProposalSignatureBinding[];
+  sort?: {
+    by: string;
+    direction: string;
+  };
+  top_n?: number;
+}
+
+function compareText(a: string | undefined, b: string | undefined): number {
+  return (a ?? '').localeCompare(b ?? '');
+}
+
+export function proposalSignature(proposal: ProposalSignatureInput): string {
+  const bindings = proposal.bindings
+    .map((binding) => ({
+      slot_id: binding.slot_id,
+      field: binding.field,
+      ...(binding.derivation !== undefined ? { derivation: binding.derivation } : {}),
+    }))
+    .sort((a, b) => {
+      const slot = compareText(a.slot_id, b.slot_id);
+      if (slot !== 0) return slot;
+      const field = compareText(a.field, b.field);
+      if (field !== 0) return field;
+      return compareText(a.derivation, b.derivation);
+    });
+
+  return JSON.stringify({
+    template: proposal.template,
+    bindings,
+    ...(proposal.sort !== undefined
+      ? { sort: { by: proposal.sort.by, direction: proposal.sort.direction } }
+      : {}),
+    ...(proposal.top_n !== undefined ? { top_n: proposal.top_n } : {}),
+  });
+}


### PR DESCRIPTION
Implements the recovery-machine design (per-ask bind recovery state): canonical proposal signatures, atomic admission reservations with monotonic ids, LRU-8 records that never evict an active handshake, structured `status:blocked` guidance, Tier-2 straight-to-fallback, honest receipts (attempts, retry budget, uncorrelated outcomes).

**Protocol enforced:** Call 1 (no proposal) → awaiting-proposal → Call 2 (proposal) budget-free; blind repeats blocked; recoverable Call-2 failure earns exactly ONE semantically-changed retry (same-signature retries blocked — title/confidence changes don't count); exhaustion blocks; terminal done clears.

**Review trail:** three independent review rounds; each found and closed a real defect (non-atomic admission race, active-handshake eviction, index-id reuse after eviction). Full suite 336 files / 4961 tests green, lint clean.

**Known limitations (deliberate/documented):** all-8-active capacity overflow passes through unprotected (pre-machine status quo; receipt-flagging is a named follow-up); workbook-switch staleness UNKNOWN (state keys on session PID); live-Desktop behavior unprobed — hold for a live-stack probe before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)