### PR TITLE
feat(knowledge): reachable, honest, findable — consult route + mustReadUri + fail-loud corpus + short-query search (2.50.0)

### DIFF
--- a/.github/workflows/upload-binaries.yml
+++ b/.github/workflows/upload-binaries.yml
@@ -32,6 +32,7 @@ jobs:
           trap 'rm -f .env' EXIT
           npx tsx src/scripts/seaSmoke.ts ./tableau-mcp
           npx tsx src/scripts/seaSmoke.ts ./tableau-mcp-desktop --require-tool bind-template
+          npx tsx src/scripts/seaSmoke.ts ./tableau-mcp-desktop --require-tool search-knowledge --min-knowledge-resources 100 --search-knowledge "pie chart of countries"
           tar -czf tableau-mcp.tar.gz tableau-mcp tableau-mcp-desktop
       - name: Upload archive to release
         run: |
@@ -74,6 +75,10 @@ jobs:
             npx tsx src/scripts/seaSmoke.ts .\tableau-mcp-desktop.exe --require-tool bind-template
             if ($LASTEXITCODE -ne 0) {
               throw "tableau-mcp-desktop.exe smoke failed"
+            }
+            npx tsx src/scripts/seaSmoke.ts .\tableau-mcp-desktop.exe --require-tool search-knowledge --min-knowledge-resources 100 --search-knowledge "pie chart of countries"
+            if ($LASTEXITCODE -ne 0) {
+              throw "tableau-mcp-desktop.exe knowledge smoke failed"
             }
           } finally {
             Remove-Item -Path .\.env -Force

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "2.47.0",
+  "version": "2.50.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/resources/desktop/knowledge/_index.md
+++ b/resources/desktop/knowledge/_index.md
@@ -5,10 +5,10 @@ Start here. This map routes an authoring task to the right expertise module. It 
 read the specific module before authoring.
 
 How agents reach this knowledge:
-- **`search_knowledge`** — fuzzy ranking by concept/keyword. Best when you don't know
+- **`search-knowledge`** — fuzzy ranking by concept/keyword. Best when you don't know
   the slug. Returns `expertise://tableau/<slug>` hits; read the top one.
 - **This map** — when you want the deliberate general → specific path.
-- **`read_knowledge_resource`** (or MCP `resources/read`) — read a known slug.
+- **`read-knowledge-resource`** (or MCP `resources/read`) — read a known slug.
 
 Slug = path under `data/knowledge/` with `.md` stripped. URI =
 `expertise://tableau/<slug>`.
@@ -25,7 +25,7 @@ The routing test (one question): *Would this statement still be true for another
 tool?* Yes → `strategy/` or `personalization/`; if it names a Tableau XML
 node/attribute or a Tableau-specific mechanic → `tactics/`.
 
-Folders are a human/slug aid — agents navigate by `search_knowledge` + this map. Many
+Folders are a human/slug aid — agents navigate by `search-knowledge` + this map. Many
 topics have a **tactics file (the XML/how) and a strategy companion (the when/why)**
 that cross-link bidirectionally: land on either, hop to the other via its
 `**Tactics companion:**` / related-knowledge line.

--- a/src/desktop/knowledge.test.ts
+++ b/src/desktop/knowledge.test.ts
@@ -28,6 +28,15 @@ describe('knowledge/search', { timeout: 30_000 }, () => {
     }
   });
 
+  it('requires the caller to read the top hit before authoring', () => {
+    const [top, second] = searchKnowledge('dashboard', 5);
+
+    expect(top.mustReadUri).toBe(top.uri);
+    expect(top.instruction).toBe('snippet is not the module — read this URI before authoring');
+    expect(second).not.toHaveProperty('mustReadUri');
+    expect(second).not.toHaveProperty('instruction');
+  });
+
   it('orders hits by descending score', () => {
     const hits = searchKnowledge('year over year date comparison by month', 5);
     for (let i = 1; i < hits.length; i++) {
@@ -43,6 +52,33 @@ describe('knowledge/search', { timeout: 30_000 }, () => {
   it('returns [] for an empty query', () => {
     expect(searchKnowledge('', 5)).toEqual([]);
     expect(searchKnowledge('   ', 5)).toEqual([]);
+  });
+
+  it('tokenizes short representative asks and surfaces the expected module in the top 3', () => {
+    const cases: Array<[string, string]> = [
+      ['waterfall sort', 'strategy/viz-design/advanced-chart-builds'],
+      ['margin definition', 'strategy/analytics/profitability-margin-definitions'],
+      ['pie chart of countries', 'strategy/viz-design/chart-selection'],
+    ];
+
+    for (const [query, expectedSlug] of cases) {
+      const top3 = searchKnowledge(query, 3);
+      expect(
+        top3.every((hit) => hit.match === 'keyword'),
+        query,
+      ).toBe(true);
+      expect(
+        top3.some((hit) => hit.slug === expectedSlug),
+        query,
+      ).toBe(true);
+    }
+  });
+
+  it('singularizes plural query tokens before ranking', () => {
+    const slugs = (query: string): string[] => searchKnowledge(query, 5).map((hit) => hit.slug);
+
+    expect(slugs('countries')).toEqual(slugs('country'));
+    expect(slugs('charts')).toEqual(slugs('chart'));
   });
 
   it('promotes long natural queries to keyword-ranked hits with expected docs in the top 3', () => {
@@ -114,7 +150,9 @@ describe('knowledge/search', { timeout: 30_000 }, () => {
       expect(query.length, query).toBeGreaterThan(32);
       expect(result.hits, query).toEqual([]);
       expect(result.nearestMatches?.length, query).toBeGreaterThan(0);
-      expect(result.note, query).toMatch(/zero exact matches/i);
+      expect(result.note, query).toMatch(/hits is empty/i);
+      expect(result.note, query).toMatch(/nearestMatches/i);
+      expect(result.nearestMatches?.[0].mustReadUri, query).toBe(result.nearestMatches?.[0].uri);
     }
   });
 

--- a/src/desktop/knowledge/index.test.ts
+++ b/src/desktop/knowledge/index.test.ts
@@ -7,10 +7,12 @@ import { Dirent, existsSync, readdirSync, readFileSync } from 'fs';
 
 import { getDirname } from '../../utils/getDirname.js';
 import {
+  _resetKnowledgeSearchCache,
   clearKnowledgeCache,
   getKnowledgeDir,
   listKnowledgeResources,
   readKnowledgeResource,
+  searchKnowledgeWithFallback,
 } from './index.js';
 
 const MOCK_ROOT = join('/', 'mock');
@@ -55,6 +57,7 @@ describe('knowledge/index', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     clearKnowledgeCache();
+    _resetKnowledgeSearchCache();
   });
 
   describe('getKnowledgeDir', () => {
@@ -80,6 +83,14 @@ describe('knowledge/index', () => {
         'expertise://tableau/strategy/viz-design/chart-selection',
         'expertise://tableau/tactics/viz/filters',
       ]);
+    });
+
+    it('throws an explicit asset-root error when the corpus is empty', () => {
+      setupFsMock({});
+
+      expect(() => listKnowledgeResources()).toThrow(
+        `Knowledge corpus is empty; expected assets under ${KNOWLEDGE_DIR}`,
+      );
     });
 
     it('extracts name from h1 heading', () => {
@@ -143,6 +154,16 @@ describe('knowledge/index', () => {
     it('returns null for slug with backslash', () => {
       setupFsMock({});
       expect(readKnowledgeResource('expertise://tableau/viz\\chart')).toBeNull();
+    });
+  });
+
+  describe('searchKnowledgeWithFallback', () => {
+    it('throws an explicit asset-root error when the search index is empty', () => {
+      setupFsMock({});
+
+      expect(() => searchKnowledgeWithFallback('chart choice', 3)).toThrow(
+        `Knowledge corpus is empty; expected assets under ${KNOWLEDGE_DIR}`,
+      );
     });
   });
 });

--- a/src/desktop/knowledge/index.ts
+++ b/src/desktop/knowledge/index.ts
@@ -14,6 +14,14 @@ export function getKnowledgeDir(): string {
   return join(getResourcesRoot(), 'knowledge');
 }
 
+function knowledgeCorpusEmptyError(): Error {
+  return new Error(`Knowledge corpus is empty; expected assets under ${getKnowledgeDir()}`);
+}
+
+export function getKnowledgeCorpusEntryCount(): number {
+  return listKnowledgeSlugs().length;
+}
+
 function extractMeta(content: string, fallbackName: string): { name: string; description: string } {
   const lines = content.split('\n');
   const titleLine = lines.find((l) => l.startsWith('# '));
@@ -33,7 +41,10 @@ let _cache: KnowledgeResource[] | null = null;
 
 export function listKnowledgeResources(): KnowledgeResource[] {
   if (_cache) return _cache;
-  _cache = listKnowledgeSlugs().map((slug) => {
+  const slugs = listKnowledgeSlugs();
+  if (slugs.length === 0) throw knowledgeCorpusEmptyError();
+
+  _cache = slugs.map((slug) => {
     const content = readKnowledgeBySlug(slug);
     const { name, description } =
       content !== null ? extractMeta(content, slug) : { name: slug, description: '' };
@@ -66,12 +77,9 @@ interface KnowledgeDoc {
 }
 
 let _knowledgeDocs: KnowledgeDoc[] | null = null;
-let _knowledgeFuse: Fuse<KnowledgeDoc> | null = null;
 let _knowledgeKeywordFuse: Fuse<KnowledgeDoc> | null = null;
 let _knowledgeFallbackFuse: Fuse<KnowledgeDoc> | null = null;
 let _knowledgeBroadNearestFuse: Fuse<KnowledgeDoc> | null = null;
-
-const MAX_WHOLE_STRING_QUERY_LENGTH = 32;
 
 const knowledgeSearchKeys = [
   { name: 'searchTerms', weight: 0.3 },
@@ -87,7 +95,7 @@ const knowledgeSearchKeys = [
   // at weight 0.04. `body` is still kept on the doc for the result snippet.
 ];
 
-const LONG_QUERY_STOPWORDS = new Set([
+const QUERY_STOPWORDS = new Set([
   'the',
   'and',
   'for',
@@ -117,7 +125,7 @@ const LONG_QUERY_STOPWORDS = new Set([
   'use',
 ]);
 
-const LONG_QUERY_TOOL_JARGON = new Set([
+const QUERY_TOOL_JARGON = new Set([
   'bind-template',
   'tableau-bind-template',
   'validate-proposal',
@@ -188,20 +196,11 @@ function buildKnowledgeIndex(): KnowledgeDoc[] {
     });
   }
 
+  if (docs.length === 0) throw knowledgeCorpusEmptyError();
+
   docs.sort((a, b) => a.slug.localeCompare(b.slug));
   _knowledgeDocs = docs;
   return docs;
-}
-
-function ensureKnowledgeFuse(): Fuse<KnowledgeDoc> {
-  if (_knowledgeFuse) return _knowledgeFuse;
-  _knowledgeFuse = new Fuse(buildKnowledgeIndex(), {
-    keys: knowledgeSearchKeys,
-    threshold: 0.4,
-    ignoreLocation: true,
-    includeScore: true,
-  });
-  return _knowledgeFuse;
 }
 
 function ensureKnowledgeKeywordFuse(): Fuse<KnowledgeDoc> {
@@ -223,6 +222,8 @@ export interface KnowledgeHit {
   score: number;
   snippet: string;
   match: 'whole-string' | 'keyword' | 'nearest';
+  mustReadUri?: string;
+  instruction?: string;
 }
 
 export interface KnowledgeSearchResult {
@@ -232,7 +233,21 @@ export interface KnowledgeSearchResult {
 }
 
 export const ZERO_HIT_NEAREST_MATCHES_NOTE =
-  'zero exact matches — nearest by keyword below; rephrase around the concept (shorter, no tool names) for better results.';
+  'hits is empty; nearestMatches contains the nearest keyword results, not exact hits.';
+
+const MUST_READ_INSTRUCTION = 'snippet is not the module — read this URI before authoring';
+
+function requireTopHitRead(hits: KnowledgeHit[]): KnowledgeHit[] {
+  if (hits.length === 0) return hits;
+  return [
+    {
+      ...hits[0],
+      mustReadUri: hits[0].uri,
+      instruction: MUST_READ_INSTRUCTION,
+    },
+    ...hits.slice(1),
+  ];
+}
 
 function ensureKnowledgeFallbackFuse(): Fuse<KnowledgeDoc> {
   if (_knowledgeFallbackFuse) return _knowledgeFallbackFuse;
@@ -258,18 +273,22 @@ function ensureKnowledgeBroadNearestFuse(): Fuse<KnowledgeDoc> {
 }
 
 function keywordFallbackQuery(query: string): string {
-  return (query.match(/[A-Za-z0-9][A-Za-z0-9_-]*/g) ?? [])
-    .filter((word) => word.length > 2)
-    .join(' | ');
+  return queryTokens(query).join(' | ');
 }
 
-function longQueryTokens(query: string): string[] {
+function singularizeToken(word: string): string {
+  if (word.length <= 3) return word;
+  if (word.endsWith('ies') && word.length > 4) return `${word.slice(0, -3)}y`;
+  if (/(?:ches|shes|sses|xes|zes)$/.test(word)) return word.slice(0, -2);
+  if (word.endsWith('s') && !/(?:ss|us|is)$/.test(word)) return word.slice(0, -1);
+  return word;
+}
+
+function queryTokens(query: string): string[] {
   const tokens = (query.match(/[A-Za-z0-9][A-Za-z0-9_-]*/g) ?? [])
     .map((word) => word.toLowerCase())
-    .filter(
-      (word) =>
-        word.length > 2 && !LONG_QUERY_STOPWORDS.has(word) && !LONG_QUERY_TOOL_JARGON.has(word),
-    );
+    .filter((word) => word.length > 2 && !QUERY_STOPWORDS.has(word) && !QUERY_TOOL_JARGON.has(word))
+    .map(singularizeToken);
   return [...new Set(tokens)];
 }
 
@@ -295,27 +314,19 @@ function toKnowledgeHit(
   };
 }
 
-function searchKnowledgeWholeString(query: string, limit: number): KnowledgeHit[] {
-  return ensureKnowledgeFuse()
-    .search(query)
-    .slice(0, Math.max(1, limit))
-    .map((r) =>
-      toKnowledgeHit(
-        r.item,
-        typeof r.score === 'number' ? Number((1 - r.score).toFixed(3)) : 0,
-        'whole-string',
-      ),
-    );
-}
-
 function searchKnowledgeByKeywordIntersection(query: string, limit: number): KnowledgeHit[] {
-  const tokens = longQueryTokens(query);
+  const tokens = queryTokens(query);
   if (tokens.length === 0) return [];
 
   const fuse = ensureKnowledgeKeywordFuse();
   const ranked = new Map<
     string,
-    { doc: KnowledgeDoc; matchedTokenCount: number; fuseScoreSum: number }
+    {
+      doc: KnowledgeDoc;
+      matchedTokenCount: number;
+      titleTokenCount: number;
+      fuseScoreSum: number;
+    }
   >();
 
   for (const token of tokens) {
@@ -328,6 +339,9 @@ function searchKnowledgeByKeywordIntersection(query: string, limit: number): Kno
         ranked.set(result.item.slug, {
           doc: result.item,
           matchedTokenCount: 1,
+          titleTokenCount: tokens.filter((candidate) =>
+            queryTokens(result.item.title).includes(candidate),
+          ).length,
           fuseScoreSum: result.score ?? 1,
         });
       }
@@ -336,9 +350,15 @@ function searchKnowledgeByKeywordIntersection(query: string, limit: number): Kno
 
   return [...ranked.values()]
     .sort((a, b) => {
-      const tokenCountDelta = b.matchedTokenCount - a.matchedTokenCount;
-      if (tokenCountDelta !== 0) return tokenCountDelta;
-      const scoreDelta = a.fuseScoreSum - b.fuseScoreSum;
+      const aScore =
+        a.matchedTokenCount * 2 +
+        a.titleTokenCount * 0.08 +
+        (1 - a.fuseScoreSum / a.matchedTokenCount);
+      const bScore =
+        b.matchedTokenCount * 2 +
+        b.titleTokenCount * 0.08 +
+        (1 - b.fuseScoreSum / b.matchedTokenCount);
+      const scoreDelta = bScore - aScore;
       if (scoreDelta !== 0) return scoreDelta;
       return a.doc.slug.localeCompare(b.doc.slug);
     })
@@ -346,7 +366,8 @@ function searchKnowledgeByKeywordIntersection(query: string, limit: number): Kno
     .map((rankedDoc) => {
       const avgFuseScore = rankedDoc.fuseScoreSum / rankedDoc.matchedTokenCount;
       const compositeScore =
-        (rankedDoc.matchedTokenCount * 2 + (1 - avgFuseScore)) / (tokens.length * 2 + 1);
+        (rankedDoc.matchedTokenCount * 2 + rankedDoc.titleTokenCount * 0.08 + (1 - avgFuseScore)) /
+        (tokens.length * 2.08 + 1);
       return toKnowledgeHit(rankedDoc.doc, Number(compositeScore.toFixed(3)), 'keyword');
     });
 }
@@ -387,8 +408,7 @@ function nearestKeywordMatches(query: string, limit: number, broaden = false): K
 export function searchKnowledge(query: string, limit = 5): KnowledgeHit[] {
   const q = (query ?? '').trim();
   if (!q) return [];
-  if (q.length <= MAX_WHOLE_STRING_QUERY_LENGTH) return searchKnowledgeWholeString(q, limit);
-  return searchKnowledgeByKeywordIntersection(q, limit);
+  return requireTopHitRead(searchKnowledgeByKeywordIntersection(q, limit));
 }
 
 export function searchKnowledgeWithFallback(query: string, limit = 5): KnowledgeSearchResult {
@@ -396,16 +416,19 @@ export function searchKnowledgeWithFallback(query: string, limit = 5): Knowledge
   if (hits.length > 0) return { hits };
 
   const q = (query ?? '').trim();
-  const nearestMatches = nearestKeywordMatches(q, limit, q.length > MAX_WHOLE_STRING_QUERY_LENGTH);
+  const nearestMatches = nearestKeywordMatches(q, limit, true);
 
   if (nearestMatches.length === 0) return { hits };
-  return { hits, nearestMatches, note: ZERO_HIT_NEAREST_MATCHES_NOTE };
+  return {
+    hits,
+    nearestMatches: requireTopHitRead(nearestMatches),
+    note: ZERO_HIT_NEAREST_MATCHES_NOTE,
+  };
 }
 
 /** Reset cached index/fuse (tests). */
 export function _resetKnowledgeSearchCache(): void {
   _knowledgeDocs = null;
-  _knowledgeFuse = null;
   _knowledgeKeywordFuse = null;
   _knowledgeFallbackFuse = null;
   _knowledgeBroadNearestFuse = null;

--- a/src/desktop/knowledge/knowledgeToolReferences.test.ts
+++ b/src/desktop/knowledge/knowledgeToolReferences.test.ts
@@ -254,4 +254,25 @@ describe('desktop knowledge tool references', () => {
       })),
     ).toEqual([]);
   });
+
+  it('never teaches underscore aliases for the knowledge tools', () => {
+    const forbiddenAliases = ['search_knowledge', 'read_knowledge_resource'];
+    const knowledgeDir = getKnowledgeDir();
+    const offenders = listMarkdownFiles(knowledgeDir).flatMap((file) => {
+      const relativeFile = relative(knowledgeDir, file);
+      return readFileSync(file, 'utf-8')
+        .split('\n')
+        .flatMap((line, index) =>
+          forbiddenAliases
+            .filter((alias) => line.includes(alias))
+            .map((alias) => ({
+              file: relativeFile,
+              alias,
+              line: `${index + 1}: ${line.trim()}`,
+            })),
+        );
+    });
+
+    expect(offenders).toEqual([]);
+  });
 });

--- a/src/desktop/knowledge/resources.test.ts
+++ b/src/desktop/knowledge/resources.test.ts
@@ -5,6 +5,10 @@ describe('desktop knowledge resources', () => {
     clearKnowledgeCache();
   });
 
+  it('ships at least 100 knowledge resources', () => {
+    expect(listKnowledgeResources().length).toBeGreaterThanOrEqual(100);
+  });
+
   it('surfaces the bulk UI translation entry for workbook translation prompts', () => {
     const query = 'translate the workbook into German';
     const resource = listKnowledgeResources().find((entry) =>

--- a/src/desktop/routeTable.test.ts
+++ b/src/desktop/routeTable.test.ts
@@ -57,6 +57,17 @@ describe('DESKTOP_ROUTE_TABLE', () => {
     expect(rendered).toContain('tableau-desktop-authoring');
   });
 
+  it('caps targeted knowledge consultation at one read before authoring proceeds', () => {
+    const knowledge = routes.find((route) => route.id === 'knowledge-consult');
+
+    expect(knowledge).toMatchObject({
+      trigger:
+        'an unfamiliar or non-trivial authoring ask (calc-heavy, uncertain which chart fits, formatting/design) — never a plain chart ask the plain-chart route already handles',
+      toolSequence: ['search-knowledge', 'read-knowledge-resource'],
+      stopConditions: ['read the top hit once, then proceed'],
+    });
+  });
+
   it('teaches plain-chart proposals may carry sort and top_n', () => {
     const plainChart = routes.find((route) => route.id === 'plain-chart');
     expect(plainChart?.action).toContain('proposals may carry sort and top_n.');

--- a/src/desktop/routeTable.ts
+++ b/src/desktop/routeTable.ts
@@ -44,6 +44,17 @@ export const DESKTOP_ROUTE_TABLE: readonly DesktopInstructionEntry[] = [
   },
   {
     kind: 'route',
+    id: 'knowledge-consult',
+    trigger:
+      'an unfamiliar or non-trivial authoring ask (calc-heavy, uncertain which chart fits, formatting/design) — never a plain chart ask the plain-chart route already handles',
+    action:
+      'FIRST search-knowledge; use read-knowledge-resource to read the top hit once, then proceed.',
+    toolSequence: ['search-knowledge', 'read-knowledge-resource'],
+    stopConditions: ['read the top hit once, then proceed'],
+    requiredEvidence: ['one targeted knowledge module or no search hit'],
+  },
+  {
+    kind: 'route',
     id: 'plain-chart',
     trigger: 'a plain viz ask (bar/line/map/KPI/etc.)',
     action:

--- a/src/scripts/buildSea.test.ts
+++ b/src/scripts/buildSea.test.ts
@@ -19,9 +19,15 @@ describe('SEA release workflow', () => {
     expect(workflow).toMatch(
       /npx tsx src\/scripts\/seaSmoke\.ts \.\/tableau-mcp-desktop --require-tool bind-template/,
     );
+    expect(workflow).toMatch(
+      /npx tsx src\/scripts\/seaSmoke\.ts \.\/tableau-mcp-desktop --require-tool search-knowledge --min-knowledge-resources 100 --search-knowledge "pie chart of countries"/,
+    );
     expect(workflow).toMatch(/npx tsx src\/scripts\/seaSmoke\.ts \.\\tableau-mcp\.exe\s/);
     expect(workflow).toMatch(
       /npx tsx src\/scripts\/seaSmoke\.ts \.\\tableau-mcp-desktop\.exe --require-tool bind-template/,
+    );
+    expect(workflow).toMatch(
+      /npx tsx src\/scripts\/seaSmoke\.ts \.\\tableau-mcp-desktop\.exe --require-tool search-knowledge --min-knowledge-resources 100 --search-knowledge "pie chart of countries"/,
     );
   });
 });

--- a/src/scripts/seaSmoke.test.ts
+++ b/src/scripts/seaSmoke.test.ts
@@ -1,4 +1,10 @@
-import { buildMcpHandshakeInput, parseArgs, requireToolName } from './seaSmoke.js';
+import {
+  buildMcpHandshakeInput,
+  parseArgs,
+  requireKnowledgeSearchHit,
+  requireMinimumKnowledgeResources,
+  requireToolName,
+} from './seaSmoke.js';
 
 describe('SEA smoke helper', () => {
   it('builds a minimal MCP initialize and tools/list handshake', () => {
@@ -7,6 +13,18 @@ describe('SEA smoke helper', () => {
     expect(input).toContain('"method":"initialize"');
     expect(input).toContain('"method":"tools/list"');
     expect(input.trim().split('\n')).toHaveLength(2);
+  });
+
+  it('adds resource-count and real-search probes when requested', () => {
+    const input = buildMcpHandshakeInput({
+      minKnowledgeResources: 100,
+      knowledgeSearchQuery: 'pie chart of countries',
+    });
+
+    expect(input).toContain('"method":"resources/list"');
+    expect(input).toContain('"method":"tools/call"');
+    expect(input).toContain('"name":"search-knowledge"');
+    expect(input).toContain('"query":"pie chart of countries"');
   });
 
   it('parses a binary path and required tool name', () => {
@@ -21,6 +39,27 @@ describe('SEA smoke helper', () => {
     ).toEqual({
       binaryPath: './tableau-mcp-desktop',
       requiredTool: 'bind-template',
+    });
+  });
+
+  it('parses knowledge corpus and search smoke options', () => {
+    expect(
+      parseArgs([
+        'node',
+        'seaSmoke.ts',
+        './tableau-mcp-desktop',
+        '--require-tool',
+        'search-knowledge',
+        '--min-knowledge-resources',
+        '100',
+        '--search-knowledge',
+        'pie chart of countries',
+      ]),
+    ).toEqual({
+      binaryPath: './tableau-mcp-desktop',
+      requiredTool: 'search-knowledge',
+      minKnowledgeResources: 100,
+      knowledgeSearchQuery: 'pie chart of countries',
     });
   });
 
@@ -56,5 +95,51 @@ describe('SEA smoke helper', () => {
         'bind-template',
       ),
     ).toThrow("Required tool 'bind-template' was not returned by tools/list");
+  });
+
+  it('requires at least the requested number of knowledge resources', () => {
+    const output = [
+      JSON.stringify({
+        jsonrpc: '2.0',
+        id: 3,
+        result: {
+          resources: Array.from({ length: 100 }, (_, index) => ({
+            uri: `expertise://tableau/${index}`,
+          })),
+        },
+      }),
+    ];
+
+    expect(() => requireMinimumKnowledgeResources(output, 100)).not.toThrow();
+    expect(() => requireMinimumKnowledgeResources(output, 101)).toThrow(
+      'Expected at least 101 knowledge resources, got 100',
+    );
+  });
+
+  it('requires a successful real knowledge search hit', () => {
+    const output = [
+      JSON.stringify({
+        jsonrpc: '2.0',
+        id: 4,
+        result: {
+          isError: false,
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify({
+                hits: [
+                  {
+                    uri: 'expertise://tableau/strategy/viz-design/chart-selection',
+                    mustReadUri: 'expertise://tableau/strategy/viz-design/chart-selection',
+                  },
+                ],
+              }),
+            },
+          ],
+        },
+      }),
+    ];
+
+    expect(() => requireKnowledgeSearchHit(output)).not.toThrow();
   });
 });

--- a/src/scripts/seaSmoke.ts
+++ b/src/scripts/seaSmoke.ts
@@ -7,6 +7,8 @@ type JsonObject = Record<string, unknown>;
 type SmokeOptions = {
   binaryPath: string;
   requiredTool?: string;
+  minKnowledgeResources?: number;
+  knowledgeSearchQuery?: string;
   timeoutMs?: number;
 };
 
@@ -33,8 +35,41 @@ const toolsListRequest = {
   params: {},
 };
 
-export function buildMcpHandshakeInput(): string {
-  return `${JSON.stringify(initializeRequest)}\n${JSON.stringify(toolsListRequest)}\n`;
+const initializedNotification = {
+  jsonrpc: '2.0',
+  method: 'notifications/initialized',
+  params: {},
+};
+
+const resourcesListRequest = {
+  jsonrpc: '2.0',
+  id: 3,
+  method: 'resources/list',
+  params: {},
+};
+
+export function buildMcpHandshakeInput(
+  options: Pick<SmokeOptions, 'minKnowledgeResources' | 'knowledgeSearchQuery'> = {},
+): string {
+  const messages: JsonObject[] = [initializeRequest, toolsListRequest];
+  if (options.minKnowledgeResources !== undefined || options.knowledgeSearchQuery !== undefined) {
+    messages.splice(1, 0, initializedNotification);
+  }
+  if (options.minKnowledgeResources !== undefined) {
+    messages.push(resourcesListRequest);
+  }
+  if (options.knowledgeSearchQuery !== undefined) {
+    messages.push({
+      jsonrpc: '2.0',
+      id: 4,
+      method: 'tools/call',
+      params: {
+        name: 'search-knowledge',
+        arguments: { query: options.knowledgeSearchQuery, limit: 3 },
+      },
+    });
+  }
+  return `${messages.map((message) => JSON.stringify(message)).join('\n')}\n`;
 }
 
 export function parseArgs(argv: string[]): SmokeOptions {
@@ -42,7 +77,7 @@ export function parseArgs(argv: string[]): SmokeOptions {
   const binaryPath = args[0];
   if (!binaryPath || binaryPath.startsWith('--')) {
     throw new Error(
-      'Usage: npx tsx src/scripts/seaSmoke.ts <binary-path> [--require-tool <tool-name>] [--timeout-ms <ms>]',
+      'Usage: npx tsx src/scripts/seaSmoke.ts <binary-path> [--require-tool <tool-name>] [--min-knowledge-resources <count>] [--search-knowledge <query>] [--timeout-ms <ms>]',
     );
   }
 
@@ -55,6 +90,18 @@ export function parseArgs(argv: string[]): SmokeOptions {
         throw new Error('--require-tool requires a tool name');
       }
       options.requiredTool = requiredTool;
+    } else if (arg === '--min-knowledge-resources') {
+      const minKnowledgeResources = Number(args[++i]);
+      if (!Number.isInteger(minKnowledgeResources) || minKnowledgeResources <= 0) {
+        throw new Error('--min-knowledge-resources requires a positive integer');
+      }
+      options.minKnowledgeResources = minKnowledgeResources;
+    } else if (arg === '--search-knowledge') {
+      const knowledgeSearchQuery = args[++i];
+      if (!knowledgeSearchQuery || knowledgeSearchQuery.startsWith('--')) {
+        throw new Error('--search-knowledge requires a query');
+      }
+      options.knowledgeSearchQuery = knowledgeSearchQuery;
     } else if (arg === '--timeout-ms') {
       const timeoutMs = Number(args[++i]);
       if (!Number.isInteger(timeoutMs) || timeoutMs <= 0) {
@@ -130,7 +177,79 @@ export function requireToolName(outputLines: string[], requiredTool: string): vo
   }
 }
 
-function validateHandshake(outputLines: string[], requiredTool?: string): void {
+export function requireMinimumKnowledgeResources(outputLines: string[], minimum: number): void {
+  const messages = parseJsonLines(outputLines);
+  assertNoJsonRpcErrors(messages);
+  const resourcesResponse = getResponse(messages, 3);
+  const result = resourcesResponse?.result;
+  const resources =
+    result && typeof result === 'object' && 'resources' in result
+      ? (result as { resources?: unknown }).resources
+      : undefined;
+  if (!Array.isArray(resources)) {
+    throw new Error('resources/list did not return a resources array');
+  }
+  const knowledgeCount = resources.filter(
+    (resource) =>
+      resource &&
+      typeof resource === 'object' &&
+      'uri' in resource &&
+      typeof (resource as { uri?: unknown }).uri === 'string' &&
+      (resource as { uri: string }).uri.startsWith('expertise://tableau/'),
+  ).length;
+  if (knowledgeCount < minimum) {
+    throw new Error(`Expected at least ${minimum} knowledge resources, got ${knowledgeCount}`);
+  }
+}
+
+export function requireKnowledgeSearchHit(outputLines: string[]): void {
+  const messages = parseJsonLines(outputLines);
+  assertNoJsonRpcErrors(messages);
+  const searchResponse = getResponse(messages, 4);
+  const result = searchResponse?.result;
+  if (!result || typeof result !== 'object') {
+    throw new Error('search-knowledge did not return a result');
+  }
+  if ((result as { isError?: unknown }).isError === true) {
+    throw new Error(`search-knowledge returned an error: ${JSON.stringify(result)}`);
+  }
+  const content = (result as { content?: unknown }).content;
+  const first = Array.isArray(content) ? content[0] : undefined;
+  if (
+    !first ||
+    typeof first !== 'object' ||
+    !('text' in first) ||
+    typeof (first as { text?: unknown }).text !== 'string'
+  ) {
+    throw new Error('search-knowledge did not return text content');
+  }
+  const payload: unknown = JSON.parse((first as { text: string }).text);
+  const hits =
+    payload && typeof payload === 'object' && 'hits' in payload
+      ? (payload as { hits?: unknown }).hits
+      : undefined;
+  if (!Array.isArray(hits) || hits.length === 0) {
+    throw new Error('search-knowledge returned no hits');
+  }
+  const topHit = hits[0];
+  if (
+    !topHit ||
+    typeof topHit !== 'object' ||
+    !('mustReadUri' in topHit) ||
+    typeof (topHit as { mustReadUri?: unknown }).mustReadUri !== 'string'
+  ) {
+    throw new Error('search-knowledge top hit did not include mustReadUri');
+  }
+}
+
+function validateHandshake(
+  outputLines: string[],
+  {
+    requiredTool,
+    minKnowledgeResources,
+    knowledgeSearchQuery,
+  }: Pick<SmokeOptions, 'requiredTool' | 'minKnowledgeResources' | 'knowledgeSearchQuery'>,
+): void {
   const messages = parseJsonLines(outputLines);
   assertNoJsonRpcErrors(messages);
 
@@ -143,11 +262,19 @@ function validateHandshake(outputLines: string[], requiredTool?: string): void {
   if (requiredTool) {
     requireToolName(outputLines, requiredTool);
   }
+  if (minKnowledgeResources !== undefined) {
+    requireMinimumKnowledgeResources(outputLines, minKnowledgeResources);
+  }
+  if (knowledgeSearchQuery !== undefined) {
+    requireKnowledgeSearchHit(outputLines);
+  }
 }
 
 export async function runSeaSmoke({
   binaryPath,
   requiredTool,
+  minKnowledgeResources,
+  knowledgeSearchQuery,
   timeoutMs = DEFAULT_TIMEOUT_MS,
 }: SmokeOptions): Promise<void> {
   const child = spawn(binaryPath, [], {
@@ -180,7 +307,7 @@ export async function runSeaSmoke({
     child.kill();
   }, timeoutMs);
 
-  child.stdin.end(buildMcpHandshakeInput());
+  child.stdin.end(buildMcpHandshakeInput({ minKnowledgeResources, knowledgeSearchQuery }));
 
   const { code, signal } = await closePromise;
   clearTimeout(timeout);
@@ -195,14 +322,18 @@ export async function runSeaSmoke({
     );
   }
 
-  validateHandshake(outputLines, requiredTool);
+  validateHandshake(outputLines, {
+    requiredTool,
+    minKnowledgeResources,
+    knowledgeSearchQuery,
+  });
 }
 
 async function main(): Promise<void> {
   const options = parseArgs(process.argv);
   await runSeaSmoke(options);
   console.log(
-    `SEA smoke passed for ${options.binaryPath}${options.requiredTool ? `; found ${options.requiredTool}` : ''}`,
+    `SEA smoke passed for ${options.binaryPath}${options.requiredTool ? `; found ${options.requiredTool}` : ''}${options.minKnowledgeResources ? `; knowledge resources >= ${options.minKnowledgeResources}` : ''}${options.knowledgeSearchQuery ? '; knowledge search returned a hit' : ''}`,
   );
 }
 

--- a/src/server.desktop.knowledge.test.ts
+++ b/src/server.desktop.knowledge.test.ts
@@ -1,0 +1,30 @@
+import * as loggerModule from './logging/logger.js';
+
+const knowledgeMocks = vi.hoisted(() => ({
+  getKnowledgeCorpusEntryCount: vi.fn(() => 0),
+  getKnowledgeDir: vi.fn(() => '/app/resources/desktop/knowledge'),
+  listKnowledgeResources: vi.fn(() => []),
+  readKnowledgeResource: vi.fn(() => null),
+}));
+
+vi.mock('./desktop/knowledge/index.js', () => knowledgeMocks);
+
+import { DesktopMcpServer } from './server.desktop.js';
+
+describe('DesktopMcpServer knowledge startup check', () => {
+  it('logs one warning naming the expected asset root when the corpus is empty', async () => {
+    const logSpy = vi.spyOn(loggerModule, 'log').mockImplementation(() => {});
+    const server = new DesktopMcpServer();
+    server.mcpServer.registerResource = vi.fn();
+
+    await server.registerResources();
+    await server.registerResources();
+
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(logSpy).toHaveBeenCalledWith({
+      message: 'Knowledge corpus is empty; expected assets under /app/resources/desktop/knowledge',
+      level: 'warning',
+      logger: 'DesktopMcpServer',
+    });
+  });
+});

--- a/src/server.desktop.test.ts
+++ b/src/server.desktop.test.ts
@@ -97,6 +97,8 @@ Load tableau-desktop-authoring; repeat failures -> tableau-agent-debug.
 
 Before dashboards, plan MAGNITUDE vs MEMBERSHIP; MEMBERSHIP uses buckets, not gradients. State plan, build.
 
+For an unfamiliar or non-trivial authoring ask (calc-heavy, uncertain which chart fits, formatting/design) — never a plain chart ask the plain-chart route already handles, FIRST search-knowledge; use read-knowledge-resource to read the top hit once, then proceed.
+
 For a plain viz ask (bar/line/map/KPI/etc.), FIRST bind-template(auto_apply:true): deterministic, ~0.3s. On propose, resubmit; proposals may carry sort and top_n. author-parameter/author-set/author-action before charts; else search-commands.
 
 For a dashboard ask with 2-6 vizzes, build sheets with bind-template (author calcs/params/sets first), then compose with dashboard-auto-apply (2-6 plain charts, one call) or plan-dashboard-creation -> build-and-apply-dashboard; search-commands only for commands the census does not list.

--- a/src/server.desktop.ts
+++ b/src/server.desktop.ts
@@ -10,7 +10,12 @@ import {
 import pkg from '../package.json';
 import { getDesktopConfig } from './config.desktop.js';
 import { DATA_ROOT, readResourceAsset, RESOURCES_ROOT } from './desktop/assets.js';
-import { listKnowledgeResources, readKnowledgeResource } from './desktop/knowledge/index.js';
+import {
+  getKnowledgeCorpusEntryCount,
+  getKnowledgeDir,
+  listKnowledgeResources,
+  readKnowledgeResource,
+} from './desktop/knowledge/index.js';
 import { buildDesktopInstructions } from './desktop/routeTable.js';
 import { SessionManager } from './desktop/sessionManager.js';
 import { log } from './logging/logger.js';
@@ -181,6 +186,7 @@ export const DESKTOP_INSTRUCTIONS = buildDesktopInstructions({ sessionPinned: fa
 
 export class DesktopMcpServer extends Server {
   private readonly sessionManager = new SessionManager();
+  private knowledgeCorpusChecked = false;
 
   constructor({ mcpServer, clientInfo }: { mcpServer?: McpServer; clientInfo?: ClientInfo } = {}) {
     super({
@@ -195,6 +201,16 @@ export class DesktopMcpServer extends Server {
   }
 
   registerResources = async (): Promise<void> => {
+    if (!this.knowledgeCorpusChecked) {
+      this.knowledgeCorpusChecked = true;
+      if (getKnowledgeCorpusEntryCount() === 0) {
+        log({
+          message: `Knowledge corpus is empty; expected assets under ${getKnowledgeDir()}`,
+          level: 'warning',
+          logger: 'DesktopMcpServer',
+        });
+      }
+    }
     await this._registerDashboardXmlGuide();
     this._registerKnowledgeResources();
   };

--- a/src/tools/desktop/knowledge/listKnowledgeResources.test.ts
+++ b/src/tools/desktop/knowledge/listKnowledgeResources.test.ts
@@ -47,14 +47,18 @@ describe('listKnowledgeResourcesTool', () => {
     expect(parsed.resources[0].uri).toBe('expertise://tableau/strategy/viz-design/chart-selection');
   });
 
-  it('should return empty list when no resources exist', async () => {
-    vi.mocked(listKnowledgeResources).mockReturnValue([]);
+  it('should return an explicit asset-root error when no resources exist', async () => {
+    vi.mocked(listKnowledgeResources).mockImplementation(() => {
+      throw new Error(
+        'Knowledge corpus is empty; expected assets under /app/resources/desktop/knowledge',
+      );
+    });
 
     const result = await getResult();
 
-    expect(result.isError).toBeFalsy();
+    expect(result.isError).toBe(true);
     invariant(result.content[0].type === 'text');
-    expect(JSON.parse(result.content[0].text).resources).toHaveLength(0);
+    expect(result.content[0].text).toContain('/app/resources/desktop/knowledge');
   });
 });
 

--- a/src/tools/desktop/knowledge/searchKnowledge.test.ts
+++ b/src/tools/desktop/knowledge/searchKnowledge.test.ts
@@ -1,0 +1,69 @@
+import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+
+import { DesktopMcpServer } from '../../../server.desktop.js';
+import invariant from '../../../utils/invariant.js';
+import { Provider } from '../../../utils/provider.js';
+import { getMockRequestHandlerExtra } from '../toolContext.mock.js';
+import { getSearchKnowledgeTool } from './searchKnowledge.js';
+
+vi.mock('../../../desktop/knowledge/index.js');
+
+import { searchKnowledgeWithFallback } from '../../../desktop/knowledge/index.js';
+
+const TOP_HIT = {
+  uri: 'expertise://tableau/strategy/viz-design/chart-selection',
+  slug: 'strategy/viz-design/chart-selection',
+  title: 'Chart Selection',
+  score: 0.9,
+  snippet: 'Choose a chart from the analytical question.',
+  match: 'keyword' as const,
+  mustReadUri: 'expertise://tableau/strategy/viz-design/chart-selection',
+  instruction: 'snippet is not the module — read this URI before authoring',
+};
+
+describe('searchKnowledgeTool', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(searchKnowledgeWithFallback).mockReturnValue({ hits: [TOP_HIT] });
+  });
+
+  it('tells callers that search snippets require a targeted read', async () => {
+    const tool = getSearchKnowledgeTool(new DesktopMcpServer());
+
+    expect(await Provider.from(tool.description)).toContain('read mustReadUri');
+  });
+
+  it('returns the top hit read requirement', async () => {
+    const result = await getResult();
+
+    expect(result.isError).toBeFalsy();
+    invariant(result.content[0].type === 'text');
+    expect(JSON.parse(result.content[0].text).hits[0]).toMatchObject({
+      mustReadUri: TOP_HIT.uri,
+      instruction: TOP_HIT.instruction,
+    });
+  });
+
+  it('returns an explicit asset-root error when the search index is empty', async () => {
+    vi.mocked(searchKnowledgeWithFallback).mockImplementation(() => {
+      throw new Error(
+        'Knowledge corpus is empty; expected assets under /app/resources/desktop/knowledge',
+      );
+    });
+
+    const result = await getResult();
+
+    expect(result.isError).toBe(true);
+    invariant(result.content[0].type === 'text');
+    expect(result.content[0].text).toContain('/app/resources/desktop/knowledge');
+  });
+});
+
+async function getResult(): Promise<CallToolResult> {
+  const tool = getSearchKnowledgeTool(new DesktopMcpServer());
+  const callback = await Provider.from(tool.callback);
+  return await callback(
+    { query: 'pie chart of countries', limit: 3 },
+    getMockRequestHandlerExtra(),
+  );
+}

--- a/src/tools/desktop/knowledge/searchKnowledge.ts
+++ b/src/tools/desktop/knowledge/searchKnowledge.ts
@@ -20,7 +20,7 @@ export const getSearchKnowledgeTool = (
     name: 'search-knowledge',
     title: toolTitle,
     description:
-      'Find relevant expertise for a task (top N by uri+title). Best queried with short concept phrases (e.g. "symbol map latitude longitude"), not tool names. Use THIS to discover knowledge, not list.',
+      'Find targeted expertise by concept phrase, not tool name. Search snippets are not modules: read mustReadUri once before authoring. Use this to discover knowledge, not list.',
     paramsSchema,
     annotations: {
       title: toolTitle,


### PR DESCRIPTION
## What / why

\"Knowledge search may not be working on the latest binary.\" The source investigation found the canonical build is structurally fine — the failure modes are reachability and silent degradation:

1. **The consult-before-authoring law existed only in comments** — the runtime route table never mentioned the knowledge tools, and nothing told the model a snippet isn't the module. New `knowledge-consult` route: targeted `search-knowledge`, read the top hit **once**, then proceed — explicitly never on plain chart asks (the plain-chart/bind-template route owns those; over-consultation was a proven regression class).
2. **Search results now demand their read** — top hit carries `mustReadUri` + a one-line instruction; empty-hit responses label `nearestMatches` explicitly.
3. **Empty corpus fails loudly** — a mispackaged binary previously returned `{hits: []}` successfully; now it errors naming the expected asset root, logs at startup, and a ≥100-resource guard test pins the corpus.
4. **Short-query dead zones fixed** — all queries tokenize (not just >32 chars) with light singularization. Probes before→after: `pie chart of countries` — chart-selection invisible → **.690**; `margin definition` — .156 → **.973**; `waterfall sort` — .126 → **.577**.
5. **Name drift** — the corpus taught `search_knowledge` (underscores, never registered); `_index.md` corrected and the anti-drift test now rejects underscore aliases.
6. **Release smoke** — the SEA smoke now requires `search-knowledge`, asserts corpus count, and runs a real search against the built artifact, so none of the above can silently regress at release again.

Out of scope by design: `demo`/`spec-loop` profile membership (curated surfaces; product call), corpus dedupe of legacy path families (reported, not moved), client-side prompts.

## Verification
Full suite 339 files / 5014 tests green firsthand. Route-table byte-pins updated deliberately with the tightened trigger wording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)