### PR TITLE
list-available-fields: drop column-ref-only fields from slim verbosity

### DIFF
--- a/src/tools/desktop/fields/listAvailableFields.test.ts
+++ b/src/tools/desktop/fields/listAvailableFields.test.ts
@@ -335,9 +335,7 @@ describe('listAvailableFieldsTool', () => {
       role: 'dimension',
       datatype: 'string',
     });
-    // Slim carries only the field-picking essentials: the full column_ref and the
-    // column-ref-reconstruction ingredients (columnInstanceName/derivation/typePivot)
-    // are omitted.
+    // Slim omits column_ref and the columnInstanceName/derivation/typePivot fields.
     const first = groupFields[0] as Record<string, unknown>;
     expect(first.column_ref).toBeUndefined();
     expect(first.columnInstanceName).toBeUndefined();

--- a/src/tools/desktop/fields/listAvailableFields.test.ts
+++ b/src/tools/desktop/fields/listAvailableFields.test.ts
@@ -287,10 +287,7 @@ describe('listAvailableFieldsTool', () => {
           z.object({
             caption: z.string(),
             localName: z.string(),
-            columnInstanceName: z.string(),
-            derivation: z.string(),
             type: z.string(),
-            typePivot: z.string(),
             role: z.string(),
             datatype: z.string().optional(),
             isAggregated: z.boolean().optional(),
@@ -327,33 +324,31 @@ describe('listAvailableFieldsTool', () => {
     expect(groupFields[0]).toMatchObject({
       caption: 'Profit',
       localName: 'Profit',
-      columnInstanceName: '[sum:Profit:qk]',
-      derivation: 'Sum',
       type: 'quantitative',
-      typePivot: 'qk',
       role: 'measure',
       datatype: 'real',
     });
     expect(groupFields[1]).toMatchObject({
       caption: 'Category',
       localName: 'Category',
-      columnInstanceName: '[none:Category:nk]',
-      derivation: 'None',
       type: 'nominal',
-      typePivot: 'nk',
       role: 'dimension',
       datatype: 'string',
     });
-    // Slim keeps enough metadata to construct [datasource].[derivation:LocalName:typePivot],
-    // while omitting the full column_ref and less common verbose metadata.
+    // Slim carries only the field-picking essentials: the full column_ref and the
+    // column-ref-reconstruction ingredients (columnInstanceName/derivation/typePivot)
+    // are omitted.
     const first = groupFields[0] as Record<string, unknown>;
     expect(first.column_ref).toBeUndefined();
+    expect(first.columnInstanceName).toBeUndefined();
+    expect(first.derivation).toBeUndefined();
+    expect(first.typePivot).toBeUndefined();
     expect(first.name).toBeUndefined();
     expect(first.datasource).toBeUndefined();
     expect(first.semanticRole).toBeUndefined();
   });
 
-  it('verbosity=slim carries usr derivation metadata for already-aggregated calc fields', async () => {
+  it('verbosity=slim flags already-aggregated calc fields with isAggregated', async () => {
     const aggregatedCalcFields = [
       {
         ...mockFields[0],
@@ -379,14 +374,15 @@ describe('listAvailableFieldsTool', () => {
     expect(calc).toMatchObject({
       caption: 'Profit Ratio',
       localName: 'Calculation_123',
-      columnInstanceName: '[usr:Calculation_123:qk]',
-      derivation: 'User',
       type: 'quantitative',
-      typePivot: 'qk',
       role: 'measure',
       datatype: 'real',
       isAggregated: true,
     });
+    // Column-ref ingredients and the raw formula/column_ref are all omitted.
+    expect(calc.columnInstanceName).toBeUndefined();
+    expect(calc.derivation).toBeUndefined();
+    expect(calc.typePivot).toBeUndefined();
     expect(calc.column_ref).toBeUndefined();
     expect(calc.formula).toBeUndefined();
   });
@@ -486,10 +482,7 @@ describe('listAvailableFieldsTool', () => {
       {
         caption: 'Sales',
         localName: 'Sales',
-        columnInstanceName: '[sum:Sales:qk]',
-        derivation: 'Sum',
         type: 'quantitative',
-        typePivot: 'qk',
         role: 'measure',
         datatype: 'real',
       },

--- a/src/tools/desktop/fields/listAvailableFields.ts
+++ b/src/tools/desktop/fields/listAvailableFields.ts
@@ -21,7 +21,9 @@ const paramsSchema = {
   verbosity: z
     .enum(['slim', 'full'])
     .optional()
-    .describe('full (default): table + column_ref. slim: grouped ref parts, no column_ref.'),
+    .describe(
+      'full (default): table + column_ref. slim: caption/localName/type/role/datatype only.',
+    ),
 };
 
 class WorkbookFileNotFoundError extends McpToolError {
@@ -47,12 +49,6 @@ const typeAbbrev = (type: string): string => {
   return type;
 };
 
-const typePivot = (type: string): string => {
-  if (type === 'quantitative') return 'qk';
-  if (type === 'ordinal') return 'ok';
-  return 'nk';
-};
-
 const tableauDatatypeLabel = (datatype?: string): string => {
   switch (datatype) {
     case 'integer':
@@ -75,10 +71,7 @@ const tableauDatatypeLabel = (datatype?: string): string => {
 interface SlimField {
   caption: string;
   localName: string;
-  columnInstanceName: string;
-  derivation: string;
   type: string;
-  typePivot: string;
   role: string;
   datatype?: string;
   isAggregated?: boolean;
@@ -174,8 +167,12 @@ export const getListAvailableFieldsTool = (
 
           const fields = listAvailableFields(workbookXml);
 
-          // Slim: no table and no full column_ref, but keep the ingredients
-          // needed to construct [datasource].[derivation:LocalName:typePivot].
+          // Slim keeps only what a field-picking caller needs: caption (display
+          // name), localName (the field identifier), type/role/datatype, and the
+          // isAggregated flag. The column-ref ingredients (columnInstanceName,
+          // derivation, typePivot) are dropped — they only serve column-ref
+          // reconstruction, which slim callers don't do, and they dominate the
+          // per-field byte count on wide datasources.
           //
           // `listAvailableFields` spans ALL datasources (one flat array, each
           // field carrying its own datasource). Slim always GROUPS by
@@ -191,10 +188,7 @@ export const getListAvailableFieldsTool = (
               return {
                 caption: f.caption || localName,
                 localName,
-                columnInstanceName: f.columnInstanceName,
-                derivation: f.derivation,
                 type: f.type,
-                typePivot: typePivot(f.type),
                 role: f.role,
                 datatype: f.datatype,
                 ...(f.isAggregated ? { isAggregated: true } : {}),


### PR DESCRIPTION
## What

`verbosity: "slim"` on `list-available-fields` now returns only the field-picking essentials per field:

```
{ caption, localName, type, role, datatype?, isAggregated? }
```

Three keys are dropped from each slim field:

- `columnInstanceName`
- `derivation`
- `typePivot`

The now-unused `typePivot()` helper is removed with them.

## Why

Those three keys were **column-ref reconstruction ingredients** — they let a caller rebuild `[datasource].[derivation:LocalName:typePivot]`. Slim callers (the viz-canvas insight-bundle flow) never reconstruct column refs; they pick fields by caption/localName/type/role and hand the localName back. The dropped keys carried no signal for that path and dominated the per-field byte count on wide datasources, so slim payloads shrink materially with no loss to any slim consumer.

Full verbosity (the default) is unchanged — it still emits the table + `column_ref`.

## Test

- `listAvailableFields.test.ts` updated: slim schema drops the three keys; the slim `toMatchObject` assertions drop them; new `toBeUndefined` assertions pin that they are absent; the aggregated-calc test is retargeted to assert `isAggregated` (the flag it actually still needs) rather than the removed derivation metadata.
- `npx tsc -p tsconfig.json --noEmit` clean, `npm run lint` clean, `npx vitest run listAvailableFields.test.ts` → 15/15 pass.