### PR TITLE
test(binder): pin bind-template's content-block envelope

### DIFF
--- a/src/tools/desktop/binder/bindTemplate.test.ts
+++ b/src/tools/desktop/binder/bindTemplate.test.ts
@@ -362,6 +362,24 @@ describe('bindTemplateTool', () => {
     expect(body.guidance).toBe(boundResult.status === 'bound' ? boundResult.apply_instruction : '');
   });
 
+  it('returns the standard MCP content-block envelope, not a bare JSON string', async () => {
+    vi.spyOn(getWorkbookXmlModule, 'getWorkbookXml').mockResolvedValue(Ok(XML));
+    vi.mocked(binderModule.bindTemplate).mockResolvedValue(boundResult);
+
+    const result = await getToolResult({ session: '1', ask: 'bar chart of Sales by Region' });
+
+    expect(result).toMatchObject({
+      isError: false,
+      content: [{ type: 'text', text: expect.any(String) }],
+    });
+    expect(result.content).toHaveLength(1);
+    invariant(result.content[0].type === 'text');
+    expect(JSON.parse(result.content[0].text)).toEqual({
+      ...boundResult,
+      guidance: boundResult.status === 'bound' ? boundResult.apply_instruction : '',
+    });
+  });
+
   it('returns status "propose" (not an error) with next-step guidance (Call 1 miss)', async () => {
     vi.spyOn(getWorkbookXmlModule, 'getWorkbookXml').mockResolvedValue(Ok(XML));
     vi.mocked(binderModule.bindTemplate).mockResolvedValue(proposeResult);

--- a/src/tools/desktop/binder/bindTemplate.ts
+++ b/src/tools/desktop/binder/bindTemplate.ts
@@ -925,6 +925,8 @@ export const getBindTemplateTool = (server: DesktopMcpServer): DesktopTool<typeo
             }),
           );
         },
+        // Keep the standard MCP content-block envelope while lifting nextAction metadata
+        // out of the JSON body so the bind/propose/bound body contract stays unchanged.
         getSuccessResult: (result) => jsonToolResult(result, { isError: false }),
       });
     },


### PR DESCRIPTION
Test-only pin. Live receipts showed a client hook receiving bind-template's response as a bare JSON string; source audit found tmcp's tool callback builds the standard `content: [{type:'text',...}]` envelope, and live stdio MCP round-trips (raw client probe, 2026-07-22) confirm the wire behavior. This regression pins the CALLBACK-level contract (envelope + body); it does not exercise MCP transport serialization — wire-level evidence is the live probe, and the observed bare-string unwrap happens in the client SDK's hook layer (where the consumer now tolerates both shapes). Full suite 336/4943 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)