### PR TITLE
fix(activate): stop activation from landing on a renamed, unloaded, or intermediate sheet

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "2.52.1",
+  "version": "2.52.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/src/desktop/commands/workbook/activateSheet.ts
+++ b/src/desktop/commands/workbook/activateSheet.ts
@@ -33,6 +33,7 @@ type FocusVerificationResult =
 
 const APPLY_SETTLE_MS = 500;
 const ACTIVATION_VERIFY_MS = 700;
+const POST_APPLY_NOT_FOUND_REVALIDATE_MS = 700;
 
 function unique(values: string[]): string[] {
   return Array.from(new Set(values));
@@ -228,7 +229,11 @@ export async function activateSheetBestEffort({
   try {
     await waitForDesktopSettle(APPLY_SETTLE_MS, signal);
 
-    const activation = await activateSheetWithValidatedGoto({ sheetName, executor, signal });
+    let activation = await activateSheetWithValidatedGoto({ sheetName, executor, signal });
+    if (activation.status === 'not-found') {
+      await waitForDesktopSettle(POST_APPLY_NOT_FOUND_REVALIDATE_MS, signal);
+      activation = await activateSheetWithValidatedGoto({ sheetName, executor, signal });
+    }
     switch (activation.status) {
       case 'activated':
         break;
@@ -279,22 +284,49 @@ export async function activateSheetBestEffort({
         );
         return;
       case 'not-focused': {
-        const reissue = await executeGotoSheet({ sheetName, executor, signal });
-        if (reissue.isErr()) {
-          logBestEffortActivationEvent(
-            sheetName,
-            'warning',
-            'Best-effort goto-sheet reissue failed after Desktop settle; primary apply remains successful',
-            { activeSheet: verification.activeSheet, error: reissue.error },
-          );
-          return;
+        const reissue = await activateSheetWithValidatedGoto({ sheetName, executor, signal });
+        switch (reissue.status) {
+          case 'activated':
+            logBestEffortActivationEvent(
+              sheetName,
+              'info',
+              'Best-effort goto-sheet reissued once after Desktop settle verification',
+              { activeSheet: verification.activeSheet },
+            );
+            return;
+          case 'not-found':
+            logBestEffortActivationEvent(
+              sheetName,
+              'warning',
+              'Best-effort goto-sheet reissue skipped after Desktop settle; target disappeared before revalidation',
+              { activeSheet: verification.activeSheet, availableSheets: reissue.availableSheets },
+            );
+            return;
+          case 'parse-failed':
+            logBestEffortActivationEvent(
+              sheetName,
+              'warning',
+              'Best-effort goto-sheet reissue skipped after Desktop settle; could not parse the fresh workbook read',
+              { activeSheet: verification.activeSheet, message: reissue.message },
+            );
+            return;
+          case 'read-failed':
+            logBestEffortActivationEvent(
+              sheetName,
+              'warning',
+              'Best-effort goto-sheet reissue skipped after Desktop settle; could not re-read the workbook',
+              { activeSheet: verification.activeSheet, error: reissue.error },
+            );
+            return;
+          case 'command-failed':
+            logBestEffortActivationEvent(
+              sheetName,
+              'warning',
+              'Best-effort goto-sheet reissue failed after Desktop settle; primary apply remains successful',
+              { activeSheet: verification.activeSheet, error: reissue.error },
+            );
+            return;
         }
-        logBestEffortActivationEvent(
-          sheetName,
-          'info',
-          'Best-effort goto-sheet reissued once after Desktop settle verification',
-          { activeSheet: verification.activeSheet },
-        );
         return;
       }
       case 'not-found':

--- a/src/desktop/vendoredAssets.test.ts
+++ b/src/desktop/vendoredAssets.test.ts
@@ -6,10 +6,13 @@
  * template's manifest without its XML, and the two loadable template dirs had
  * drifted. These tests make that drift class a CI failure instead of a live one.
  */
+import { createHash } from 'crypto';
 import { existsSync, readdirSync, readFileSync } from 'fs';
 import { join, resolve } from 'path';
 
 import { getDataRoot, getResourcesRoot } from './assets.js';
+
+type ContentManifestResource = { path: string; sha256: string; bytes: number };
 
 function listFileStems(dir: string, suffix: string): string[] {
   return readdirSync(dir, { withFileTypes: true })
@@ -33,6 +36,10 @@ function countFilesRecursively(dir: string, suffix: string): number {
 function diff(left: string[], right: string[]): string[] {
   const rightSet = new Set(right);
   return left.filter((name) => !rightSet.has(name));
+}
+
+function sha256(buffer: Buffer): string {
+  return createHash('sha256').update(buffer).digest('hex');
 }
 
 describe('desktop vendored assets', () => {
@@ -59,38 +66,78 @@ describe('desktop vendored assets', () => {
   it('keeps the two loadable template XML directories identical', () => {
     const templateXmlNames = listFileStems(templateXmlDir, '.xml');
     const legacyTemplateNames = listFileStems(legacyTemplatesDir, '.xml');
+    const commonNames = templateXmlNames.filter((name) => legacyTemplateNames.includes(name));
+    const byteMismatches = commonNames.flatMap((name) => {
+      const templateXml = readFileSync(join(templateXmlDir, `${name}.xml`));
+      const legacyTemplateXml = readFileSync(join(legacyTemplatesDir, `${name}.xml`));
+      return templateXml.equals(legacyTemplateXml)
+        ? []
+        : [
+            {
+              name,
+              dataVisualizationTemplatesXml: {
+                sha256: sha256(templateXml),
+                bytes: templateXml.byteLength,
+              },
+              templates: {
+                sha256: sha256(legacyTemplateXml),
+                bytes: legacyTemplateXml.byteLength,
+              },
+            },
+          ];
+    });
 
     expect({
       onlyInDataVisualizationTemplatesXml: diff(templateXmlNames, legacyTemplateNames),
       onlyInTemplates: diff(legacyTemplateNames, templateXmlNames),
-    }).toEqual({ onlyInDataVisualizationTemplatesXml: [], onlyInTemplates: [] });
+      byteMismatches,
+    }).toEqual({
+      onlyInDataVisualizationTemplatesXml: [],
+      onlyInTemplates: [],
+      byteMismatches: [],
+    });
   });
 
   it('declares every shipped template XML in content-manifest.json (regenerate on sync)', () => {
     // The provenance surface (BundledIntelligenceProvider.getContentManifest) must not
     // under-report shipped content: rerun buildTemplateManifests.ts after any vendor copy.
     const manifest = JSON.parse(readFileSync(join(dataRoot, 'content-manifest.json'), 'utf-8')) as {
-      resources: Array<{ path: string }>;
+      resources: ContentManifestResource[];
     };
     const declared = new Set(manifest.resources.map((r) => r.path));
     const undeclaredXml = listFileStems(templateXmlDir, '.xml')
       .map((name) => `data-visualization-templates-xml/${name}.xml`)
       .filter((p) => !declared.has(p));
+    const integrityMismatches = manifest.resources.flatMap((resource) => {
+      const bytes = readFileSync(join(dataRoot, resource.path));
+      const actual = { sha256: sha256(bytes), bytes: bytes.byteLength };
+      return actual.sha256 === resource.sha256 && actual.bytes === resource.bytes
+        ? []
+        : [{ path: resource.path, expected: resource, actual }];
+    });
 
-    expect(undeclaredXml).toEqual([]);
+    expect({ undeclaredXml, integrityMismatches }).toEqual({
+      undeclaredXml: [],
+      integrityMismatches: [],
+    });
   });
 
   it('ships template XML windows without focus-restoring active/maximized flags', () => {
-    const flaggedWindows = readdirSync(templateXmlDir, { withFileTypes: true })
-      .filter((entry) => entry.isFile() && entry.name.endsWith('.xml'))
-      .flatMap((entry) => {
-        const xml = readFileSync(join(templateXmlDir, entry.name), 'utf-8');
-        return Array.from(xml.matchAll(/<windows\b[\s\S]*?<\/windows>/g)).flatMap((section) =>
-          Array.from(section[0].matchAll(/<window\b[^>]*(?:\bactive=|\bmaximized=)[^>]*>/g)).map(
-            (match) => `${entry.name}: ${match[0]}`,
-          ),
-        );
-      });
+    const flaggedWindows = [
+      ['data-visualization-templates-xml', templateXmlDir],
+      ['templates', legacyTemplatesDir],
+    ].flatMap(([label, dir]) =>
+      readdirSync(dir, { withFileTypes: true })
+        .filter((entry) => entry.isFile() && entry.name.endsWith('.xml'))
+        .flatMap((entry) => {
+          const xml = readFileSync(join(dir, entry.name), 'utf-8');
+          return Array.from(xml.matchAll(/<windows\b[\s\S]*?<\/windows>/g)).flatMap((section) =>
+            Array.from(section[0].matchAll(/<window\b[^>]*(?:\bactive=|\bmaximized=)[^>]*>/g)).map(
+              (match) => `${label}/${entry.name}: ${match[0]}`,
+            ),
+          );
+        }),
+    );
 
     expect(flaggedWindows).toEqual([]);
   });

--- a/src/scripts/buildTemplateManifests.ts
+++ b/src/scripts/buildTemplateManifests.ts
@@ -83,6 +83,7 @@ console.log(`✅ Wrote ${relative(process.cwd(), INDEX_PATH)} (${templates.lengt
 // Hash every bundled authoring resource. Deterministic: files are enumerated in
 // sorted relative-path order, and `generated` is date-only so a same-day re-run
 // produces no spurious diff. content-manifest.json itself is excluded.
+// Flag-only windows-section edits can change XML hashes while leaving render-affecting bytes unchanged; retained render_verified evidence is deliberate.
 const resourcePaths = [
   ...manifestFiles.map((f) => join(MANIFESTS_DIR, f)),
   INDEX_PATH,

--- a/src/tools/desktop/binder/bindTemplate.test.ts
+++ b/src/tools/desktop/binder/bindTemplate.test.ts
@@ -1180,7 +1180,7 @@ describe('bindTemplateTool auto_apply gate', () => {
     });
 
     expect(result.isError).toBe(false);
-    expect(vi.mocked(getWorkbookXmlModule.getWorkbookXml)).toHaveBeenCalledTimes(3);
+    expect(vi.mocked(getWorkbookXmlModule.getWorkbookXml)).toHaveBeenCalledTimes(4);
     expect(applyWorkbookDocument).toHaveBeenCalledTimes(1);
     expect(executeCommand).toHaveBeenCalledTimes(2);
     expect(executeCommand).toHaveBeenCalledWith(
@@ -2053,7 +2053,7 @@ describe('bindTemplateTool auto_apply target_worksheet (e1/s7 stray-sheet class)
     vi.mocked(externalDiscovery.discoverInstances).mockReturnValue([]);
   });
 
-  it('applies onto the named existing sheet: inject titled with the target, sheet_name reports it', async () => {
+  it('applies onto the named existing sheet without activation for composition-neutral replacement', async () => {
     const targetWorkbookXml = INJECTED_WORKBOOK_WITH_NEW_SHEET_WINDOW.replace(
       /Sales by Region/g,
       'se-eval-scratch',
@@ -2081,12 +2081,7 @@ describe('bindTemplateTool auto_apply target_worksheet (e1/s7 stray-sheet class)
     );
     expect(vi.mocked(classifyWorksheetReplaceTarget)).toHaveBeenCalledWith(XML, 'se-eval-scratch');
     expect(applyWorkbookDocument).toHaveBeenCalledTimes(1);
-    expect(executeCommand).toHaveBeenCalledWith(
-      expect.objectContaining({
-        command: 'goto-sheet',
-        args: { Sheet: 'se-eval-scratch' },
-      }),
-    );
+    expect(executeCommand).not.toHaveBeenCalled();
   });
 
   it('unknown target fails closed BEFORE the bind even runs', async () => {

--- a/src/tools/desktop/binder/bindTemplate.ts
+++ b/src/tools/desktop/binder/bindTemplate.ts
@@ -652,6 +652,7 @@ async function performAutoApply({
   bindMs,
   eventsAnchor,
   schemaSummary,
+  suppressActivation,
 }: {
   res: BoundResult;
   base: BindTemplateToolResultBase;
@@ -662,6 +663,7 @@ async function performAutoApply({
   bindMs: number;
   eventsAnchor?: number;
   schemaSummary: SchemaSummary;
+  suppressActivation: boolean;
 }): Promise<StructuredBindTemplateToolResult> {
   const { args } = res;
 
@@ -743,14 +745,13 @@ async function performAutoApply({
   if (applyResult.isErr()) {
     return applyFallback(base, `apply failed: ${describeApplyError(applyResult.error)}`);
   }
-  // Activation policy signal: this is the public standalone plain-chart auto-apply
-  // boundary. Dashboard composition binds/injects its intermediate sheets internally
-  // and never enters this path, so only the requested standalone chart navigates.
-  await activateSheetBestEffort({
-    sheetName: literalTitle,
-    executor,
-    signal,
-  });
+  if (!suppressActivation) {
+    await activateSheetBestEffort({
+      sheetName: literalTitle,
+      executor,
+      signal,
+    });
+  }
   const applyMs = Date.now() - applyStart;
 
   // W60 response-shape trim (P4): on success, return ONLY the trimmed fast-path shape —
@@ -1127,6 +1128,7 @@ export const getBindTemplateTool = (server: DesktopMcpServer): DesktopTool<typeo
             bindMs,
             eventsAnchor,
             schemaSummary,
+            suppressActivation: target_worksheet !== undefined,
           });
           recordBoundRecoveryAfterFinalResult({
             session: resolvedSession,

--- a/src/tools/desktop/dashboard/dashboardAutoApply.test.ts
+++ b/src/tools/desktop/dashboard/dashboardAutoApply.test.ts
@@ -303,9 +303,9 @@ describe('dashboardAutoApplyTool happy path', () => {
       'sheets',
     ]);
 
-    // The public dashboard boundary performs the one primary read plus a fresh
-    // best-effort activation read; internal worksheets never activate independently.
-    expect(vi.mocked(getWorkbookXmlModule.getWorkbookXml)).toHaveBeenCalledTimes(2);
+    // The public dashboard boundary performs the one primary read plus the bounded
+    // not-found activation revalidation; internal worksheets never activate independently.
+    expect(vi.mocked(getWorkbookXmlModule.getWorkbookXml)).toHaveBeenCalledTimes(3);
     expect(applyWorkbookDocument).toHaveBeenCalledTimes(1);
   });
 

--- a/src/tools/desktop/workbook/activateSheet.test.ts
+++ b/src/tools/desktop/workbook/activateSheet.test.ts
@@ -180,7 +180,7 @@ describe('activateSheetBestEffort', () => {
   });
 
   it('does not navigate when validation cannot find the target', async () => {
-    const { executor, executeCommand } = makeExecutor({
+    const { executor, getWorkbookDocument, executeCommand } = makeExecutor({
       xml: buildWorkbook({ worksheetNames: ['Alpha'] }),
     });
 
@@ -190,10 +190,46 @@ describe('activateSheetBestEffort', () => {
       signal,
     });
 
-    await vi.advanceTimersByTimeAsync(500);
+    await vi.advanceTimersByTimeAsync(1200);
 
     await expect(activation).resolves.toBeUndefined();
+    expect(getWorkbookDocument).toHaveBeenCalledTimes(2);
     expect(executeCommand).not.toHaveBeenCalled();
+  });
+
+  it('revalidates once after a post-apply not-found read before navigating', async () => {
+    const { executor, getWorkbookDocument, executeCommand } = makeExecutor({
+      xmlSequence: [
+        buildWorkbook({ worksheetNames: ['Alpha'] }),
+        buildWorkbook({ activeSheetName: 'Beta' }),
+      ],
+    });
+
+    const activation = activateSheetBestEffort({
+      sheetName: 'Beta',
+      executor,
+      signal,
+    });
+
+    await vi.advanceTimersByTimeAsync(500);
+    expect(getWorkbookDocument).toHaveBeenCalledTimes(1);
+    expect(executeCommand).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(699);
+    expect(getWorkbookDocument).toHaveBeenCalledTimes(1);
+    expect(executeCommand).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(getWorkbookDocument).toHaveBeenCalledTimes(2);
+    expect(executeCommand).toHaveBeenCalledTimes(1);
+    expect(executeCommand).toHaveBeenLastCalledWith(
+      expect.objectContaining({ command: 'goto-sheet', args: { Sheet: 'Beta' } }),
+    );
+
+    await vi.advanceTimersByTimeAsync(700);
+    await expect(activation).resolves.toBeUndefined();
+    expect(getWorkbookDocument).toHaveBeenCalledTimes(3);
+    expect(executeCommand).toHaveBeenCalledTimes(1);
   });
 
   it('waits for settle, verifies focus, and reissues goto-sheet once after snap-back', async () => {
@@ -226,11 +262,33 @@ describe('activateSheetBestEffort', () => {
 
     await vi.advanceTimersByTimeAsync(1);
     await expect(activation).resolves.toBeUndefined();
-    expect(getWorkbookDocument).toHaveBeenCalledTimes(2);
+    expect(getWorkbookDocument).toHaveBeenCalledTimes(3);
     expect(executeCommand).toHaveBeenCalledTimes(2);
     expect(executeCommand).toHaveBeenLastCalledWith(
       expect.objectContaining({ command: 'goto-sheet', args: { Sheet: 'Beta' } }),
     );
+  });
+
+  it('revalidates before a snap-back reissue and suppresses it if the target disappeared', async () => {
+    const { executor, getWorkbookDocument, executeCommand } = makeExecutor({
+      xmlSequence: [
+        buildWorkbook({ activeSheetName: 'Alpha' }),
+        buildWorkbook({ activeSheetName: 'Alpha' }),
+        buildWorkbook({ worksheetNames: ['Alpha'], activeSheetName: 'Alpha' }),
+      ],
+    });
+
+    const activation = activateSheetBestEffort({
+      sheetName: 'Beta',
+      executor,
+      signal,
+    });
+
+    await vi.advanceTimersByTimeAsync(1200);
+
+    await expect(activation).resolves.toBeUndefined();
+    expect(getWorkbookDocument).toHaveBeenCalledTimes(3);
+    expect(executeCommand).toHaveBeenCalledTimes(1);
   });
 
   it('does not reissue goto-sheet when the verification read shows the target is focused', async () => {


### PR DESCRIPTION
## Decision

Four fixes to sheet activation, all so focus lands on the sheet it should. (Follow-up to #608, merged; a fresh-eyes review of the activation work surfaced these, rehomed onto the post-#608 base.)

1. **Reissue through the validated path** — a verification-failure reissue now routes through `activateSheetWithValidatedGoto` (fresh read + exact-name check). A target renamed or removed during the ~700ms verify window can no longer trigger a raw `goto-sheet` at a dead target, keeping the 47BF7751 modal closed.
2. **One bounded re-check for a slow sheet** — a newly applied sheet that isn't readable yet gets one bounded delayed re-check instead of a permanent not-found exit.
3. **Composition intermediates don't steal focus** — `target_worksheet` auto-applies suppress activation via an explicit flag, so dashboard/batch composition intermediates can't grab focus. The policy comes from the threaded flag, not from comments.
4. **Byte-verified template mirrors** — the `vendoredAssets` test now compares mirror bytes plus manifest sha256/bytes, not just filenames. The flag-only hash restamp carries an attestation comment.

Note: item 4 is test hardening, unrelated to the focus fixes. Folded in here; under the new writing rule it would be separate.

## What future work must preserve

Activation reissues route through the validated path; composition intermediates never take focus.

## Reviewer decision

Approve = activation stays on the correct sheet across rename, slow load, and dashboard composition. Full suite 339 files / 5045 tests green (isolated HOME to avoid ambient live-Desktop discovery pollution). Live-verified: a bound sheet holds focus through the settle window.

Posted by MattGPT (automation) on Matt Filbert's behalf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
