### PR TITLE
feat(desktop): surface server luid on list-workbook-datasources

### DIFF
--- a/src/desktop/externalApi/__fixtures__/externalClientApi-openapi.json
+++ b/src/desktop/externalApi/__fixtures__/externalClientApi-openapi.json
@@ -1423,6 +1423,9 @@
           "id": {
             "type": "string"
           },
+          "luid": {
+            "type": ["string", "null"]
+          },
           "name": {
             "type": "string"
           },

--- a/src/desktop/externalApi/externalApiClient.test.ts
+++ b/src/desktop/externalApi/externalApiClient.test.ts
@@ -212,8 +212,13 @@ describe('ExternalApiClient', () => {
 
     expect(result.isOk()).toBe(true);
     expect(result.unwrap().datasources).toEqual([
-      { id: 'wb-ds-superstore', name: 'Sample - Superstore', caption: 'Sample - Superstore' },
-      { id: 'wb-ds-quota', name: 'Quota Targets', caption: 'Quota Targets' },
+      {
+        id: 'wb-ds-superstore',
+        luid: 'luid-superstore',
+        name: 'Sample - Superstore',
+        caption: 'Sample - Superstore',
+      },
+      { id: 'wb-ds-quota', luid: null, name: 'Quota Targets', caption: 'Quota Targets' },
     ]);
 
     const last = server.requests.at(-1);

--- a/src/desktop/externalApi/externalApiClient.test.ts
+++ b/src/desktop/externalApi/externalApiClient.test.ts
@@ -211,6 +211,9 @@ describe('ExternalApiClient', () => {
     const result = await client.listWorkbookDatasources();
 
     expect(result.isOk()).toBe(true);
+    // The client passes the wire shape through verbatim: a real luid, an explicit
+    // null (embedded/federated), and an absent luid (legacy build) all round-trip
+    // as-is — the nullish() schema accepts string | null | undefined.
     expect(result.unwrap().datasources).toEqual([
       {
         id: 'wb-ds-superstore',
@@ -219,6 +222,7 @@ describe('ExternalApiClient', () => {
         caption: 'Sample - Superstore',
       },
       { id: 'wb-ds-quota', luid: null, name: 'Quota Targets', caption: 'Quota Targets' },
+      { id: 'wb-ds-legacy', name: 'Legacy Extract', caption: 'Legacy Extract' },
     ]);
 
     const last = server.requests.at(-1);

--- a/src/desktop/externalApi/externalApiContract.test.ts
+++ b/src/desktop/externalApi/externalApiContract.test.ts
@@ -39,7 +39,11 @@ import {
  * growth, route add/remove) surfaces as a red/green diff instead of a manual reread.
  *
  * Fixture provenance: live Desktop `/openapi.json`, `info.version` 0.1.0,
- * captured 2026-07-20.
+ * captured 2026-07-20 — PLUS one hand-applied edit: `DatasourceItem.luid`
+ * (["string","null"]) added ahead of the next capture, since the deployed spec
+ * had not yet surfaced the field when this shipped. Re-capture will replace it;
+ * if a future 0.1.x ever marks workbook `luid` required, this hand-edit would
+ * mask that until the next capture.
  */
 
 type SpecSchema = {

--- a/src/desktop/externalApi/mockExternalApiServer.ts
+++ b/src/desktop/externalApi/mockExternalApiServer.ts
@@ -95,11 +95,15 @@ const DEFAULT_STORYBOARDS = [
 const DEFAULT_WORKBOOK_DATASOURCES = [
   {
     id: 'wb-ds-superstore',
+    // Published, non-federated: the server resolves a real LUID.
+    luid: 'luid-superstore',
     name: 'Sample - Superstore',
     caption: 'Sample - Superstore',
   },
   {
     id: 'wb-ds-quota',
+    // Embedded/federated: the API emits luid: null.
+    luid: null,
     name: 'Quota Targets',
     caption: 'Quota Targets',
   },

--- a/src/desktop/externalApi/mockExternalApiServer.ts
+++ b/src/desktop/externalApi/mockExternalApiServer.ts
@@ -107,6 +107,14 @@ const DEFAULT_WORKBOOK_DATASOURCES = [
     name: 'Quota Targets',
     caption: 'Quota Targets',
   },
+  {
+    // luid absent entirely (older API build that predates the field): exercises
+    // the `undefined` leg of `luid: z.string().nullish()` — the reason it's
+    // nullish() rather than nullable(). Projected out of the tool output like null.
+    id: 'wb-ds-legacy',
+    name: 'Legacy Extract',
+    caption: 'Legacy Extract',
+  },
 ];
 const DEFAULT_SUMMARY_DATA = {
   columns: [

--- a/src/desktop/externalApi/types.ts
+++ b/src/desktop/externalApi/types.ts
@@ -266,6 +266,9 @@ export type WorkbookInventory = z.infer<typeof workbookInventorySchema>;
 export const datasourceItemSchema = z
   .object({
     id: z.string().optional(),
+    // Server LUID of the datasource; present only for a published, non-federated datasource and null
+    // otherwise. Mirrors the luid on `GET /v0/site/datasources` (nullable string in OpenAPI 3.1).
+    luid: z.string().nullish(),
     name: z.string().optional(),
     caption: z.string().optional(),
   })

--- a/src/desktop/externalApi/types.ts
+++ b/src/desktop/externalApi/types.ts
@@ -267,7 +267,9 @@ export const datasourceItemSchema = z
   .object({
     id: z.string().optional(),
     // Server LUID of the datasource; present only for a published, non-federated datasource and null
-    // otherwise. Mirrors the luid on `GET /v0/site/datasources` (nullable string in OpenAPI 3.1).
+    // otherwise. Same field as the luid on `GET /v0/site/datasources`, but nullable here (["string",
+    // "null"]) because the workbook endpoint emits null for embedded/federated datasources, whereas
+    // the site endpoint's luid is a plain string.
     luid: z.string().nullish(),
     name: z.string().optional(),
     caption: z.string().optional(),

--- a/src/tools/desktop/data-source/listWorkbookDatasources.test.ts
+++ b/src/tools/desktop/data-source/listWorkbookDatasources.test.ts
@@ -21,6 +21,7 @@ const resultSchema = z.object({
   datasources: z.array(
     z.object({
       id: z.string().optional(),
+      luid: z.string().optional(),
       name: z.string().optional(),
       caption: z.string().optional(),
     }),
@@ -38,7 +39,7 @@ describe('listWorkbookDatasourcesTool', () => {
 
     expect(tool.name).toBe('list-workbook-datasources');
     expect(tool.description).toContain("workbook's OWN connected datasources");
-    expect(tool.description).toContain('pair with list-site-datasources');
+    expect(tool.description).toContain('luid for published');
     expect(tool.paramsSchema).toMatchObject({ session: expect.any(Object) });
     expect(tool.annotations).toMatchObject({
       title: 'List Workbook Datasources',
@@ -63,8 +64,14 @@ describe('listWorkbookDatasourcesTool', () => {
       const result = await callback({ session: undefined }, extra);
 
       expect(result.isError).toBe(false);
+      // The published datasource surfaces its server LUID; the embedded one (luid: null) omits it.
       expect(parseResult(result).datasources).toEqual([
-        { id: 'wb-ds-superstore', name: 'Sample - Superstore', caption: 'Sample - Superstore' },
+        {
+          id: 'wb-ds-superstore',
+          luid: 'luid-superstore',
+          name: 'Sample - Superstore',
+          caption: 'Sample - Superstore',
+        },
         { id: 'wb-ds-quota', name: 'Quota Targets', caption: 'Quota Targets' },
       ]);
       expect(server.requests.at(-1)?.path).toBe('/v0/workbook/datasources');

--- a/src/tools/desktop/data-source/listWorkbookDatasources.test.ts
+++ b/src/tools/desktop/data-source/listWorkbookDatasources.test.ts
@@ -64,7 +64,9 @@ describe('listWorkbookDatasourcesTool', () => {
       const result = await callback({ session: undefined }, extra);
 
       expect(result.isError).toBe(false);
-      // The published datasource surfaces its server LUID; the embedded one (luid: null) omits it.
+      // The published datasource surfaces its server LUID; the embedded one
+      // (luid: null) and the legacy one (luid absent — the nullish() undefined
+      // leg) both omit it. Only a non-null string luid is projected.
       expect(parseResult(result).datasources).toEqual([
         {
           id: 'wb-ds-superstore',
@@ -73,6 +75,7 @@ describe('listWorkbookDatasourcesTool', () => {
           caption: 'Sample - Superstore',
         },
         { id: 'wb-ds-quota', name: 'Quota Targets', caption: 'Quota Targets' },
+        { id: 'wb-ds-legacy', name: 'Legacy Extract', caption: 'Legacy Extract' },
       ]);
       expect(server.requests.at(-1)?.path).toBe('/v0/workbook/datasources');
     } finally {

--- a/src/tools/desktop/data-source/listWorkbookDatasources.ts
+++ b/src/tools/desktop/data-source/listWorkbookDatasources.ts
@@ -20,7 +20,7 @@ export const getListWorkbookDatasourcesTool = (
     name: 'list-workbook-datasources',
     title,
     description:
-      "List the workbook's OWN connected datasources (id/name/caption); pair with list-site-datasources for published LUIDs.",
+      "List the workbook's OWN connected datasources (id/name/caption; luid for published, non-federated ones).",
     paramsSchema,
     annotations: {
       title,
@@ -60,11 +60,14 @@ export const getListWorkbookDatasourcesTool = (
 
 function projectDatasource(datasource: DatasourceItem): {
   id?: string;
+  luid?: string;
   name?: string;
   caption?: string;
 } {
   return {
     ...(datasource.id !== undefined ? { id: datasource.id } : {}),
+    // The API emits luid: null for embedded/federated datasources; only surface a real LUID.
+    ...(typeof datasource.luid === 'string' ? { luid: datasource.luid } : {}),
     ...(datasource.name !== undefined ? { name: datasource.name } : {}),
     ...(datasource.caption !== undefined ? { caption: datasource.caption } : {}),
   };


### PR DESCRIPTION
## What

Surfaces the new server `luid` on the `list-workbook-datasources` desktop tool.

The External Client API now returns a `luid` on each item of `GET /v0/workbook/datasources` — the server-assigned LUID for a published, non-federated datasource, and `null` otherwise. (Monolith side: sf-analyticscloud/monolith#60876, which corrects that field to resolve the datasource's contentUrl to the real server LUID so it mirrors `/v0/site/datasources`.) This PR wires that field through the MCP so `list-workbook-datasources` reports the LUID inline, instead of a consumer needing a second `list-site-datasources` call (or the `resolve-datasource-luid` web tool) to map a workbook connection to its published LUID.

I'm picking up the MCP follow-up while Lauren is out; this stacks on the desktop external-API read routes she wired in earlier.

## How

Mirrors how `siteDatasourceItemSchema` / `list-site-datasources` already handle `luid`:

- **types** — add a nullable `luid` (`z.string().nullish()`) to `datasourceItemSchema`.
- **list-workbook-datasources** — project `luid` only when it is a non-null string (the API emits `luid: null` for embedded/federated datasources); refresh the tool description.
- **tests/fixtures** — the mock workbook-datasources fixture now has one published datasource (`luid` set) and one embedded (`luid: null`); client + tool assertions updated; added `luid` (as the nullable `["string","null"]` shape the API emits) to the captured `externalClientApi-openapi.json` so the contract drift-guard test stays green.

## Testing

- Affected vitest suites green: `listWorkbookDatasources`, `externalApiClient`, `externalApiContract`, `externalApiToolExecutor` (121 tests).
- `eslint` and `tsc --project tsconfig.providers.json` clean.

## Notes

- Targets `feature/desktop` (where the desktop external-API surface lives), matching the base of the related desktop work.
- Depends on the monolith build that ships the `luid` field (#60876); until that lands the field is simply absent/`null` on the wire, which this handles gracefully (projected out).
