### PR TITLE
@W-23558751: Add render-interactive-viz MCP App tool

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "3.5.5",
+  "version": "3.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "3.5.5",
+      "version": "3.6.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.7.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "3.5.5",
+  "version": "3.6.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/src/server/oauth/scopes.ts
+++ b/src/server/oauth/scopes.ts
@@ -326,6 +326,10 @@ const toolScopeMap: Record<
     mcp: [],
     api: new Set<TableauApiScope>(),
   },
+  'render-interactive-viz': {
+    mcp: ['tableau:mcp:view:read', 'tableau:mcp:workbook:read'],
+    api: new Set(['tableau:content:read', ...RESOURCE_ACCESS_CHECKER_REQUIRED_API_SCOPES]),
+  },
   // Dispatches on `kind` to ts-events, site-content, job-performance (raw VDS) or stale-content
   // (server-side anti-join). Union of the scopes required by all four kinds.
   'query-admin-insights': {
@@ -392,6 +396,7 @@ async function getEnabledToolNames(): Promise<Set<WebToolName>> {
   if (!mcpAppsEnabled) {
     enabledTools.delete('get-embed-token');
     enabledTools.delete('record-event');
+    enabledTools.delete('render-interactive-viz');
     enabledTools.delete('confirm-update-cloud-extract-refresh-task');
     enabledTools.delete('confirm-delete-content');
   }

--- a/src/tools/web/recordEvent/recordEvent.ts
+++ b/src/tools/web/recordEvent/recordEvent.ts
@@ -5,6 +5,7 @@ import { z } from 'zod';
 import { getFeatureGate } from '../../../features/init.js';
 import { WebMcpServer } from '../../../server.web.js';
 import { getProductTelemetry } from '../../../telemetry/productTelemetry/telemetryForwarder.js';
+import { Provider } from '../../../utils/provider.js';
 import { WebTool } from '../tool.js';
 
 // Starting field set — the final app-supplied schema is expected to grow later.
@@ -52,7 +53,7 @@ export const getRecordEventTool = (server: WebMcpServer): WebTool<typeof paramsS
         visibility: ['app'], // Only visible to the app, not the model
       },
     },
-    disabled: !getFeatureGate().isFeatureEnabled('mcp-apps'),
+    disabled: new Provider(async () => !(await getFeatureGate().isFeatureEnabled('mcp-apps'))),
     callback: async (args, extra): Promise<CallToolResult> => {
       return recordEventTool.logAndExecute<{ recorded: true }>({
         extra,

--- a/src/tools/web/renderInteractiveViz/renderInteractiveViz.test.ts
+++ b/src/tools/web/renderInteractiveViz/renderInteractiveViz.test.ts
@@ -59,7 +59,7 @@ describe('renderInteractiveVizTool', () => {
   it('should have correct tool properties', () => {
     const tool = getRenderInteractiveVizTool(new WebMcpServer());
     expect(tool.name).toBe('render-interactive-viz');
-    expect(tool.description).toContain('interactive embedded Tableau viz');
+    expect(tool.description).toContain('interactive, embedded Tableau visualization');
     expect(tool.paramsSchema).toMatchObject({
       luid: expect.any(Object),
       objectType: expect.any(Object),

--- a/src/tools/web/renderInteractiveViz/renderInteractiveViz.test.ts
+++ b/src/tools/web/renderInteractiveViz/renderInteractiveViz.test.ts
@@ -1,0 +1,176 @@
+import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+
+import { WebMcpServer } from '../../../server.web.js';
+import { stubDefaultEnvVars } from '../../../testShared.js';
+import invariant from '../../../utils/invariant.js';
+import { Provider } from '../../../utils/provider.js';
+import { exportedForTesting as resourceAccessCheckerExportedForTesting } from '../resourceAccessChecker.js';
+import { getMockRequestHandlerExtra } from '../toolContext.mock.js';
+import { mockView } from '../views/mockView.js';
+import { mockWorkbook } from '../workbooks/mockWorkbook.js';
+import { getRenderInteractiveVizTool } from './renderInteractiveViz.js';
+
+const { resetResourceAccessCheckerSingleton } = resourceAccessCheckerExportedForTesting;
+
+const mocks = vi.hoisted(() => ({
+  mockGetView: vi.fn(),
+  mockGetWorkbook: vi.fn(),
+  mockResourceAccessChecker: {
+    isViewAllowed: vi.fn(),
+    isWorkbookAllowed: vi.fn(),
+  },
+}));
+
+vi.mock('../../../restApiInstance.js', () => ({
+  useRestApi: vi.fn().mockImplementation(async ({ callback }) =>
+    callback({
+      viewsMethods: {
+        getView: mocks.mockGetView,
+      },
+      workbooksMethods: {
+        getWorkbook: mocks.mockGetWorkbook,
+      },
+      siteId: 'test-site-id',
+    }),
+  ),
+}));
+
+vi.mock('../resourceAccessChecker.js', () => ({
+  resourceAccessChecker: mocks.mockResourceAccessChecker,
+  exportedForTesting: {
+    resetResourceAccessCheckerSingleton: vi.fn(),
+  },
+}));
+
+describe('renderInteractiveVizTool', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllEnvs();
+    stubDefaultEnvVars();
+    resetResourceAccessCheckerSingleton();
+    mocks.mockResourceAccessChecker.isViewAllowed.mockResolvedValue({ allowed: true });
+    mocks.mockResourceAccessChecker.isWorkbookAllowed.mockResolvedValue({ allowed: true });
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('should have correct tool properties', () => {
+    const tool = getRenderInteractiveVizTool(new WebMcpServer());
+    expect(tool.name).toBe('render-interactive-viz');
+    expect(tool.description).toContain('interactive embedded Tableau viz');
+    expect(tool.paramsSchema).toMatchObject({
+      luid: expect.any(Object),
+      objectType: expect.any(Object),
+    });
+    expect(tool.app?.resourceUri).toBe('ui://render-interactive-viz/mcp-app.html');
+  });
+
+  it('should return correct payload for an allowed view', async () => {
+    mocks.mockGetView.mockResolvedValue(mockView);
+
+    const result = await getToolResult({ luid: mockView.id, objectType: 'view' });
+
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+    const response = JSON.parse(result.content[0].text);
+    expect(response.data).toEqual({
+      luid: mockView.id,
+      objectType: 'view',
+      name: mockView.name,
+    });
+    expect(response.url).toBe(
+      'https://my-tableau-server.com/#/site/tc25/views/Superstore/Overview',
+    );
+  });
+
+  it('should return ViewNotAllowed error when view is not allowed', async () => {
+    mocks.mockResourceAccessChecker.isViewAllowed.mockResolvedValue({
+      allowed: false,
+      message: 'Querying the view with LUID test-view-id is not allowed.',
+    });
+
+    const result = await getToolResult({ luid: 'test-view-id', objectType: 'view' });
+
+    expect(result.isError).toBe(true);
+    invariant(result.content[0].type === 'text');
+    expect(result.content[0].text).toContain(
+      'Querying the view with LUID test-view-id is not allowed',
+    );
+  });
+
+  it('should return correct payload for an allowed workbook with default view', async () => {
+    mocks.mockGetWorkbook.mockResolvedValue(mockWorkbook);
+
+    const result = await getToolResult({ luid: mockWorkbook.id, objectType: 'workbook' });
+
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+    const response = JSON.parse(result.content[0].text);
+    expect(response.data).toEqual({
+      luid: mockWorkbook.id,
+      objectType: 'workbook',
+      name: mockWorkbook.name,
+    });
+    expect(response.url).toBe(
+      'https://my-tableau-server.com/#/site/tc25/views/Superstore/Overview',
+    );
+  });
+
+  it('should return WorkbookNotAllowed error when workbook is not allowed', async () => {
+    mocks.mockResourceAccessChecker.isWorkbookAllowed.mockResolvedValue({
+      allowed: false,
+      message: 'Querying the workbook with LUID test-wb-id is not allowed.',
+    });
+
+    const result = await getToolResult({ luid: 'test-wb-id', objectType: 'workbook' });
+
+    expect(result.isError).toBe(true);
+    invariant(result.content[0].type === 'text');
+    expect(result.content[0].text).toContain(
+      'Querying the workbook with LUID test-wb-id is not allowed',
+    );
+  });
+
+  it('should fall back to webpageUrl when workbook has no views', async () => {
+    const workbookNoViews = {
+      ...mockWorkbook,
+      views: { view: [] },
+      webpageUrl: 'https://tableau.example.com/workbook/123',
+    };
+    mocks.mockGetWorkbook.mockResolvedValue(workbookNoViews);
+
+    const result = await getToolResult({ luid: workbookNoViews.id, objectType: 'workbook' });
+
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+    const response = JSON.parse(result.content[0].text);
+    expect(response.url).toBe('https://tableau.example.com/workbook/123');
+  });
+
+  it('should fall back to empty string when workbook has no views and no webpageUrl', async () => {
+    const workbookNoViewsNoUrl = {
+      ...mockWorkbook,
+      views: { view: [] },
+      webpageUrl: undefined,
+    };
+    mocks.mockGetWorkbook.mockResolvedValue(workbookNoViewsNoUrl);
+
+    const result = await getToolResult({ luid: workbookNoViewsNoUrl.id, objectType: 'workbook' });
+
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+    const response = JSON.parse(result.content[0].text);
+    expect(response.url).toBe('');
+  });
+});
+
+async function getToolResult(params: {
+  luid: string;
+  objectType: 'workbook' | 'view';
+}): Promise<CallToolResult> {
+  const tool = getRenderInteractiveVizTool(new WebMcpServer());
+  const callback = await Provider.from(tool.callback);
+  return await callback(params, getMockRequestHandlerExtra());
+}

--- a/src/tools/web/renderInteractiveViz/renderInteractiveViz.ts
+++ b/src/tools/web/renderInteractiveViz/renderInteractiveViz.ts
@@ -28,7 +28,8 @@ export const getRenderInteractiveVizTool = (server: WebMcpServer): WebTool<typeo
   const renderInteractiveVizTool = new WebTool({
     server,
     name: 'render-interactive-viz',
-    description: 'Renders the specified workbook or view as an interactive embedded Tableau viz.',
+    description:
+      'Use when the user wants to see or view an interactive Tableau view, workbook, or viz — e.g. "show me the view", "show me the workbook", "open this dashboard interactively". Renders the workbook or view identified by luid (objectType "workbook" or "view") as an interactive, embedded Tableau visualization the user can explore.',
     paramsSchema,
     annotations: {
       title: 'Render Interactive Viz',

--- a/src/tools/web/renderInteractiveViz/renderInteractiveViz.ts
+++ b/src/tools/web/renderInteractiveViz/renderInteractiveViz.ts
@@ -1,0 +1,120 @@
+import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { Ok } from 'ts-results-es';
+import { z } from 'zod';
+
+import { ViewNotAllowedError, WorkbookNotAllowedError } from '../../../errors/mcpToolError.js';
+import { getFeatureGate } from '../../../features/init.js';
+import { useRestApi } from '../../../restApiInstance.js';
+import { WebMcpServer } from '../../../server.web.js';
+import { Provider } from '../../../utils/provider.js';
+import { getAppConfig } from '../../../web/apps/appConfig.js';
+import { resourceAccessChecker } from '../resourceAccessChecker.js';
+import { AppToolResult, WebTool } from '../tool.js';
+import { constructViewWebUrl, getDefaultViewWebUrl } from '../utils/viewUrlUtils.js';
+
+const paramsSchema = {
+  luid: z
+    .string()
+    .nonempty()
+    .describe('The LUID of the workbook or view to render as an interactive embedded viz.'),
+  objectType: z
+    .enum(['workbook', 'view'])
+    .describe('Whether the luid refers to a "workbook" or a "view".'),
+};
+
+type RenderInteractiveVizResult = { luid: string; objectType: 'workbook' | 'view'; name: string };
+
+export const getRenderInteractiveVizTool = (server: WebMcpServer): WebTool<typeof paramsSchema> => {
+  const renderInteractiveVizTool = new WebTool({
+    server,
+    name: 'render-interactive-viz',
+    description: 'Renders the specified workbook or view as an interactive embedded Tableau viz.',
+    paramsSchema,
+    annotations: {
+      title: 'Render Interactive Viz',
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
+    app: getAppConfig('render-interactive-viz'),
+    disabled: new Provider(async () => !(await getFeatureGate().isFeatureEnabled('mcp-apps'))),
+    callback: async ({ luid, objectType }, extra): Promise<CallToolResult> => {
+      return await renderInteractiveVizTool.logAndExecute<
+        AppToolResult<RenderInteractiveVizResult>
+      >({
+        extra,
+        args: { luid, objectType },
+        callback: async () => {
+          if (objectType === 'view') {
+            const isViewAllowedResult = await resourceAccessChecker.isViewAllowed({
+              viewId: luid,
+              extra,
+            });
+
+            if (!isViewAllowedResult.allowed) {
+              return new ViewNotAllowedError(isViewAllowedResult.message).toErr();
+            }
+
+            const view = await useRestApi({
+              ...extra,
+              jwtScopes: renderInteractiveVizTool.requiredApiScopes,
+              callback: async (restApi) => {
+                return (
+                  isViewAllowedResult.content ??
+                  (await restApi.viewsMethods.getView({
+                    viewId: luid,
+                    siteId: restApi.siteId,
+                    includeUsageStatistics: false,
+                  }))
+                );
+              },
+            });
+
+            const url = constructViewWebUrl(
+              extra.config.server,
+              extra.getSiteName(),
+              view.contentUrl,
+            );
+
+            return new Ok({ data: { luid, objectType, name: view.name }, url });
+          }
+
+          // objectType === 'workbook'
+          const isWorkbookAllowedResult = await resourceAccessChecker.isWorkbookAllowed({
+            workbookId: luid,
+            extra,
+          });
+
+          if (!isWorkbookAllowedResult.allowed) {
+            return new WorkbookNotAllowedError(isWorkbookAllowedResult.message).toErr();
+          }
+
+          const workbook = await useRestApi({
+            ...extra,
+            jwtScopes: renderInteractiveVizTool.requiredApiScopes,
+            callback: async (restApi) => {
+              return (
+                isWorkbookAllowedResult.content ??
+                (await restApi.workbooksMethods.getWorkbook({
+                  workbookId: luid,
+                  siteId: restApi.siteId,
+                }))
+              );
+            },
+          });
+
+          const url =
+            getDefaultViewWebUrl(workbook, extra.config.server, extra.getSiteName()) ??
+            workbook.webpageUrl ??
+            '';
+
+          return new Ok({ data: { luid, objectType, name: workbook.name }, url });
+        },
+        constrainSuccessResult: (result) => ({ type: 'success', result }),
+      });
+    },
+  });
+
+  return renderInteractiveVizTool;
+};

--- a/src/tools/web/toolName.ts
+++ b/src/tools/web/toolName.ts
@@ -39,6 +39,7 @@ export const webToolNames = [
   'update-user',
   'delete-content',
   'confirm-delete-content',
+  'render-interactive-viz',
 ] as const;
 export type WebToolName = (typeof webToolNames)[number];
 
@@ -99,7 +100,7 @@ export const webToolGroups = {
   jobs: ['list-jobs'],
   users: ['list-users', 'update-user'],
   'token-management': ['revoke-access-token', 'reset-consent'],
-  'mcp-apps': ['get-embed-token', 'record-event'],
+  'mcp-apps': ['get-embed-token', 'record-event', 'render-interactive-viz'],
   'admin-insights': ['query-admin-insights'],
   content: ['delete-content', 'confirm-delete-content'],
 } as const satisfies Record<WebToolGroupName, Array<WebToolName>>;

--- a/src/tools/web/tools.ts
+++ b/src/tools/web/tools.ts
@@ -25,6 +25,7 @@ import { getListPulseMetricsFromMetricIdsTool } from './pulse/listMetricsFromMet
 import { getListPulseMetricSubscriptionsTool } from './pulse/listMetricSubscriptions/listPulseMetricSubscriptions.js';
 import { getQueryDatasourceTool } from './queryDatasource/queryDatasource.js';
 import { getRecordEventTool } from './recordEvent/recordEvent.js';
+import { getRenderInteractiveVizTool } from './renderInteractiveViz/renderInteractiveViz.js';
 import { getResetConsentTool } from './resetConsent/resetConsent.js';
 import { getRevokeAccessTokenTool } from './revokeAccessToken/revokeAccessToken.js';
 import { getListUsersTool } from './users/listUsers.js';
@@ -43,6 +44,7 @@ export const webToolFactories = [
   getGetDatasourceMetadataTool,
   getEmbedTokenTool,
   getRecordEventTool,
+  getRenderInteractiveVizTool,
   getListDatasourcesTool,
   getResolveDatasourceLuidTool,
   getListExtractRefreshTasksTool,

--- a/src/tools/web/utils/viewUrlUtils.ts
+++ b/src/tools/web/utils/viewUrlUtils.ts
@@ -1,3 +1,5 @@
+import { Workbook } from '../../../sdks/tableau/types/workbook.js';
+
 /**
  * Constructs a web URL for a Tableau view
  *
@@ -21,4 +23,31 @@ export function constructViewWebUrl(server: string, siteName: string, contentUrl
   }
 
   return url.toString();
+}
+
+export function getDefaultViewWebUrl(
+  workbook: Workbook,
+  server: string,
+  siteName: string,
+): string | undefined {
+  const views = workbook.views?.view;
+  if (!views || views.length === 0) {
+    return undefined;
+  }
+
+  // Try to find the default view first
+  let targetView = workbook.defaultViewId
+    ? views.find((view) => view.id === workbook.defaultViewId)
+    : undefined;
+
+  // If default view was filtered out, fall back to the first view
+  if (!targetView) {
+    targetView = views[0];
+  }
+
+  if (!targetView?.contentUrl) {
+    return undefined;
+  }
+
+  return constructViewWebUrl(server, siteName, targetView.contentUrl);
 }

--- a/src/tools/web/workbooks/getWorkbook.ts
+++ b/src/tools/web/workbooks/getWorkbook.ts
@@ -17,38 +17,11 @@ import { getExceptionMessage } from '../../../utils/getExceptionMessage.js';
 import { getAppConfig } from '../../../web/apps/appConfig.js';
 import { resourceAccessChecker } from '../resourceAccessChecker.js';
 import { AppToolResult, WebTool } from '../tool.js';
-import { constructViewWebUrl } from '../utils/viewUrlUtils.js';
+import { getDefaultViewWebUrl } from '../utils/viewUrlUtils.js';
 
 const paramsSchema = {
   workbookId: z.string(),
 };
-
-function getDefaultViewWebUrl(
-  workbook: Workbook,
-  server: string,
-  siteName: string,
-): string | undefined {
-  const views = workbook.views?.view;
-  if (!views || views.length === 0) {
-    return undefined;
-  }
-
-  // Try to find the default view first
-  let targetView = workbook.defaultViewId
-    ? views.find((view) => view.id === workbook.defaultViewId)
-    : undefined;
-
-  // If default view was filtered out, fall back to the first view
-  if (!targetView) {
-    targetView = views[0];
-  }
-
-  if (!targetView?.contentUrl) {
-    return undefined;
-  }
-
-  return constructViewWebUrl(server, siteName, targetView.contentUrl);
-}
 
 export const getGetWorkbookTool = (server: WebMcpServer): WebTool<typeof paramsSchema> => {
   const getWorkbookTool = new WebTool({

--- a/tests/e2e/server.test.ts
+++ b/tests/e2e/server.test.ts
@@ -44,14 +44,20 @@ describe('server', () => {
         'delete-content',
       ];
       // These tools are gated by the mcp-apps feature (disabled by default in features.json):
-      // get-embed-token, plus the app-only confirm-* tools.
+      // get-embed-token and render-interactive-viz, plus the app-only confirm-* tools.
       const mcpAppsTools: ReadonlyArray<WebToolName> = [
         'get-embed-token',
+        'render-interactive-viz',
         'confirm-delete-content',
         'confirm-update-cloud-extract-refresh-task',
       ];
       // flow tools are gated off by default (FLOW_TOOLS_ENABLED)
-      const flowTools: ReadonlyArray<WebToolName> = ['list-flows', 'get-flow'];
+      const flowTools: ReadonlyArray<WebToolName> = [
+        'list-flows',
+        'get-flow',
+        'list-flow-runs',
+        'list-flow-tasks',
+      ];
       // insights tools are gated off by default (INSIGHTS_TOOLS_ENABLED)
       const insightsTools: ReadonlyArray<WebToolName> = [
         'generate-insight-cards',
@@ -149,14 +155,20 @@ describe('server', () => {
         'delete-content',
       ];
       // These tools are gated by the mcp-apps feature (disabled by default in features.json):
-      // get-embed-token, plus the app-only confirm-* tools.
+      // get-embed-token and render-interactive-viz, plus the app-only confirm-* tools.
       const mcpAppsTools: ReadonlyArray<WebToolName> = [
         'get-embed-token',
+        'render-interactive-viz',
         'confirm-delete-content',
         'confirm-update-cloud-extract-refresh-task',
       ];
       // flow tools are gated off by default (FLOW_TOOLS_ENABLED)
-      const flowTools: ReadonlyArray<WebToolName> = ['list-flows', 'get-flow'];
+      const flowTools: ReadonlyArray<WebToolName> = [
+        'list-flows',
+        'get-flow',
+        'list-flow-runs',
+        'list-flow-tasks',
+      ];
       // insights tools are gated off by default (INSIGHTS_TOOLS_ENABLED)
       const insightsTools: ReadonlyArray<WebToolName> = [
         'generate-insight-cards',

--- a/tests/e2e/server.test.ts
+++ b/tests/e2e/server.test.ts
@@ -44,10 +44,11 @@ describe('server', () => {
         'delete-content',
       ];
       // These tools are gated by the mcp-apps feature (disabled by default in features.json):
-      // get-embed-token and render-interactive-viz, plus the app-only confirm-* tools.
+      // get-embed-token and render-interactive-viz, plus the app-only record-event and confirm-* tools.
       const mcpAppsTools: ReadonlyArray<WebToolName> = [
         'get-embed-token',
         'render-interactive-viz',
+        'record-event',
         'confirm-delete-content',
         'confirm-update-cloud-extract-refresh-task',
       ];
@@ -155,10 +156,11 @@ describe('server', () => {
         'delete-content',
       ];
       // These tools are gated by the mcp-apps feature (disabled by default in features.json):
-      // get-embed-token and render-interactive-viz, plus the app-only confirm-* tools.
+      // get-embed-token and render-interactive-viz, plus the app-only record-event and confirm-* tools.
       const mcpAppsTools: ReadonlyArray<WebToolName> = [
         'get-embed-token',
         'render-interactive-viz',
+        'record-event',
         'confirm-delete-content',
         'confirm-update-cloud-extract-refresh-task',
       ];


### PR DESCRIPTION
## Description

Adds a new `render-interactive-viz` MCP App tool. It takes a `luid` and an `objectType` (`workbook` | `view`) and returns an MCP App that renders the object as an interactive embedded Tableau viz via the existing `embed-viz` bundle.

- Model-facing `data` payload is minimal (`{ luid, objectType, name }`) to avoid app-tool context bloat; the full viz renders in the iframe.
- Gated behind the `mcp-apps` feature flag — hidden entirely from `tools/list` and scope advertisement when off (`disabled: Provider(!mcp-apps)`).
- Enforces resource access checks on both paths (`isViewAllowed` / `isWorkbookAllowed`).
- Promotes `getDefaultViewWebUrl` from `getWorkbook.ts` into shared `viewUrlUtils.ts` (single source of truth).

## Motivation and Context

Lets an MCP App client render a workbook or view interactively through the proven embed workflow, without dumping the full object into model context. W-23558751.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## How Has This Been Tested?

New unit tests in `renderInteractiveViz.test.ts` cover the view path (allowed / not-allowed) and workbook path (allowed default-view URL, not-allowed, no-views fallback to `webpageUrl`, and to empty string). Full suite (2509 tests), `tsc`, `build:dev`, and lint all pass.

## Related Issues

W-23558751

## Checklist

- [ ] I have updated the version in the package.json file by using \`npm run version\`.
- [ ] I have made any necessary changes to the documentation
- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have documented any breaking changes in the PR description (none).