### PR TITLE
fix(add-field): accept a worksheet name; expose get-worksheet-xml in the lean profile

### DIFF
--- a/src/server.desktop.test.ts
+++ b/src/server.desktop.test.ts
@@ -348,10 +348,10 @@ describe('selectToolsForProfile (TOOL_PROFILE, W60 spike lever 1 / preamble P1)'
     expect(selected.map((t) => t.name)).toContain('execute-tableau-command');
   });
 
-  it('TOOL_PROFILE=dynamic-authoring registers exactly the 31-tool data-first singable surface — native authoring + workbook reads + atomic sheet activation, no workbook round-trip/cache/validation XML tools', () => {
+  it('TOOL_PROFILE=dynamic-authoring registers exactly the 32-tool data-first singable surface — native authoring + workbook reads + atomic sheet activation + the manual path read leg, no workbook round-trip/cache/validation XML tools', () => {
     const selected = selectToolsForProfile(allTools(), 'dynamic-authoring');
     expect(new Set(selected.map((t) => t.name))).toEqual(DYNAMIC_AUTHORING_TOOL_PROFILE);
-    expect(selected).toHaveLength(31);
+    expect(selected).toHaveLength(32);
     // The full dynamic dialect, semantically named — every author-* verb present,
     // plus the ask-for-help, command-discovery, deterministic fast-path, and the three
     // knowledge doors the system prompt's "consult the expertise library" law routes to.
@@ -382,16 +382,19 @@ describe('selectToolsForProfile (TOOL_PROFILE, W60 spike lever 1 / preamble P1)'
       'list-workbook-datasources',
       'list-site-datasources',
       'activate-sheet',
+      // The manual field-edit path's read leg — mints the worksheetFile add-field/
+      // remove-field/apply-worksheet consume.
+      'get-worksheet-xml',
     ]) {
       expect(selected.map((t) => t.name)).toContain(verb);
     }
     // Zero agent-visible workbook round-trip/cache/validation XML tools: the full hand-XML
     // surgery surface stays OUT, including get-workbook-xml + apply-workbook. Navigation gets
-    // only the dedicated atomic activate-sheet fallback.
+    // only the dedicated atomic activate-sheet fallback. get-worksheet-xml is the lone
+    // per-sheet read exception (asserted present above) — the manual path cannot start without it.
     for (const banished of [
       'get-workbook-xml',
       'apply-workbook',
-      'get-worksheet-xml',
       'read-cached-xml',
       'write-cached-xml',
       'validate-workbook-xml',

--- a/src/server.desktop.ts
+++ b/src/server.desktop.ts
@@ -92,12 +92,13 @@ export const SPEC_LOOP_TOOL_PROFILE: ReadonlySet<DesktopToolName> = new Set<Desk
  * all, so verified Tableau behavior (e.g. the waterfall subtotal/total exclusion rule,
  * the Top-N-needs-a-context-filter rule) stayed dark on every sing. The corpus is
  * served as MCP resources anyway; these two tiny tools are the only way the model reaches it.
- * Thirty-one tools cover the full Workout-Wednesday-W44 dialect plus on-demand expertise
- * and first-class workbook/data reads/navigation;
- * no raw XML get/apply, no cache, no validation. This is the "make it shorter" answer — a
- * lean, semantically-named surface under the 46k tools/list cliff, not a describe-stub trim
- * of the 45-tool default. Mechanism map live-proven 2026-07-19 (CODA): calcs/sets/
- * actions/formatting MERGE; parameters born at OPEN via author-parameter.
+ * Thirty-two tools cover the full Workout-Wednesday-W44 dialect plus on-demand expertise
+ * and first-class workbook/data reads/navigation; the only raw XML read is get-worksheet-xml,
+ * the read leg the manual add-field/remove-field/apply-worksheet path needs to mint its
+ * worksheetFile — no whole-workbook get/apply, no cache, no validation XML tools. This is the
+ * "make it shorter" answer — a lean, semantically-named surface under the 46k tools/list cliff,
+ * not a describe-stub trim of the 45-tool default. Mechanism map live-proven 2026-07-19 (CODA):
+ * calcs/sets/actions/formatting MERGE; parameters born at OPEN via author-parameter.
  */
 export const DYNAMIC_AUTHORING_TOOL_PROFILE: ReadonlySet<DesktopToolName> =
   new Set<DesktopToolName>([
@@ -106,6 +107,9 @@ export const DYNAMIC_AUTHORING_TOOL_PROFILE: ReadonlySet<DesktopToolName> =
     'add-field',
     'remove-field',
     'resolve-field',
+    // The manual field-edit path's read leg: mints the worksheetFile cache path that
+    // add-field/remove-field/apply-worksheet consume. Without it the manual path cannot start.
+    'get-worksheet-xml',
     'apply-worksheet',
     'build-and-apply-worksheet',
     'dashboard-auto-apply',

--- a/src/tools/desktop/emittedToolReferences.test.ts
+++ b/src/tools/desktop/emittedToolReferences.test.ts
@@ -24,6 +24,7 @@ const NON_TOOL_VOCABULARY = [
   'base-column-conflict',
   'bind-template-shaped',
   'calc-dependency-unmet',
+  'endpoint-not-in-this-build',
   'column-instance',
   'cross-datasource-binding',
   'data-source',

--- a/src/tools/desktop/fields/addField.test.ts
+++ b/src/tools/desktop/fields/addField.test.ts
@@ -1,14 +1,17 @@
 import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { existsSync, readFileSync, writeFileSync } from 'fs';
+import { Err, Ok } from 'ts-results-es';
 import { z } from 'zod';
 
 import * as configModule from '../../../config.desktop.js';
 import * as cacheFingerprintModule from '../../../desktop/commands/workbook/cacheFingerprint.js';
+import * as getWorksheetXmlModule from '../../../desktop/commands/workbook/getWorksheetXml.js';
 import * as metadataModule from '../../../desktop/metadata/index.js';
 import {
   ArgsValidationError,
   FileNotFoundError,
   FileReadError,
+  GetWorksheetXmlFailedError,
   XmlModificationError,
 } from '../../../errors/mcpToolError.js';
 import { DesktopMcpServer } from '../../../server.desktop.js';
@@ -19,6 +22,7 @@ import { getAddFieldTool } from './addField.js';
 
 vi.mock('../../../desktop/metadata/index.js');
 vi.mock('../../../desktop/commands/workbook/cacheFingerprint.js');
+vi.mock('../../../desktop/commands/workbook/getWorksheetXml.js');
 vi.mock('fs');
 
 type EncodingType = 'color' | 'size' | 'lod' | 'detail' | 'text' | 'tooltip' | 'path' | 'angle';
@@ -57,6 +61,7 @@ describe('addFieldTool', () => {
     );
     expect(tool.paramsSchema).toMatchObject({
       session: expect.any(Object),
+      worksheetName: expect.any(Object),
       worksheetFile: expect.any(Object),
       target: expect.any(Object),
       columnRef: expect.any(Object),
@@ -199,6 +204,7 @@ describe('addFieldTool', () => {
     const result = await callback(
       {
         session: SESSION,
+        worksheetName: undefined,
         worksheetFile: WORKSHEET_FILE,
         target: 'rows',
         columnRef: COLUMN_REF,
@@ -211,6 +217,92 @@ describe('addFieldTool', () => {
 
     expect(result.isError).toBe(false);
     expect(extra.getExecutor).not.toHaveBeenCalled();
+  });
+
+  // --- name-based path (no prior get-worksheet-xml call) ---
+  it('fetches + caches the sheet by name when no worksheetFile is given, then edits it', async () => {
+    const FRAGMENT = '<worksheet name="Sheet 1"><table/></worksheet>';
+    vi.mocked(getWorksheetXmlModule.getWorksheetFragment).mockResolvedValue(Ok(FRAGMENT));
+    // The minted cache file exists after the internal write; the edit reads it back.
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue(FRAGMENT);
+    vi.mocked(metadataModule.addFieldToRows).mockReturnValue(MODIFIED_XML);
+    vi.mocked(writeFileSync).mockReturnValue(undefined);
+
+    const result = await getResult({
+      worksheetName: 'Sheet 1',
+      target: 'rows',
+      columnRef: COLUMN_REF,
+    });
+
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+    const body = resultSchema.parse(JSON.parse(result.content[0].text));
+    expect(body.message).toContain('Rows shelf');
+    // The fetch happened, and the minted cache path (worksheet-Sheet_1-*) is returned so
+    // follow-up edits can pass it as worksheetFile.
+    expect(getWorksheetXmlModule.getWorksheetFragment).toHaveBeenCalledWith(
+      expect.objectContaining({ worksheetName: 'Sheet 1' }),
+    );
+    expect(body.file).toMatch(/worksheet-Sheet_1-/);
+    // The minted fragment was written to the cache before the field edit.
+    expect(writeFileSync).toHaveBeenCalledWith(body.file, FRAGMENT, 'utf-8');
+    // ...and the modified XML was written back to the same path.
+    expect(writeFileSync).toHaveBeenCalledWith(body.file, MODIFIED_XML, 'utf-8');
+  });
+
+  it('surfaces a fetch error (unknown worksheet) without writing anything', async () => {
+    const fetchErr = {
+      type: 'get-worksheet-xml-error' as const,
+      error: { type: 'no-worksheet-found' as const, message: 'No worksheet found for Ghost.' },
+    };
+    vi.mocked(getWorksheetXmlModule.getWorksheetFragment).mockResolvedValue(Err(fetchErr));
+
+    const result = await getResult({
+      worksheetName: 'Ghost',
+      target: 'rows',
+      columnRef: COLUMN_REF,
+    });
+
+    expect(result.isError).toBe(true);
+    invariant(result.content[0].type === 'text');
+    expect(result.content[0].text).toBe(new GetWorksheetXmlFailedError(fetchErr.error).message);
+    expect(writeFileSync).not.toHaveBeenCalled();
+    expect(metadataModule.addFieldToRows).not.toHaveBeenCalled();
+  });
+
+  it('errors when neither worksheetName nor worksheetFile is provided', async () => {
+    const result = await getResult({ target: 'rows', columnRef: COLUMN_REF });
+
+    expect(result.isError).toBe(true);
+    invariant(result.content[0].type === 'text');
+    expect(result.content[0].text).toBe(
+      new ArgsValidationError(
+        'Provide either worksheetName (to edit an existing sheet) or worksheetFile (a cached path).',
+      ).message,
+    );
+    expect(getWorksheetXmlModule.getWorksheetFragment).not.toHaveBeenCalled();
+    expect(writeFileSync).not.toHaveBeenCalled();
+  });
+
+  it('prefers worksheetFile over worksheetName when both are given (no fetch)', async () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue('<worksheet/>');
+    vi.mocked(metadataModule.addFieldToRows).mockReturnValue(MODIFIED_XML);
+    vi.mocked(writeFileSync).mockReturnValue(undefined);
+
+    const result = await getResult({
+      worksheetName: 'Sheet 1',
+      worksheetFile: WORKSHEET_FILE,
+      target: 'rows',
+      columnRef: COLUMN_REF,
+    });
+
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+    expect(resultSchema.parse(JSON.parse(result.content[0].text)).file).toBe(WORKSHEET_FILE);
+    // worksheetFile is authoritative — the name-based fetch must not run.
+    expect(getWorksheetXmlModule.getWorksheetFragment).not.toHaveBeenCalled();
   });
 
   it('should pass index and workbookFile to addFieldToRows (target=rows)', async () => {
@@ -477,7 +569,8 @@ describe('addFieldTool', () => {
 });
 
 async function getResult(params: {
-  worksheetFile: string;
+  worksheetName?: string;
+  worksheetFile?: string;
   target: Target;
   columnRef: string;
   encodingType?: EncodingType;
@@ -485,12 +578,13 @@ async function getResult(params: {
   workbookFile?: string;
   session?: string;
 }): Promise<CallToolResult> {
-  const { worksheetFile, target, columnRef, encodingType, index, workbookFile } = params;
+  const { worksheetName, worksheetFile, target, columnRef, encodingType, index, workbookFile } =
+    params;
   const session = ('session' in params ? params.session : SESSION) as string;
   const tool = getAddFieldTool(new DesktopMcpServer());
   const callback = await Provider.from(tool.callback);
   return await callback(
-    { session, worksheetFile, target, columnRef, encodingType, index, workbookFile },
+    { session, worksheetName, worksheetFile, target, columnRef, encodingType, index, workbookFile },
     getMockRequestHandlerExtra(),
   );
 }

--- a/src/tools/desktop/fields/addField.ts
+++ b/src/tools/desktop/fields/addField.ts
@@ -1,9 +1,14 @@
 import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { existsSync, readFileSync, writeFileSync } from 'fs';
-import { Ok } from 'ts-results-es';
+import { Err, Ok, Result } from 'ts-results-es';
 import { z } from 'zod';
 
+import { DesktopCache } from '../../../desktop/cache.js';
 import { writeSidecar } from '../../../desktop/commands/workbook/cacheFingerprint.js';
+import {
+  getWorksheetFragment,
+  isRouteMissing,
+} from '../../../desktop/commands/workbook/getWorksheetXml.js';
 import {
   addFieldToCols,
   addFieldToEncoding,
@@ -13,13 +18,18 @@ import { resolveSession } from '../../../desktop/sessionResolution.js';
 import { wellFormedXmlRule } from '../../../desktop/validation/rules/wellFormedXml.js';
 import {
   ArgsValidationError,
+  DesktopCommandExecutionError,
   FileNotFoundError,
   FileReadError,
+  GetWorksheetXmlFailedError,
+  McpToolError,
+  UnknownError,
   XmlModificationError,
   XmlValidationError,
 } from '../../../errors/mcpToolError.js';
 import { DesktopMcpServer } from '../../../server.desktop.js';
 import { DesktopTool } from '../tool.js';
+import { TableauDesktopRequestHandlerExtra } from '../toolContext.js';
 
 /** Encoding channels a field can be placed on. */
 const ENCODING_TYPES = [
@@ -35,14 +45,70 @@ const ENCODING_TYPES = [
 /** Shelf / encoding a field can be added to. */
 const FIELD_TARGETS = ['rows', 'cols', 'encoding'] as const;
 
+/**
+ * Fetch an existing worksheet by display name and write it to a cache file, returning that
+ * path — the same mint get-worksheet-xml performs. Lets add-field/remove-field be used with
+ * a plain worksheet name (no prior get-worksheet-xml call) while preserving the
+ * get-once/edit-many/apply-once contract: the returned path is reused across edits.
+ */
+async function fetchAndCacheWorksheet({
+  worksheetName,
+  resolvedSession,
+  extra,
+}: {
+  worksheetName: string;
+  resolvedSession: string;
+  extra: TableauDesktopRequestHandlerExtra;
+}): Promise<Result<string, McpToolError>> {
+  const executor = await extra.getExecutor(resolvedSession);
+  const fetched = await getWorksheetFragment({ worksheetName, executor, signal: extra.signal });
+  if (fetched.isErr()) {
+    const { type, error } = fetched.error;
+    switch (type) {
+      case 'get-worksheet-xml-error':
+        return Err(new GetWorksheetXmlFailedError(error));
+      case 'execute-command-error':
+        if (isRouteMissing(error)) {
+          return Err(
+            new McpToolError({
+              type: 'endpoint-not-in-this-build',
+              message:
+                'This Tableau Desktop build does not serve the worksheet document endpoint yet. ' +
+                'Use get-app-info to identify the build; this read lights up on a newer Desktop update. Do not retry.',
+              statusCode: 404,
+            }),
+          );
+        }
+        return Err(new DesktopCommandExecutionError(error));
+      default: {
+        const _: never = type;
+        return Err(new UnknownError(error));
+      }
+    }
+  }
+
+  const safeName = worksheetName.replace(/[^a-zA-Z0-9]/g, '_');
+  const cacheFile = new DesktopCache().getCacheFilePath({ prefix: `worksheet-${safeName}` });
+  writeFileSync(cacheFile, fetched.value, 'utf-8');
+  writeSidecar(cacheFile, resolvedSession);
+  return Ok(cacheFile);
+}
+
 const paramsSchema = {
-  session: z.string(),
-  worksheetFile: z.string(),
-  target: z.enum(FIELD_TARGETS),
-  columnRef: z.string(),
-  encodingType: z.enum(ENCODING_TYPES).optional(),
-  index: z.number().optional(),
-  workbookFile: z.string().optional(),
+  session: z.string().optional().describe('Desktop session; omit if one.'),
+  worksheetName: z
+    .string()
+    .optional()
+    .describe('Sheet to edit; cached on first use. Give this or worksheetFile.'),
+  worksheetFile: z
+    .string()
+    .optional()
+    .describe('Cached sheet path from a prior edit; stacks edits.'),
+  target: z.enum(FIELD_TARGETS).describe('Placement shelf.'),
+  columnRef: z.string().describe('Field to add.'),
+  encodingType: z.enum(ENCODING_TYPES).optional().describe('Required when target=encoding.'),
+  index: z.number().optional().describe('Optional position.'),
+  workbookFile: z.string().optional().describe('Optional workbook.'),
 };
 
 const title = 'Add Field';
@@ -62,18 +128,57 @@ export const getAddFieldTool = (server: DesktopMcpServer): DesktopTool<typeof pa
       idempotentHint: false,
     },
     callback: async (
-      { session, worksheetFile, target, columnRef, encodingType, index, workbookFile },
+      {
+        session,
+        worksheetName,
+        worksheetFile,
+        target,
+        columnRef,
+        encodingType,
+        index,
+        workbookFile,
+      },
       extra,
     ): Promise<CallToolResult> => {
       return await addFieldTool.logAndExecute({
         extra,
-        args: { session, worksheetFile, target, columnRef, encodingType, index, workbookFile },
+        args: {
+          session,
+          worksheetName,
+          worksheetFile,
+          target,
+          columnRef,
+          encodingType,
+          index,
+          workbookFile,
+        },
         callback: async () => {
           const sessionResult = resolveSession(session);
           if (sessionResult.isErr()) {
             return sessionResult.error.toErr();
           }
           const resolvedSession = sessionResult.value;
+
+          if (!worksheetFile?.trim() && !worksheetName?.trim()) {
+            return new ArgsValidationError(
+              'Provide either worksheetName (to edit an existing sheet) or worksheetFile (a cached path).',
+            ).toErr();
+          }
+
+          // Name-based path: no cache file yet — fetch the sheet fragment and mint one. The
+          // returned worksheetFile lets follow-up add-field/remove-field calls accumulate edits
+          // on the same cache before a single apply-worksheet (get-once, edit-many, apply-once).
+          if (!worksheetFile?.trim()) {
+            const minted = await fetchAndCacheWorksheet({
+              worksheetName: worksheetName!.trim(),
+              resolvedSession,
+              extra,
+            });
+            if (minted.isErr()) {
+              return minted.error.toErr();
+            }
+            worksheetFile = minted.value;
+          }
 
           if (!existsSync(worksheetFile)) {
             return new FileNotFoundError(worksheetFile).toErr();


### PR DESCRIPTION
## Summary

`add-field` is exposed in the default (lean `dynamic-authoring`) tool profile, but it required a `worksheetFile` **cache path** that only `get-worksheet-xml` mints — and `get-worksheet-xml` was **not** in that profile. So an agent given a plain worksheet name had no in-profile way to obtain a valid `worksheetFile`: the tool was exposed but unsatisfiable, and passing a display name returned `File not found: <name>`.

This closes the gap two ways (verified live in Tableau Desktop):

**1. `add-field` accepts a worksheet name.** New optional `worksheetName` param: when no `worksheetFile` is given, the tool fetches the sheet fragment and mints a cache file internally (the same mint `get-worksheet-xml` performs), then returns that path. Follow-up `add-field`/`remove-field` calls can pass the returned `worksheetFile` to accumulate edits before a single `apply-worksheet` — preserving the get-once / edit-many / apply-once contract. `worksheetFile` stays authoritative when both are given. Errors clearly when neither is provided.

**2. `get-worksheet-xml` added to the `dynamic-authoring` profile.** It's the read leg the manual `add-field`/`remove-field`/`apply-worksheet` path needs to start. The lean profile still banishes the whole-workbook get/apply and cache/validation XML surface — this is the lone per-sheet read exception.

Also gave every `add-field` param a real `.describe(...)` (the schema had none — an AGENTS.md violation), kept XML-free to satisfy the Tableau-vocabulary rule, and trimmed to stay under the 1200-byte per-tool tools/list budget.

## Verification

- Reproduced the original failure live, then confirmed the fix live: `add-field(worksheetName: "Sheet 1", target: rows, columnRef: [Category])` → minted a cache file and placed the field; a second `add-field` stacked `Sales` on cols via the returned `worksheetFile`; `apply-worksheet` landed both; `get-summary-data` renders all four fields with real data.
- 98 unit tests pass across `src/tools/desktop/fields` + `src/server.desktop.test.ts` (added 4 name-based `add-field` cases; updated the profile test to 32 tools with `get-worksheet-xml` present).
- `tsc --noEmit` clean; `eslint` clean.

## Scope

Separate from the refine-worksheet crash fix (PR #612). Both surfaced in the same session log but are independent bugs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
