### PR TITLE
docs: ask PR authors to write plain titles and state the decision first

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,6 +8,15 @@ the pull request._
 <!-- Thank you for your contribution! Please fill out the following template to help us review your pull
 request! -->
 
+<!-- TITLE: say plainly what the change does. Keep the `type(scope):` prefix; skip jargon, slogans, and
+version numbers. Good: "fix(remove-field): refetch the worksheet before removing a field". -->
+
+## Decision
+
+<!-- The one thing a reviewer is being asked to accept. State whether it is a RULE WE NOW KEEP (e.g.
+"every worksheet-mutating tool refreshes state first") or a ONE-OFF for this case. Do not leave the
+reviewer to infer which. This is the most important line in the PR. -->
+
 ## Description
 
 <!-- Please include a summary of the change. -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -281,3 +281,12 @@ npm run docs:start   # Start dev server
 ```
 
 Official docs: https://tableau.github.io/tableau-mcp/
+
+## Writing PRs, commits, and comments for humans
+
+Reviewers approve what they can read. When you write a PR title, PR body, commit subject, or review comment:
+
+- **Title:** keep the `type(scope):` prefix, then say plainly what the change does. No invented compound nouns, no slogans, no version number in the title.
+- **Body — decision first:** open with the one thing the reviewer must accept, and say whether it is a rule the codebase now keeps or a one-off for this case. Don't make the reviewer infer the policy from the diff.
+- **One PR, one decision:** if the title needs "and" to join two independent changes, it is probably two PRs.
+- Prefer short words, active voice, and cutting every word you can. Break a rule before writing something unreadable.


### PR DESCRIPTION
## Decision — a rule we now keep

Anyone writing a PR title, PR body, commit subject, or review comment writes it plainly, and opens the PR body with the decision the reviewer must accept. This adds a `Decision` section to the PR template and a short writing rule to `CLAUDE.md`. It sets a house style; it does not change any code.

The prompt: a reviewer told us our recent PR titles were unreadable ("what does `feat(remove-field): name-based self-feed via shared helper — fail-closed, no cache reuse` mean?") and that our descriptions never said whether a change set a new rule or was a one-off. Orwell's plain-writing rules fix the words; a decision-first template fixes the missing decision.

## Scope

- `.github/pull_request_template.md` — a title hint plus a `Decision` section that asks the author to state whether the change is a rule we keep or a one-off.
- `CLAUDE.md` — a short "Writing PRs, commits, and comments for humans" section.

No behavior change, no dependency change, no version bump.

## Reviewer decision

Approve = we ask PR authors to write plain titles and state the decision first. Everything else in the template is unchanged.

Posted by MattGPT (automation) on Matt Filbert's behalf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
