### PR TITLE
Render view images at standard resolution

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "3.5.5",
+  "version": "3.5.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "3.5.5",
+      "version": "3.5.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.7.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "3.5.5",
+  "version": "3.5.6",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/src/sdks/tableau/methods/viewsMethods.ts
+++ b/src/sdks/tableau/methods/viewsMethods.ts
@@ -163,7 +163,7 @@ export default class ViewsMethods extends AuthenticatedMethods<typeof viewsApis>
     siteId,
     width,
     height,
-    resolution = 'high',
+    resolution,
     format,
     viewFilters,
   }: {

--- a/src/tools/web/views/getCustomViewImage.test.ts
+++ b/src/tools/web/views/getCustomViewImage.test.ts
@@ -90,7 +90,6 @@ describe('getCustomViewImageTool', () => {
       customViewId: mockCustomView.id,
       width: undefined,
       height: undefined,
-      resolution: 'high',
       format: undefined,
       viewFilters: undefined,
     });
@@ -112,7 +111,6 @@ describe('getCustomViewImageTool', () => {
       customViewId: mockCustomView.id,
       width: undefined,
       height: undefined,
-      resolution: 'high',
       format: 'SVG',
       viewFilters: undefined,
     });
@@ -142,7 +140,7 @@ describe('getCustomViewImageTool', () => {
       customViewId: mockCustomView.id,
       width: undefined,
       height: undefined,
-      resolution: 'high',
+      format: undefined,
       viewFilters: { Region: 'West' },
     });
   });
@@ -189,7 +187,6 @@ describe('getCustomViewImageTool', () => {
       customViewId: mockCustomView.id,
       width: undefined,
       height: undefined,
-      resolution: 'high',
       format: undefined,
       viewFilters: undefined,
     });
@@ -223,7 +220,6 @@ describe('getCustomViewImageTool', () => {
       customViewId: mockCustomView.id,
       width: undefined,
       height: undefined,
-      resolution: 'high',
       format: undefined,
       viewFilters: undefined,
     });
@@ -242,8 +238,8 @@ describe('getCustomViewImageTool', () => {
       customViewId: mockCustomView.id,
       width: undefined,
       height: undefined,
-      resolution: 'high',
       format: 'PNG',
+      viewFilters: undefined,
     });
   });
 
@@ -260,8 +256,8 @@ describe('getCustomViewImageTool', () => {
       customViewId: mockCustomView.id,
       width: undefined,
       height: undefined,
-      resolution: 'high',
       format: 'SVG',
+      viewFilters: undefined,
     });
   });
 

--- a/src/tools/web/views/getCustomViewImage.ts
+++ b/src/tools/web/views/getCustomViewImage.ts
@@ -90,7 +90,6 @@ export const getGetCustomViewImageTool = (
                 siteId: restApi.siteId,
                 width,
                 height,
-                resolution: 'high',
                 format: formatResult.value,
                 viewFilters,
               });

--- a/src/tools/web/views/getViewImage.test.ts
+++ b/src/tools/web/views/getViewImage.test.ts
@@ -84,8 +84,8 @@ describe('getViewImageTool', () => {
       viewId: '4d18c547-bbb1-4187-ae5a-7f78b35adf2d',
       width: undefined,
       height: undefined,
-      resolution: 'high',
       format: undefined,
+      viewFilters: undefined,
     });
   });
 
@@ -108,8 +108,8 @@ describe('getViewImageTool', () => {
       viewId: '4d18c547-bbb1-4187-ae5a-7f78b35adf2d',
       width: undefined,
       height: undefined,
-      resolution: 'high',
       format: 'SVG',
+      viewFilters: undefined,
     });
   });
 
@@ -189,8 +189,8 @@ describe('getViewImageTool', () => {
       viewId: mockView.id,
       width: undefined,
       height: undefined,
-      resolution: 'high',
       format: undefined,
+      viewFilters: undefined,
     });
     // viewIds is a synchronous Set lookup — no need to fetch the view itself.
     expect(mocks.mockGetView).not.toHaveBeenCalled();
@@ -224,8 +224,8 @@ describe('getViewImageTool', () => {
       viewId: '4d18c547-bbb1-4187-ae5a-7f78b35adf2d',
       width: undefined,
       height: undefined,
-      resolution: 'high',
       format: undefined,
+      viewFilters: undefined,
     });
   });
 
@@ -242,8 +242,8 @@ describe('getViewImageTool', () => {
       viewId: '4d18c547-bbb1-4187-ae5a-7f78b35adf2d',
       width: undefined,
       height: undefined,
-      resolution: 'high',
       format: 'PNG',
+      viewFilters: undefined,
     });
   });
 
@@ -260,8 +260,8 @@ describe('getViewImageTool', () => {
       viewId: '4d18c547-bbb1-4187-ae5a-7f78b35adf2d',
       width: undefined,
       height: undefined,
-      resolution: 'high',
       format: 'SVG',
+      viewFilters: undefined,
     });
   });
 

--- a/src/tools/web/views/getViewImage.ts
+++ b/src/tools/web/views/getViewImage.ts
@@ -83,7 +83,6 @@ export const getGetViewImageTool = (
                 siteId: restApi.siteId,
                 width,
                 height,
-                resolution: 'high',
                 format: formatResult.value,
                 viewFilters,
               });


### PR DESCRIPTION
## Description

- `get-view-image` and `get-custom-view-image` no longer force `resolution: 'high'` on the Tableau image render — they render at Tableau's default (standard) resolution.
- Removed the `resolution: 'high'` argument from both tool → SDK calls and dropped the `resolution = 'high'` default in the `getCustomViewImage` SDK method.
- Bumped version 3.5.5 → 3.5.6.

## Motivation and Context

Forcing high resolution makes Tableau render a large image for every call. On large dashboards the render is slow enough that the MCP client times out and aborts the request (`CanceledError`). The host vision layer downsamples the image to ~1568px regardless, so the forced high-res render is wasted work — it costs latency without improving what the model actually sees.

Rendering at standard resolution fixes the timeout/abort and stays token-safe. The SDK/API type still accepts `resolution: 'high'`, so the ability to request high-res is preserved at the API layer; the tools simply stop forcing it.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## How Has This Been Tested?

- Updated the affected unit tests in `getViewImage.test.ts` and `getCustomViewImage.test.ts` so the `toHaveBeenCalledWith` assertions reflect the real SDK call (resolution omitted).
- Full unit suite green: `npx vitest run` → 160 files, 2502 tests passing.
- `npm run lint` clean; `npm run build` succeeds.

## Related Issues

N/A

## Checklist

- [x] I have updated the version in the package.json file by using `npm run version` (patch: 3.5.5 → 3.5.6).
- [ ] I have made any necessary changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works