### PR TITLE
fix(remove-field): always refetch the worksheet before removing a field

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "2.52.1",
+  "version": "2.53.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/src/tools/desktop/fields/addField.test.ts
+++ b/src/tools/desktop/fields/addField.test.ts
@@ -278,6 +278,35 @@ describe('addFieldTool', () => {
     expect(metadataModule.addFieldToRows).not.toHaveBeenCalled();
   });
 
+  it('uses in-profile recovery guidance when the worksheet endpoint is absent', async () => {
+    const routeMissingErr = {
+      type: 'execute-command-error' as const,
+      error: {
+        type: 'command-failed' as const,
+        error: {
+          code: 'not-found',
+          message: 'No route matches GET /api/v1/worksheets/sheet-1/document',
+          recoverable: false,
+        },
+      },
+    };
+    vi.mocked(getWorksheetXmlModule.getWorksheetFragment).mockResolvedValue(Err(routeMissingErr));
+    vi.mocked(getWorksheetXmlModule.isRouteMissing).mockReturnValue(true);
+
+    const result = await getResult({
+      worksheetName: 'Sheet 1',
+      target: 'rows',
+      columnRef: COLUMN_REF,
+    });
+
+    expect(result.isError).toBe(true);
+    invariant(result.content[0].type === 'text');
+    expect(result.content[0].text).toContain('list-worksheets');
+    expect(result.content[0].text).toContain('retry');
+    expect(result.content[0].text).not.toContain('get-app-info');
+    expect(writeFileSync).not.toHaveBeenCalled();
+  });
+
   it('errors when neither worksheetName nor worksheetFile is provided', async () => {
     const result = await getResult({ target: 'rows', columnRef: COLUMN_REF });
 

--- a/src/tools/desktop/fields/addField.ts
+++ b/src/tools/desktop/fields/addField.ts
@@ -1,14 +1,9 @@
 import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { existsSync, readFileSync, writeFileSync } from 'fs';
-import { Err, Ok, Result } from 'ts-results-es';
+import { Ok } from 'ts-results-es';
 import { z } from 'zod';
 
-import { DesktopCache } from '../../../desktop/cache.js';
 import { writeSidecar } from '../../../desktop/commands/workbook/cacheFingerprint.js';
-import {
-  getWorksheetFragment,
-  isRouteMissing,
-} from '../../../desktop/commands/workbook/getWorksheetXml.js';
 import {
   addFieldToCols,
   addFieldToEncoding,
@@ -18,18 +13,14 @@ import { resolveSession } from '../../../desktop/sessionResolution.js';
 import { wellFormedXmlRule } from '../../../desktop/validation/rules/wellFormedXml.js';
 import {
   ArgsValidationError,
-  DesktopCommandExecutionError,
   FileNotFoundError,
   FileReadError,
-  GetWorksheetXmlFailedError,
-  McpToolError,
-  UnknownError,
   XmlModificationError,
   XmlValidationError,
 } from '../../../errors/mcpToolError.js';
 import { DesktopMcpServer } from '../../../server.desktop.js';
 import { DesktopTool } from '../tool.js';
-import { TableauDesktopRequestHandlerExtra } from '../toolContext.js';
+import { fetchAndCacheWorksheet } from './worksheetCache.js';
 
 /** Encoding channels a field can be placed on. */
 const ENCODING_TYPES = [
@@ -44,55 +35,6 @@ const ENCODING_TYPES = [
 ] as const;
 /** Shelf / encoding a field can be added to. */
 const FIELD_TARGETS = ['rows', 'cols', 'encoding'] as const;
-
-/**
- * Fetch an existing worksheet by display name and write it to a cache file, returning that
- * path — the same mint get-worksheet-xml performs. Lets add-field/remove-field be used with
- * a plain worksheet name (no prior get-worksheet-xml call) while preserving the
- * get-once/edit-many/apply-once contract: the returned path is reused across edits.
- */
-async function fetchAndCacheWorksheet({
-  worksheetName,
-  resolvedSession,
-  extra,
-}: {
-  worksheetName: string;
-  resolvedSession: string;
-  extra: TableauDesktopRequestHandlerExtra;
-}): Promise<Result<string, McpToolError>> {
-  const executor = await extra.getExecutor(resolvedSession);
-  const fetched = await getWorksheetFragment({ worksheetName, executor, signal: extra.signal });
-  if (fetched.isErr()) {
-    const { type, error } = fetched.error;
-    switch (type) {
-      case 'get-worksheet-xml-error':
-        return Err(new GetWorksheetXmlFailedError(error));
-      case 'execute-command-error':
-        if (isRouteMissing(error)) {
-          return Err(
-            new McpToolError({
-              type: 'endpoint-not-in-this-build',
-              message:
-                'This Tableau Desktop build does not serve the worksheet document endpoint yet. ' +
-                'Use get-app-info to identify the build; this read lights up on a newer Desktop update. Do not retry.',
-              statusCode: 404,
-            }),
-          );
-        }
-        return Err(new DesktopCommandExecutionError(error));
-      default: {
-        const _: never = type;
-        return Err(new UnknownError(error));
-      }
-    }
-  }
-
-  const safeName = worksheetName.replace(/[^a-zA-Z0-9]/g, '_');
-  const cacheFile = new DesktopCache().getCacheFilePath({ prefix: `worksheet-${safeName}` });
-  writeFileSync(cacheFile, fetched.value, 'utf-8');
-  writeSidecar(cacheFile, resolvedSession);
-  return Ok(cacheFile);
-}
 
 const paramsSchema = {
   session: z.string().optional().describe('Desktop session; omit if one.'),

--- a/src/tools/desktop/fields/addField.ts
+++ b/src/tools/desktop/fields/addField.ts
@@ -41,7 +41,7 @@ const paramsSchema = {
   worksheetName: z
     .string()
     .optional()
-    .describe('Sheet to edit; cached on first use. Give this or worksheetFile.'),
+    .describe('Sheet to edit (fetched fresh); or pass worksheetFile to stack edits.'),
   worksheetFile: z
     .string()
     .optional()

--- a/src/tools/desktop/fields/removeField.test.ts
+++ b/src/tools/desktop/fields/removeField.test.ts
@@ -1,25 +1,33 @@
 import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { existsSync, readFileSync, writeFileSync } from 'fs';
+import { Err, Ok } from 'ts-results-es';
 import { z } from 'zod';
 
 import * as configModule from '../../../config.desktop.js';
 import * as cacheFingerprintModule from '../../../desktop/commands/workbook/cacheFingerprint.js';
+import * as getWorksheetXmlModule from '../../../desktop/commands/workbook/getWorksheetXml.js';
+import * as loadWorksheetXmlModule from '../../../desktop/commands/workbook/loadWorksheetXml.js';
 import * as discoveryModule from '../../../desktop/externalApi/discovery.js';
 import * as metadataModule from '../../../desktop/metadata/index.js';
 import {
   ArgsValidationError,
   FileNotFoundError,
   FileReadError,
+  GetWorksheetXmlFailedError,
   XmlModificationError,
 } from '../../../errors/mcpToolError.js';
 import { DesktopMcpServer } from '../../../server.desktop.js';
 import invariant from '../../../utils/invariant.js';
 import { Provider } from '../../../utils/provider.js';
 import { getMockRequestHandlerExtra } from '../toolContext.mock.js';
+import { getApplyWorksheetTool } from '../worksheet/applyWorksheet.js';
+import { getAddFieldTool } from './addField.js';
 import { getRemoveFieldTool } from './removeField.js';
 
 vi.mock('../../../desktop/metadata/index.js');
 vi.mock('../../../desktop/commands/workbook/cacheFingerprint.js');
+vi.mock('../../../desktop/commands/workbook/getWorksheetXml.js');
+vi.mock('../../../desktop/commands/workbook/loadWorksheetXml.js');
 vi.mock('../../../desktop/externalApi/discovery.js');
 vi.mock('fs');
 
@@ -59,6 +67,7 @@ describe('removeFieldTool', () => {
     );
     expect(tool.paramsSchema).toMatchObject({
       session: expect.any(Object),
+      worksheetName: expect.any(Object),
       worksheetFile: expect.any(Object),
       target: expect.any(Object),
       columnRef: expect.any(Object),
@@ -206,6 +215,7 @@ describe('removeFieldTool', () => {
     const result = await callback(
       {
         session: SESSION,
+        worksheetName: undefined,
         worksheetFile: WORKSHEET_FILE,
         target: 'rows',
         columnRef: COLUMN_REF,
@@ -216,6 +226,161 @@ describe('removeFieldTool', () => {
 
     expect(result.isError).toBe(false);
     expect(extra.getExecutor).not.toHaveBeenCalled();
+  });
+
+  it('fetches and caches the sheet by name when no worksheetFile is given, then edits it', async () => {
+    const fragment = '<worksheet name="Sheet 1"><table/></worksheet>';
+    vi.mocked(getWorksheetXmlModule.getWorksheetFragment).mockResolvedValue(Ok(fragment));
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue(fragment);
+    vi.mocked(metadataModule.removeFieldFromRows).mockReturnValue(MODIFIED_XML);
+    vi.mocked(writeFileSync).mockReturnValue(undefined);
+
+    const result = await getResult({
+      worksheetName: 'Sheet 1',
+      target: 'rows',
+      columnRef: COLUMN_REF,
+    });
+
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+    const body = resultSchema.parse(JSON.parse(result.content[0].text));
+    expect(body.message).toContain('Rows shelf');
+    expect(getWorksheetXmlModule.getWorksheetFragment).toHaveBeenCalledWith(
+      expect.objectContaining({ worksheetName: 'Sheet 1' }),
+    );
+    expect(body.file).toMatch(/worksheet-Sheet_1-/);
+    expect(writeFileSync).toHaveBeenCalledWith(body.file, fragment, 'utf-8');
+    expect(writeFileSync).toHaveBeenCalledWith(body.file, MODIFIED_XML, 'utf-8');
+  });
+
+  it('uses a supplied worksheetFile without fetching when worksheetName is also given', async () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue('<worksheet/>');
+    vi.mocked(metadataModule.removeFieldFromRows).mockReturnValue(MODIFIED_XML);
+    vi.mocked(writeFileSync).mockReturnValue(undefined);
+
+    const result = await getResult({
+      worksheetName: 'Sheet 1',
+      worksheetFile: WORKSHEET_FILE,
+      target: 'rows',
+      columnRef: COLUMN_REF,
+    });
+
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+    expect(resultSchema.parse(JSON.parse(result.content[0].text)).file).toBe(WORKSHEET_FILE);
+    expect(getWorksheetXmlModule.getWorksheetFragment).not.toHaveBeenCalled();
+  });
+
+  it('errors when neither worksheetName nor worksheetFile is provided', async () => {
+    const result = await getResult({ target: 'rows', columnRef: COLUMN_REF });
+
+    expect(result.isError).toBe(true);
+    invariant(result.content[0].type === 'text');
+    expect(result.content[0].text).toBe(
+      new ArgsValidationError(
+        'Provide either worksheetName (to edit an existing sheet) or worksheetFile (a cached path).',
+      ).message,
+    );
+    expect(getWorksheetXmlModule.getWorksheetFragment).not.toHaveBeenCalled();
+    expect(writeFileSync).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a fetch error (unknown worksheet) without writing anything', async () => {
+    const fetchErr = {
+      type: 'get-worksheet-xml-error' as const,
+      error: { type: 'no-worksheet-found' as const, message: 'No worksheet found for Ghost.' },
+    };
+    vi.mocked(getWorksheetXmlModule.getWorksheetFragment).mockResolvedValue(Err(fetchErr));
+
+    const result = await getResult({
+      worksheetName: 'Ghost',
+      target: 'rows',
+      columnRef: COLUMN_REF,
+    });
+
+    expect(result.isError).toBe(true);
+    invariant(result.content[0].type === 'text');
+    expect(result.content[0].text).toBe(new GetWorksheetXmlFailedError(fetchErr.error).message);
+    expect(writeFileSync).not.toHaveBeenCalled();
+    expect(metadataModule.removeFieldFromRows).not.toHaveBeenCalled();
+  });
+
+  it('uses in-profile recovery guidance when the worksheet endpoint is absent', async () => {
+    const routeMissingErr = {
+      type: 'execute-command-error' as const,
+      error: {
+        type: 'command-failed' as const,
+        error: {
+          code: 'not-found',
+          message: 'No route matches GET /api/v1/worksheets/sheet-1/document',
+          recoverable: false,
+        },
+      },
+    };
+    vi.mocked(getWorksheetXmlModule.getWorksheetFragment).mockResolvedValue(Err(routeMissingErr));
+    vi.mocked(getWorksheetXmlModule.isRouteMissing).mockReturnValue(true);
+
+    const result = await getResult({
+      worksheetName: 'Sheet 1',
+      target: 'rows',
+      columnRef: COLUMN_REF,
+    });
+
+    expect(result.isError).toBe(true);
+    invariant(result.content[0].type === 'text');
+    expect(result.content[0].text).toContain('list-worksheets');
+    expect(result.content[0].text).toContain('retry');
+    expect(result.content[0].text).not.toContain('get-app-info');
+    expect(writeFileSync).not.toHaveBeenCalled();
+  });
+
+  it('stacks add then remove on the returned worksheetFile before one apply-worksheet', async () => {
+    const baseXml = '<worksheet name="Sheet 1"><table/></worksheet>';
+    const addedXml = '<worksheet name="Sheet 1"><table><rows>[Profit]</rows></table></worksheet>';
+    const removedXml = '<worksheet name="Sheet 1"><table><rows/></table></worksheet>';
+    const files = new Map<string, string>();
+    vi.mocked(getWorksheetXmlModule.getWorksheetFragment).mockResolvedValue(Ok(baseXml));
+    vi.mocked(existsSync).mockImplementation((path) => files.has(String(path)));
+    vi.mocked(readFileSync).mockImplementation((path) => files.get(String(path)) ?? '');
+    vi.mocked(writeFileSync).mockImplementation((path, data) => {
+      files.set(String(path), String(data));
+    });
+    vi.mocked(metadataModule.addFieldToRows).mockReturnValue(addedXml);
+    vi.mocked(metadataModule.removeFieldFromRows).mockReturnValue(removedXml);
+    vi.mocked(cacheFingerprintModule.checkSidecar).mockReturnValue({ ok: true });
+    vi.mocked(loadWorksheetXmlModule.loadWorksheetXml).mockResolvedValue(
+      Ok({ readbackWarnings: [] }),
+    );
+
+    const addResult = await getAddResult({ worksheetName: 'Sheet 1', target: 'rows' });
+
+    expect(addResult.isError).toBe(false);
+    invariant(addResult.content[0].type === 'text');
+    const addBody = resultSchema.parse(JSON.parse(addResult.content[0].text));
+
+    const removeResult = await getResult({
+      worksheetFile: addBody.file,
+      target: 'rows',
+      columnRef: COLUMN_REF,
+    });
+
+    expect(removeResult.isError).toBe(false);
+    invariant(removeResult.content[0].type === 'text');
+    const removeBody = resultSchema.parse(JSON.parse(removeResult.content[0].text));
+    expect(removeBody.file).toBe(addBody.file);
+
+    const applyResult = await getApplyResult({
+      worksheetName: 'Sheet 1',
+      worksheetFile: removeBody.file,
+    });
+
+    expect(applyResult.isError).toBe(false);
+    expect(getWorksheetXmlModule.getWorksheetFragment).toHaveBeenCalledTimes(1);
+    expect(loadWorksheetXmlModule.loadWorksheetXml).toHaveBeenCalledWith(
+      expect.objectContaining({ worksheetName: 'Sheet 1', xml: removedXml }),
+    );
   });
 
   // --- target=cols (ported from removeFieldFromCols) ---
@@ -380,18 +545,65 @@ describe('removeFieldTool', () => {
 });
 
 async function getResult(params: {
-  worksheetFile: string;
+  worksheetName?: string;
+  worksheetFile?: string;
   target: Target;
   columnRef: string;
   encodingType?: EncodingType;
   session?: string;
 }): Promise<CallToolResult> {
-  const { worksheetFile, target, columnRef, encodingType } = params;
+  const { worksheetName, worksheetFile, target, columnRef, encodingType } = params;
   const session = ('session' in params ? params.session : SESSION) as string;
   const tool = getRemoveFieldTool(new DesktopMcpServer());
   const callback = await Provider.from(tool.callback);
   return await callback(
-    { session, worksheetFile, target, columnRef, encodingType },
+    { session, worksheetName, worksheetFile, target, columnRef, encodingType },
+    getMockRequestHandlerExtra(),
+  );
+}
+
+async function getAddResult(params: {
+  worksheetName?: string;
+  worksheetFile?: string;
+  target: Target;
+  columnRef?: string;
+  encodingType?: EncodingType;
+  session?: string;
+}): Promise<CallToolResult> {
+  const session = ('session' in params ? params.session : SESSION) as string;
+  const tool = getAddFieldTool(new DesktopMcpServer());
+  const callback = await Provider.from(tool.callback);
+  return await callback(
+    {
+      session,
+      worksheetName: params.worksheetName,
+      worksheetFile: params.worksheetFile,
+      target: params.target,
+      columnRef: params.columnRef ?? COLUMN_REF,
+      encodingType: params.encodingType,
+      index: undefined,
+      workbookFile: undefined,
+    },
+    getMockRequestHandlerExtra(),
+  );
+}
+
+async function getApplyResult(params: {
+  worksheetName: string;
+  worksheetFile: string;
+  session?: string;
+}): Promise<CallToolResult> {
+  const session = ('session' in params ? params.session : SESSION) as string;
+  const tool = getApplyWorksheetTool(new DesktopMcpServer());
+  const callback = await Provider.from(tool.callback);
+  return await callback(
+    {
+      session,
+      worksheetName: params.worksheetName,
+      mode: 'file',
+      worksheetFile: params.worksheetFile,
+      worksheetXml: undefined,
+    },
     getMockRequestHandlerExtra(),
   );
 }

--- a/src/tools/desktop/fields/removeField.ts
+++ b/src/tools/desktop/fields/removeField.ts
@@ -41,7 +41,7 @@ const paramsSchema = {
   worksheetName: z
     .string()
     .optional()
-    .describe('Sheet to edit; cached on first use. Give this or worksheetFile.'),
+    .describe('Sheet to edit (fetched fresh); or pass worksheetFile to stack edits.'),
   worksheetFile: z
     .string()
     .optional()

--- a/src/tools/desktop/fields/removeField.ts
+++ b/src/tools/desktop/fields/removeField.ts
@@ -20,6 +20,7 @@ import {
 } from '../../../errors/mcpToolError.js';
 import { DesktopMcpServer } from '../../../server.desktop.js';
 import { DesktopTool } from '../tool.js';
+import { fetchAndCacheWorksheet } from './worksheetCache.js';
 
 /** Encoding channels a field can be removed from. */
 const ENCODING_TYPES = [
@@ -36,11 +37,18 @@ const ENCODING_TYPES = [
 const FIELD_TARGETS = ['rows', 'cols', 'encoding'] as const;
 
 const paramsSchema = {
-  session: z.string().optional(),
-  worksheetFile: z.string(),
-  target: z.enum(FIELD_TARGETS),
-  columnRef: z.string(),
-  encodingType: z.enum(ENCODING_TYPES).optional(),
+  session: z.string().optional().describe('Desktop session; omit if one.'),
+  worksheetName: z
+    .string()
+    .optional()
+    .describe('Sheet to edit; cached on first use. Give this or worksheetFile.'),
+  worksheetFile: z
+    .string()
+    .optional()
+    .describe('Cached sheet path from a prior edit; stacks edits.'),
+  target: z.enum(FIELD_TARGETS).describe('Placement shelf.'),
+  columnRef: z.string().describe('Field to remove.'),
+  encodingType: z.enum(ENCODING_TYPES).optional().describe('Required when target=encoding.'),
 };
 
 const title = 'Remove Field';
@@ -59,18 +67,38 @@ export const getRemoveFieldTool = (server: DesktopMcpServer): DesktopTool<typeof
       idempotentHint: false,
     },
     callback: async (
-      { session, worksheetFile, target, columnRef, encodingType },
+      { session, worksheetName, worksheetFile, target, columnRef, encodingType },
       extra,
     ): Promise<CallToolResult> => {
       return await removeFieldTool.logAndExecute({
         extra,
-        args: { session, worksheetFile, target, columnRef, encodingType },
+        args: { session, worksheetName, worksheetFile, target, columnRef, encodingType },
         callback: async () => {
           const sessionResult = resolveSession(session);
           if (sessionResult.isErr()) {
             return sessionResult.error.toErr();
           }
           const resolvedSession = sessionResult.value;
+
+          if (!worksheetFile?.trim() && !worksheetName?.trim()) {
+            return new ArgsValidationError(
+              'Provide either worksheetName (to edit an existing sheet) or worksheetFile (a cached path).',
+            ).toErr();
+          }
+
+          // Name-based path: always fetch fresh and mint a new cache file. Follow-up
+          // add-field/remove-field calls should pass the returned worksheetFile to stack edits.
+          if (!worksheetFile?.trim()) {
+            const minted = await fetchAndCacheWorksheet({
+              worksheetName: worksheetName!.trim(),
+              resolvedSession,
+              extra,
+            });
+            if (minted.isErr()) {
+              return minted.error.toErr();
+            }
+            worksheetFile = minted.value;
+          }
 
           if (!existsSync(worksheetFile)) {
             return new FileNotFoundError(worksheetFile).toErr();

--- a/src/tools/desktop/fields/worksheetCache.ts
+++ b/src/tools/desktop/fields/worksheetCache.ts
@@ -1,0 +1,65 @@
+import { writeFileSync } from 'fs';
+import { Err, Ok, Result } from 'ts-results-es';
+
+import { DesktopCache } from '../../../desktop/cache.js';
+import { writeSidecar } from '../../../desktop/commands/workbook/cacheFingerprint.js';
+import {
+  getWorksheetFragment,
+  isRouteMissing,
+} from '../../../desktop/commands/workbook/getWorksheetXml.js';
+import {
+  DesktopCommandExecutionError,
+  GetWorksheetXmlFailedError,
+  McpToolError,
+  UnknownError,
+} from '../../../errors/mcpToolError.js';
+import { TableauDesktopRequestHandlerExtra } from '../toolContext.js';
+
+/**
+ * Fetch an existing worksheet by display name and write it to a new cache file.
+ *
+ * This intentionally does not look up or reuse an existing cache path: the sidecar
+ * proves Desktop instance identity, not workbook-content freshness.
+ */
+export async function fetchAndCacheWorksheet({
+  worksheetName,
+  resolvedSession,
+  extra,
+}: {
+  worksheetName: string;
+  resolvedSession: string;
+  extra: TableauDesktopRequestHandlerExtra;
+}): Promise<Result<string, McpToolError>> {
+  const executor = await extra.getExecutor(resolvedSession);
+  const fetched = await getWorksheetFragment({ worksheetName, executor, signal: extra.signal });
+  if (fetched.isErr()) {
+    const { type, error } = fetched.error;
+    switch (type) {
+      case 'get-worksheet-xml-error':
+        return Err(new GetWorksheetXmlFailedError(error));
+      case 'execute-command-error':
+        if (isRouteMissing(error)) {
+          return Err(
+            new McpToolError({
+              type: 'endpoint-not-in-this-build',
+              message:
+                'This Tableau Desktop build does not serve the worksheet document endpoint yet. ' +
+                'Use list-worksheets to confirm the target sheet is visible, then retry on a Desktop build that serves worksheet documents.',
+              statusCode: 404,
+            }),
+          );
+        }
+        return Err(new DesktopCommandExecutionError(error));
+      default: {
+        const _: never = type;
+        return Err(new UnknownError(error));
+      }
+    }
+  }
+
+  const safeName = worksheetName.replace(/[^a-zA-Z0-9]/g, '_');
+  const cacheFile = new DesktopCache().getCacheFilePath({ prefix: `worksheet-${safeName}` });
+  writeFileSync(cacheFile, fetched.value, 'utf-8');
+  writeSidecar(cacheFile, resolvedSession);
+  return Ok(cacheFile);
+}


### PR DESCRIPTION
## Decision — read this first

remove-field now reads a fresh worksheet on every name-based call, matching add-field (#615).

**This is not a new "all tools refresh first" invariant.** It is a deliberate per-tool choice for the two name-based field tools. Here is why, and it answers the question directly: the cache sidecar proves only *which Desktop instance* it came from (pid / port / start_time), not that the workbook *content* is current. There is no events endpoint yet to detect staleness. So reusing the cache would let the agent clobber a change the External Client API just made: API mutates the workbook → agent reuses a stale-but-fingerprint-valid cache → overwrites the API's change. The two field tools therefore always refetch. Other tools are unchanged, and this PR does not ask you to accept a repo-wide refresh rule.

(Coherence analysis prompted by @tableaukyler's stale-overwrite scenario.)

## Scope

remove-field plus a shared `worksheetCache.ts` helper (extracted so both field tools work in the lean profile without a hidden XML producer). Deliberately **no cache reuse**: edit-stacking works only through the explicitly returned `worksheetFile`. Each name-based call does a cheap per-worksheet GET, not a full-workbook serialization.

## What future work must preserve

Name-based field tools never reuse a cache to write.

## Future

The durable fix is a host revision / If-Match contract (captured separately, with open questions for the Desktop team). It aligns with Lauren's async-polling MR (monolith #60234).

## Reviewer decision

Approve = remove-field refetches fresh on each name-based call and never reuses the cache, the same as add-field. This is per-tool, not a new global invariant. Full suite 339 / 5054 green; confirmed no `readFileSync` / `checkSidecar` / reuse path in the helper.

Posted by MattGPT (automation) on Matt Filbert's behalf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
