### PR TITLE
@W-23567697 - Reuse list-datasources resolver mode for datasource identity

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -306,9 +306,9 @@ export class Config extends BaseConfig {
     // Flow tools are gated off by default while flow rollouts are staged into
     // production; set FLOW_TOOLS_ENABLED=true to register them.
     this.flowToolsEnabled = flowToolsEnabled === 'true';
-    // Insight-cards tools (generate-insight-cards, resolve-datasource-luid) are
-    // gated off by default while the insights rollout is staged (keeps hosts
-    // like Slackbot stable); set INSIGHTS_TOOLS_ENABLED=true to register them.
+    // Insight-card tools are gated off by default while the rollout is staged
+    // (keeps hosts like Slackbot stable); set INSIGHTS_TOOLS_ENABLED=true to
+    // register generate-insight-cards and resolver paths.
     this.insightsToolsEnabled = insightsToolsEnabled === 'true';
 
     this.auth = isAuthType(auth) ? auth : this.oauth.enabled ? 'oauth' : 'pat';

--- a/src/scripts/createClaudeMcpBundleManifest.ts
+++ b/src/scripts/createClaudeMcpBundleManifest.ts
@@ -679,7 +679,7 @@ const envVars = {
     type: 'boolean',
     title: 'Enable insight-cards MCP tools',
     description:
-      'Registers the datasource-context insight tools (generate-insight-cards, resolve-datasource-luid). Disabled by default; set to "true" to enable them.',
+      'Registers insight-card tooling (generate-insight-cards plus datasource resolver paths including list-datasources resolveContentUrl and resolve-datasource-luid). Disabled by default; set to "true" to enable.',
     required: false,
     sensitive: false,
   },

--- a/src/tools/web/datasources/listDatasources.test.ts
+++ b/src/tools/web/datasources/listDatasources.test.ts
@@ -10,6 +10,7 @@ import { mockDatasources } from './mockDatasources.js';
 
 const mocks = vi.hoisted(() => ({
   mockListDatasources: vi.fn(),
+  mockIsDatasourceAllowed: vi.fn(),
 }));
 
 vi.mock('../../../restApiInstance.js', () => ({
@@ -23,9 +24,16 @@ vi.mock('../../../restApiInstance.js', () => ({
   ),
 }));
 
+vi.mock('../resourceAccessChecker.js', () => ({
+  resourceAccessChecker: {
+    isDatasourceAllowed: mocks.mockIsDatasourceAllowed,
+  },
+}));
+
 describe('listDatasourcesTool', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.mockIsDatasourceAllowed.mockResolvedValue({ allowed: true });
   });
 
   it('should create a tool instance with correct properties', () => {
@@ -56,6 +64,142 @@ describe('listDatasourcesTool', () => {
     expect(result.isError).toBe(true);
     invariant(result.content[0].type === 'text');
     expect(result.content[0].text).toContain(errorMessage);
+  });
+
+  it('should resolve a datasource by exact contentUrl using optional resolver mode', async () => {
+    mocks.mockListDatasources.mockResolvedValue({
+      ...mockDatasources,
+      datasources: [
+        { ...mockDatasources.datasources[0], id: 'wrong-case', contentUrl: 'gus-work' },
+        { ...mockDatasources.datasources[0], id: 'exact-case', contentUrl: 'GUS-Work' },
+      ],
+    });
+
+    const result = await getToolResult({ resolveContentUrl: 'GUS-Work' });
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0].id).toBe('exact-case');
+    expect(mocks.mockListDatasources).toHaveBeenCalledWith({
+      siteId: 'test-site-id',
+      filter: 'contentUrl:eq:GUS-Work',
+      pageSize: 100,
+      pageNumber: 1,
+    });
+    expect(mocks.mockIsDatasourceAllowed).toHaveBeenCalledWith(
+      expect.objectContaining({ datasourceLuid: 'exact-case' }),
+    );
+  });
+
+  it('should return identical no-match error for denied resolver hits (no existence oracle)', async () => {
+    mocks.mockListDatasources.mockResolvedValue({
+      ...mockDatasources,
+      datasources: [{ ...mockDatasources.datasources[0], id: 'denied', contentUrl: 'GUS-Work' }],
+    });
+    mocks.mockIsDatasourceAllowed.mockResolvedValue({ allowed: false, message: 'denied' });
+    const denied = await getToolResult({ resolveContentUrl: 'GUS-Work' });
+
+    mocks.mockListDatasources.mockResolvedValue({ ...mockDatasources, datasources: [] });
+    mocks.mockIsDatasourceAllowed.mockResolvedValue({ allowed: true });
+    const absent = await getToolResult({ resolveContentUrl: 'GUS-Work' });
+
+    expect(denied.isError).toBe(true);
+    expect(absent.isError).toBe(true);
+    invariant(denied.content[0].type === 'text');
+    invariant(absent.content[0].type === 'text');
+    expect(denied.content[0].text).toContain('No datasource matched contentUrl');
+    expect(denied.content[0].text).toBe(absent.content[0].text);
+  });
+
+  it('should return no-match when multiple exact candidates are all denied (no existence oracle)', async () => {
+    mocks.mockListDatasources.mockResolvedValue({
+      ...mockDatasources,
+      datasources: [
+        { ...mockDatasources.datasources[0], id: 'd1', contentUrl: 'GUS-Work' },
+        { ...mockDatasources.datasources[0], id: 'd2', contentUrl: 'GUS-Work' },
+      ],
+    });
+    mocks.mockIsDatasourceAllowed.mockResolvedValue({ allowed: false, message: 'denied' });
+
+    const result = await getToolResult({ resolveContentUrl: 'GUS-Work' });
+    expect(result.isError).toBe(true);
+    invariant(result.content[0].type === 'text');
+    expect(result.content[0].text).toContain('No datasource matched contentUrl');
+  });
+
+  it('should return the single allowed candidate when exact set includes denied items', async () => {
+    mocks.mockListDatasources.mockResolvedValue({
+      ...mockDatasources,
+      datasources: [
+        { ...mockDatasources.datasources[0], id: 'denied', contentUrl: 'GUS-Work' },
+        { ...mockDatasources.datasources[0], id: 'allowed', contentUrl: 'GUS-Work' },
+      ],
+    });
+    mocks.mockIsDatasourceAllowed.mockImplementation(async ({ datasourceLuid }) => ({
+      allowed: datasourceLuid === 'allowed',
+      message: 'denied',
+    }));
+
+    const result = await getToolResult({ resolveContentUrl: 'GUS-Work' });
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0].id).toBe('allowed');
+  });
+
+  it('should return ambiguous error when multiple allowed candidates remain', async () => {
+    mocks.mockListDatasources.mockResolvedValue({
+      ...mockDatasources,
+      datasources: [
+        { ...mockDatasources.datasources[0], id: 'a1', contentUrl: 'GUS-Work' },
+        { ...mockDatasources.datasources[0], id: 'a2', contentUrl: 'GUS-Work' },
+      ],
+    });
+    mocks.mockIsDatasourceAllowed.mockResolvedValue({ allowed: true });
+
+    const result = await getToolResult({ resolveContentUrl: 'GUS-Work' });
+    expect(result.isError).toBe(true);
+    invariant(result.content[0].type === 'text');
+    expect(result.content[0].text).toContain('Multiple datasources matched contentUrl');
+  });
+
+  it('should reject requests that pass filter and resolveContentUrl together', async () => {
+    const result = await getToolResult({
+      filter: 'name:eq:Superstore',
+      resolveContentUrl: 'GUS-Work',
+    });
+    expect(result.isError).toBe(true);
+    invariant(result.content[0].type === 'text');
+    expect(result.content[0].text).toContain('Pass either "filter" or "resolveContentUrl"');
+  });
+
+  it('should reject pagination arguments in resolver mode', async () => {
+    const result = await getToolResult({
+      resolveContentUrl: 'GUS-Work',
+      pageSize: 25,
+    });
+    expect(result.isError).toBe(true);
+    invariant(result.content[0].type === 'text');
+    expect(result.content[0].text).toContain('Resolver mode does not accept "pageSize" or "limit"');
+  });
+
+  it('should reject resolver mode when INSIGHTS_TOOLS_ENABLED is false', async () => {
+    const result = await getToolResult({
+      resolveContentUrl: 'GUS-Work',
+      insightsToolsEnabled: false,
+    });
+    expect(result.isError).toBe(true);
+    invariant(result.content[0].type === 'text');
+    expect(result.content[0].text).toContain('Resolver mode is disabled');
+  });
+
+  it('should reject resolver contentUrl values that break filter grammar', async () => {
+    const result = await getToolResult({ resolveContentUrl: 'Sales,Ops' });
+    expect(result.isError).toBe(true);
+    invariant(result.content[0].type === 'text');
+    expect(result.content[0].text).toContain('Invalid filter expression format');
   });
 
   describe('constrainDatasources', () => {
@@ -131,11 +275,24 @@ describe('listDatasourcesTool', () => {
   });
 });
 
-async function getToolResult(params: { filter: string }): Promise<CallToolResult> {
+async function getToolResult(params: {
+  filter?: string;
+  resolveContentUrl?: string;
+  pageSize?: number;
+  limit?: number;
+  insightsToolsEnabled?: boolean;
+}): Promise<CallToolResult> {
   const listDatasourcesTool = getListDatasourcesTool(new WebMcpServer());
   const callback = await Provider.from(listDatasourcesTool.callback);
+  const extra = getMockRequestHandlerExtra();
+  extra.config.insightsToolsEnabled = params.insightsToolsEnabled ?? true;
   return await callback(
-    { filter: params.filter, pageSize: undefined, limit: undefined },
-    getMockRequestHandlerExtra(),
+    {
+      filter: params.filter,
+      resolveContentUrl: params.resolveContentUrl,
+      pageSize: params.pageSize,
+      limit: params.limit,
+    },
+    extra,
   );
 }

--- a/src/tools/web/datasources/listDatasources.ts
+++ b/src/tools/web/datasources/listDatasources.ts
@@ -2,17 +2,20 @@ import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { Ok } from 'ts-results-es';
 import { z } from 'zod';
 
+import { ArgsValidationError } from '../../../errors/mcpToolError.js';
 import { BoundedContext } from '../../../overridableConfig.js';
 import { useRestApi } from '../../../restApiInstance.js';
 import { DataSource } from '../../../sdks/tableau/types/dataSource.js';
 import { WebMcpServer } from '../../../server.web.js';
 import { paginate } from '../../../utils/paginate.js';
 import { genericFilterDescription } from '../genericFilterDescription.js';
+import { resourceAccessChecker } from '../resourceAccessChecker.js';
 import { ConstrainedResult, WebTool } from '../tool.js';
 import { parseAndValidateDatasourcesFilterString } from './datasourcesFilterUtils.js';
 
 const paramsSchema = {
   filter: z.string().optional(),
+  resolveContentUrl: z.string().nonempty().optional(),
   pageSize: z.number().gt(0).optional(),
   limit: z.number().gt(0).optional(),
 };
@@ -23,6 +26,8 @@ export const getListDatasourcesTool = (server: WebMcpServer): WebTool<typeof par
     name: 'list-datasources',
     description: `
   Retrieves a list of published data sources from a specified Tableau site using the Tableau REST API. Supports optional filtering via field:operator:value expressions (e.g., name:eq:Views) for precise and flexible data source discovery. Use this tool when a user requests to list, search, or filter Tableau data sources on a site.
+
+  Resolver mode: pass "resolveContentUrl" to deterministically resolve one datasource by exact, case-sensitive contentUrl and return a single-entry array containing the canonical datasource LUID.
 
   **Supported Filter Fields and Operators**
   | Field                  | Operators                                 |
@@ -70,6 +75,8 @@ export const getListDatasourcesTool = (server: WebMcpServer): WebTool<typeof par
       filter: "createdAt:gt:2023-01-01T00:00:00Z"
   - List data sources with the name "Project Views" in the "Finance" project and created after January 1, 2023:
       filter: "name:eq:Project Views,projectName:eq:Finance,createdAt:gt:2023-01-01T00:00:00Z"
+  - Resolve a datasource LUID from exact contentUrl (single-tool mode):
+      resolveContentUrl: "GUS-Work"
   `,
     paramsSchema,
     annotations: {
@@ -79,17 +86,57 @@ export const getListDatasourcesTool = (server: WebMcpServer): WebTool<typeof par
       idempotentHint: true,
       openWorldHint: false,
     },
-    callback: async ({ filter, pageSize, limit }, extra): Promise<CallToolResult> => {
+    callback: async (
+      { filter, resolveContentUrl, pageSize, limit },
+      extra,
+    ): Promise<CallToolResult> => {
       const configWithOverrides = await extra.getConfigWithOverrides();
-      const validatedFilter = filter ? parseAndValidateDatasourcesFilterString(filter) : undefined;
       return await listDatasourcesTool.logAndExecute({
         extra,
-        args: { filter, pageSize, limit },
+        args: { filter, resolveContentUrl, pageSize, limit },
         callback: async () => {
+          if (filter && resolveContentUrl) {
+            return new ArgsValidationError(
+              'Pass either "filter" or "resolveContentUrl", not both in the same request.',
+            ).toErr();
+          }
+
+          const validatedFilter = filter
+            ? parseAndValidateDatasourcesFilterString(filter)
+            : undefined;
+
+          if (
+            resolveContentUrl &&
+            (typeof pageSize !== 'undefined' || typeof limit !== 'undefined')
+          ) {
+            return new ArgsValidationError(
+              'Resolver mode does not accept "pageSize" or "limit". Remove those arguments.',
+            ).toErr();
+          }
+
+          if (resolveContentUrl && !extra.config.insightsToolsEnabled) {
+            return new ArgsValidationError(
+              'Resolver mode is disabled. Set INSIGHTS_TOOLS_ENABLED=true to use "resolveContentUrl".',
+            ).toErr();
+          }
+
           const datasources = await useRestApi({
             ...extra,
             jwtScopes: listDatasourcesTool.requiredApiScopes,
             callback: async (restApi) => {
+              if (resolveContentUrl) {
+                const resolverFilter = parseAndValidateDatasourcesFilterString(
+                  `contentUrl:eq:${resolveContentUrl}`,
+                );
+                const response = await restApi.datasourcesMethods.listDatasources({
+                  siteId: restApi.siteId,
+                  filter: resolverFilter,
+                  pageSize: 100,
+                  pageNumber: 1,
+                });
+                return response.datasources;
+              }
+
               const maxResultLimit = configWithOverrides.getMaxResultLimit(
                 listDatasourcesTool.name,
               );
@@ -118,10 +165,53 @@ export const getListDatasourcesTool = (server: WebMcpServer): WebTool<typeof par
             },
           });
 
+          if (resolveContentUrl) {
+            const exact = datasources.filter(
+              (datasource) => datasource.contentUrl === resolveContentUrl,
+            );
+
+            const allowedExact: Array<DataSource> = [];
+            await Promise.all(
+              exact.map(async (candidate) => {
+                const allowed = (
+                  await resourceAccessChecker.isDatasourceAllowed({
+                    datasourceLuid: candidate.id,
+                    extra,
+                  })
+                ).allowed;
+                if (allowed) {
+                  allowedExact.push(candidate);
+                }
+              }),
+            );
+
+            if (allowedExact.length === 0) {
+              return new ArgsValidationError(
+                `No datasource matched contentUrl "${resolveContentUrl}"`,
+              ).toErr();
+            }
+
+            if (allowedExact.length > 1) {
+              return new ArgsValidationError(
+                `Multiple datasources matched contentUrl "${resolveContentUrl}" in allowed scope.`,
+              ).toErr();
+            }
+
+            return new Ok(allowedExact);
+          }
+
           return new Ok(datasources);
         },
-        constrainSuccessResult: (datasources) =>
-          constrainDatasources({ datasources, boundedContext: configWithOverrides.boundedContext }),
+        constrainSuccessResult: (datasources) => {
+          if (resolveContentUrl) {
+            return { type: 'success', result: datasources };
+          }
+
+          return constrainDatasources({
+            datasources,
+            boundedContext: configWithOverrides.boundedContext,
+          });
+        },
       });
     },
   });

--- a/src/tools/web/datasources/resolveDatasourceLuid.test.ts
+++ b/src/tools/web/datasources/resolveDatasourceLuid.test.ts
@@ -82,6 +82,13 @@ describe('resolveDatasourceLuid', () => {
       expect.objectContaining({ datasourceLuid: '2' }),
     );
   });
+
+  it('rejects contentUrl values that break filter grammar', async () => {
+    const result = await getToolResult('Sales,Ops');
+    expect(result.isError).toBe(true);
+    invariant(result.content[0].type === 'text');
+    expect(result.content[0].text).toContain('Invalid filter expression format');
+  });
 });
 
 async function getToolResult(contentUrl: string): Promise<CallToolResult> {

--- a/src/tools/web/datasources/resolveDatasourceLuid.ts
+++ b/src/tools/web/datasources/resolveDatasourceLuid.ts
@@ -8,6 +8,7 @@ import { useRestApi } from '../../../restApiInstance.js';
 import { WebMcpServer } from '../../../server.web.js';
 import { resourceAccessChecker } from '../resourceAccessChecker.js';
 import { WebTool } from '../tool.js';
+import { parseAndValidateDatasourcesFilterString } from './datasourcesFilterUtils.js';
 
 const paramsSchema = {
   contentUrl: z.string().nonempty(),
@@ -21,7 +22,7 @@ export const getResolveDatasourceLuidTool = (
     server,
     name: 'resolve-datasource-luid',
     description:
-      'Resolve a published datasource LUID by exact, case-sensitive datasource contentUrl match.',
+      'Resolve a published datasource LUID by exact, case-sensitive datasource contentUrl match. Prefer list-datasources with resolveContentUrl for new callers.',
     // Gated off by default (INSIGHTS_TOOLS_ENABLED) alongside generate-insight-cards.
     disabled: !config.insightsToolsEnabled,
     paramsSchema,
@@ -41,9 +42,12 @@ export const getResolveDatasourceLuidTool = (
             ...extra,
             jwtScopes: tool.requiredApiScopes,
             callback: async (restApi) => {
+              const resolverFilter = parseAndValidateDatasourcesFilterString(
+                `contentUrl:eq:${contentUrl}`,
+              );
               const response = await restApi.datasourcesMethods.listDatasources({
                 siteId: restApi.siteId,
-                filter: `contentUrl:eq:${contentUrl}`,
+                filter: resolverFilter,
                 pageSize: 100,
                 pageNumber: 1,
               });


### PR DESCRIPTION
## Summary
- add optional `resolveContentUrl` mode to `list-datasources` so callers can deterministically resolve exact `contentUrl -> LUID` through a single tool surface
- preserve no-oracle behavior in resolver mode by returning the same error for denied-vs-absent matches, and reject ambiguous parameter usage (`filter` + `resolveContentUrl`)
- keep `resolve-datasource-luid` available for compatibility, while documenting `list-datasources` resolver mode as the preferred path

## Test plan
- [x] `nvm use 22 && npm run test -- src/tools/web/datasources/listDatasources.test.ts src/tools/web/datasources/resolveDatasourceLuid.test.ts`
- [x] `nvm use 22 && npm run lint -- src/tools/web/datasources/listDatasources.ts src/tools/web/datasources/listDatasources.test.ts src/tools/web/datasources/resolveDatasourceLuid.ts src/config.ts src/scripts/createClaudeMcpBundleManifest.ts`

Made with [Cursor](https://cursor.com)