### PR TITLE
@W-23558751: Remove MCP App wiring from get-view and get-workbook

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "3.6.0",
+      "version": "3.6.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.7.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/src/server.web.test.ts
+++ b/src/server.web.test.ts
@@ -6,7 +6,7 @@ import { getQueryDatasourceTool } from './tools/web/queryDatasource/queryDatasou
 import { WebTool } from './tools/web/tool.js';
 import { TableauWebToolCallback } from './tools/web/toolContext.js';
 import { getMockRequestHandlerExtra } from './tools/web/toolContext.mock.js';
-import { webToolNames } from './tools/web/toolName.js';
+import { WebToolName, webToolNames } from './tools/web/toolName.js';
 import { webToolFactories } from './tools/web/tools.js';
 import invariant from './utils/invariant.js';
 import { Provider } from './utils/provider.js';
@@ -57,7 +57,7 @@ describe('server', () => {
 
   function createMockAppTool(): WebTool<any> {
     return {
-      name: 'get-workbook',
+      name: 'mock-app-tool' as WebToolName,
       server: {} as any,
       title: 'Test App Tool',
       description: 'Test App Tool',
@@ -293,7 +293,7 @@ describe('server', () => {
 
     expect(mocks.mockRegisterAppTool).toHaveBeenCalledWith(
       server.mcpServer,
-      'get-workbook',
+      'mock-app-tool',
       {
         title: 'Test App Tool',
         description: 'Test App Tool',
@@ -317,7 +317,7 @@ describe('server', () => {
     // Assert registerAppResource was called with correct options (no _meta in options)
     expect(mocks.mockRegisterAppResource).toHaveBeenCalledWith(
       server.mcpServer,
-      'get-workbook',
+      'mock-app-tool',
       'tableau://app/test',
       {
         mimeType: expect.any(String),
@@ -374,7 +374,7 @@ describe('server', () => {
 
     // Should register as standard tool, not app tool
     expect(server.mcpServer.registerTool).toHaveBeenCalledWith(
-      'get-workbook',
+      'mock-app-tool',
       {
         title: 'Test App Tool',
         description: 'Test App Tool',

--- a/src/tools/web/views/getView.ts
+++ b/src/tools/web/views/getView.ts
@@ -13,9 +13,8 @@ import {
 import { View } from '../../../sdks/tableau/types/view.js';
 import { WebMcpServer } from '../../../server.web.js';
 import { getExceptionMessage } from '../../../utils/getExceptionMessage.js';
-import { getAppConfig } from '../../../web/apps/appConfig.js';
 import { resourceAccessChecker } from '../resourceAccessChecker.js';
-import { AppToolResult, WebTool } from '../tool.js';
+import { WebTool } from '../tool.js';
 import { constructViewWebUrl } from '../utils/viewUrlUtils.js';
 
 const paramsSchema = {
@@ -36,11 +35,10 @@ export const getGetViewTool = (server: WebMcpServer): WebTool<typeof paramsSchem
       idempotentHint: true,
       openWorldHint: false,
     },
-    app: getAppConfig('get-view'),
     callback: async ({ viewId }, extra): Promise<CallToolResult> => {
       const configWithOverrides = await extra.getConfigWithOverrides();
 
-      return await getViewTool.logAndExecute<AppToolResult<View>>({
+      return await getViewTool.logAndExecute<{ data: View; url: string }>({
         extra,
         args: { viewId },
         callback: async () => {

--- a/src/tools/web/workbooks/getWorkbook.ts
+++ b/src/tools/web/workbooks/getWorkbook.ts
@@ -14,9 +14,8 @@ import {
 import { Workbook } from '../../../sdks/tableau/types/workbook.js';
 import { WebMcpServer } from '../../../server.web.js';
 import { getExceptionMessage } from '../../../utils/getExceptionMessage.js';
-import { getAppConfig } from '../../../web/apps/appConfig.js';
 import { resourceAccessChecker } from '../resourceAccessChecker.js';
-import { AppToolResult, WebTool } from '../tool.js';
+import { WebTool } from '../tool.js';
 import { getDefaultViewWebUrl } from '../utils/viewUrlUtils.js';
 
 const paramsSchema = {
@@ -37,11 +36,10 @@ export const getGetWorkbookTool = (server: WebMcpServer): WebTool<typeof paramsS
       idempotentHint: true,
       openWorldHint: false,
     },
-    app: getAppConfig('get-workbook'),
     callback: async ({ workbookId }, extra): Promise<CallToolResult> => {
       const configWithOverrides = await extra.getConfigWithOverrides();
 
-      return await getWorkbookTool.logAndExecute<AppToolResult<Workbook>>({
+      return await getWorkbookTool.logAndExecute<{ data: Workbook; url: string }>({
         extra,
         args: { workbookId },
         callback: async () => {


### PR DESCRIPTION
## Description

- Remove the `app: getAppConfig(...)` wiring from `get-view` and `get-workbook` so they no longer register an embedded-viz MCP App UI resource.
- Both tools keep returning `{ data, url }` — the Tableau web URL stays available to the model as metadata.
- Rename the synthetic app-tool test fixture in `server.web.test.ts` off the real `get-workbook` name (`mock-app-tool`) so it no longer implies these tools are App tools.

## Motivation and Context

Rendering an interactive viz is now the job of `render-interactive-viz` (#625). `get-view`/`get-workbook` should not also embed a viz. Shared embed infrastructure (the `embed-viz` bundle, `get-embed-token`, `record-event`) is intentionally left untouched — it is still used by `render-interactive-viz`.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Other (please describe): Remove a tool capability (MCP App UI) while preserving the tool result shape

## How Has This Been Tested?

- `npx vitest run` — 2515 tests pass (161 files)
- `npx tsc --noEmit` — clean
- `npm run build` — MCP Apps build successfully
- `npx eslint` on the changed files — clean

## Related Issues

W-23558751 (follow-on to #625)

## Checklist

- [x] I have updated the version in the package.json file (`npm run version:patch` → 3.6.1)
- [ ] I have made any necessary changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have documented any breaking changes in the PR description