### PR TITLE
fix(knowledge): review hardening — route precedence, tokenizer fallback, response-driven SEA smoke (2.52.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "2.50.0",
+  "version": "2.52.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/src/desktop/knowledge.test.ts
+++ b/src/desktop/knowledge.test.ts
@@ -74,11 +74,34 @@ describe('knowledge/search', { timeout: 30_000 }, () => {
     }
   });
 
-  it('singularizes plural query tokens before ranking', () => {
+  it('singularizes only conservative trailing-s plural query tokens before ranking', () => {
     const slugs = (query: string): string[] => searchKnowledge(query, 5).map((hit) => hit.slug);
 
-    expect(slugs('countries')).toEqual(slugs('country'));
     expect(slugs('charts')).toEqual(slugs('chart'));
+  });
+
+  it('falls back to whole-string fuzzy search when tokenization removes every term', () => {
+    const result = searchKnowledgeWithFallback('AI', 5);
+    const candidates = result.hits.length > 0 ? result.hits : (result.nearestMatches ?? []);
+
+    expect(candidates.length).toBeGreaterThan(0);
+    expect(candidates[0].mustReadUri).toBe(candidates[0].uri);
+    if (result.hits.length > 0) {
+      expect(result.hits.every((hit) => hit.match === 'whole-string')).toBe(true);
+    } else {
+      expect(result.note).toMatch(/nearestMatches/i);
+    }
+  });
+
+  it('keeps axes intact so axis-related modules remain reachable', () => {
+    const hits = searchKnowledge('axes', 5);
+
+    expect(hits.length).toBeGreaterThan(0);
+    expect([
+      'tactics/workflow/export-worksheet-image-full-canvas',
+      'tactics/viz/pane-structure',
+      'tactics/viz/marks-and-encodings',
+    ]).toContain(hits[0].slug);
   });
 
   it('promotes long natural queries to keyword-ranked hits with expected docs in the top 3', () => {

--- a/src/desktop/knowledge/index.ts
+++ b/src/desktop/knowledge/index.ts
@@ -273,14 +273,14 @@ function ensureKnowledgeBroadNearestFuse(): Fuse<KnowledgeDoc> {
 }
 
 function keywordFallbackQuery(query: string): string {
-  return queryTokens(query).join(' | ');
+  const tokens = queryTokens(query);
+  return tokens.length > 0 ? tokens.join(' | ') : query.trim();
 }
 
 function singularizeToken(word: string): string {
-  if (word.length <= 3) return word;
-  if (word.endsWith('ies') && word.length > 4) return `${word.slice(0, -3)}y`;
-  if (/(?:ches|shes|sses|xes|zes)$/.test(word)) return word.slice(0, -2);
-  if (word.endsWith('s') && !/(?:ss|us|is)$/.test(word)) return word.slice(0, -1);
+  if (word.length >= 5 && word.endsWith('s') && !word.endsWith('ss') && !word.endsWith('es')) {
+    return word.slice(0, -1);
+  }
   return word;
 }
 
@@ -316,7 +316,7 @@ function toKnowledgeHit(
 
 function searchKnowledgeByKeywordIntersection(query: string, limit: number): KnowledgeHit[] {
   const tokens = queryTokens(query);
-  if (tokens.length === 0) return [];
+  if (tokens.length === 0) return searchKnowledgeByWholeString(query, limit);
 
   const fuse = ensureKnowledgeKeywordFuse();
   const ranked = new Map<
@@ -370,6 +370,22 @@ function searchKnowledgeByKeywordIntersection(query: string, limit: number): Kno
         (tokens.length * 2.08 + 1);
       return toKnowledgeHit(rankedDoc.doc, Number(compositeScore.toFixed(3)), 'keyword');
     });
+}
+
+function searchKnowledgeByWholeString(query: string, limit: number): KnowledgeHit[] {
+  const q = query.trim();
+  if (!q) return [];
+
+  return ensureKnowledgeFallbackFuse()
+    .search(q)
+    .slice(0, Math.max(1, limit))
+    .map((r) =>
+      toKnowledgeHit(
+        r.item,
+        typeof r.score === 'number' ? Number((1 - r.score).toFixed(3)) : 0,
+        'whole-string',
+      ),
+    );
 }
 
 function nearestKeywordMatches(query: string, limit: number, broaden = false): KnowledgeHit[] {

--- a/src/desktop/routeTable.test.ts
+++ b/src/desktop/routeTable.test.ts
@@ -62,10 +62,16 @@ describe('DESKTOP_ROUTE_TABLE', () => {
 
     expect(knowledge).toMatchObject({
       trigger:
-        'an unfamiliar or non-trivial authoring ask (calc-heavy, uncertain which chart fits, formatting/design) — never a plain chart ask the plain-chart route already handles',
+        'an unfamiliar or non-trivial authoring ask (calc-heavy, uncertain which chart fits, formatting/design) only when no plain-chart binding path applies; a named chart type always takes plain-chart first, even with calc/formatting riders; chart-route escalation may still consult',
       toolSequence: ['search-knowledge', 'read-knowledge-resource'],
       stopConditions: ['read the top hit once, then proceed'],
     });
+  });
+
+  it('places the deterministic plain-chart route before knowledge consultation', () => {
+    const routeIds = routes.map((route) => route.id);
+
+    expect(routeIds.indexOf('plain-chart')).toBeLessThan(routeIds.indexOf('knowledge-consult'));
   });
 
   it('teaches plain-chart proposals may carry sort and top_n', () => {

--- a/src/desktop/routeTable.ts
+++ b/src/desktop/routeTable.ts
@@ -44,17 +44,6 @@ export const DESKTOP_ROUTE_TABLE: readonly DesktopInstructionEntry[] = [
   },
   {
     kind: 'route',
-    id: 'knowledge-consult',
-    trigger:
-      'an unfamiliar or non-trivial authoring ask (calc-heavy, uncertain which chart fits, formatting/design) — never a plain chart ask the plain-chart route already handles',
-    action:
-      'FIRST search-knowledge; use read-knowledge-resource to read the top hit once, then proceed.',
-    toolSequence: ['search-knowledge', 'read-knowledge-resource'],
-    stopConditions: ['read the top hit once, then proceed'],
-    requiredEvidence: ['one targeted knowledge module or no search hit'],
-  },
-  {
-    kind: 'route',
     id: 'plain-chart',
     trigger: 'a plain viz ask (bar/line/map/KPI/etc.)',
     action:
@@ -68,6 +57,17 @@ export const DESKTOP_ROUTE_TABLE: readonly DesktopInstructionEntry[] = [
     ],
     stopConditions: ['deterministic, ~0.3s'],
     requiredEvidence: ['bind-template applied result (auto-apply receipt)'],
+  },
+  {
+    kind: 'route',
+    id: 'knowledge-consult',
+    trigger:
+      'an unfamiliar or non-trivial authoring ask (calc-heavy, uncertain which chart fits, formatting/design) only when no plain-chart binding path applies; a named chart type always takes plain-chart first, even with calc/formatting riders; chart-route escalation may still consult',
+    action:
+      'FIRST search-knowledge; use read-knowledge-resource to read the top hit once, then proceed.',
+    toolSequence: ['search-knowledge', 'read-knowledge-resource'],
+    stopConditions: ['read the top hit once, then proceed'],
+    requiredEvidence: ['one targeted knowledge module or no search hit'],
   },
   {
     kind: 'route',

--- a/src/scripts/seaSmoke.test.ts
+++ b/src/scripts/seaSmoke.test.ts
@@ -1,18 +1,31 @@
+import { EventEmitter } from 'events';
+import { PassThrough, Writable } from 'stream';
+
+const spawnMock = vi.hoisted(() => vi.fn());
+
+vi.mock('child_process', () => ({ spawn: spawnMock }));
+
 import {
   buildMcpHandshakeInput,
   parseArgs,
   requireKnowledgeSearchHit,
   requireMinimumKnowledgeResources,
   requireToolName,
+  runSeaSmoke,
 } from './seaSmoke.js';
 
 describe('SEA smoke helper', () => {
+  beforeEach(() => {
+    spawnMock.mockReset();
+  });
+
   it('builds a minimal MCP initialize and tools/list handshake', () => {
     const input = buildMcpHandshakeInput();
 
     expect(input).toContain('"method":"initialize"');
     expect(input).toContain('"method":"tools/list"');
-    expect(input.trim().split('\n')).toHaveLength(2);
+    expect(input).toContain('"method":"notifications/initialized"');
+    expect(input.trim().split('\n')).toHaveLength(3);
   });
 
   it('adds resource-count and real-search probes when requested', () => {
@@ -141,5 +154,111 @@ describe('SEA smoke helper', () => {
     ];
 
     expect(() => requireKnowledgeSearchHit(output)).not.toThrow();
+  });
+
+  it('sends each request only after the previous response arrives', async () => {
+    const child = new EventEmitter() as EventEmitter & {
+      stdin: Writable;
+      stdout: PassThrough;
+      stderr: PassThrough;
+      kill: ReturnType<typeof vi.fn>;
+    };
+    const writes: string[] = [];
+    child.stdin = new Writable({
+      write(chunk, _encoding, callback) {
+        writes.push(String(chunk));
+        callback();
+      },
+    });
+    child.stdout = new PassThrough();
+    child.stderr = new PassThrough();
+    child.kill = vi.fn();
+    spawnMock.mockReturnValue(child);
+
+    const writtenMethods = (): string[] =>
+      writes
+        .join('')
+        .trim()
+        .split('\n')
+        .filter(Boolean)
+        .map((line) => JSON.parse(line))
+        .map((message) => message.method);
+    const flush = async (): Promise<void> => {
+      await new Promise((resolve) => setImmediate(resolve));
+    };
+
+    const smoke = runSeaSmoke({
+      binaryPath: './tableau-mcp-desktop',
+      requiredTool: 'search-knowledge',
+      minKnowledgeResources: 1,
+      knowledgeSearchQuery: 'pie chart of countries',
+      timeoutMs: 1_000,
+    });
+    await flush();
+
+    expect(writtenMethods()).toEqual(['initialize']);
+
+    child.stdout.write(
+      `${JSON.stringify({ jsonrpc: '2.0', id: 1, result: { protocolVersion: '2025-06-18' } })}\n`,
+    );
+    await flush();
+    expect(writtenMethods()).toEqual(['initialize', 'notifications/initialized', 'tools/list']);
+
+    child.stdout.write(
+      `${JSON.stringify({
+        jsonrpc: '2.0',
+        id: 2,
+        result: { tools: [{ name: 'search-knowledge' }] },
+      })}\n`,
+    );
+    await flush();
+    expect(writtenMethods()).toEqual([
+      'initialize',
+      'notifications/initialized',
+      'tools/list',
+      'resources/list',
+    ]);
+
+    child.stdout.write(
+      `${JSON.stringify({
+        jsonrpc: '2.0',
+        id: 3,
+        result: { resources: [{ uri: 'expertise://tableau/strategy/viz-design/chart-selection' }] },
+      })}\n`,
+    );
+    await flush();
+    expect(writtenMethods()).toEqual([
+      'initialize',
+      'notifications/initialized',
+      'tools/list',
+      'resources/list',
+      'tools/call',
+    ]);
+
+    child.stdout.write(
+      `${JSON.stringify({
+        jsonrpc: '2.0',
+        id: 4,
+        result: {
+          isError: false,
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify({
+                hits: [
+                  {
+                    uri: 'expertise://tableau/strategy/viz-design/chart-selection',
+                    mustReadUri: 'expertise://tableau/strategy/viz-design/chart-selection',
+                  },
+                ],
+              }),
+            },
+          ],
+        },
+      })}\n`,
+    );
+    child.emit('close', 0, null);
+
+    await expect(smoke).resolves.toBeUndefined();
   });
 });

--- a/src/scripts/seaSmoke.ts
+++ b/src/scripts/seaSmoke.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-console */
 
 import { spawn } from 'child_process';
+import { createInterface } from 'readline';
 
 type JsonObject = Record<string, unknown>;
 
@@ -51,10 +52,7 @@ const resourcesListRequest = {
 export function buildMcpHandshakeInput(
   options: Pick<SmokeOptions, 'minKnowledgeResources' | 'knowledgeSearchQuery'> = {},
 ): string {
-  const messages: JsonObject[] = [initializeRequest, toolsListRequest];
-  if (options.minKnowledgeResources !== undefined || options.knowledgeSearchQuery !== undefined) {
-    messages.splice(1, 0, initializedNotification);
-  }
+  const messages: JsonObject[] = [initializeRequest, initializedNotification, toolsListRequest];
   if (options.minKnowledgeResources !== undefined) {
     messages.push(resourcesListRequest);
   }
@@ -282,37 +280,121 @@ export async function runSeaSmoke({
     stdio: ['pipe', 'pipe', 'pipe'],
   });
 
-  let stdout = '';
   let stderr = '';
   let timedOut = false;
 
   child.stdout.setEncoding('utf8');
   child.stderr.setEncoding('utf8');
-  child.stdout.on('data', (chunk: string) => {
-    stdout += chunk;
-  });
   child.stderr.on('data', (chunk: string) => {
     stderr += chunk;
+  });
+
+  const outputLines: string[] = [];
+  const pending = new Map<
+    number,
+    {
+      resolve: (message: JsonObject) => void;
+      reject: (error: Error) => void;
+    }
+  >();
+
+  const rejectPending = (error: Error): void => {
+    for (const { reject } of pending.values()) reject(error);
+    pending.clear();
+  };
+
+  const stdoutLines = createInterface({ input: child.stdout });
+  stdoutLines.on('line', (line) => {
+    if (!line.trim()) return;
+    outputLines.push(line);
+
+    let message: JsonObject;
+    try {
+      message = parseJsonLine(line);
+    } catch (error) {
+      rejectPending(error instanceof Error ? error : new Error(String(error)));
+      return;
+    }
+
+    if (typeof message.id !== 'number') return;
+    const waiter = pending.get(message.id);
+    if (!waiter) return;
+    pending.delete(message.id);
+    waiter.resolve(message);
   });
 
   const closePromise = new Promise<{ code: number | null; signal: NodeJS.Signals | null }>(
     (resolve, reject) => {
       child.once('error', reject);
-      child.once('close', (code, signal) => resolve({ code, signal }));
+      child.once('close', (code, signal) => {
+        const error = new Error(
+          `SEA smoke process closed before all responses arrived (code ${String(code)} signal ${String(signal)})`,
+        );
+        rejectPending(error);
+        resolve({ code, signal });
+      });
     },
   );
+
+  const awaitResponse = async (id: number): Promise<JsonObject> => {
+    return await new Promise<JsonObject>((resolve, reject) => {
+      pending.set(id, { resolve, reject });
+    });
+  };
+
+  const writeMessage = (message: JsonObject): void => {
+    child.stdin.write(`${JSON.stringify(message)}\n`);
+  };
+
+  const writeRequestAndAwait = async (message: JsonObject, id: number): Promise<void> => {
+    const response = awaitResponse(id);
+    writeMessage(message);
+    await response;
+  };
+
+  const exchange = async (): Promise<void> => {
+    await writeRequestAndAwait(initializeRequest, 1);
+    writeMessage(initializedNotification);
+    await writeRequestAndAwait(toolsListRequest, 2);
+    if (minKnowledgeResources !== undefined) {
+      await writeRequestAndAwait(resourcesListRequest, 3);
+    }
+    if (knowledgeSearchQuery !== undefined) {
+      await writeRequestAndAwait(
+        {
+          jsonrpc: '2.0',
+          id: 4,
+          method: 'tools/call',
+          params: {
+            name: 'search-knowledge',
+            arguments: { query: knowledgeSearchQuery, limit: 3 },
+          },
+        },
+        4,
+      );
+    }
+    child.stdin.end();
+  };
 
   const timeout = setTimeout(() => {
     timedOut = true;
     child.kill();
   }, timeoutMs);
 
-  child.stdin.end(buildMcpHandshakeInput({ minKnowledgeResources, knowledgeSearchQuery }));
+  try {
+    await exchange();
+  } catch (error) {
+    child.kill();
+    clearTimeout(timeout);
+    if (timedOut) {
+      throw new Error(`SEA smoke timed out after ${timeoutMs}ms. stderr: ${stderr.trim()}`);
+    }
+    throw error;
+  }
 
   const { code, signal } = await closePromise;
   clearTimeout(timeout);
 
-  const outputLines = stdout.split(/\r?\n/).filter((line) => line.trim());
   if (timedOut) {
     throw new Error(`SEA smoke timed out after ${timeoutMs}ms. stderr: ${stderr.trim()}`);
   }

--- a/src/server.desktop.knowledge.test.ts
+++ b/src/server.desktop.knowledge.test.ts
@@ -1,3 +1,6 @@
+import { mkdirSync, mkdtempSync, rmSync } from 'fs';
+import { join } from 'path';
+
 import * as loggerModule from './logging/logger.js';
 
 const knowledgeMocks = vi.hoisted(() => ({
@@ -26,5 +29,28 @@ describe('DesktopMcpServer knowledge startup check', () => {
       level: 'warning',
       logger: 'DesktopMcpServer',
     });
+  });
+
+  it('real knowledge resource listing throws a loud asset-root error for an empty root', async () => {
+    const emptyRoot = mkdtempSync(join(process.cwd(), '.tmp-empty-knowledge-root-'));
+    const resourcesRoot = join(emptyRoot, 'resources', 'desktop');
+    mkdirSync(resourcesRoot, { recursive: true });
+
+    try {
+      vi.resetModules();
+      vi.doMock('./utils/getDirname.js', () => ({ getDirname: () => emptyRoot }));
+      vi.doUnmock('./desktop/knowledge/index.js');
+      const realKnowledge = await import('./desktop/knowledge/index.js');
+      realKnowledge.clearKnowledgeCache();
+      realKnowledge._resetKnowledgeSearchCache();
+
+      expect(() => realKnowledge.listKnowledgeResources()).toThrow(
+        `Knowledge corpus is empty; expected assets under ${join(resourcesRoot, 'knowledge')}`,
+      );
+    } finally {
+      rmSync(emptyRoot, { recursive: true, force: true });
+      vi.doUnmock('./utils/getDirname.js');
+      vi.resetModules();
+    }
   });
 });

--- a/src/server.desktop.test.ts
+++ b/src/server.desktop.test.ts
@@ -97,9 +97,9 @@ Load tableau-desktop-authoring; repeat failures -> tableau-agent-debug.
 
 Before dashboards, plan MAGNITUDE vs MEMBERSHIP; MEMBERSHIP uses buckets, not gradients. State plan, build.
 
-For an unfamiliar or non-trivial authoring ask (calc-heavy, uncertain which chart fits, formatting/design) — never a plain chart ask the plain-chart route already handles, FIRST search-knowledge; use read-knowledge-resource to read the top hit once, then proceed.
-
 For a plain viz ask (bar/line/map/KPI/etc.), FIRST bind-template(auto_apply:true): deterministic, ~0.3s. On propose, resubmit; proposals may carry sort and top_n. author-parameter/author-set/author-action before charts; else search-commands.
+
+For an unfamiliar or non-trivial authoring ask (calc-heavy, uncertain which chart fits, formatting/design) only when no plain-chart binding path applies; a named chart type always takes plain-chart first, even with calc/formatting riders; chart-route escalation may still consult, FIRST search-knowledge; use read-knowledge-resource to read the top hit once, then proceed.
 
 For a dashboard ask with 2-6 vizzes, build sheets with bind-template (author calcs/params/sets first), then compose with dashboard-auto-apply (2-6 plain charts, one call) or plan-dashboard-creation -> build-and-apply-dashboard; search-commands only for commands the census does not list.
 


### PR DESCRIPTION
Follow-ups from the #611 fresh-eyes review, landed as their own PR since #611 merged mid-fix:

1. **Deterministic route precedence (High):** plain-chart now precedes knowledge-consult in the route table, and consult explicitly defers — a named chart type always takes the bind path first, even with calc/formatting riders ("bar chart of profit margin, color negatives red" can no longer detour through search+read before binding).
2. **Tokenizer regressions (Medium):** zero-token short queries fall back to the original whole-string fuzzy match (`AI` regains hits); singularization is conservative (≥5 chars, plain `-s` only — `axes` stays `axes`; `countries` deliberately no longer stems, regression updated honestly).
3. **SEA smoke race (Medium):** the smoke script now performs a response-driven MCP exchange (await initialize → initialized → sequential calls) instead of batching stdin blind, killing the CI race where resources/list could beat async registration.
4. The empty-corpus loud-error path gained a real empty-asset-root test (was previously only exercised against a mock).

Full suite 339 files / 5019 tests green firsthand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)