### PR TITLE
@W-23546248 - Support exploration insight bundle type

### DIFF
--- a/docs/docs/tools/pulse/generate-pulse-metric-value-insight-bundle.md
+++ b/docs/docs/tools/pulse/generate-pulse-metric-value-insight-bundle.md
@@ -4,7 +4,7 @@ sidebar_position: 6
 
 # Generate Insight Bundle
 
-Generates the selected insight bundle for a Pulse metric.
+Generates an insight bundle for the current aggregated value for a Pulse metric.
 
 ## APIs called
 

--- a/docs/docs/tools/pulse/generate-pulse-metric-value-insight-bundle.md
+++ b/docs/docs/tools/pulse/generate-pulse-metric-value-insight-bundle.md
@@ -116,7 +116,7 @@ The type of bundle to generate. The default is `ban`.
 | `basic`       | Return a basic insight bundle. Similar to a springboard insight, but data is focused on the dimensions of a metric that are low bandwidth because they have small value sets. It shows the current value, period over period change, and the highest ranked insight for the metric for that data. |
 | `springboard` | Return a springboard insight bundle with the current value, period over period change, and the highest ranked insight for the metric.                                                                                                                                                             |
 | `detail`      | Shows insights on performance over time of the metric, a summary visualization of metric highs and lows and trends, breakdowns of top contributors for each filterable dimension of the metric, and followup insights based on the top ranked insights not already presented.                     |
-| `exploration` | Return an exploration insight bundle focused on performance trends, with BAN, anchor, and follow-up insight groups. Available in API 3.26 (Tableau Cloud September 2025) and later. Not available for Tableau Server.                                                                             |
+| `exploration` | Return an exploration insight bundle focused on performance trends, with BAN, anchor, and follow-up insight groups.                                                                                                                                                                               |
 
 ## Example result
 

--- a/docs/docs/tools/pulse/generate-pulse-metric-value-insight-bundle.md
+++ b/docs/docs/tools/pulse/generate-pulse-metric-value-insight-bundle.md
@@ -4,13 +4,14 @@ sidebar_position: 6
 
 # Generate Insight Bundle
 
-Generates an insight bundle for the current aggregated value for a Pulse metric.
+Generates the selected insight bundle for a Pulse metric.
 
 ## APIs called
 
 - [Generate current metric value insight bundle](https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref_pulse.htm#PulseInsightsService_GenerateInsightBundleBAN)
 - [Generate basic insight bundle](https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref_pulse.htm#PulseInsightsService_GenerateInsightBundleBasic)
 - [Generate detail insight bundle](https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref_pulse.htm#PulseInsightsService_GenerateInsightBundleDetail)
+- [Generate exploration insight bundle](https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref_pulse.htm#PulseInsightsService_GenerateInsightBundleExploration)
 - [Generate springboard insight bundle](https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref_pulse.htm#PulseInsightsService_GenerateInsightBundleSpringboard)
 
 ## Required arguments
@@ -115,6 +116,7 @@ The type of bundle to generate. The default is `ban`.
 | `basic`       | Return a basic insight bundle. Similar to a springboard insight, but data is focused on the dimensions of a metric that are low bandwidth because they have small value sets. It shows the current value, period over period change, and the highest ranked insight for the metric for that data. |
 | `springboard` | Return a springboard insight bundle with the current value, period over period change, and the highest ranked insight for the metric.                                                                                                                                                             |
 | `detail`      | Shows insights on performance over time of the metric, a summary visualization of metric highs and lows and trends, breakdowns of top contributors for each filterable dimension of the metric, and followup insights based on the top ranked insights not already presented.                     |
+| `exploration` | Return an exploration insight bundle focused on performance trends, with BAN, anchor, and follow-up insight groups. Available in API 3.26 (Tableau Cloud September 2025) and later. Not available for Tableau Server.                                                                             |
 
 ## Example result
 

--- a/docs/docs/tools/pulse/generate-pulse-metric-value-insight-bundle.md
+++ b/docs/docs/tools/pulse/generate-pulse-metric-value-insight-bundle.md
@@ -116,7 +116,7 @@ The type of bundle to generate. The default is `ban`.
 | `basic`       | Return a basic insight bundle. Similar to a springboard insight, but data is focused on the dimensions of a metric that are low bandwidth because they have small value sets. It shows the current value, period over period change, and the highest ranked insight for the metric for that data. |
 | `springboard` | Return a springboard insight bundle with the current value, period over period change, and the highest ranked insight for the metric.                                                                                                                                                             |
 | `detail`      | Shows insights on performance over time of the metric, a summary visualization of metric highs and lows and trends, breakdowns of top contributors for each filterable dimension of the metric, and followup insights based on the top ranked insights not already presented.                     |
-| `exploration` | Return an exploration insight bundle focused on performance trends, with BAN, anchor, and follow-up insight groups.                                                                                                                                                                               |
+| `exploration` | Return an exploration insight bundle focused on performance trends, with BAN, anchor, and follow-up insight groups. Available in API 3.26 (Tableau Cloud September 2025) and later. Not available for Tableau Server.                                                                             |
 
 ## Example result
 

--- a/src/sdks/tableau/methods/pulseMethods.ts
+++ b/src/sdks/tableau/methods/pulseMethods.ts
@@ -176,12 +176,13 @@ export default class PulseMethods extends AuthenticatedMethods<typeof pulseApis>
   };
 
   /**
-   * Returns the generated bundle of the current aggregate value for the Pulse metric.
+   * Generates the requested insight bundle for a Pulse metric.
    *
    * Required scopes: `tableau:insights:read`
    *
    * @param bundleRequest - The request to generate a bundle for.
-   * @link https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref_pulse.htm#PulseInsightsService_GenerateInsightBundleBasic
+   * @param bundleType - The type of insight bundle to generate.
+   * @link https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref_pulse.htm
    */
   generatePulseMetricValueInsightBundle = async (
     bundleRequest: z.infer<typeof pulseBundleRequestSchema>,

--- a/src/sdks/tableau/types/pulse.ts
+++ b/src/sdks/tableau/types/pulse.ts
@@ -481,7 +481,13 @@ export const pulseInsightBriefResponseSchema = z.object({
 export type PulseBundleResponse = z.infer<typeof pulseBundleResponseSchema>;
 export type PulseInsightBriefResponse = z.infer<typeof pulseInsightBriefResponseSchema>;
 
-export const pulseInsightBundleTypeEnum = ['ban', 'springboard', 'basic', 'detail'] as const;
+export const pulseInsightBundleTypeEnum = [
+  'ban',
+  'springboard',
+  'basic',
+  'detail',
+  'exploration',
+] as const;
 export type PulseInsightBundleType = (typeof pulseInsightBundleTypeEnum)[number];
 
 export const pulseMetricDefinitionViewEnum = [

--- a/src/tools/web/pulse/generateMetricValueInsightBundle/generatePulseMetricValueInsightBundleTool.test.ts
+++ b/src/tools/web/pulse/generateMetricValueInsightBundle/generatePulseMetricValueInsightBundleTool.test.ts
@@ -202,7 +202,7 @@ describe('getGeneratePulseMetricValueInsightBundleTool', () => {
     expect(parsedValue).toEqual(mockBundleRequestResponse);
   });
 
-  it.each(['ban', 'springboard', 'basic', 'detail'] as const)(
+  it.each(['ban', 'springboard', 'basic', 'detail', 'exploration'] as const)(
     'should call generatePulseMetricValueInsightBundle with bundleType "%s" and return Ok result',
     async (bundleType) => {
       mocks.mockGeneratePulseMetricValueInsightBundle.mockResolvedValue(
@@ -224,9 +224,7 @@ describe('getGeneratePulseMetricValueInsightBundleTool', () => {
     const tool = getGeneratePulseMetricValueInsightBundleTool(new WebMcpServer());
     const paramsSchema = await Provider.from(tool.paramsSchema);
     expect(tool.name).toBe('generate-pulse-metric-value-insight-bundle');
-    expect(tool.description).toContain(
-      'Generate an insight bundle for the current aggregated value',
-    );
+    expect(tool.description).toContain('Generate the selected insight bundle for a Pulse metric');
     expect(paramsSchema).toMatchObject({
       bundleRequest: expect.any(Object),
       slim: expect.any(Object),

--- a/src/tools/web/pulse/generateMetricValueInsightBundle/generatePulseMetricValueInsightBundleTool.test.ts
+++ b/src/tools/web/pulse/generateMetricValueInsightBundle/generatePulseMetricValueInsightBundleTool.test.ts
@@ -224,7 +224,9 @@ describe('getGeneratePulseMetricValueInsightBundleTool', () => {
     const tool = getGeneratePulseMetricValueInsightBundleTool(new WebMcpServer());
     const paramsSchema = await Provider.from(tool.paramsSchema);
     expect(tool.name).toBe('generate-pulse-metric-value-insight-bundle');
-    expect(tool.description).toContain('Generate the selected insight bundle for a Pulse metric');
+    expect(tool.description).toContain(
+      'Generate an insight bundle for the current aggregated value',
+    );
     expect(paramsSchema).toMatchObject({
       bundleRequest: expect.any(Object),
       slim: expect.any(Object),

--- a/src/tools/web/pulse/generateMetricValueInsightBundle/generatePulseMetricValueInsightBundleTool.ts
+++ b/src/tools/web/pulse/generateMetricValueInsightBundle/generatePulseMetricValueInsightBundleTool.ts
@@ -33,7 +33,7 @@ export const getGeneratePulseMetricValueInsightBundleTool = (
     server,
     name: 'generate-pulse-metric-value-insight-bundle',
     description: `
-Generate an insight bundle for the current aggregated value for Pulse Metric using Tableau REST API.  You need the full information of the Pulse Metric and Pulse Metric Definition to use this tool.
+Generate the selected insight bundle for a Pulse metric using the Tableau REST API. Provide the Pulse metric and metric definition details in \`bundleRequest\`.
 
 **Parameters:**
 - \`bundleRequest\` (required): The request to generate a bundle for.  Most of the information comes from data returned from other tools that retrieve Pulse Metric and Pulse Metric Definition information.  When creating the bundleRequest, you will need to set options using the following values:
@@ -49,6 +49,7 @@ Generate an insight bundle for the current aggregated value for Pulse Metric usi
   - 'springboard' - Return a springboard insight bundle with the current value, period over period change, and the highest ranked insight for the metric.
   - 'basic' - Similar to a springboard insight, but data is focused on the dimensions of a metric that are low bandwidth because they have small value sets. It shows the current value, period over period change, and the highest ranked insight for the metric for that data.
   - 'detail' - Shows insights on performance over time of the metric, a summary visualization of metric highs and lows and trends, breakdowns of top contributors for each filterable dimension of the metric, and followup insights based on the top ranked insights not already presented.
+  - 'exploration' - Return an exploration insight bundle focused on performance trends, with BAN, anchor, and follow-up insight groups. Available in API 3.26 (Tableau Cloud September 2025) and later. Not available for Tableau Server.
 - \`verbosity\` (optional): 'full' returns the response verbatim, including \`viz\`. 'slim' strips the large \`viz\` (Vega chart-spec) blobs from every insight and summary result. Defaults to 'full'.
 - \`slim\` (optional): Deprecated: use \`verbosity=slim\`.
 
@@ -143,6 +144,9 @@ Generate an insight bundle for the current aggregated value for Pulse Metric usi
     bundleRequest: (See default example above)
 - Generate the detail insight bundle for the Pulse metric:
     bundleType: 'detail',
+    bundleRequest: (See default example above)
+- Generate the exploration insight bundle for the Pulse metric:
+    bundleType: 'exploration',
     bundleRequest: (See default example above)
 `,
     paramsSchema,

--- a/src/tools/web/pulse/generateMetricValueInsightBundle/generatePulseMetricValueInsightBundleTool.ts
+++ b/src/tools/web/pulse/generateMetricValueInsightBundle/generatePulseMetricValueInsightBundleTool.ts
@@ -49,7 +49,7 @@ Generate an insight bundle for the current aggregated value for Pulse Metric usi
   - 'springboard' - Return a springboard insight bundle with the current value, period over period change, and the highest ranked insight for the metric.
   - 'basic' - Similar to a springboard insight, but data is focused on the dimensions of a metric that are low bandwidth because they have small value sets. It shows the current value, period over period change, and the highest ranked insight for the metric for that data.
   - 'detail' - Shows insights on performance over time of the metric, a summary visualization of metric highs and lows and trends, breakdowns of top contributors for each filterable dimension of the metric, and followup insights based on the top ranked insights not already presented.
-  - 'exploration' - Return an exploration insight bundle focused on performance trends, with BAN, anchor, and follow-up insight groups.
+  - 'exploration' - Return an exploration insight bundle focused on performance trends, with BAN, anchor, and follow-up insight groups. Available in API 3.26 (Tableau Cloud September 2025) and later. Not available for Tableau Server.
 - \`verbosity\` (optional): 'full' returns the response verbatim, including \`viz\`. 'slim' strips the large \`viz\` (Vega chart-spec) blobs from every insight and summary result. Defaults to 'full'.
 - \`slim\` (optional): Deprecated: use \`verbosity=slim\`.
 

--- a/src/tools/web/pulse/generateMetricValueInsightBundle/generatePulseMetricValueInsightBundleTool.ts
+++ b/src/tools/web/pulse/generateMetricValueInsightBundle/generatePulseMetricValueInsightBundleTool.ts
@@ -33,7 +33,7 @@ export const getGeneratePulseMetricValueInsightBundleTool = (
     server,
     name: 'generate-pulse-metric-value-insight-bundle',
     description: `
-Generate the selected insight bundle for a Pulse metric using the Tableau REST API. Provide the Pulse metric and metric definition details in \`bundleRequest\`.
+Generate an insight bundle for the current aggregated value for Pulse Metric using Tableau REST API.  You need the full information of the Pulse Metric and Pulse Metric Definition to use this tool.
 
 **Parameters:**
 - \`bundleRequest\` (required): The request to generate a bundle for.  Most of the information comes from data returned from other tools that retrieve Pulse Metric and Pulse Metric Definition information.  When creating the bundleRequest, you will need to set options using the following values:

--- a/src/tools/web/pulse/generateMetricValueInsightBundle/generatePulseMetricValueInsightBundleTool.ts
+++ b/src/tools/web/pulse/generateMetricValueInsightBundle/generatePulseMetricValueInsightBundleTool.ts
@@ -49,7 +49,7 @@ Generate the selected insight bundle for a Pulse metric using the Tableau REST A
   - 'springboard' - Return a springboard insight bundle with the current value, period over period change, and the highest ranked insight for the metric.
   - 'basic' - Similar to a springboard insight, but data is focused on the dimensions of a metric that are low bandwidth because they have small value sets. It shows the current value, period over period change, and the highest ranked insight for the metric for that data.
   - 'detail' - Shows insights on performance over time of the metric, a summary visualization of metric highs and lows and trends, breakdowns of top contributors for each filterable dimension of the metric, and followup insights based on the top ranked insights not already presented.
-  - 'exploration' - Return an exploration insight bundle focused on performance trends, with BAN, anchor, and follow-up insight groups. Available in API 3.26 (Tableau Cloud September 2025) and later. Not available for Tableau Server.
+  - 'exploration' - Return an exploration insight bundle focused on performance trends, with BAN, anchor, and follow-up insight groups.
 - \`verbosity\` (optional): 'full' returns the response verbatim, including \`viz\`. 'slim' strips the large \`viz\` (Vega chart-spec) blobs from every insight and summary result. Defaults to 'full'.
 - \`slim\` (optional): Deprecated: use \`verbosity=slim\`.
 


### PR DESCRIPTION
## Description

- Add `exploration` to the supported Pulse insight bundle types.
- Document its API availability and BAN, anchor, and follow-up insight groups.
- Extend tool tests to verify the exploration type is forwarded to the Pulse API.

## Motivation and Context

The Pulse API supports exploration bundles, but the shared MCP bundle-type schema rejected `exploration`. This prevented clients from requesting performance-trend exploration insights through `generate-pulse-metric-value-insight-bundle`.

The existing `ban` default and `full`/`slim` response behavior are unchanged.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Other (please describe):

## How Has This Been Tested?

- `npx vitest run src/tools/web/pulse/generateMetricValueInsightBundle/generatePulseMetricValueInsightBundleTool.test.ts` — 20 tests passed
- `npx tsc --noEmit` — passed
- ESLint on the changed TypeScript files — passed

`scripts/agent-check` was also run. Lint, typecheck, and desktop unit tests passed; the overall command remains red because this checkout is missing `jsdom`, the sandbox blocks the desktop build's tsx IPC socket, and the existing lockstep manifest reports unrelated desktop binder drift.

## Related Issues

- [W-23546248](https://gus.my.salesforce.com/lightning/r/ADM_Work__c/a07EE00002fVKTdYAO/view)

## Checklist

- [ ] I have updated the version in the package.json file by using `npm run version`. For example,
      use `npm run version:patch` for a patch version bump.
- [x] I have made any necessary changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have documented any breaking changes in the PR description. No breaking changes.

## Contributor Agreement

By submitting this pull request, I confirm that:

- [x] I have read the [CONTRIBUTING guidelines](../../CONTRIBUTING.md) for this project and followed
      its Contribution Checklist.

Made with [Cursor](https://cursor.com)