### PR TITLE
@W-22794435 Add describe-flow tool to summarize a Prep flow's document

### DIFF
--- a/docs/docs/configuration/mcp-config/env-vars.md
+++ b/docs/docs/configuration/mcp-config/env-vars.md
@@ -463,6 +463,7 @@ Controls whether the Tableau Prep flow tools are registered.
 - Set to `true` to enable the Tableau Prep flow tools:
   - [`list-flows`](../../tools/flows/list-flows.md)
   - [`get-flow`](../../tools/flows/get-flow.md)
+  - [`describe-flow`](../../tools/flows/describe-flow.md)
 - Only the exact value `true` enables them; any other value (or leaving it unset) keeps them
   disabled.
 - When enabled, individual flow tools can still be excluded via

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -46,6 +46,7 @@ Slack channel in the Tableau #DataDev workspace.
 | [get-flow](tools/flows/get-flow.md)                                                                                   | Retrieves information on a Tableau Prep flow including output steps and recent runs ([REST API][get-flow])                          | All SKUs     |
 | [list-flow-runs](tools/flows/list-flow-runs.md)                                                                       | Retrieves the run history (executions) of Tableau Prep flows on a site ([REST API][list-flow-runs])                                 | All SKUs     |
 | [list-flow-tasks](tools/flows/list-flow-tasks.md)                                                                     | Retrieves the scheduled flow run tasks (schedules) for Tableau Prep flows on a site ([REST API][list-flow-tasks])                   | All SKUs     |
+| [describe-flow](tools/flows/describe-flow.md)                                                                         | Summarizes a Tableau Prep flow's design — inputs, outputs, steps, lineage, and connections ([REST API][describe-flow])               | All SKUs     |
 | [delete-content](tools/content/delete-content.md)                                                                     | Admin-only. Two-phase (preview/confirm) delete of a workbook, data source, or extract refresh task ([REST API][delete-workbook], [REST API][delete-datasource], [REST API][delete-extract-refresh-task]) | All SKUs     |
 | [get-view-data](tools/views/get-view-data.md)                                                                         | Retrieves data in CSV format for the specified view in a Tableau workbook. *Note: the get-view-data api currently has a limitation that when used on a dashboard sheet type, it will only return data for the first worksheet in the dashboard. This will be fixed in the 26.3 fall release.* ([REST API][get-view-data])               | All SKUs     |
 | [get-view-image](tools/views/get-view-image.md)                                                                       | Retrieves an image for the specified view in a Tableau workbook ([REST API][get-view-image])                        | All SKUs     |
@@ -89,6 +90,7 @@ Slack channel in the Tableau #DataDev workspace.
   https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref_flow.htm#get_flow_runs
 [list-flow-tasks]:
   https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref_flow.htm#get_flow_run_tasks
+[describe-flow]: https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref_flow.htm
 [delete-workbook]:
   https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref_workbooks_and_views.htm#delete_workbook
 [delete-datasource]:

--- a/docs/docs/tools/flows/describe-flow.md
+++ b/docs/docs/tools/flows/describe-flow.md
@@ -1,0 +1,244 @@
+---
+sidebar_position: 3
+---
+
+# Describe Flow
+
+Explains what a Tableau Prep flow actually **does** by reading and summarizing the flow's underlying
+document (the design of the flow itself, not just its catalog metadata). Use this when a
+user asks "what does this flow do?", "where does this flow get its data?", "what does it output?",
+or "walk me through this flow".
+
+## Describe Flow vs Get Flow
+
+- [Get Flow](get-flow.md) returns catalog **metadata** — name, owner, project, tags, output step
+  names, input connections, recent run history. Use it for "who owns this?" or "did the last run
+  succeed?".
+- **Describe Flow** returns the flow's **internal design** — its inputs and their data connections,
+  its output destinations, the transformation steps in between, and the step-to-step lineage. Use it
+  to understand the flow's purpose and how data moves through it.
+
+## APIs called
+
+- `GET /api/exp/sites/{siteId}/flows/{flowId}/document` — an **experimental** Tableau REST API that
+  returns the flow's sanitized document as JSON.
+- [Query Flow](https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref_flow.htm#query_flow)
+  — used to enrich the summary with the flow's identity (name, owner, project, tags, parameters).
+  Best-effort: if it fails, the structural summary is still returned with a note.
+
+:::warning Experimental API
+
+The flow-document endpoint lives under `/api/exp` and must be enabled server-side. If it is not
+enabled, this tool returns a clear "experimental flow-document API is not enabled" error — fall
+back to [Get Flow](get-flow.md) for metadata.
+
+:::
+
+## Data safety
+
+The document is fetched through a server-side **sanitized** endpoint: connection credentials,
+secrets, and email-shaped PII are redacted before the document leaves Tableau. This tool surfaces
+only structural/topology fields (step types, connection servers/databases/files, lineage) and never
+returns passwords or tokens.
+
+## Required Tableau API scopes
+
+When the MCP server authenticates with OAuth (connected-app JWT), this tool requests:
+
+- `tableau:flows:read` — resolves the flow's identity (name / project / owner) for the summary.
+- `tableau:flows:download` — authorizes the experimental document endpoint.
+- `tableau:mcp_site_settings:read`
+
+Flows use the dedicated `tableau:flows:*` scopes, not the `tableau:content:read` scope used by
+workbooks, data sources, and views. See
+[OAuth configuration](../../configuration/mcp-config/oauth.md) for details.
+
+## Caller-role visibility
+
+The document download applies the same permission as downloading the flow file in the Tableau web
+UI. Server / site administrators can describe any flow on the site; non-admin callers can describe
+only flows they are allowed to download. When the MCP server is configured with a bounded context
+(`PROJECT_IDS` / `TAGS`), flows outside the allowed set are rejected before any document is fetched.
+
+## Required arguments
+
+### `flowId`
+
+The LUID of the flow, typically retrieved from the [List Flows](list-flows.md) tool.
+
+Example: `d00700fe-28a0-4ece-a7af-5543ddf38a82`
+
+## Optional arguments
+
+### `includeFieldSchemas`
+
+When `true`, additionally returns a `fields` map of per-step column lists (`{name, type}`). This is
+verbose, so it defaults to `false` — request it only when the user asks about specific columns or
+schema. Default: `false`.
+
+## Response shape
+
+A compact, structured summary (not the raw document):
+
+| Field          | Description                                                                                                |
+| -------------- | ---------------------------------------------------------------------------------------------------------- |
+| `flow`         | Identity — `id`, `name`, `description`, `project`, `owner`, `fileType`, `updatedAt`, `webpageUrl`, `tags`. |
+| `stats`        | Counts — `nodeCount`, `inputCount`, `outputCount`, `transformCount`, `connectionCount`.                    |
+| `inputs`       | Each input step with a human-readable `role` and, where available, its resolved `connection`.              |
+| `outputs`      | Each output/write step with a `role` and any recognizable `target` details.                                |
+| `steps`        | The transformation steps (joins, aggregates, filters, calculations, pivots, …), each with a `role`.        |
+| `lineage`      | Directed `{from, to}` edges (by step name) describing how data flows step-to-step.                         |
+| `connections`  | The de-duplicated list of all data connections referenced by the flow.                                     |
+| `parameters`   | The flow's parameters (`name`, `type`, `value`).                                                           |
+| `fields`       | Only when `includeFieldSchemas: true` — per-step column lists.                                             |
+| `mcp.warnings` | Only when present — structured, non-fatal warnings (see [Partial failure](#partial-failure-mcpwarnings)).  |
+
+## Partial failure (`mcp.warnings`)
+
+The primary call — downloading the flow document — is atomic: if it fails, the tool returns an error
+(see [Errors](#errors) below). Everything else is best-effort, so when a non-fatal problem occurs
+the tool still returns the structural summary and surfaces a structured warning under `mcp.warnings`
+instead of failing the whole call. This mirrors the `mcp.warnings` shape used by
+[Get Flow](get-flow.md#partial-failure-mcpwarnings) so both flow tools report partial failures the
+same way. Two warning types can appear:
+
+### `METADATA_FETCH_FAILED`
+
+Emitted when the best-effort [Query Flow](get-flow.md) enrichment call fails. The identity fields
+under `flow` (name, owner, project, tags) may be missing, but the structural summary derived from
+the document is still valid.
+
+```json
+{
+  "type": "METADATA_FETCH_FAILED",
+  "severity": "WARNING",
+  "message": "Could not load flow metadata (name/owner/project): HTTP 403 Forbidden. The structural summary below is derived from the flow document only.",
+  "affectedField": "flow",
+  "httpStatus": "403"
+}
+```
+
+### `EMPTY_DOCUMENT`
+
+Emitted when the document was downloaded and parsed but contained no recognizable steps. The flow
+may genuinely be empty, or the experimental document format may have changed.
+
+```json
+{
+  "type": "EMPTY_DOCUMENT",
+  "severity": "WARNING",
+  "message": "The flow document contained no recognizable steps. It may be empty, or the experimental document format may have changed.",
+  "affectedField": "steps"
+}
+```
+
+## Errors
+
+- **Experimental API not enabled** (HTTP 403, Tableau error code `403200`): the experimental
+  flow-document API is not enabled on this server. Use [Get Flow](get-flow.md) for metadata
+  instead.
+- **Not authorized to download** (HTTP 403, any other code): the caller lacks permission to download
+  this flow (the same permission as downloading its `.tfl`/`.tflx` file in Tableau), or the token
+  lacks the `tableau:flows:download` scope. This is reported separately from the not-enabled case
+  so a permission problem is never misread as a disabled API. Confirm you can download the flow in
+  Tableau, or use [Get Flow](get-flow.md) for metadata that does not require download permission.
+- **No flow document available** (HTTP 404): the flow id is unknown, not visible to the caller, or
+  has no stored document (for example a metadata-only seeded flow). Use [List Flows](list-flows.md)
+  to find a valid flow id.
+
+## Limitations
+
+- Relies on an experimental Tableau REST API that may change or be unavailable depending on the
+  server version and configuration.
+- The summary is derived from the flow document's structure. Highly customized or future node types
+  that the summarizer does not recognize are still listed, with a humanized label derived from their
+  raw type, but without a curated friendly role.
+- Row-level transformation logic (e.g. the exact calculation expression or filter predicate) is not
+  extracted; the tool reports the **kind** of each step and the flow's shape, not its full formula
+  text.
+
+## Example result
+
+```json
+{
+  "flow": {
+    "id": "d00700fe-28a0-4ece-a7af-5543ddf38a82",
+    "name": "Sales Cleanup",
+    "description": "Cleans up the daily sales feed",
+    "project": "Finance",
+    "owner": "Dana Owner",
+    "fileType": "tflx",
+    "updatedAt": "2024-11-06T21:31:00Z",
+    "webpageUrl": "https://10ax.online.tableau.com/#/site/mcp-test/flows/3",
+    "tags": ["sales", "daily"]
+  },
+  "stats": {
+    "nodeCount": 6,
+    "inputCount": 2,
+    "outputCount": 1,
+    "transformCount": 3,
+    "connectionCount": 2
+  },
+  "inputs": [
+    {
+      "nodeId": "n-input-csv",
+      "name": "Orders.csv",
+      "nodeType": "LoadCsv",
+      "role": "Input — CSV file",
+      "connection": { "id": "c-csv", "type": "textscan", "file": "Orders.csv", "isPackaged": true }
+    },
+    {
+      "nodeId": "n-input-sql",
+      "name": "Customers",
+      "nodeType": "LoadSql",
+      "role": "Input — database query",
+      "connection": {
+        "id": "c-sql",
+        "type": "sqlserver",
+        "server": "sql.internal.example.com",
+        "database": "SalesDW",
+        "schema": "dbo",
+        "isPackaged": false
+      }
+    }
+  ],
+  "outputs": [
+    {
+      "nodeId": "n-output",
+      "name": "Sales Mart",
+      "nodeType": "PublishExtract",
+      "role": "Output — published data source / extract",
+      "target": { "datasourceName": "Sales Mart", "projectName": "Finance" }
+    }
+  ],
+  "steps": [
+    { "nodeId": "n-join", "name": "Join Orders + Customers", "nodeType": "Join", "role": "Join" },
+    { "nodeId": "n-filter", "name": "Keep 2024", "nodeType": "Filter", "role": "Filter rows" },
+    {
+      "nodeId": "n-calc",
+      "name": "Profit Ratio",
+      "nodeType": "AddColumn",
+      "role": "Add column (calculation)"
+    }
+  ],
+  "lineage": [
+    { "from": "Orders.csv", "to": "Join Orders + Customers" },
+    { "from": "Customers", "to": "Join Orders + Customers" },
+    { "from": "Join Orders + Customers", "to": "Keep 2024" },
+    { "from": "Keep 2024", "to": "Profit Ratio" },
+    { "from": "Profit Ratio", "to": "Sales Mart" }
+  ],
+  "connections": [
+    { "id": "c-csv", "type": "textscan", "file": "Orders.csv", "isPackaged": true },
+    {
+      "id": "c-sql",
+      "type": "sqlserver",
+      "server": "sql.internal.example.com",
+      "database": "SalesDW",
+      "schema": "dbo",
+      "isPackaged": false
+    }
+  ],
+  "parameters": [{ "name": "Region", "type": "string", "value": "West" }]
+}
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.7.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/src/errors/mcpToolError.ts
+++ b/src/errors/mcpToolError.ts
@@ -82,6 +82,50 @@ export class FlowNotAllowedError extends McpToolError {
   }
 }
 
+/**
+ * The experimental flow-document REST API is not enabled on this server.
+ *
+ * The endpoint returns 403 with Tableau error code `403200` when its
+ * `GetFlowDocumentRestApi` feature flag is off. describe-flow maps ONLY that
+ * specific code into this clearer, actionable error — any other 403 (insufficient
+ * download permission, insufficient token scope, generic forbidden) is surfaced
+ * as a {@link FlowDocumentForbiddenError} so a permission problem is never
+ * misreported as a disabled API.
+ */
+export class FlowDocumentApiDisabledError extends McpToolError {
+  constructor(message: string) {
+    super({ type: 'flow-document-api-disabled', message, statusCode: 403 });
+  }
+}
+
+/**
+ * The caller is not authorized to download the requested flow's document.
+ *
+ * The flow-document endpoint also returns 403 for ordinary authorization
+ * failures — the caller lacks permission to download the flow (the same
+ * permission as downloading its `.tfl`/`.tflx` file in Tableau) or the token
+ * lacks the `tableau:flows:download` scope. These are distinct from the
+ * feature-flag-off case (Tableau error code `403200`), which maps to
+ * {@link FlowDocumentApiDisabledError}.
+ */
+export class FlowDocumentForbiddenError extends McpToolError {
+  constructor(message: string) {
+    super({ type: 'flow-document-forbidden', message, statusCode: 403 });
+  }
+}
+
+/**
+ * No flow document could be downloaded for the requested flow.
+ *
+ * The endpoint returns 404 when the flow does not exist, is not visible to the
+ * caller, or has no stored file on the FileServer (e.g. a metadata-only seeded flow).
+ */
+export class FlowDocumentNotFoundError extends McpToolError {
+  constructor(message: string) {
+    super({ type: 'flow-document-not-found', message, statusCode: 404 });
+  }
+}
+
 export class PulseDisabledError extends McpToolError {
   constructor() {
     super({ type: 'pulse-disabled', message: 'Pulse is disabled', statusCode: 400 });

--- a/src/restApiInstance.ts
+++ b/src/restApiInstance.ts
@@ -45,6 +45,7 @@ type JwtScopes =
   | 'tableau:users:read'
   | 'tableau:users:update'
   | 'tableau:flows:read'
+  | 'tableau:flows:download'
   | 'tableau:flow_connections:read'
   | 'tableau:flow_runs:read';
 

--- a/src/scripts/createClaudeMcpBundleManifest.ts
+++ b/src/scripts/createClaudeMcpBundleManifest.ts
@@ -644,7 +644,7 @@ const envVars = {
     type: 'boolean',
     title: 'Enable Tableau Prep flow MCP tools',
     description:
-      'Registers the Tableau Prep flow tools (list-flows, get-flow). Disabled by default; set to "true" to enable them.',
+      'Registers the Tableau Prep flow tools (list-flows, get-flow, describe-flow). Disabled by default; set to "true" to enable them.',
     required: false,
     sensitive: false,
   },

--- a/src/sdks/tableau/apis/flowDocumentApi.ts
+++ b/src/sdks/tableau/apis/flowDocumentApi.ts
@@ -1,0 +1,19 @@
+import { makeApi, makeEndpoint, ZodiosEndpointDefinitions } from '@zodios/core';
+
+import { flowDocumentSchema } from '../types/flowDocument.js';
+
+// Experimental endpoint. It lives under `/api/exp` (NOT the versioned `/api/3.x`
+// path the other flow endpoints use), so it is exposed through its own methods
+// class whose base URL is `${host}/api/exp` (see RestApi.flowDocumentMethods).
+const getFlowDocumentEndpoint = makeEndpoint({
+  method: 'get',
+  path: '/sites/:siteId/flows/:flowId/document',
+  alias: 'getFlowDocument',
+  description:
+    "Returns the specified flow's document as sanitized JSON. Experimental API (api/exp) that must be enabled server-side; requires the tableau:flows:download scope.",
+  response: flowDocumentSchema,
+});
+
+const flowDocumentApi = makeApi([getFlowDocumentEndpoint]);
+
+export const flowDocumentApis = [...flowDocumentApi] as const satisfies ZodiosEndpointDefinitions;

--- a/src/sdks/tableau/methods/flowDocumentMethods.ts
+++ b/src/sdks/tableau/methods/flowDocumentMethods.ts
@@ -1,0 +1,48 @@
+import { Zodios } from '@zodios/core';
+
+import { AxiosRequestConfig } from '../../../utils/axios.js';
+import { flowDocumentApis } from '../apis/flowDocumentApi.js';
+import { RestApiCredentials } from '../restApi.js';
+import { FlowDocument } from '../types/flowDocument.js';
+import AuthenticatedMethods from './authenticatedMethods.js';
+
+/**
+ * Experimental flow-document method of the Tableau Server REST API.
+ *
+ * Unlike {@link FlowsMethods} (which targets the versioned `/api/3.x` path), this
+ * class is constructed with the `${host}/api/exp` base URL so it can reach the
+ * experimental document endpoint.
+ *
+ * @export
+ * @class FlowDocumentMethods
+ */
+export default class FlowDocumentMethods extends AuthenticatedMethods<typeof flowDocumentApis> {
+  constructor(baseUrl: string, creds: RestApiCredentials, axiosConfig: AxiosRequestConfig) {
+    super(new Zodios(baseUrl, flowDocumentApis, { axiosConfig }), creds);
+  }
+
+  /**
+   * Returns the specified flow's document as sanitized JSON.
+   *
+   * Experimental: `GET {host}/api/exp/sites/:siteId/flows/:flowId/document`.
+   * The response has credential/secret connection attributes and Tableau
+   * identity attributes removed and email-shaped PII redacted server-side.
+   *
+   * Required scopes: `tableau:flows:download`
+   *
+   * @param siteId - The Tableau site ID
+   * @param flowId - The LUID of the flow to return the document for
+   */
+  getFlowDocument = async ({
+    siteId,
+    flowId,
+  }: {
+    siteId: string;
+    flowId: string;
+  }): Promise<FlowDocument> => {
+    return await this._apiClient.getFlowDocument({
+      params: { siteId, flowId },
+      ...this.authHeader,
+    });
+  };
+}

--- a/src/sdks/tableau/restApi.ts
+++ b/src/sdks/tableau/restApi.ts
@@ -16,6 +16,7 @@ import {
 } from './methods/authenticationMethods.js';
 import ContentExplorationMethods from './methods/contentExplorationMethods.js';
 import DatasourcesMethods from './methods/datasourcesMethods.js';
+import FlowDocumentMethods from './methods/flowDocumentMethods.js';
 import FlowsMethods from './methods/flowsMethods.js';
 import JobsMethods from './methods/jobsMethods.js';
 import McpSettingsMethods from './methods/mcpSettingsMethods.js';
@@ -180,6 +181,18 @@ export class RestApi {
     });
     this._addInterceptors(RestApi.baseUrl, flowsMethods.interceptors);
     return flowsMethods;
+  }
+
+  get flowDocumentMethods(): FlowDocumentMethods {
+    // Experimental endpoint lives under `/api/exp`, not the versioned `/api/3.x`
+    // path used by the other flow methods.
+    const baseUrl = `${RestApi.host}/api/exp`;
+    const flowDocumentMethods = new FlowDocumentMethods(baseUrl, this.creds, {
+      timeout: this._maxRequestTimeoutMs,
+      signal: this._signal,
+    });
+    this._addInterceptors(baseUrl, flowDocumentMethods.interceptors);
+    return flowDocumentMethods;
   }
 
   get metadataMethods(): MetadataMethods {

--- a/src/sdks/tableau/types/flowDocument.ts
+++ b/src/sdks/tableau/types/flowDocument.ts
@@ -1,0 +1,106 @@
+import { z } from 'zod';
+
+/**
+ * Sanitized flow document returned by the experimental
+ * `GET /api/exp/sites/:siteId/flows/:flowId/document` endpoint.
+ *
+ * The real document is large and, because the endpoint is experimental, its
+ * shape may evolve. We therefore validate only the handful of structural fields
+ * the describe-flow summarizer reads and keep everything permissive: every
+ * object uses `.passthrough()` and nearly every field is optional. The endpoint
+ * already strips credentials/secrets and redacts email-shaped PII server-side,
+ * so nothing sensitive is expected here.
+ */
+
+export const flowDocumentNodeNextNodeSchema = z
+  .object({
+    nextNodeId: z.string().optional(),
+    namespace: z.string().optional(),
+    nextNamespace: z.string().optional(),
+  })
+  .passthrough();
+
+export const flowDocumentFieldSchema = z
+  .object({
+    name: z.string().optional(),
+    type: z.string().optional(),
+  })
+  .passthrough();
+
+export const flowDocumentNodeSchema = z
+  .object({
+    id: z.string().optional(),
+    name: z.string().optional(),
+    // e.g. ".v1.LoadCsv", ".v1.Join", ".v1.PublishExtract"
+    nodeType: z.string().optional(),
+    // e.g. "input", "output", "transform", "superNode"
+    baseType: z.string().optional(),
+    connectionId: z.string().optional(),
+    nextNodes: z.array(flowDocumentNodeNextNodeSchema).optional(),
+    fields: z.array(flowDocumentFieldSchema).optional(),
+  })
+  .passthrough();
+
+/**
+ * Parses `isPackaged`, which may arrive as a real boolean or as a string. We do
+ * NOT use `z.coerce.boolean()` here: coercion delegates to `Boolean(value)`,
+ * which maps the string "false" to `true` and would invert packaged status.
+ * Instead we accept actual booleans as-is and interpret the case-insensitive
+ * strings "true"/"false" correctly; any other / missing value yields
+ * `undefined` (the field is optional and the document shape is permissive).
+ */
+const looseBooleanSchema = z
+  .unknown()
+  .transform((value) => {
+    if (typeof value === 'boolean') {
+      return value;
+    }
+    if (typeof value === 'string') {
+      const normalized = value.trim().toLowerCase();
+      if (normalized === 'true') {
+        return true;
+      }
+      if (normalized === 'false') {
+        return false;
+      }
+    }
+    return undefined;
+  })
+  .optional();
+
+export const flowDocumentConnectionSchema = z
+  .object({
+    id: z.string().optional(),
+    // e.g. ".v1.SqlConnection", ".v1.FileConnection"
+    connectionType: z.string().optional(),
+    name: z.string().optional(),
+    isPackaged: looseBooleanSchema,
+    // Descriptive topology (class, server, dbname, filename, ...). Credentials are
+    // stripped server-side, so we read these freely but keep the shape open.
+    connectionAttributes: z.record(z.unknown()).optional(),
+  })
+  .passthrough();
+
+export const flowDocumentSchema = z
+  .object({
+    nodes: z.record(flowDocumentNodeSchema).optional(),
+    initialNodes: z.array(z.string()).optional(),
+    connections: z.record(flowDocumentConnectionSchema).optional(),
+    dataConnections: z.record(flowDocumentConnectionSchema).optional(),
+    parameters: z
+      .object({
+        parameters: z.record(z.unknown()).optional(),
+      })
+      .passthrough()
+      .optional(),
+    majorVersion: z.number().optional(),
+    minorVersion: z.number().optional(),
+    documentId: z.string().optional(),
+  })
+  .passthrough();
+
+export type FlowDocumentNextNode = z.infer<typeof flowDocumentNodeNextNodeSchema>;
+export type FlowDocumentField = z.infer<typeof flowDocumentFieldSchema>;
+export type FlowDocumentNode = z.infer<typeof flowDocumentNodeSchema>;
+export type FlowDocumentConnection = z.infer<typeof flowDocumentConnectionSchema>;
+export type FlowDocument = z.infer<typeof flowDocumentSchema>;

--- a/src/server.web.test.ts
+++ b/src/server.web.test.ts
@@ -142,6 +142,7 @@ describe('server', () => {
     expect(registeredToolNames).not.toContain('get-flow');
     expect(registeredToolNames).not.toContain('list-flow-runs');
     expect(registeredToolNames).not.toContain('list-flow-tasks');
+    expect(registeredToolNames).not.toContain('describe-flow');
     // ...while unrelated tools stay registered.
     expect(registeredToolNames).toContain('list-datasources');
   });
@@ -160,6 +161,7 @@ describe('server', () => {
     expect(registeredToolNames).toContain('get-flow');
     expect(registeredToolNames).toContain('list-flow-runs');
     expect(registeredToolNames).toContain('list-flow-tasks');
+    expect(registeredToolNames).toContain('describe-flow');
     // ...alongside the unrelated tools.
     expect(registeredToolNames).toContain('list-datasources');
   });

--- a/src/server/oauth/scopes.test.ts
+++ b/src/server/oauth/scopes.test.ts
@@ -231,6 +231,24 @@ describe('scopes', () => {
       expect(scopes).not.toContain('tableau:flows:read');
     });
 
+    it('should include tableau:flows:download when flowToolsEnabled is true', async () => {
+      mockGetConfig.mockReturnValue({
+        flowToolsEnabled: true,
+      } as any);
+
+      const scopes = await getSupportedApiScopes();
+      expect(scopes).toContain('tableau:flows:download');
+    });
+
+    it('should exclude tableau:flows:download when flowToolsEnabled is false', async () => {
+      mockGetConfig.mockReturnValue({
+        flowToolsEnabled: false,
+      } as any);
+
+      const scopes = await getSupportedApiScopes();
+      expect(scopes).not.toContain('tableau:flows:download');
+    });
+
     it('should include tableau:users:update when adminToolsEnabled is true', async () => {
       mockGetConfig.mockReturnValue({
         adminToolsEnabled: true,

--- a/src/server/oauth/scopes.ts
+++ b/src/server/oauth/scopes.ts
@@ -37,6 +37,7 @@ export type TableauApiScope =
   | 'tableau:views:download'
   | 'tableau:views:embed'
   | 'tableau:flows:read'
+  | 'tableau:flows:download'
   | 'tableau:flow_connections:read'
   | 'tableau:flow_runs:read'
   | 'tableau:insight_definitions_metrics:read'
@@ -134,6 +135,17 @@ export const LIST_FLOW_RUNS_PRIMARY_API_SCOPES: ReadonlyArray<TableauApiScope> =
 export const LIST_FLOW_RUNS_FAILURE_INSIGHT_API_SCOPE: TableauApiScope = 'tableau:flows:read';
 
 /**
+ * Minimum scopes needed by `describe-flow`. This is also the tool's complete
+ * static scope surface, so both runtime JWT minting and OAuth discovery share
+ * one source of truth.
+ */
+export const DESCRIBE_FLOW_API_SCOPES: ReadonlyArray<TableauApiScope> = [
+  'tableau:flows:read',
+  'tableau:flows:download',
+  'tableau:mcp_site_settings:read',
+];
+
+/**
  * Validates that a scope string is a valid MCP scope
  */
 export async function isValidScope(scope: string): Promise<boolean> {
@@ -217,6 +229,10 @@ const toolScopeMap: Record<
   'list-flow-tasks': {
     mcp: ['tableau:mcp:flow:read'],
     api: new Set(['tableau:flow_tasks:read', 'tableau:mcp_site_settings:read']),
+  },
+  'describe-flow': {
+    mcp: ['tableau:mcp:flow:read'],
+    api: new Set(DESCRIBE_FLOW_API_SCOPES),
   },
   'query-datasource': {
     mcp: ['tableau:mcp:datasource:read'],
@@ -409,6 +425,7 @@ async function getEnabledToolNames(): Promise<Set<WebToolName>> {
     enabledTools.delete('get-flow');
     enabledTools.delete('list-flow-runs');
     enabledTools.delete('list-flow-tasks');
+    enabledTools.delete('describe-flow');
   }
 
   return enabledTools;

--- a/src/tools/web/flows/describeFlow/describeFlow.test.ts
+++ b/src/tools/web/flows/describeFlow/describeFlow.test.ts
@@ -1,0 +1,235 @@
+import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+
+import { WebMcpServer } from '../../../../server.web.js';
+import invariant from '../../../../utils/invariant.js';
+import { Provider } from '../../../../utils/provider.js';
+import { getMockRequestHandlerExtra } from '../../toolContext.mock.js';
+import { mockFlow, mockOutputSteps } from '../getFlow/mockFlow.js';
+import { getDescribeFlowTool } from './describeFlow.js';
+import { mockFlowDocument } from './mockFlowDocument.js';
+
+const mocks = vi.hoisted(() => ({
+  mockGetFlowDocument: vi.fn(),
+  mockQueryFlow: vi.fn(),
+  mockIsFlowAllowed: vi.fn(),
+}));
+
+vi.mock('../../resourceAccessChecker.js', () => ({
+  resourceAccessChecker: {
+    isFlowAllowed: mocks.mockIsFlowAllowed,
+  },
+}));
+
+vi.mock('../../../../restApiInstance.js', () => ({
+  useRestApi: vi.fn().mockImplementation(async ({ callback }) =>
+    callback({
+      flowDocumentMethods: {
+        getFlowDocument: mocks.mockGetFlowDocument,
+      },
+      flowsMethods: {
+        queryFlow: mocks.mockQueryFlow,
+      },
+      siteId: 'test-site-id',
+    }),
+  ),
+}));
+
+vi.mock('../../../../config.js', () => ({
+  getConfig: vi.fn(() => ({
+    flowToolsEnabled: true,
+    productTelemetryEnabled: false,
+    productTelemetryEndpoint: 'https://test.com',
+    server: 'https://test.tableau.com',
+  })),
+}));
+
+/**
+ * Builds an Error that `getHttpStatus` reads as an Axios HTTP error, optionally
+ * carrying a Tableau REST error code in the response body (the shape Tableau
+ * uses: `{ error: { code, summary, detail } }`).
+ */
+function axiosError(status: number, tableauErrorCode?: string): Error {
+  const error = new Error(`HTTP ${status}`) as Error & {
+    isAxiosError: boolean;
+    response: { status: number; data?: unknown };
+  };
+  error.isAxiosError = true;
+  error.response = {
+    status,
+    ...(tableauErrorCode
+      ? { data: { error: { code: tableauErrorCode, summary: 'Forbidden', detail: 'test' } } }
+      : {}),
+  };
+  return error;
+}
+
+describe('describeFlowTool', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Default: no bounded context, document downloads, metadata resolves.
+    mocks.mockIsFlowAllowed.mockResolvedValue({ allowed: true });
+    mocks.mockGetFlowDocument.mockResolvedValue(mockFlowDocument);
+    mocks.mockQueryFlow.mockResolvedValue({ flow: mockFlow, outputSteps: mockOutputSteps });
+  });
+
+  it('creates a tool instance with the correct properties', () => {
+    const tool = getDescribeFlowTool(new WebMcpServer());
+    expect(tool.name).toBe('describe-flow');
+    expect(tool.description).toContain('underlying document');
+    expect(tool.paramsSchema).toMatchObject({ flowId: expect.any(Object) });
+  });
+
+  it('is enabled when flow tools are turned on', async () => {
+    const tool = getDescribeFlowTool(new WebMcpServer());
+    expect(await Provider.from(tool.disabled)).toBe(false);
+  });
+
+  it('is disabled when flow tools are turned off', async () => {
+    const { getConfig } = await import('../../../../config.js');
+    vi.mocked(getConfig).mockReturnValueOnce({
+      flowToolsEnabled: false,
+    } as ReturnType<typeof getConfig>);
+
+    const tool = getDescribeFlowTool(new WebMcpServer());
+    expect(await Provider.from(tool.disabled)).toBe(true);
+  });
+
+  it('summarizes the flow document and enriches it with metadata', async () => {
+    const result = await getToolResult({ flowId: mockFlow.id });
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(parsed.flow.name).toBe(mockFlow.name);
+    expect(parsed.stats).toMatchObject({ inputCount: 2, outputCount: 1, transformCount: 3 });
+    expect(parsed.inputs).toHaveLength(2);
+    expect(parsed.outputs).toHaveLength(1);
+    expect(parsed.connections).toHaveLength(2);
+    expect(parsed.fields).toBeUndefined();
+    expect(parsed.mcp).toBeUndefined();
+
+    expect(mocks.mockGetFlowDocument).toHaveBeenCalledWith({
+      siteId: 'test-site-id',
+      flowId: mockFlow.id,
+    });
+  });
+
+  it('includes per-step field schemas when includeFieldSchemas=true', async () => {
+    const result = await getToolResult({ flowId: mockFlow.id, includeFieldSchemas: true });
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.fields).toBeDefined();
+    expect(parsed.fields['Orders.csv']).toBeDefined();
+  });
+
+  it('reuses the flow fetched by the access check instead of querying it again', async () => {
+    mocks.mockIsFlowAllowed.mockResolvedValue({
+      allowed: true,
+      content: { flow: mockFlow, outputSteps: mockOutputSteps },
+    });
+
+    const result = await getToolResult({ flowId: mockFlow.id });
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.flow.name).toBe(mockFlow.name);
+    expect(mocks.mockQueryFlow).not.toHaveBeenCalled();
+  });
+
+  it('returns an error and downloads nothing when the flow is not allowed', async () => {
+    mocks.mockIsFlowAllowed.mockResolvedValue({
+      allowed: false,
+      message:
+        'The set of allowed flows that can be queried is limited by the server configuration.',
+    });
+
+    const result = await getToolResult({ flowId: mockFlow.id });
+    expect(result.isError).toBe(true);
+    invariant(result.content[0].type === 'text');
+    expect(result.content[0].text).toContain('limited by the server configuration');
+    expect(mocks.mockGetFlowDocument).not.toHaveBeenCalled();
+  });
+
+  it('maps a 403 with Tableau code 403200 to a clear "experimental API not enabled" error', async () => {
+    mocks.mockGetFlowDocument.mockRejectedValue(axiosError(403, '403200'));
+
+    const result = await getToolResult({ flowId: mockFlow.id });
+    expect(result.isError).toBe(true);
+    invariant(result.content[0].type === 'text');
+    expect(result.content[0].text).toContain('experimental flow-document API is not enabled');
+  });
+
+  it('maps a non-403200 403 to a forbidden/download-permission error (not "API disabled")', async () => {
+    // A readable flow whose caller lacks download permission / scope returns a
+    // 403 with a different Tableau code; it must NOT be reported as the API
+    // being disabled.
+    mocks.mockGetFlowDocument.mockRejectedValue(axiosError(403, '403126'));
+
+    const result = await getToolResult({ flowId: mockFlow.id });
+    expect(result.isError).toBe(true);
+    invariant(result.content[0].type === 'text');
+    expect(result.content[0].text).not.toContain('experimental flow-document API is not enabled');
+    expect(result.content[0].text).toContain('Not authorized to download');
+    expect(result.content[0].text).toContain('tableau:flows:download');
+  });
+
+  it('treats a 403 with no identifiable Tableau code as a forbidden error', async () => {
+    // No body code at all (e.g. a generic proxy 403): default to the safe
+    // forbidden message rather than claiming the feature is disabled.
+    mocks.mockGetFlowDocument.mockRejectedValue(axiosError(403));
+
+    const result = await getToolResult({ flowId: mockFlow.id });
+    expect(result.isError).toBe(true);
+    invariant(result.content[0].type === 'text');
+    expect(result.content[0].text).not.toContain('experimental flow-document API is not enabled');
+    expect(result.content[0].text).toContain('Not authorized to download');
+  });
+
+  it('maps a 404 to a clear "no flow document available" error', async () => {
+    mocks.mockGetFlowDocument.mockRejectedValue(axiosError(404));
+
+    const result = await getToolResult({ flowId: mockFlow.id });
+    expect(result.isError).toBe(true);
+    invariant(result.content[0].type === 'text');
+    expect(result.content[0].text).toContain('No flow document is available');
+  });
+
+  it('still returns the structural summary (with a note) when metadata fails', async () => {
+    mocks.mockQueryFlow.mockRejectedValue(new Error('metadata boom'));
+
+    const result = await getToolResult({ flowId: mockFlow.id });
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(parsed.stats.inputCount).toBe(2);
+    expect(parsed.mcp.warnings[0]).toMatchObject({
+      type: 'METADATA_FETCH_FAILED',
+      severity: 'WARNING',
+      affectedField: 'flow',
+    });
+    expect(parsed.mcp.warnings[0].message).toContain('Could not load flow metadata');
+  });
+
+  it('never surfaces auth headers in the response', async () => {
+    const result = await getToolResult({ flowId: mockFlow.id });
+    invariant(result.content[0].type === 'text');
+    expect(result.content[0].text).not.toMatch(/X-Tableau-Auth/);
+  });
+});
+
+async function getToolResult(params: {
+  flowId: string;
+  includeFieldSchemas?: boolean;
+}): Promise<CallToolResult> {
+  const tool = getDescribeFlowTool(new WebMcpServer());
+  const callback = await Provider.from(tool.callback);
+  return await callback(
+    {
+      flowId: params.flowId,
+      includeFieldSchemas: params.includeFieldSchemas ?? false,
+    },
+    getMockRequestHandlerExtra(),
+  );
+}

--- a/src/tools/web/flows/describeFlow/describeFlow.ts
+++ b/src/tools/web/flows/describeFlow/describeFlow.ts
@@ -1,0 +1,214 @@
+import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { Ok } from 'ts-results-es';
+import { z } from 'zod';
+
+import { getConfig } from '../../../../config.js';
+import {
+  FlowDocumentApiDisabledError,
+  FlowDocumentForbiddenError,
+  FlowDocumentNotFoundError,
+  FlowNotAllowedError,
+} from '../../../../errors/mcpToolError.js';
+import { useRestApi } from '../../../../restApiInstance.js';
+import { Flow } from '../../../../sdks/tableau/types/flow.js';
+import { WebMcpServer } from '../../../../server.web.js';
+import { DESCRIBE_FLOW_API_SCOPES } from '../../../../server/oauth/scopes.js';
+import { isAxiosError } from '../../../../utils/axios.js';
+import { getExceptionMessage } from '../../../../utils/getExceptionMessage.js';
+import { getHttpStatus } from '../../../../utils/getHttpStatus.js';
+import { resourceAccessChecker } from '../../resourceAccessChecker.js';
+import { WebTool } from '../../tool.js';
+import {
+  DescribeFlowResult,
+  DescribeFlowWarning,
+  summarizeFlowDocument,
+} from './flowDocumentSummary.js';
+
+const paramsSchema = {
+  flowId: z.string().nonempty(),
+  // Per-step column schemas are verbose and rarely needed to understand "what
+  // does this flow do?", so they are opt-in.
+  includeFieldSchemas: z.boolean().optional().default(false),
+};
+
+// Tableau error code returned by the flow-document endpoint when the
+// experimental `GetFlowDocumentRestApi` feature flag is OFF. Verified live.
+const FLOW_DOCUMENT_API_DISABLED_CODE = '403200';
+
+/**
+ * Reads the Tableau REST error code (e.g. "403200") from an Axios error. Tableau
+ * serializes REST errors as `{ error: { code, summary, detail } }` in the body
+ * and also echoes the code in the `tableau_error_code` response header, so we
+ * check both. Used to distinguish the feature-flag-off 403 (code 403200) from an
+ * ordinary forbidden / insufficient-permission 403.
+ */
+function getTableauErrorCode(error: unknown): string | undefined {
+  if (!isAxiosError(error)) {
+    return undefined;
+  }
+  const bodyCode = error.response?.data?.error?.code;
+  if (typeof bodyCode === 'string' && bodyCode.length > 0) {
+    return bodyCode;
+  }
+  const headerCode = error.response?.headers?.tableau_error_code;
+  if (typeof headerCode === 'string' && headerCode.length > 0) {
+    return headerCode;
+  }
+  return undefined;
+}
+
+export const getDescribeFlowTool = (server: WebMcpServer): WebTool<typeof paramsSchema> => {
+  const config = getConfig();
+
+  const describeFlowTool = new WebTool({
+    server,
+    name: 'describe-flow',
+    disabled: !config.flowToolsEnabled,
+    description: `
+  Explains what a Tableau Prep flow actually *does* by reading and summarizing the flow's underlying document (the design of the flow itself, not just its catalog metadata). Use this when a user asks "what does this flow do?", "where does this flow get its data?", "what does it output?", "walk me through this flow", or wants to understand a flow's logic, sources, destinations, or shape without opening Tableau Prep.
+
+  **describe-flow vs get-flow**
+  - \`get-flow\` returns catalog *metadata* (name, owner, project, tags, output step names, input connections, recent run history). Use it for "who owns this?", "did the last run succeed?".
+  - \`describe-flow\` returns the flow's *internal design*: its inputs and their data connections, its output destinations, the transformation steps in between, and the step-to-step lineage. Use it to understand the flow's purpose and data movement.
+
+  **Returned fields (structured summary, not the raw document)**
+  - \`flow\`: identity — id, name, description, project, owner, fileType, updatedAt, webpageUrl, tags.
+  - \`stats\`: counts — nodeCount, inputCount, outputCount, transformCount, connectionCount. A cheap at-a-glance size/shape signal.
+  - \`inputs\`: each input step with a human-readable \`role\` (e.g. "Input — CSV file") and, where available, its resolved \`connection\` (type, server, database, schema, file, isPackaged).
+  - \`outputs\`: each output/write step with a \`role\` (e.g. "Output — published data source / extract") and any recognizable \`target\` details.
+  - \`steps\`: the transformation steps (joins, aggregates, filters, calculations, pivots, …) each with a friendly \`role\`.
+  - \`lineage\`: directed \`{from, to}\` edges (by step name) describing how data flows step-to-step.
+  - \`connections\`: the de-duplicated list of all data connections referenced by the flow.
+  - \`parameters\`: the flow's parameters (name, type, value).
+  - \`fields\` (only when \`includeFieldSchemas=true\`): per-step column lists ({name, type}). Verbose — request only when the user asks about specific columns/schema.
+
+  **Data safety**
+  The document is fetched through a server-side sanitized endpoint: credentials, secrets, and email-shaped PII are redacted before the document leaves Tableau. This tool surfaces only structural/topology fields and never returns passwords or tokens.
+
+  **Availability & errors**
+  - This relies on an experimental Tableau REST API (\`/api/exp/.../flows/{id}/document\`). If the server has not enabled it, the call fails with a clear "experimental flow-document API is not enabled" message — fall back to \`get-flow\` for metadata.
+  - If the flow id is unknown, not visible to the caller, or has no stored document (e.g. a metadata-only seeded flow), the call fails with a "no flow document available" message — use \`list-flows\` to find a valid flow id.
+
+  **Example usage**
+  - Describe a flow's purpose and data movement:
+      flowId: "d00700fe-28a0-4ece-a7af-5543ddf38a82"
+  - Also include each step's column schema (verbose):
+      flowId: "d00700fe-28a0-4ece-a7af-5543ddf38a82"
+      includeFieldSchemas: true`,
+    paramsSchema,
+    annotations: {
+      title: 'Describe Flow',
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
+    callback: async ({ flowId, includeFieldSchemas }, extra): Promise<CallToolResult> => {
+      return await describeFlowTool.logAndExecute<DescribeFlowResult>({
+        extra,
+        args: { flowId, includeFieldSchemas },
+        callback: async () => {
+          // Bounded-context gate (mirrors get-flow). When the instance is
+          // restricted via PROJECT_IDS / TAGS, reject flows outside the allowed
+          // set BEFORE downloading any document. When no bounded context is
+          // configured, this resolves to `{ allowed: true }` without a REST call.
+          const isFlowAllowedResult = await resourceAccessChecker.isFlowAllowed({
+            flowId,
+            extra,
+          });
+
+          if (!isFlowAllowedResult.allowed) {
+            return new FlowNotAllowedError(isFlowAllowedResult.message).toErr();
+          }
+
+          return new Ok(
+            await useRestApi({
+              ...extra,
+              jwtScopes: DESCRIBE_FLOW_API_SCOPES,
+              callback: async (restApi) => {
+                const warnings: DescribeFlowWarning[] = [];
+
+                // Primary call: download the sanitized flow document. Map the
+                // expected failure modes to actionable errors; anything else
+                // propagates to the generic handler.
+                let document;
+                try {
+                  document = await restApi.flowDocumentMethods.getFlowDocument({
+                    siteId: restApi.siteId,
+                    flowId,
+                  });
+                } catch (error) {
+                  const status = error instanceof Error ? getHttpStatus(error) : '';
+                  if (status === '403') {
+                    // A 403 has two very different meanings here. Only Tableau
+                    // error code 403200 means the experimental API is disabled.
+                    // Any other 403 is an authorization failure (no download
+                    // permission, insufficient token scope, generic forbidden)
+                    // and must NOT be reported as a feature-flag problem.
+                    if (getTableauErrorCode(error) === FLOW_DOCUMENT_API_DISABLED_CODE) {
+                      throw new FlowDocumentApiDisabledError(
+                        `The experimental flow-document API is not enabled on this Tableau server, so the flow's design cannot be read. Ask a server administrator to enable it, or use get-flow for this flow's metadata instead. (flowId: ${flowId})`,
+                      );
+                    }
+                    throw new FlowDocumentForbiddenError(
+                      `Not authorized to download the document for flow ${flowId}. Reading a flow's design requires permission to download the flow (the same permission as downloading its .tfl/.tflx file in Tableau) and a token with the tableau:flows:download scope. Confirm you can download this flow in Tableau, then retry; otherwise use get-flow for metadata that does not require download permission.`,
+                    );
+                  }
+                  if (status === '404') {
+                    throw new FlowDocumentNotFoundError(
+                      `No flow document is available for flow ${flowId}. The flow may not exist, may not be visible to you, or has no stored document (for example a metadata-only seeded flow). Use list-flows to find a valid flow id.`,
+                    );
+                  }
+                  throw error;
+                }
+
+                // Identity enrichment. Reuse the flow already fetched by the
+                // bounded-context check when present; otherwise fetch it. This is
+                // best-effort: the document is the primary artifact, so if the
+                // metadata call fails we still return the structural summary.
+                let flow: Flow | undefined = isFlowAllowedResult.content?.flow;
+                if (!flow) {
+                  try {
+                    flow = (
+                      await restApi.flowsMethods.queryFlow({
+                        siteId: restApi.siteId,
+                        flowId,
+                      })
+                    ).flow;
+                  } catch (error) {
+                    warnings.push({
+                      type: 'METADATA_FETCH_FAILED',
+                      severity: 'WARNING',
+                      message: `Could not load flow metadata (name/owner/project): ${getExceptionMessage(error)}. The structural summary below is derived from the flow document only.`,
+                      affectedField: 'flow',
+                      httpStatus:
+                        error instanceof Error ? getHttpStatus(error) || undefined : undefined,
+                    });
+                  }
+                }
+
+                const result = summarizeFlowDocument({ document, flow, includeFieldSchemas });
+
+                if (warnings.length > 0) {
+                  result.mcp = { warnings: [...(result.mcp?.warnings ?? []), ...warnings] };
+                }
+
+                return result;
+              },
+            }),
+          );
+        },
+        constrainSuccessResult: (result) => ({
+          type: 'success',
+          result,
+        }),
+      });
+    },
+  });
+
+  return describeFlowTool;
+};
+
+export const exportedForTesting = {
+  describeFlowParamsSchema: paramsSchema,
+};

--- a/src/tools/web/flows/describeFlow/flowDocumentSummary.test.ts
+++ b/src/tools/web/flows/describeFlow/flowDocumentSummary.test.ts
@@ -1,0 +1,262 @@
+import { Flow } from '../../../../sdks/tableau/types/flow.js';
+import {
+  FlowDocument,
+  flowDocumentConnectionSchema,
+} from '../../../../sdks/tableau/types/flowDocument.js';
+import { summarizeFlowDocument } from './flowDocumentSummary.js';
+import { mockFlowDocument } from './mockFlowDocument.js';
+
+const mockFlow = {
+  id: 'd00700fe-28a0-4ece-a7af-5543ddf38a82',
+  name: 'Sales Cleanup',
+  description: 'Cleans up the daily sales feed',
+  webpageUrl: 'http://tableau.example.com/#/flows/3',
+  fileType: 'tflx',
+  updatedAt: '2024-11-06T21:31:00Z',
+  project: { id: 'proj-1', name: 'Finance' },
+  owner: { id: 'owner-1', fullName: 'Dana Owner', name: 'downer' },
+  tags: { tag: [{ label: 'sales' }, { label: 'daily' }] },
+} satisfies Flow;
+
+describe('summarizeFlowDocument', () => {
+  it('classifies nodes into inputs / outputs / transforms and counts them', () => {
+    const result = summarizeFlowDocument({ document: mockFlowDocument });
+
+    expect(result.stats).toEqual({
+      nodeCount: 6,
+      inputCount: 2,
+      outputCount: 1,
+      transformCount: 3,
+      connectionCount: 2,
+    });
+    expect(result.inputs.map((i) => i.name).sort()).toEqual(['Customers', 'Orders.csv']);
+    expect(result.outputs.map((o) => o.name)).toEqual(['Sales Mart']);
+    expect(result.steps.map((s) => s.name).sort()).toEqual([
+      'Join Orders + Customers',
+      'Keep 2024',
+      'Profit Ratio',
+    ]);
+  });
+
+  it('assigns friendly roles to known node types', () => {
+    const result = summarizeFlowDocument({ document: mockFlowDocument });
+
+    const csv = result.inputs.find((i) => i.name === 'Orders.csv');
+    expect(csv?.role).toBe('Input — CSV file');
+    const output = result.outputs[0];
+    expect(output.role).toBe('Output — published data source / extract');
+    const join = result.steps.find((s) => s.name === 'Join Orders + Customers');
+    expect(join?.role).toBe('Join');
+  });
+
+  it('resolves each input to its data connection (file + database)', () => {
+    const result = summarizeFlowDocument({ document: mockFlowDocument });
+
+    const csv = result.inputs.find((i) => i.name === 'Orders.csv');
+    expect(csv?.connection).toMatchObject({
+      type: 'textscan',
+      file: 'Orders.csv',
+      isPackaged: true,
+    });
+
+    const sql = result.inputs.find((i) => i.name === 'Customers');
+    expect(sql?.connection).toMatchObject({
+      type: 'sqlserver',
+      server: 'sql.internal.example.com',
+      database: 'SalesDW',
+      schema: 'dbo',
+      isPackaged: false,
+    });
+  });
+
+  it('surfaces recognizable output target details', () => {
+    const result = summarizeFlowDocument({ document: mockFlowDocument });
+    expect(result.outputs[0].target).toMatchObject({
+      datasourceName: 'Sales Mart',
+      projectName: 'Finance',
+    });
+  });
+
+  it('builds step-to-step lineage edges by name', () => {
+    const result = summarizeFlowDocument({ document: mockFlowDocument });
+    expect(result.lineage).toEqual(
+      expect.arrayContaining([
+        { from: 'Orders.csv', to: 'Join Orders + Customers' },
+        { from: 'Customers', to: 'Join Orders + Customers' },
+        { from: 'Join Orders + Customers', to: 'Keep 2024' },
+        { from: 'Keep 2024', to: 'Profit Ratio' },
+        { from: 'Profit Ratio', to: 'Sales Mart' },
+      ]),
+    );
+    expect(result.lineage).toHaveLength(5);
+  });
+
+  it('reads parameters from the document when no flow metadata is supplied', () => {
+    const result = summarizeFlowDocument({ document: mockFlowDocument });
+    expect(result.parameters).toEqual([{ name: 'Region', type: 'string', value: 'West' }]);
+  });
+
+  it('prefers strongly-typed flow parameters over the document parameter map', () => {
+    const flowWithParams: Flow = {
+      ...mockFlow,
+      parameters: {
+        parameter: [
+          { id: 'p1', name: 'Region', type: 'string', value: 'West' },
+          { id: 'p2', name: 'Year', type: 'integer', value: '2024' },
+        ],
+      },
+    };
+    const result = summarizeFlowDocument({ document: mockFlowDocument, flow: flowWithParams });
+    expect(result.parameters).toEqual([
+      { name: 'Region', type: 'string', value: 'West' },
+      { name: 'Year', type: 'integer', value: '2024' },
+    ]);
+  });
+
+  it('summarizes flow identity from the supplied flow metadata', () => {
+    const result = summarizeFlowDocument({ document: mockFlowDocument, flow: mockFlow });
+    expect(result.flow).toMatchObject({
+      id: mockFlow.id,
+      name: 'Sales Cleanup',
+      project: 'Finance',
+      owner: 'Dana Owner',
+      fileType: 'tflx',
+      tags: ['sales', 'daily'],
+    });
+  });
+
+  it('omits per-step field schemas unless includeFieldSchemas is set', () => {
+    const without = summarizeFlowDocument({ document: mockFlowDocument });
+    expect(without.fields).toBeUndefined();
+
+    const withFields = summarizeFlowDocument({
+      document: mockFlowDocument,
+      includeFieldSchemas: true,
+    });
+    expect(withFields.fields).toBeDefined();
+    expect(withFields.fields?.['Orders.csv']).toEqual([
+      { name: 'OrderId', type: 'integer' },
+      { name: 'Amount', type: 'real' },
+    ]);
+  });
+
+  it('falls back to initialNodes for classification when baseType is absent', () => {
+    // No baseType anywhere; only `initialNodes` marks the input. A node with an
+    // unknown type should be humanized rather than dropped.
+    const doc: FlowDocument = {
+      initialNodes: ['a'],
+      nodes: {
+        a: {
+          id: 'a',
+          name: 'Source',
+          nodeType: '.v1.SomeWeirdLoader',
+          nextNodes: [{ nextNodeId: 'b' }],
+        },
+        b: { id: 'b', name: 'Reshape', nodeType: '.v1.ChangeColumnType', nextNodes: [] },
+      },
+    };
+    const result = summarizeFlowDocument({ document: doc });
+    expect(result.inputs.map((i) => i.name)).toEqual(['Source']);
+    expect(result.steps[0].role).toBe('Change column type');
+  });
+
+  it('classifies real baseTypes (container / superNode / transform) as steps with friendly roles', () => {
+    // Mirrors live document shapes: a "Clean" container step plus Super*/Simple*
+    // operation nodes. baseType is authoritative; Super/Simple prefixes are
+    // normalized for the role label.
+    const doc: FlowDocument = {
+      initialNodes: ['in'],
+      nodes: {
+        in: {
+          id: 'in',
+          name: 'orders',
+          nodeType: '.v1.LoadCsv',
+          baseType: 'input',
+          nextNodes: [{ nextNodeId: 'clean' }],
+        },
+        clean: {
+          id: 'clean',
+          name: 'Remove Nulls',
+          nodeType: '.v1.Container',
+          baseType: 'container',
+          nextNodes: [{ nextNodeId: 'join' }],
+        },
+        join: {
+          id: 'join',
+          name: 'Join 1',
+          nodeType: '.v1.SuperJoin',
+          baseType: 'superNode',
+          nextNodes: [{ nextNodeId: 'union' }],
+        },
+        union: {
+          id: 'union',
+          name: 'Union 1',
+          nodeType: '.v1.SimpleUnion',
+          baseType: 'transform',
+          nextNodes: [{ nextNodeId: 'out' }],
+        },
+        out: {
+          id: 'out',
+          name: 'Output',
+          nodeType: '.v1.PublishExtract',
+          baseType: 'output',
+          nextNodes: [],
+        },
+      },
+    };
+    const result = summarizeFlowDocument({ document: doc });
+
+    expect(result.stats).toMatchObject({ inputCount: 1, outputCount: 1, transformCount: 3 });
+    // The container "Remove Nulls" must NOT be treated as an input.
+    expect(result.inputs.map((i) => i.name)).toEqual(['orders']);
+    const byName = Object.fromEntries(result.steps.map((s) => [s.name, s.role]));
+    expect(byName['Remove Nulls']).toBe('Clean step (prep operations)');
+    expect(byName['Join 1']).toBe('Join');
+    expect(byName['Union 1']).toBe('Union');
+  });
+
+  it('returns zeroed stats and a warning for an empty document', () => {
+    const result = summarizeFlowDocument({ document: {} });
+    expect(result.stats.nodeCount).toBe(0);
+    expect(result.inputs).toEqual([]);
+    expect(result.outputs).toEqual([]);
+    expect(result.mcp?.warnings?.[0]).toMatchObject({
+      type: 'EMPTY_DOCUMENT',
+      severity: 'WARNING',
+      affectedField: 'steps',
+    });
+    expect(result.mcp?.warnings?.[0].message).toContain('no recognizable steps');
+  });
+});
+
+describe('flowDocumentConnectionSchema isPackaged parsing', () => {
+  it('parses the string "false" as false (not true)', () => {
+    // Regression: z.coerce.boolean() would turn "false" into `true`.
+    expect(flowDocumentConnectionSchema.parse({ id: 'c', isPackaged: 'false' }).isPackaged).toBe(
+      false,
+    );
+  });
+
+  it('parses the string "true" as true (case-insensitively)', () => {
+    expect(flowDocumentConnectionSchema.parse({ id: 'c', isPackaged: 'true' }).isPackaged).toBe(
+      true,
+    );
+    expect(flowDocumentConnectionSchema.parse({ id: 'c', isPackaged: 'TRUE' }).isPackaged).toBe(
+      true,
+    );
+  });
+
+  it('passes real booleans through unchanged', () => {
+    expect(flowDocumentConnectionSchema.parse({ id: 'c', isPackaged: true }).isPackaged).toBe(true);
+    expect(flowDocumentConnectionSchema.parse({ id: 'c', isPackaged: false }).isPackaged).toBe(
+      false,
+    );
+  });
+
+  it('leaves isPackaged undefined when absent or unrecognized', () => {
+    expect(flowDocumentConnectionSchema.parse({ id: 'c' }).isPackaged).toBeUndefined();
+    expect(flowDocumentConnectionSchema.parse({ id: 'c', isPackaged: 'maybe' }).isPackaged).toBe(
+      undefined,
+    );
+  });
+});

--- a/src/tools/web/flows/describeFlow/flowDocumentSummary.ts
+++ b/src/tools/web/flows/describeFlow/flowDocumentSummary.ts
@@ -1,0 +1,491 @@
+import { Flow } from '../../../../sdks/tableau/types/flow.js';
+import {
+  FlowDocument,
+  FlowDocumentConnection,
+  FlowDocumentNode,
+} from '../../../../sdks/tableau/types/flowDocument.js';
+
+/**
+ * Turns a raw, sanitized flow document into a compact,
+ * LLM-friendly description of what the flow IS and DOES: its identity, the data
+ * it reads (inputs + connections), the data it writes (outputs), the
+ * transformation steps in between, the step-to-step lineage, and its parameters.
+ *
+ * The raw document is large, deeply nested, and full of layout/UI noise that is
+ * useless (and expensive) for an LLM. This summarizer is intentionally
+ * defensive: the experimental document format may evolve, so it reads only
+ * well-known structural fields and degrades gracefully when they are absent.
+ */
+
+/**
+ * A single data connection referenced by the flow, reduced to its descriptive
+ * topology. All fields are optional because the experimental document does not
+ * populate every attribute for every connection class (a file connection has a
+ * `file` but no `server`/`database`, and vice versa). Credentials are stripped
+ * server-side, so nothing sensitive appears here.
+ */
+export type FlowConnectionSummary = {
+  id?: string;
+  type?: string;
+  class?: string;
+  server?: string;
+  port?: string;
+  database?: string;
+  schema?: string;
+  warehouse?: string;
+  file?: string;
+  isPackaged?: boolean;
+};
+
+/** An input (data-source) step, with its resolved data connection when available. */
+export type FlowInputSummary = {
+  nodeId?: string;
+  name?: string;
+  nodeType?: string;
+  role: string;
+  connection?: FlowConnectionSummary;
+};
+
+/**
+ * An output (write/publish) step. `target` holds whatever recognizable
+ * destination details the node exposed (e.g. datasource/project/table name).
+ */
+export type FlowOutputSummary = {
+  nodeId?: string;
+  name?: string;
+  nodeType?: string;
+  role: string;
+  target?: Record<string, string>;
+};
+
+/** A transformation step (join, filter, aggregate, calculation, …). */
+export type FlowStepSummary = {
+  nodeId?: string;
+  name?: string;
+  nodeType?: string;
+  role: string;
+};
+
+/** A directed step-to-step edge (by step name) describing how data flows. */
+export type FlowLineageEdge = { from: string; to: string };
+
+/** A flow parameter (name, type, and current/default value). */
+export type FlowParameterSummary = { name?: string; type?: string; value?: string };
+
+/** The flow's catalog identity, enriched from Query Flow metadata when available. */
+export type FlowIdentitySummary = {
+  id?: string;
+  name?: string;
+  description?: string;
+  project?: string;
+  owner?: string;
+  fileType?: string;
+  updatedAt?: string;
+  webpageUrl?: string;
+  tags?: string[];
+};
+
+/**
+ * A structured, non-fatal issue surfaced under `mcp.warnings`. Mirrors the
+ * `GetFlowWarning` shape used by get-flow (type / severity / message /
+ * affectedField) so the two flow tools report partial failures consistently.
+ *
+ * - `METADATA_FETCH_FAILED`: the best-effort Query Flow enrichment failed; the
+ *   structural summary is still derived from the document.
+ * - `EMPTY_DOCUMENT`: the document parsed but contained no recognizable steps
+ *   (it may be empty, or the experimental format may have changed).
+ */
+export type DescribeFlowWarning =
+  | {
+      type: 'METADATA_FETCH_FAILED';
+      severity: 'WARNING';
+      message: string;
+      affectedField: 'flow';
+      httpStatus?: string;
+    }
+  | {
+      type: 'EMPTY_DOCUMENT';
+      severity: 'WARNING';
+      message: string;
+      affectedField: 'steps';
+    };
+
+/** The structured, LLM-friendly summary returned by the describe-flow tool. */
+export type DescribeFlowResult = {
+  flow: FlowIdentitySummary;
+  stats: {
+    nodeCount: number;
+    inputCount: number;
+    outputCount: number;
+    transformCount: number;
+    connectionCount: number;
+  };
+  inputs: FlowInputSummary[];
+  outputs: FlowOutputSummary[];
+  steps: FlowStepSummary[];
+  lineage: FlowLineageEdge[];
+  connections: FlowConnectionSummary[];
+  parameters: FlowParameterSummary[];
+  fields?: Record<string, Array<{ name?: string; type?: string }>>;
+  mcp?: { warnings: DescribeFlowWarning[] };
+};
+
+type NodeCategory = 'input' | 'output' | 'transform';
+
+// Friendly labels for the flow node types we recognize, keyed by the node's
+// short type (the `.vN.` namespace stripped). Operation nodes appear with
+// `Super`/`Simple` prefixes in real documents (e.g. `SuperJoin`, `SimpleUnion`),
+// so `roleLabel` also looks up the prefix-stripped form. Anything still
+// unmatched falls back to a humanized version of the raw type.
+const NODE_ROLE_LABELS: Record<string, string> = {
+  // Inputs
+  LoadCsv: 'Input — CSV file',
+  LoadCsvInputUnion: 'Input — CSV files (union)',
+  LoadExcel: 'Input — Excel file',
+  LoadExcelInputUnion: 'Input — Excel files (union)',
+  LoadJson: 'Input — JSON file',
+  LoadSql: 'Input — database table/query',
+  LoadInitialSql: 'Input — database (custom SQL)',
+  LoadDataSource: 'Input — published data source',
+  LoadExtract: 'Input — extract',
+  LoadSpatial: 'Input — spatial file',
+  // Transforms (after Super/Simple normalization)
+  Container: 'Clean step (prep operations)',
+  Join: 'Join',
+  Union: 'Union',
+  Aggregate: 'Aggregate',
+  Pivot: 'Pivot',
+  Unpivot: 'Unpivot',
+  Filter: 'Filter rows',
+  AddColumn: 'Add column (calculation)',
+  CalculatedField: 'Add column (calculation)',
+  RemoveColumns: 'Remove columns',
+  RenameColumn: 'Rename column',
+  Group: 'Group / cluster values',
+  ChangeColumnType: 'Change column type',
+  Sample: 'Sample rows',
+  Sort: 'Sort',
+  SplitColumn: 'Split column',
+  // Outputs
+  PublishExtract: 'Output — published data source / extract',
+  WriteToDatabase: 'Output — database table',
+  WriteToCsv: 'Output — CSV file',
+  WriteToHyper: 'Output — Hyper extract',
+  WriteToFile: 'Output — file',
+  Output: 'Output',
+};
+
+/** Strips the leading version namespace from a node type (".v1.LoadCsv" → "LoadCsv"). */
+function shortType(t: string | undefined): string | undefined {
+  if (!t) {
+    return undefined;
+  }
+  const parts = t.split('.');
+  return parts[parts.length - 1] || t;
+}
+
+/** "ChangeColumnType" → "Change Column Type". */
+function humanize(s: string | undefined): string | undefined {
+  if (!s) {
+    return undefined;
+  }
+  return s
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .replace(/([A-Z]+)([A-Z][a-z])/g, '$1 $2')
+    .trim();
+}
+
+function str(v: unknown): string | undefined {
+  return typeof v === 'string' && v.length > 0 ? v : undefined;
+}
+
+function pickStrings(
+  obj: Record<string, unknown> | undefined,
+  keys: string[],
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  if (!obj) {
+    return out;
+  }
+  for (const key of keys) {
+    const value = str(obj[key]);
+    if (value !== undefined) {
+      out[key] = value;
+    }
+  }
+  return out;
+}
+
+/** Drops `undefined`, empty-array, and empty-object values so the JSON stays terse. */
+function prune<T extends Record<string, unknown>>(obj: T): T {
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(obj)) {
+    if (value === undefined) {
+      continue;
+    }
+    if (Array.isArray(value) && value.length === 0) {
+      continue;
+    }
+    if (
+      typeof value === 'object' &&
+      value !== null &&
+      !Array.isArray(value) &&
+      Object.keys(value as object).length === 0
+    ) {
+      continue;
+    }
+    out[key] = value;
+  }
+  return out as T;
+}
+
+/** Strips the `Super`/`Simple` operation-node prefix (`SuperJoin` → `Join`). */
+function normalizeType(short: string | undefined): string | undefined {
+  return short?.replace(/^(Super|Simple)/, '');
+}
+
+function roleLabel(short: string | undefined, category: NodeCategory): string {
+  if (short && NODE_ROLE_LABELS[short]) {
+    return NODE_ROLE_LABELS[short];
+  }
+  const normalized = normalizeType(short);
+  if (normalized && NODE_ROLE_LABELS[normalized]) {
+    return NODE_ROLE_LABELS[normalized];
+  }
+  const human = humanize(normalized) ?? 'Step';
+  if (category === 'input') {
+    return `Input — ${human}`;
+  }
+  if (category === 'output') {
+    return `Output — ${human}`;
+  }
+  return human;
+}
+
+function classify(
+  node: FlowDocumentNode,
+  short: string | undefined,
+  initialNodeIds: Set<string>,
+): NodeCategory {
+  // `baseType` is the authoritative classifier in real documents. Verified live
+  // values: input, output, container (clean steps), superNode (join/union/
+  // aggregate/pivot), transform (simple join/union). Everything that is not an
+  // input or output is a transformation step.
+  const base = node.baseType?.toLowerCase();
+  if (base === 'input') {
+    return 'input';
+  }
+  if (base === 'output') {
+    return 'output';
+  }
+  if (base === 'container' || base === 'supernode' || base === 'transform') {
+    return 'transform';
+  }
+  // Fallbacks for when baseType is missing/unknown (defensive — not seen live).
+  if (node.id && initialNodeIds.has(node.id)) {
+    return 'input';
+  }
+  if (short) {
+    if (/^Load/.test(short)) {
+      return 'input';
+    }
+    if (/^(Publish|WriteTo|Output|SaveTo)/.test(short)) {
+      return 'output';
+    }
+  }
+  return 'transform';
+}
+
+function summarizeConnection(
+  id: string | undefined,
+  conn: FlowDocumentConnection | undefined,
+): FlowConnectionSummary {
+  if (!conn) {
+    return prune({ id });
+  }
+  const attrs = conn.connectionAttributes;
+  const cls = str(attrs?.['class']);
+  return prune({
+    id: conn.id ?? id,
+    type: cls ?? shortType(conn.connectionType),
+    class: cls,
+    server: str(attrs?.['server']),
+    port: str(attrs?.['port']),
+    database: str(attrs?.['dbname']) ?? str(attrs?.['database']),
+    schema: str(attrs?.['schema']),
+    warehouse: str(attrs?.['warehouse']),
+    file: str(attrs?.['filename']) ?? str(attrs?.['file']),
+    isPackaged: conn.isPackaged,
+  });
+}
+
+function summarizeIdentity(flow: Flow | undefined): FlowIdentitySummary {
+  if (!flow) {
+    return {};
+  }
+  return prune({
+    id: flow.id,
+    name: flow.name,
+    description: str(flow.description),
+    project: flow.project?.name,
+    owner: flow.owner?.fullName ?? flow.owner?.name,
+    fileType: flow.fileType,
+    updatedAt: flow.updatedAt,
+    webpageUrl: flow.webpageUrl,
+    tags: flow.tags?.tag?.map((t) => t.label).filter((l): l is string => !!l),
+  });
+}
+
+export function summarizeFlowDocument({
+  document,
+  flow,
+  includeFieldSchemas = false,
+}: {
+  document: FlowDocument;
+  flow?: Flow;
+  includeFieldSchemas?: boolean;
+}): DescribeFlowResult {
+  const nodeEntries = Object.entries(document.nodes ?? {});
+  const initialNodeIds = new Set(document.initialNodes ?? []);
+
+  // Merge the two connection maps (the document splits "connections" and
+  // "dataConnections"); key by the connection's own id so node lookups resolve.
+  const connMap = new Map<string, FlowDocumentConnection>();
+  for (const [cid, conn] of Object.entries(document.connections ?? {})) {
+    connMap.set(conn.id ?? cid, conn);
+  }
+  for (const [cid, conn] of Object.entries(document.dataConnections ?? {})) {
+    connMap.set(conn.id ?? cid, conn);
+  }
+
+  // Human-readable lineage: resolve node ids to names where possible.
+  const nameById = new Map<string, string>();
+  for (const [nid, node] of nodeEntries) {
+    nameById.set(node.id ?? nid, node.name ?? shortType(node.nodeType) ?? nid);
+  }
+
+  const inputs: FlowInputSummary[] = [];
+  const outputs: FlowOutputSummary[] = [];
+  const steps: FlowStepSummary[] = [];
+  const lineage: FlowLineageEdge[] = [];
+  const fields: Record<string, Array<{ name?: string; type?: string }>> = {};
+
+  for (const [nid, node] of nodeEntries) {
+    const id = node.id ?? nid;
+    const short = shortType(node.nodeType);
+    const category = classify(node, short, initialNodeIds);
+
+    for (const next of node.nextNodes ?? []) {
+      if (next.nextNodeId) {
+        lineage.push({
+          from: nameById.get(id) ?? id,
+          to: nameById.get(next.nextNodeId) ?? next.nextNodeId,
+        });
+      }
+    }
+
+    if (includeFieldSchemas && node.fields && node.fields.length > 0) {
+      fields[node.name ?? id] = node.fields.map((f) => prune({ name: f.name, type: f.type }));
+    }
+
+    if (category === 'input') {
+      const conn = node.connectionId ? connMap.get(node.connectionId) : undefined;
+      inputs.push(
+        prune({
+          nodeId: id,
+          name: node.name,
+          nodeType: short,
+          role: roleLabel(short, 'input'),
+          connection: node.connectionId ? summarizeConnection(node.connectionId, conn) : undefined,
+        }),
+      );
+    } else if (category === 'output') {
+      const target = pickStrings(node as unknown as Record<string, unknown>, [
+        'outputFile',
+        'filename',
+        'datasourceName',
+        'projectName',
+        'tableName',
+        'dbName',
+        'schema',
+        'outputType',
+      ]);
+      outputs.push(
+        prune({
+          nodeId: id,
+          name: node.name,
+          nodeType: short,
+          role: roleLabel(short, 'output'),
+          target,
+        }),
+      );
+    } else {
+      steps.push(
+        prune({
+          nodeId: id,
+          name: node.name,
+          nodeType: short,
+          role: roleLabel(short, 'transform'),
+        }),
+      );
+    }
+  }
+
+  const connections: FlowConnectionSummary[] = [];
+  for (const [cid, conn] of connMap) {
+    connections.push(summarizeConnection(cid, conn));
+  }
+
+  // Prefer the strongly-typed parameters from the Flow metadata (Query Flow);
+  // fall back to the document's parameter map only when metadata is absent.
+  const parameters: FlowParameterSummary[] = [];
+  const flowParams = flow?.parameters?.parameter ?? [];
+  if (flowParams.length > 0) {
+    for (const p of flowParams) {
+      parameters.push(prune({ name: p.name, type: p.type, value: p.value }));
+    }
+  } else {
+    for (const raw of Object.values(document.parameters?.parameters ?? {})) {
+      if (raw && typeof raw === 'object') {
+        const rec = raw as Record<string, unknown>;
+        parameters.push(
+          prune({
+            name: str(rec['name']),
+            type: str(rec['type']) ?? str(rec['parameterType']),
+            value: str(rec['value']) ?? str(rec['defaultValue']),
+          }),
+        );
+      }
+    }
+  }
+
+  const warnings: DescribeFlowWarning[] = [];
+  if (nodeEntries.length === 0) {
+    warnings.push({
+      type: 'EMPTY_DOCUMENT',
+      severity: 'WARNING',
+      message:
+        'The flow document contained no recognizable steps. It may be empty, or the experimental document format may have changed.',
+      affectedField: 'steps',
+    });
+  }
+
+  return {
+    flow: summarizeIdentity(flow),
+    stats: {
+      nodeCount: nodeEntries.length,
+      inputCount: inputs.length,
+      outputCount: outputs.length,
+      transformCount: steps.length,
+      connectionCount: connections.length,
+    },
+    inputs,
+    outputs,
+    steps,
+    lineage,
+    connections,
+    parameters,
+    ...(includeFieldSchemas ? { fields } : {}),
+    ...(warnings.length > 0 ? { mcp: { warnings } } : {}),
+  };
+}

--- a/src/tools/web/flows/describeFlow/mockFlowDocument.ts
+++ b/src/tools/web/flows/describeFlow/mockFlowDocument.ts
@@ -1,0 +1,94 @@
+import { FlowDocument } from '../../../../sdks/tableau/types/flowDocument.js';
+
+/**
+ * A representative sanitized flow document: two inputs (a packaged CSV and a
+ * SQL Server table) join → filter → calculated column → publish-as-extract
+ * output. Exercises every classification branch the summarizer cares about
+ * (input/output/transform), connection resolution (file + database), lineage
+ * edges, per-node field schemas, and a document-level parameter.
+ */
+export const mockFlowDocument = {
+  documentId: 'doc-aaaa-bbbb',
+  majorVersion: 2024,
+  minorVersion: 3,
+  initialNodes: ['n-input-csv', 'n-input-sql'],
+  connections: {
+    'c-csv': {
+      id: 'c-csv',
+      connectionType: '.v1.FileConnection',
+      name: 'Orders.csv',
+      isPackaged: true,
+      connectionAttributes: { class: 'textscan', filename: 'Orders.csv' },
+    },
+    'c-sql': {
+      id: 'c-sql',
+      connectionType: '.v1.SqlConnection',
+      name: 'Sales DB',
+      isPackaged: false,
+      connectionAttributes: {
+        class: 'sqlserver',
+        server: 'sql.internal.example.com',
+        dbname: 'SalesDW',
+        schema: 'dbo',
+      },
+    },
+  },
+  dataConnections: {},
+  parameters: {
+    parameters: {
+      p1: { name: 'Region', type: 'string', value: 'West' },
+    },
+  },
+  nodes: {
+    'n-input-csv': {
+      id: 'n-input-csv',
+      name: 'Orders.csv',
+      nodeType: '.v1.LoadCsv',
+      baseType: 'input',
+      connectionId: 'c-csv',
+      nextNodes: [{ nextNodeId: 'n-join' }],
+      fields: [
+        { name: 'OrderId', type: 'integer' },
+        { name: 'Amount', type: 'real' },
+      ],
+    },
+    'n-input-sql': {
+      id: 'n-input-sql',
+      name: 'Customers',
+      nodeType: '.v1.LoadSql',
+      baseType: 'input',
+      connectionId: 'c-sql',
+      nextNodes: [{ nextNodeId: 'n-join' }],
+    },
+    'n-join': {
+      id: 'n-join',
+      name: 'Join Orders + Customers',
+      nodeType: '.v1.Join',
+      baseType: 'transform',
+      nextNodes: [{ nextNodeId: 'n-filter' }],
+    },
+    'n-filter': {
+      id: 'n-filter',
+      name: 'Keep 2024',
+      nodeType: '.v1.Filter',
+      baseType: 'transform',
+      nextNodes: [{ nextNodeId: 'n-calc' }],
+    },
+    'n-calc': {
+      id: 'n-calc',
+      name: 'Profit Ratio',
+      nodeType: '.v1.AddColumn',
+      baseType: 'transform',
+      nextNodes: [{ nextNodeId: 'n-output' }],
+    },
+    'n-output': {
+      id: 'n-output',
+      name: 'Sales Mart',
+      nodeType: '.v1.PublishExtract',
+      baseType: 'output',
+      datasourceName: 'Sales Mart',
+      projectName: 'Finance',
+      nextNodes: [],
+    },
+  },
+} satisfies FlowDocument;

--- a/src/tools/web/toolName.ts
+++ b/src/tools/web/toolName.ts
@@ -20,6 +20,7 @@ export const webToolNames = [
   'get-flow',
   'list-flow-runs',
   'list-flow-tasks',
+  'describe-flow',
   'get-view-data',
   'get-view-image',
   'get-custom-view-data',
@@ -80,7 +81,7 @@ export const webToolGroups = {
     'get-custom-view-data',
     'get-custom-view-image',
   ],
-  flow: ['list-flows', 'get-flow', 'list-flow-runs', 'list-flow-tasks'],
+  flow: ['list-flows', 'get-flow', 'list-flow-runs', 'list-flow-tasks', 'describe-flow'],
   pulse: [
     'list-all-pulse-metric-definitions',
     'list-pulse-metric-definitions-from-definition-ids',

--- a/src/tools/web/tools.ts
+++ b/src/tools/web/tools.ts
@@ -7,6 +7,7 @@ import { getResolveDatasourceLuidTool } from './datasources/resolveDatasourceLui
 import { getConfirmUpdateCloudExtractRefreshTaskTool } from './extractRefreshTasks/confirmUpdateCloudExtractRefreshTask.js';
 import { getListExtractRefreshTasksTool } from './extractRefreshTasks/listExtractRefreshTasks.js';
 import { getUpdateCloudExtractRefreshTaskTool } from './extractRefreshTasks/updateCloudExtractRefreshTask.js';
+import { getDescribeFlowTool } from './flows/describeFlow/describeFlow.js';
 import { getGetFlowTool } from './flows/getFlow/getFlow.js';
 import { getListFlowRunsTool } from './flows/listFlowRuns/listFlowRuns.js';
 import { getListFlowsTool } from './flows/listFlows/listFlows.js';
@@ -58,6 +59,7 @@ export const webToolFactories = [
   getGetFlowTool,
   getListFlowRunsTool,
   getListFlowTasksTool,
+  getDescribeFlowTool,
   getListAllPulseMetricDefinitionsTool,
   getListPulseMetricDefinitionsFromDefinitionIdsTool,
   getListPulseMetricsFromMetricDefinitionIdTool,

--- a/tests/e2e/server.test.ts
+++ b/tests/e2e/server.test.ts
@@ -58,6 +58,7 @@ describe('server', () => {
         'get-flow',
         'list-flow-runs',
         'list-flow-tasks',
+        'describe-flow',
       ];
       // insights tools are gated off by default (INSIGHTS_TOOLS_ENABLED)
       const insightsTools: ReadonlyArray<WebToolName> = [
@@ -170,6 +171,7 @@ describe('server', () => {
         'get-flow',
         'list-flow-runs',
         'list-flow-tasks',
+        'describe-flow',
       ];
       // insights tools are gated off by default (INSIGHTS_TOOLS_ENABLED)
       const insightsTools: ReadonlyArray<WebToolName> = [


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of
the pull request._

# Pull Request Template

## Description

Adds a read-only `describe-flow` tool that summarizes a Tableau Prep flow’s inputs, transformations, outputs, lineage, connections, parameters, and optional field schemas.

Also adds the sanitized flow-document API client, OAuth scopes, feature gating, tests, and documentation.

## Motivation and Context

`get-flow` provides catalog metadata but cannot explain a flow’s internal logic or data movement. `describe-flow` enables agents to answer those questions without parsing raw `.tfl` or `.tflx` files or exposing sensitive connection information.

## Type of Change

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## How Has This Been Tested?

- Unit tests for summarization, API handling, scopes, feature gating, and errors.
- Full lint, typecheck, and unit-test suite (2,533 tests).
- Live end-to-end validation against a Tableau server, including field schemas and the not-found path.

## Related Issues

[Support Tableau Prep flow design summaries with describe-flow](https://github.com/tableau/tableau-mcp/issues/626)

## Checklist

- [X] I have updated the version in the package.json file by using `npm run version`. For example,
      use `npm run version:patch` for a patch version bump.
- [X] I have made any necessary changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have documented any breaking changes in the PR description. For example, renaming a config
      environment variable or changing its default value.

## Contributor Agreement

By submitting this pull request, I confirm that:

- [X] I have read the [CONTRIBUTING guidelines](../../CONTRIBUTING.md) for this project and followed
      its Contribution Checklist.
