### PR TITLE
@W-XXXX: log OAuth client id on tool calls

### DIFF
--- a/src/tools/web/tool.test.ts
+++ b/src/tools/web/tool.test.ts
@@ -4,6 +4,7 @@ import { Ok } from 'ts-results-es';
 import { z, ZodError } from 'zod';
 
 import { DatasourceNotAllowedError, ZodiosValidationError } from '../../errors/mcpToolError.js';
+import * as logger from '../../logging/logger.js';
 import { notifier } from '../../logging/notification.js';
 import { WebMcpServer } from '../../server.web.js';
 import { TableauAuthInfo } from '../../server/oauth/schemas.js';
@@ -451,6 +452,84 @@ describe('Tool', () => {
           oauth_client_display_name: 'Claude',
         }),
       );
+    });
+  });
+
+  describe('invocation log', () => {
+    let logSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      logSpy = vi.spyOn(logger, 'log').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      logSpy.mockRestore();
+    });
+
+    function loggedClientId(): unknown {
+      const entry = vi
+        .mocked(logger.log)
+        .mock.calls.map((call) => call[0])
+        .find((entry) => entry.logger === 'tool' && entry.message.includes('invoked'));
+      invariant(entry);
+      return (entry.data as { oauthClientId?: unknown }).oauthClientId;
+    }
+
+    async function invoke(extra: typeof mockExtra): Promise<void> {
+      const tool = new WebTool(mockParams);
+      await tool.logAndExecute({
+        extra,
+        args: { param1: 'test-value' },
+        callback: () => Promise.resolve(Ok({ data: 'success' })),
+        constrainSuccessResult: (result) => ({ type: 'success', result }),
+      });
+    }
+
+    it('logs the Bearer clientId', async () => {
+      const clientId = 'https://claude.ai/.well-known/oauth/client-metadata.json';
+      await invoke({
+        ...mockExtra,
+        tableauAuthInfo: {
+          type: 'Bearer',
+          username: 'user@example.com',
+          server: 'https://my-tableau.example.com',
+          siteId: 'abc123',
+          siteName: 'my-site',
+          userId: 'uid-1',
+          raw: 'fake-token',
+          clientId,
+        },
+      });
+
+      expect(loggedClientId()).toBe(clientId);
+    });
+
+    it('falls back to authInfo.clientId on the embedded-OAuth path', async () => {
+      const clientId = 'https://claude.ai/.well-known/oauth/client-metadata.json';
+      const embeddedTableauAuthInfo: TableauAuthInfo = {
+        type: 'X-Tableau-Auth',
+        username: 'user@example.com',
+        server: 'https://my-tableau.example.com',
+        siteName: 'my-site',
+        userId: 'uid-1',
+      };
+      await invoke({
+        ...mockExtra,
+        tableauAuthInfo: embeddedTableauAuthInfo,
+        authInfo: {
+          token: 'fake-mcp-access-token',
+          clientId,
+          scopes: [],
+          extra: embeddedTableauAuthInfo,
+        },
+      });
+
+      expect(loggedClientId()).toBe(clientId);
+    });
+
+    it('logs undefined when no client id is present', async () => {
+      await invoke(mockExtra);
+      expect(loggedClientId()).toBeUndefined();
     });
   });
 

--- a/src/tools/web/tool.ts
+++ b/src/tools/web/tool.ts
@@ -153,6 +153,7 @@ export class WebTool<Args extends ZodRawShape | undefined = undefined> extends T
       message: `Tool ${this.name} invoked: requestId=${requestId}, args=${JSON.stringify(args)}`,
       level: 'debug',
       logger: 'tool',
+      data: { oauthClientId },
     });
 
     const productTelemetryForwarder = getProductTelemetry(


### PR DESCRIPTION
## Description

Adds OAuth client ID logging to all tool calls for improved observability and debugging.

## Motivation and Context

This change enhances the existing per-tool-call debug logging by including the OAuth client ID. This helps trace which OAuth clients are invoking specific tools, supporting both standard Tableau OAuth and embedded OAuth flows.

## Type of Change

- [x] New feature

## How Has This Been Tested?

- Added comprehensive unit tests in `src/tools/web/tool.test.ts` covering three scenarios:
  - Tableau OAuth (Bearer token with `.clientId`)
  - Embedded OAuth (`extra.authInfo.clientId` fallback)
  - Missing client ID (logs as `undefined`)
- All tests pass locally
- Independent review completed with VERDICT: PASS

## Related Issues

N/A

## Checklist

- [ ] I have updated the version in the package.json file by using `npm run version`.
- [ ] I have made any necessary changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have documented any breaking changes in the PR description.

## Contributor Agreement

- [x] I have read the [CONTRIBUTING guidelines](../../CONTRIBUTING.md) for this project and followed its Contribution Checklist.