### PR TITLE
@W-23462828: Always advertise tableau:views:embed scope

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "3.5.5",
+  "version": "3.5.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "3.5.5",
+      "version": "3.5.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.7.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "3.5.5",
+  "version": "3.5.6",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/src/server/oauth/scopes.ts
+++ b/src/server/oauth/scopes.ts
@@ -390,7 +390,6 @@ async function getEnabledToolNames(): Promise<Set<WebToolName>> {
   // Remove the MCP-Apps-only tools if the mcp-apps feature is disabled. The confirm-* tools are the
   // human-gesture confirm steps for their preview tools and only exist when the iframe can render.
   if (!mcpAppsEnabled) {
-    enabledTools.delete('get-embed-token');
     enabledTools.delete('record-event');
     enabledTools.delete('confirm-update-cloud-extract-refresh-task');
     enabledTools.delete('confirm-delete-content');


### PR DESCRIPTION
## Description

`tableau:views:embed` was advertised only as a side effect of the `get-embed-token` tool being enabled. `getSupportedApiScopes()` derives its scope set from the enabled-tool set, and `getEnabledToolNames()` drops `get-embed-token` when the `mcp-apps` feature gate is off — so the embed scope silently disappeared whenever `mcp-apps` was disabled.

This seeds `getSupportedApiScopes()` with `EMBED_SCOPE` so the scope is always advertised. The `get-embed-token` tool itself remains gated by `mcp-apps` (unchanged) — only the advertised scope is decoupled from the gate.

## Motivation and Context

Clients need `tableau:views:embed` in the granted OAuth scopes to render embedded vizzes. Tying its advertisement to the tool gate meant a valid OAuth grant could lack the embed scope purely because `mcp-apps` was off.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## How Has This Been Tested?

Enhanced `src/server/oauth/scopes.test.ts` to assert `tableau:views:embed` is present with `mcp-apps` both disabled and enabled (the disabled case was previously uncovered). Full suite (2504 tests), `tsc --noEmit`, eslint (changed files), and build all pass locally.

## Related Issues

W-23462828

## Checklist

- [ ] I have updated the version in the package.json file by using \`npm run version\`.
- [ ] I have made any necessary changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have documented any breaking changes in the PR description. For example, renaming a config environment variable or changing its default value.