### PR TITLE
feat(desktop): put a deadline on every Tableau Desktop call

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "2.33.0",
+  "version": "2.57.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "2.33.0",
+      "version": "2.57.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.7.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "2.56.2",
+  "version": "2.57.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/src/config.desktop.ts
+++ b/src/config.desktop.ts
@@ -1,4 +1,8 @@
 import { BaseConfig, removeClaudeMcpBundleUserConfigTemplates } from './config.shared.js';
+import {
+  DEFAULT_DESKTOP_CALL_TIMEOUT_MS,
+  MIN_DESKTOP_CALL_TIMEOUT_MS,
+} from './desktop/callDeadline.js';
 import { DEFAULT_INLINE_XML_MAX_BYTES } from './desktop/inlineXmlCap.js';
 import { parseNumber } from './utils/parseNumber.js';
 
@@ -23,6 +27,13 @@ export class Config extends BaseConfig {
    */
   desktopSessionId: string | undefined;
 
+  /**
+   * Wall-clock ceiling (ms) on a single desktop tool call. Past it the call aborts and the
+   * agent is told Desktop stopped answering. Env-overridable via TABLEAU_DESKTOP_CALL_TIMEOUT_MS;
+   * values under MIN_DESKTOP_CALL_TIMEOUT_MS are ignored because they would cut real work.
+   */
+  desktopCallTimeoutMs: number;
+
   constructor() {
     super();
 
@@ -31,6 +42,7 @@ export class Config extends BaseConfig {
       INLINE_XML_MAX_BYTES: inlineXmlMaxBytes,
       TABLEAU_EXTERNAL_API_DISCOVERY_DIR: externalApiDiscoveryDir,
       TABLEAU_DESKTOP_SESSION_ID: desktopSessionId,
+      TABLEAU_DESKTOP_CALL_TIMEOUT_MS: desktopCallTimeoutMs,
     } = cleansedVars;
 
     if (this.transport !== 'stdio') {
@@ -44,6 +56,11 @@ export class Config extends BaseConfig {
     this.inlineXmlMaxBytes = parseNumber(inlineXmlMaxBytes, {
       defaultValue: DEFAULT_INLINE_XML_MAX_BYTES,
       minValue: 1,
+    });
+
+    this.desktopCallTimeoutMs = parseNumber(desktopCallTimeoutMs, {
+      defaultValue: DEFAULT_DESKTOP_CALL_TIMEOUT_MS,
+      minValue: MIN_DESKTOP_CALL_TIMEOUT_MS,
     });
   }
 }

--- a/src/desktop/callDeadline.test.ts
+++ b/src/desktop/callDeadline.test.ts
@@ -1,0 +1,115 @@
+import {
+  createCallDeadline,
+  DEFAULT_DESKTOP_CALL_TIMEOUT_MS,
+  DesktopCallTimeoutError,
+  desktopCallTimeoutMessage,
+  isDesktopCallTimeout,
+} from './callDeadline.js';
+
+describe('createCallDeadline', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('defaults to a budget that clears the largest legitimate measured call (37.5s)', () => {
+    expect(DEFAULT_DESKTOP_CALL_TIMEOUT_MS).toBeGreaterThan(37_543);
+    // ...and stays below the fastest observed hang (212.4s), so it lands inside the empty band.
+    expect(DEFAULT_DESKTOP_CALL_TIMEOUT_MS).toBeLessThan(212_388);
+  });
+
+  it('aborts its signal and rejects whenExpired once the budget elapses', async () => {
+    const deadline = createCallDeadline({ budgetMs: 60_000 });
+    const expiry = deadline.whenExpired();
+
+    expect(deadline.signal.aborted).toBe(false);
+    expect(deadline.expired()).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(deadline.signal.aborted).toBe(true);
+    expect(deadline.expired()).toBe(true);
+    expect(deadline.signal.reason).toBeInstanceOf(DesktopCallTimeoutError);
+    await expect(expiry).rejects.toBeInstanceOf(DesktopCallTimeoutError);
+
+    deadline.dispose();
+  });
+
+  it('does not cut a legitimate 37.5s call', async () => {
+    const deadline = createCallDeadline({ budgetMs: DEFAULT_DESKTOP_CALL_TIMEOUT_MS });
+
+    // The real measured apply-workbook success from the episode logs.
+    await vi.advanceTimersByTimeAsync(37_543);
+
+    expect(deadline.signal.aborted).toBe(false);
+    expect(deadline.expired()).toBe(false);
+    deadline.dispose();
+  });
+
+  it('still aborts when the client cancels, and does not call that a timeout', async () => {
+    const client = new AbortController();
+    const deadline = createCallDeadline({ clientSignal: client.signal, budgetMs: 60_000 });
+
+    client.abort(new Error('client went away'));
+
+    expect(deadline.signal.aborted).toBe(true);
+    expect(deadline.expired()).toBe(false);
+    expect(isDesktopCallTimeout(deadline.signal.reason)).toBe(false);
+    deadline.dispose();
+  });
+
+  it('is already aborted when the client signal arrives aborted', () => {
+    const client = new AbortController();
+    client.abort(new Error('cancelled before dispatch'));
+
+    const deadline = createCallDeadline({ clientSignal: client.signal, budgetMs: 60_000 });
+
+    expect(deadline.signal.aborted).toBe(true);
+    deadline.dispose();
+  });
+
+  it('stops the clock on dispose so a finished call cannot fire later', async () => {
+    const deadline = createCallDeadline({ budgetMs: 60_000 });
+    deadline.dispose();
+
+    await vi.advanceTimersByTimeAsync(120_000);
+
+    expect(deadline.signal.aborted).toBe(false);
+    expect(deadline.expired()).toBe(false);
+  });
+
+  it('leaves no unhandled rejection when the deadline expires unwatched', async () => {
+    const unhandled = vi.fn();
+    process.on('unhandledRejection', unhandled);
+    try {
+      const deadline = createCallDeadline({ budgetMs: 1_000 });
+      await vi.advanceTimersByTimeAsync(1_000);
+      deadline.dispose();
+
+      vi.useRealTimers();
+      await new Promise((resolve) => setImmediate(resolve));
+      expect(unhandled).not.toHaveBeenCalled();
+    } finally {
+      process.off('unhandledRejection', unhandled);
+    }
+  });
+});
+
+describe('desktopCallTimeoutMessage', () => {
+  it('names the budget, the likely cause, and forbids a blind retry', () => {
+    const message = desktopCallTimeoutMessage({
+      budgetMs: 60_000,
+      tool: 'apply-workbook',
+      session: '31875',
+    });
+
+    expect(message).toContain('did not respond within 60s');
+    expect(message).toContain('tool: apply-workbook, session: 31875');
+    expect(message).toContain('blocking dialog');
+    expect(message).toContain('Do not retry this call');
+    expect(message).toContain('list-instances');
+  });
+});

--- a/src/desktop/callDeadline.ts
+++ b/src/desktop/callDeadline.ts
@@ -1,0 +1,131 @@
+/**
+ * Per-call deadline for Tableau Desktop tool calls.
+ *
+ * Every desktop tool call gets one clock. The clock starts when the MCP request handler
+ * mints the tool's `extra` and stops when the tool returns. It composes with the client's
+ * cancellation signal rather than replacing it: a client cancel still aborts, and a client
+ * signal never removes the clock.
+ *
+ * Budget rationale (309 episode logs, 1,174 timed tool calls): the four slowest legitimate
+ * calls are 37.5s, 28.1s, 21.5s and 12.5s, and the three hung calls are 212.4s, 265.2s and
+ * 308.1s. Nothing at all falls between 37,543 ms and 212,388 ms, so any ceiling inside that
+ * band cuts every hang and no real work. 60s sits in the band with 1.6x headroom over the
+ * largest legitimate call.
+ */
+
+/** Ceiling for one desktop tool call. See the band argument above. */
+export const DEFAULT_DESKTOP_CALL_TIMEOUT_MS = 60_000;
+
+/** Floor for the env override — below the observed 37.5s legitimate max, real work gets cut. */
+export const MIN_DESKTOP_CALL_TIMEOUT_MS = 40_000;
+
+export class DesktopCallTimeoutError extends Error {
+  readonly budgetMs: number;
+
+  constructor(budgetMs: number) {
+    super(`Tableau Desktop did not respond within ${formatBudget(budgetMs)}.`);
+    this.name = 'DesktopCallTimeoutError';
+    this.budgetMs = budgetMs;
+  }
+}
+
+export function isDesktopCallTimeout(error: unknown): error is DesktopCallTimeoutError {
+  return error instanceof DesktopCallTimeoutError;
+}
+
+export function formatBudget(budgetMs: number): string {
+  return budgetMs % 1000 === 0 ? `${budgetMs / 1000}s` : `${budgetMs}ms`;
+}
+
+/**
+ * The agent-facing text for an expired call. It names the budget, says what is most likely
+ * wrong, and forbids a blind retry — retrying a call that raised a blocking Desktop dialog
+ * just hangs against the same dialog.
+ */
+export function desktopCallTimeoutMessage({
+  budgetMs,
+  tool,
+  session,
+}: {
+  budgetMs: number;
+  tool?: string;
+  session?: string;
+}): string {
+  const scope = [tool ? `tool: ${tool}` : undefined, session ? `session: ${session}` : undefined]
+    .filter(Boolean)
+    .join(', ');
+
+  return [
+    `Tableau Desktop did not respond within ${formatBudget(budgetMs)} and the call was aborted${
+      scope ? ` (${scope})` : ''
+    }.`,
+    'Desktop is most likely showing a blocking dialog that a person has to dismiss, or the instance is wedged.',
+    'Do not retry this call — it will hang against the same dialog.',
+    'Tell the user to dismiss any open Tableau dialog, then call list-instances to confirm the session is still reachable and re-target if the pid changed.',
+  ].join(' ');
+}
+
+export type CallDeadline = {
+  /** The client signal composed with the clock. Aborts on client cancel OR on expiry. */
+  readonly signal: AbortSignal;
+  /** The budget this deadline enforces, in ms. */
+  readonly budgetMs: number;
+  /** True once the clock — not the client — aborted the call. */
+  expired: () => boolean;
+  /**
+   * Rejects with {@link DesktopCallTimeoutError} when the clock expires, and never settles
+   * otherwise. Safe to leave un-raced: a rejection handler is attached at creation.
+   */
+  whenExpired: () => Promise<never>;
+  /** Clears the timer and detaches the client listener. Always call this when the tool returns. */
+  dispose: () => void;
+};
+
+export function createCallDeadline({
+  clientSignal,
+  budgetMs = DEFAULT_DESKTOP_CALL_TIMEOUT_MS,
+}: {
+  clientSignal?: AbortSignal;
+  budgetMs?: number;
+}): CallDeadline {
+  const controller = new AbortController();
+  let timedOut = false;
+  let rejectExpiry: (error: unknown) => void = () => undefined;
+
+  const expiry = new Promise<never>((_resolve, reject) => {
+    rejectExpiry = reject;
+  });
+  // A deadline nobody races must not surface as an unhandled rejection.
+  expiry.catch(() => undefined);
+
+  const timer = setTimeout(() => {
+    timedOut = true;
+    const error = new DesktopCallTimeoutError(budgetMs);
+    controller.abort(error);
+    rejectExpiry(error);
+  }, budgetMs);
+  timer.unref?.();
+
+  const onClientAbort = (): void => {
+    controller.abort(clientSignal?.reason);
+  };
+
+  if (clientSignal) {
+    if (clientSignal.aborted) {
+      controller.abort(clientSignal.reason);
+    } else {
+      clientSignal.addEventListener('abort', onClientAbort, { once: true });
+    }
+  }
+
+  return {
+    signal: controller.signal,
+    budgetMs,
+    expired: () => timedOut,
+    whenExpired: () => expiry,
+    dispose: () => {
+      clearTimeout(timer);
+      clientSignal?.removeEventListener('abort', onClientAbort);
+    },
+  };
+}

--- a/src/desktop/externalApi/externalApiClient.ts
+++ b/src/desktop/externalApi/externalApiClient.ts
@@ -353,7 +353,9 @@ export class ExternalApiClient {
       headers['content-type'] = options.contentType;
     }
 
-    const signal = options.signal ?? AbortSignal.timeout(this.timeoutMs);
+    // A caller signal is a cancellation channel, not a clock — compose, never replace. `??` here
+    // meant the default timeout never applied, because every desktop tool passes extra.signal.
+    const signal = composeWithTimeout(options.signal, this.timeoutMs);
 
     try {
       const res = await this.fetchFn(this.url(route), {
@@ -371,6 +373,11 @@ export class ExternalApiClient {
   private url(route: string): string {
     return `${this.instance.baseUrl.replace(/\/$/, '')}${route}`;
   }
+}
+
+function composeWithTimeout(signal: AbortSignal | undefined, timeoutMs: number): AbortSignal {
+  const timeout = AbortSignal.timeout(timeoutMs);
+  return signal ? AbortSignal.any([signal, timeout]) : timeout;
 }
 
 function buildWorksheetByIdRoute(worksheetId: string): string {

--- a/src/desktop/externalApi/externalApiClientTimeout.test.ts
+++ b/src/desktop/externalApi/externalApiClientTimeout.test.ts
@@ -1,0 +1,86 @@
+import { ExternalApiClient } from './externalApiClient.js';
+import { ExternalApiInstance } from './types.js';
+
+const instance: ExternalApiInstance = {
+  baseUrl: 'http://127.0.0.1:65535',
+  token: 'valid-token',
+  pid: 4321,
+  instanceId: 'inst-test',
+  apiVersion: '1.0',
+};
+
+// Real timers: AbortSignal.timeout runs on a native timer that vi.useFakeTimers cannot advance,
+// so these use a small budget instead. The budget's size is not what is under test — whether the
+// clock applies at all is.
+const BUDGET_MS = 60;
+
+/** A Desktop that accepted the socket and then went quiet — settles only when aborted. */
+function hangingFetch(): typeof fetch {
+  return ((_url: string, init?: RequestInit): Promise<Response> =>
+    new Promise((_resolve, reject) => {
+      init?.signal?.addEventListener('abort', () => reject(init.signal?.reason), { once: true });
+    })) as unknown as typeof fetch;
+}
+
+describe('ExternalApiClient request deadline', () => {
+  it('applies its own clock even when the caller supplies a signal', async () => {
+    // The `??` this replaces meant a caller signal removed the timeout entirely, and every
+    // desktop tool supplies extra.signal — so the 60s default was unreachable in shipped code.
+    const client = new ExternalApiClient(instance, {
+      fetchFn: hangingFetch(),
+      timeoutMs: BUDGET_MS,
+    });
+    const neverAborts = new AbortController().signal;
+
+    const result = await client.health(neverAborts);
+
+    expect(result.isErr()).toBe(true);
+    const error = result.unwrapErr();
+    expect(error.type).toBe('network');
+    expect((error as { error: unknown }).error).toMatchObject({ name: 'TimeoutError' });
+  });
+
+  it('still applies the clock when the caller supplies no signal', async () => {
+    const client = new ExternalApiClient(instance, {
+      fetchFn: hangingFetch(),
+      timeoutMs: BUDGET_MS,
+    });
+
+    const result = await client.health();
+
+    expect(result.isErr()).toBe(true);
+    expect((result.unwrapErr() as { error: unknown }).error).toMatchObject({
+      name: 'TimeoutError',
+    });
+  });
+
+  it('lets the caller cancel before the clock runs out', async () => {
+    const client = new ExternalApiClient(instance, {
+      fetchFn: hangingFetch(),
+      timeoutMs: 60_000,
+    });
+    const controller = new AbortController();
+
+    const pending = client.health(controller.signal);
+    controller.abort(new Error('client cancelled'));
+    const result = await pending;
+
+    expect(result.isErr()).toBe(true);
+    const error = result.unwrapErr();
+    expect(error.type).toBe('network');
+    expect((error as { error: unknown }).error).toMatchObject({ message: 'client cancelled' });
+  });
+
+  it('does not cut a request that finishes inside the budget', async () => {
+    const fetchFn = ((): Promise<Response> =>
+      new Promise((resolve) => {
+        setTimeout(() => resolve(new Response('{}', { status: 200 })), 5);
+      })) as unknown as typeof fetch;
+    const client = new ExternalApiClient(instance, { fetchFn, timeoutMs: 5_000 });
+
+    const result = await client.health(new AbortController().signal);
+
+    expect(result.isOk()).toBe(true);
+    expect(result.unwrap().healthy).toBe(true);
+  });
+});

--- a/src/desktop/externalApi/externalApiToolExecutor.test.ts
+++ b/src/desktop/externalApi/externalApiToolExecutor.test.ts
@@ -71,7 +71,8 @@ describe('ExternalApiToolExecutor', () => {
       const error = result.unwrapErr();
       expect(error.type).toBe('unknown');
       if (error.type === 'unknown') {
-        expect(String(error.error)).toContain('pid 12345');
+        expect(String(error.error)).toContain('PID 12345');
+        expect(String(error.error)).toContain('Call list-instances');
       }
     });
 
@@ -489,7 +490,8 @@ describe('ExternalApiToolExecutor', () => {
         const error = result.unwrapErr();
         expect(error.type).toBe('unknown');
         if (error.type === 'unknown') {
-          expect(String(error.error)).toContain('pid 999');
+          expect(String(error.error)).toContain('PID 999');
+          expect(String(error.error)).toContain('Call list-instances');
         }
         expect(other.requests).toHaveLength(0);
       } finally {

--- a/src/desktop/externalApi/externalApiToolExecutor.ts
+++ b/src/desktop/externalApi/externalApiToolExecutor.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 
 import { log } from '../../logging/logger.js';
 import { GetCommandStatusResponse, GetEventsResponse } from '../../sdks/desktop/agentApi/types.js';
+import { desktopCallTimeoutMessage, isDesktopCallTimeout } from '../callDeadline.js';
 import {
   ExecuteCommandArgs,
   ExecuteCommandError,
@@ -10,6 +11,11 @@ import {
   GetEventsArgs,
   ToolExecutor,
 } from '../toolExecutor/toolExecutor.js';
+import {
+  noInstanceFoundMessage,
+  unknownInstanceUnreachableMessage,
+  unreachableInstanceMessage,
+} from '../unreachableInstance.js';
 import {
   ExternalApiClient,
   ExternalApiClientOptions,
@@ -150,7 +156,7 @@ export class ExternalApiToolExecutor extends ToolExecutor {
     );
 
     if (outcomeResult.isErr()) {
-      const mapped = mapClientError(outcomeResult.error);
+      const mapped = mapClientError(outcomeResult.error, this.deps.pid);
       log({
         message: `Failed to execute command ${namespace}:${command} via External Client API`,
         level: 'error',
@@ -214,7 +220,7 @@ export class ExternalApiToolExecutor extends ToolExecutor {
     });
 
     if (outcomeResult.isErr()) {
-      const mapped = mapClientError(outcomeResult.error);
+      const mapped = mapClientError(outcomeResult.error, this.deps.pid);
       log({
         message: 'Failed to apply workbook document via External Client API',
         level: 'error',
@@ -419,7 +425,7 @@ export class ExternalApiToolExecutor extends ToolExecutor {
   ): Promise<Result<T, ExecuteCommandError>> {
     const result = await this.withClientRescan(op);
     if (result.isErr()) {
-      return Err(mapClientError(result.error));
+      return Err(mapClientError(result.error, this.deps.pid));
     }
     return Ok(result.value);
   }
@@ -534,7 +540,10 @@ function supportsOperationResult(apiVersion: string | undefined): boolean {
   return major > 0 || (major === 0 && (minor > 1 || (minor === 1 && patch >= 1)));
 }
 
-function mapClientError(error: ExternalApiError | NoInstance): ExecuteCommandError {
+function mapClientError(
+  error: ExternalApiError | NoInstance,
+  pinnedPid?: number,
+): ExecuteCommandError {
   switch (error.type) {
     case 'problem':
       return {
@@ -553,16 +562,42 @@ function mapClientError(error: ExternalApiError | NoInstance): ExecuteCommandErr
     case 'invalid-response':
       return { type: 'invalid-response', error: error.error };
     case 'network':
-      return { type: 'unknown', error: error.error };
+      return mapNetworkFailure(error.error, pinnedPid);
     case 'no-instance':
       return {
         type: 'unknown',
         error:
           error.pinnedPid !== undefined
-            ? `Pinned Tableau Desktop (pid ${error.pinnedPid}) is no longer running — relaunch the agent from the Desktop you want to control.`
-            : 'No External Client API instance available.',
+            ? noInstanceFoundMessage(error.pinnedPid)
+            : unknownInstanceUnreachableMessage(),
       };
   }
+}
+
+/**
+ * A dead-but-cached Desktop used to surface as a raw `fetch failed`, which the agent could not
+ * act on. Name the instance so it can re-target, and keep a timeout honest as a timeout.
+ */
+function mapNetworkFailure(cause: unknown, pinnedPid?: number): ExecuteCommandError {
+  if (isDesktopCallTimeout(cause)) {
+    return {
+      type: 'command-timed-out',
+      error: desktopCallTimeoutMessage({ budgetMs: cause.budgetMs }),
+    };
+  }
+
+  if (cause instanceof Error && cause.name === 'TimeoutError') {
+    return { type: 'command-timed-out', error: cause.message };
+  }
+
+  const detail = cause instanceof Error ? cause.message : undefined;
+  return {
+    type: 'unknown',
+    error:
+      pinnedPid !== undefined
+        ? unreachableInstanceMessage(pinnedPid, detail)
+        : unknownInstanceUnreachableMessage(detail),
+  };
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/src/desktop/sessionManager.externalApi.test.ts
+++ b/src/desktop/sessionManager.externalApi.test.ts
@@ -61,7 +61,7 @@ describe('SessionManager executor selection', () => {
     ] as never);
 
     await expect(new SessionManager().getExecutor('12345')).rejects.toThrow(
-      'The requested Tableau Desktop session is no longer running — it was closed. Call list-instances and retry with a current session.',
+      'No Desktop instance found with PID 12345. Session 12345 is stale: that Tableau Desktop process is no longer reachable or was restarted. Call list-instances and retry with the current session.',
     );
   });
 
@@ -77,7 +77,7 @@ describe('SessionManager executor selection', () => {
     ] as never);
 
     await expect(new SessionManager().getExecutor('12345')).rejects.toThrow(
-      'The requested Tableau Desktop session is no longer running — it was closed. Call list-instances and retry with a current session.',
+      'No Desktop instance found with PID 12345. Session 12345 is stale: that Tableau Desktop process is no longer reachable or was restarted. Call list-instances and retry with the current session.',
     );
   });
 });

--- a/src/desktop/sessionManager.ts
+++ b/src/desktop/sessionManager.ts
@@ -4,6 +4,7 @@ import { getDesktopConfig } from '../config.desktop.js';
 import { log } from '../logging/logger.js';
 import { discoverInstances } from './externalApi/discovery.js';
 import { ExternalApiToolExecutor } from './externalApi/externalApiToolExecutor.js';
+import { CACHED_XML_WARNING, noInstanceFoundMessage } from './unreachableInstance.js';
 
 export type DesktopConnection = {
   sessionId: string;
@@ -17,9 +18,6 @@ export const EXTERNAL_API_UNAVAILABLE_MESSAGE =
 export const PINNED_DESKTOP_UNREACHABLE_MESSAGE =
   'The pinned Tableau Desktop is no longer reachable — it was closed or restarted. Relaunch the agent from Tableau Desktop to reconnect.';
 
-export const STALE_SESSION_MESSAGE =
-  'The requested Tableau Desktop session is no longer running — it was closed. Call list-instances and retry with a current session.';
-
 export type DesktopUnavailableReason = 'pinned-unreachable' | 'stale-session' | 'no-api';
 
 export class ExternalClientApiUnavailableError extends Error {
@@ -30,10 +28,11 @@ export class ExternalClientApiUnavailableError extends Error {
 
   private static messageFor(sessionId: string | number, reason: DesktopUnavailableReason): string {
     switch (reason) {
+      // A pinned session hides list-instances, so this one must not tell the agent to call it.
       case 'pinned-unreachable':
-        return `${PINNED_DESKTOP_UNREACHABLE_MESSAGE} Session: ${sessionId}.`;
+        return `${PINNED_DESKTOP_UNREACHABLE_MESSAGE} Pinned PID: ${sessionId}. ${CACHED_XML_WARNING}`;
       case 'stale-session':
-        return `${STALE_SESSION_MESSAGE} Session: ${sessionId}.`;
+        return noInstanceFoundMessage(sessionId);
       case 'no-api':
         return `${EXTERNAL_API_UNAVAILABLE_MESSAGE} Requested session: ${sessionId}.`;
     }

--- a/src/desktop/unreachableInstance.test.ts
+++ b/src/desktop/unreachableInstance.test.ts
@@ -1,0 +1,88 @@
+import { ExternalApiToolExecutor } from './externalApi/externalApiToolExecutor.js';
+import {
+  CACHED_XML_WARNING,
+  noInstanceFoundMessage,
+  staleSessionRecoveryMessage,
+  unknownInstanceUnreachableMessage,
+  unreachableInstanceMessage,
+} from './unreachableInstance.js';
+
+describe('unreachable-instance messages', () => {
+  it('names the pid, says the session is stale, and points at list-instances', () => {
+    const message = noInstanceFoundMessage(31875);
+
+    expect(message).toContain('No Desktop instance found with PID 31875');
+    expect(message).toContain('Session 31875 is stale');
+    expect(message).toContain('Call list-instances and retry with the current session');
+    expect(message).toContain(CACHED_XML_WARNING);
+  });
+
+  it('keeps the same shape for a pid that stopped answering', () => {
+    expect(unreachableInstanceMessage(31875, 'fetch failed')).toContain(
+      'Tableau Desktop instance PID 31875 is not responding',
+    );
+    expect(unreachableInstanceMessage(31875, 'fetch failed')).toContain(
+      staleSessionRecoveryMessage(31875),
+    );
+    expect(unreachableInstanceMessage(31875, 'fetch failed')).toContain('Cause: fetch failed');
+  });
+
+  it('still tells the agent what to do when nothing is pinned', () => {
+    expect(unknownInstanceUnreachableMessage()).toContain('Call list-instances');
+  });
+});
+
+describe('ExternalApiToolExecutor unreachable-instance reporting', () => {
+  const instance = {
+    baseUrl: 'http://127.0.0.1:65535',
+    token: 'valid-token',
+    pid: 31875,
+    instanceId: 'inst-test',
+    apiVersion: '1.0',
+  };
+
+  function makeExecutor(fetchFn: typeof fetch): ExternalApiToolExecutor {
+    return new ExternalApiToolExecutor({
+      pid: 31875,
+      discover: () => [instance] as never,
+      clientOptions: { fetchFn },
+    } as never);
+  }
+
+  it('names the unreachable pid instead of leaking a raw fetch failure', async () => {
+    // A Desktop that died after the executor cached its client: the old path returned the raw
+    // TypeError, which the agent could not act on.
+    const fetchFn = (() =>
+      Promise.reject(new TypeError('fetch failed'))) as unknown as typeof fetch;
+    const executor = makeExecutor(fetchFn);
+    await executor.start();
+
+    const result = await executor.getWorkbookDocument(new AbortController().signal);
+
+    expect(result.isErr()).toBe(true);
+    const error = result.unwrapErr();
+    expect(error.type).toBe('unknown');
+    expect(String(error.error)).toContain('PID 31875');
+    expect(String(error.error)).toContain('Call list-instances');
+    expect(String(error.error)).toContain('Cause: fetch failed');
+  });
+
+  it('reports a timed-out request as a timeout, not as an unreachable instance', async () => {
+    // Real timers with a small budget: AbortSignal.timeout is native and vi cannot advance it.
+    const fetchFn = ((_url: string, init?: RequestInit): Promise<Response> =>
+      new Promise((_resolve, reject) => {
+        init?.signal?.addEventListener('abort', () => reject(init.signal?.reason), { once: true });
+      })) as unknown as typeof fetch;
+    const executor = new ExternalApiToolExecutor({
+      pid: 31875,
+      discover: () => [instance] as never,
+      clientOptions: { fetchFn, timeoutMs: 60 },
+    } as never);
+    await executor.start();
+
+    const result = await executor.getWorkbookDocument(new AbortController().signal);
+
+    expect(result.isErr()).toBe(true);
+    expect(result.unwrapErr().type).toBe('command-timed-out');
+  });
+});

--- a/src/desktop/unreachableInstance.ts
+++ b/src/desktop/unreachableInstance.ts
@@ -1,0 +1,38 @@
+/**
+ * One message shape for "the Desktop you asked for is not answering".
+ *
+ * Leaf module on purpose: both `sessionManager` (which owns session creation) and
+ * `externalApiToolExecutor` (which owns the wire) need it, and sessionManager already
+ * imports the executor.
+ *
+ * The agent can only re-target if the error names the instance, so every variant names the
+ * pid and points at list-instances. Cached XML is called out because a restarted Desktop
+ * keeps the same tool-side cache but not the same workbook.
+ */
+
+/** A restarted Desktop keeps the tool-side XML cache but not the workbook it was read from. */
+export const CACHED_XML_WARNING =
+  'Cached XML from the old session may not match the current workbook — re-read before applying.';
+
+export function staleSessionRecoveryMessage(sessionId: string | number): string {
+  return (
+    `Session ${sessionId} is stale: that Tableau Desktop process is no longer reachable or was restarted. ` +
+    `Call list-instances and retry with the current session. ${CACHED_XML_WARNING}`
+  );
+}
+
+export function noInstanceFoundMessage(pid: string | number): string {
+  return `No Desktop instance found with PID ${pid}. ${staleSessionRecoveryMessage(pid)}`;
+}
+
+export function unreachableInstanceMessage(pid: string | number, cause?: string): string {
+  const base = `Tableau Desktop instance PID ${pid} is not responding. ${staleSessionRecoveryMessage(pid)}`;
+  return cause ? `${base} Cause: ${cause}` : base;
+}
+
+export function unknownInstanceUnreachableMessage(cause?: string): string {
+  const base =
+    'Tableau Desktop is not responding and no instance is pinned. ' +
+    'Call list-instances to find a running Desktop and retry with that session.';
+  return cause ? `${base} Cause: ${cause}` : base;
+}

--- a/src/server.desktop.ts
+++ b/src/server.desktop.ts
@@ -10,6 +10,7 @@ import {
 import pkg from '../package.json';
 import { getDesktopConfig } from './config.desktop.js';
 import { DATA_ROOT, readResourceAsset, RESOURCES_ROOT } from './desktop/assets.js';
+import { createCallDeadline } from './desktop/callDeadline.js';
 import {
   getKnowledgeCorpusEntryCount,
   getKnowledgeDir,
@@ -240,16 +241,28 @@ export class DesktopMcpServer extends Server {
         extra: RequestHandlerExtra<ServerRequest, ServerNotification>,
       ) => {
         const tableauToolCallback = await Provider.from(callback);
-        const tableauRequestHandlerExtra: TableauDesktopRequestHandlerExtra = {
-          ...extra,
-          config,
-          getExecutor: async (sessionId: string) => {
-            return await this.sessionManager.getExecutor(sessionId);
-          },
-          server: this,
-        };
+        // One clock per tool call, composed into extra.signal so the socket really aborts.
+        const deadline = createCallDeadline({
+          clientSignal: extra.signal,
+          budgetMs: config.desktopCallTimeoutMs,
+        });
 
-        return tableauToolCallback(args, tableauRequestHandlerExtra);
+        try {
+          const tableauRequestHandlerExtra: TableauDesktopRequestHandlerExtra = {
+            ...extra,
+            signal: deadline.signal,
+            deadline,
+            config,
+            getExecutor: async (sessionId: string) => {
+              return await this.sessionManager.getExecutor(sessionId);
+            },
+            server: this,
+          };
+
+          return await tableauToolCallback(args, tableauRequestHandlerExtra);
+        } finally {
+          deadline.dispose();
+        }
       };
 
       this.mcpServer.registerTool(

--- a/src/tools/desktop/tool.ts
+++ b/src/tools/desktop/tool.ts
@@ -2,6 +2,7 @@ import { AnySchema, ZodRawShapeCompat } from '@modelcontextprotocol/sdk/server/z
 import { CallToolResult, RequestId } from '@modelcontextprotocol/sdk/types.js';
 import { ZodRawShape } from 'zod';
 
+import { desktopCallTimeoutMessage, isDesktopCallTimeout } from '../../desktop/callDeadline.js';
 import {
   currentEpisodeId,
   emitEpisodeEvent,
@@ -57,7 +58,7 @@ export class DesktopTool<Args extends ZodRawShape | undefined = undefined> exten
     });
 
     try {
-      const result = await callback();
+      const result = await raceDeadline(extra, callback);
       if (result.isOk()) {
         toolResult = getSuccessResult
           ? getSuccessResult(result.value)
@@ -98,14 +99,29 @@ export class DesktopTool<Args extends ZodRawShape | undefined = undefined> exten
       });
       return toolResult;
     } catch (error) {
+      const timedOut = isDesktopCallTimeout(error);
       log({
-        message: 'Tool execution failed',
+        message: timedOut
+          ? 'Tool execution exceeded the Desktop call deadline'
+          : 'Tool execution failed',
         level: 'error',
         logger: 'tool',
         data: error,
       });
-      await emitToolErrorEvent({ config: extra.config, sessionId, tool: this.name, error });
-      toolResult = getErrorResult(requestId, error);
+
+      if (timedOut) {
+        // Report the deadline in the agent's own words, not as a generic failure it can paper over.
+        const text = desktopCallTimeoutMessage({
+          budgetMs: error.budgetMs,
+          tool: this.name,
+          session: sessionId,
+        });
+        await emitToolErrorEvent({ config: extra.config, sessionId, tool: this.name, error: text });
+        toolResult = { isError: true, content: [{ type: 'text', text }] };
+      } else {
+        await emitToolErrorEvent({ config: extra.config, sessionId, tool: this.name, error });
+        toolResult = getErrorResult(requestId, error);
+      }
       await emitEpisodeEvent(extra.config, {
         type: 'tool_end',
         session_id: sessionId,
@@ -117,6 +133,26 @@ export class DesktopTool<Args extends ZodRawShape | undefined = undefined> exten
       return toolResult;
     }
   }
+}
+
+/**
+ * Runs the tool body against the per-call clock. A tool that forwards `extra.signal` aborts on
+ * its own; this race also covers a tool that awaits something the signal cannot interrupt.
+ */
+async function raceDeadline<T, Args extends undefined | ZodRawShapeCompat | AnySchema>(
+  extra: DesktopToolLogAndExecuteParams<T, Args>['extra'],
+  callback: DesktopToolLogAndExecuteParams<T, Args>['callback'],
+): ReturnType<DesktopToolLogAndExecuteParams<T, Args>['callback']> {
+  const { deadline } = extra;
+  if (!deadline) {
+    return await callback();
+  }
+
+  const work = callback();
+  // The loser keeps running; swallow its late rejection so a timeout never leaks unhandled.
+  void work.catch(() => undefined);
+
+  return await Promise.race([work, deadline.whenExpired()]);
 }
 
 function getErrorResult(requestId: RequestId, error: unknown): CallToolResult {

--- a/src/tools/desktop/toolContext.ts
+++ b/src/tools/desktop/toolContext.ts
@@ -8,6 +8,7 @@ import {
 } from '@modelcontextprotocol/sdk/types.js';
 
 import { Config } from '../../config.desktop.js';
+import { CallDeadline } from '../../desktop/callDeadline.js';
 import { ExternalApiToolExecutor } from '../../desktop/externalApi/externalApiToolExecutor.js';
 import { DesktopMcpServer } from '../../server.desktop.js';
 import { TableauToolContext } from '../toolContext.js';
@@ -16,6 +17,12 @@ import { TableauToolContext } from '../toolContext.js';
 export type TableauDesktopToolContext = TableauToolContext<DesktopMcpServer> & {
   config: Config;
   getExecutor: (sessionId: string) => Promise<ExternalApiToolExecutor>;
+  /**
+   * The per-call clock. `extra.signal` is already composed with it, so a tool that forwards
+   * `extra.signal` gets the deadline for free; `logAndExecute` races it so a tool that ignores
+   * the signal still returns the honest timeout instead of hanging.
+   */
+  deadline?: CallDeadline;
 };
 
 // An extension of the RequestHandlerExtra type that includes the TableauDesktopToolContext

--- a/src/tools/desktop/toolDeadline.test.ts
+++ b/src/tools/desktop/toolDeadline.test.ts
@@ -1,0 +1,216 @@
+import { mkdtempSync, readdirSync, readFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { Ok } from 'ts-results-es';
+
+import { createCallDeadline } from '../../desktop/callDeadline.js';
+import { beginEpisode, resetEpisodeEventsForTests } from '../../desktop/episode-events.js';
+import { DesktopMcpServer } from '../../server.desktop.js';
+import { Provider } from '../../utils/provider.js';
+import { DesktopTool } from './tool.js';
+import { getMockRequestHandlerExtra } from './toolContext.mock.js';
+
+const tmpDirs: string[] = [];
+
+function tmpDir(): string {
+  const dir = mkdtempSync(join(process.cwd(), 'desktop-deadline-test-'));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+function readEvents(dir: string): Array<Record<string, unknown>> {
+  return readdirSync(dir)
+    .filter((file) => /^episodes-.*\.jsonl$/.test(file))
+    .flatMap((file) =>
+      readFileSync(join(dir, file), 'utf-8')
+        .trim()
+        .split('\n')
+        .filter(Boolean)
+        .map((line) => JSON.parse(line) as Record<string, unknown>),
+    );
+}
+
+function makeTool(): DesktopTool<{ session: any }> {
+  return new DesktopTool({
+    server: new DesktopMcpServer(),
+    name: 'apply-workbook',
+    title: 'Apply Workbook',
+    description: 'Test tool',
+    paramsSchema: { session: { _def: {} } as any },
+    annotations: {
+      title: 'Apply Workbook',
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: false,
+      openWorldHint: false,
+    },
+    callback: new Provider(async () => async () => ({ isError: false, content: [] })),
+  });
+}
+
+function makeExtra(dir?: string, budgetMs = 60_000): any {
+  const base = getMockRequestHandlerExtra();
+  const deadline = createCallDeadline({ budgetMs });
+  return {
+    ...base,
+    signal: deadline.signal,
+    deadline,
+    config: dir
+      ? { ...base.config, episodeEventsEnabled: true, episodeEventsDirectory: dir }
+      : base.config,
+  };
+}
+
+afterEach(() => {
+  resetEpisodeEventsForTests();
+  for (const dir of tmpDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+  vi.useRealTimers();
+});
+
+describe('DesktopTool per-call deadline', () => {
+  it('cuts a call that outruns the budget and returns the honest, actionable error', async () => {
+    vi.useFakeTimers();
+    const tool = makeTool();
+    const extra = makeExtra(undefined, 60_000);
+
+    const pending = tool.logAndExecute({
+      extra,
+      args: { session: '31875' },
+      // A wedged Desktop: the request never settles.
+      callback: () => new Promise(() => undefined),
+    });
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    const result = await pending;
+
+    expect(result.isError).toBe(true);
+    const text = (result.content as Array<{ text: string }>)[0].text;
+    expect(text).toContain('Tableau Desktop did not respond within 60s');
+    expect(text).toContain('session: 31875');
+    expect(text).toContain('blocking dialog');
+    expect(text).toContain('Do not retry this call');
+    // Not dressed up as a generic tool failure the agent can paper over.
+    expect(text).not.toContain('requestId:');
+
+    extra.deadline.dispose();
+  });
+
+  it('aborts the signal the tool handed to Desktop, so the request does not keep running', async () => {
+    vi.useFakeTimers();
+    const tool = makeTool();
+    const extra = makeExtra(undefined, 60_000);
+    let abortedWith: unknown;
+
+    const pending = tool.logAndExecute({
+      extra,
+      args: { session: '31875' },
+      callback: () =>
+        new Promise(() => {
+          extra.signal.addEventListener('abort', () => {
+            abortedWith = extra.signal.reason;
+          });
+        }),
+    });
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    await pending;
+
+    expect(abortedWith).toBeInstanceOf(Error);
+    expect((abortedWith as Error).name).toBe('DesktopCallTimeoutError');
+    extra.deadline.dispose();
+  });
+
+  it('does not cut the real 37.5s apply-workbook', async () => {
+    vi.useFakeTimers();
+    const tool = makeTool();
+    const extra = makeExtra(undefined, 60_000);
+
+    const pending = tool.logAndExecute<{ applied: boolean }>({
+      extra,
+      args: { session: '31875' },
+      callback: () =>
+        new Promise((resolve) => {
+          setTimeout(() => resolve(new Ok({ applied: true })), 37_543);
+        }),
+    });
+
+    await vi.advanceTimersByTimeAsync(37_543);
+    const result = await pending;
+
+    expect(result.isError).toBe(false);
+    expect(extra.deadline.expired()).toBe(false);
+    extra.deadline.dispose();
+  });
+
+  it('records the timeout as a failed call instead of a silent success', async () => {
+    vi.useFakeTimers();
+    const dir = tmpDir();
+    const tool = makeTool();
+    const extra = makeExtra(dir, 60_000);
+    await beginEpisode(extra.config, { sessionId: '31875' });
+
+    const pending = tool.logAndExecute({
+      extra,
+      args: { session: '31875' },
+      callback: () => new Promise(() => undefined),
+    });
+    await vi.advanceTimersByTimeAsync(60_000);
+    await pending;
+
+    expect(readEvents(dir)).toMatchObject([
+      { type: 'episode_begin' },
+      { type: 'tool_start', tool: 'apply-workbook' },
+      { type: 'tool_error', tool: 'apply-workbook' },
+      { type: 'tool_end', tool: 'apply-workbook', success: false },
+    ]);
+    const toolError = readEvents(dir)[2];
+    expect(String(toolError.error)).toContain('did not respond within 60s');
+
+    extra.deadline.dispose();
+  });
+
+  it('leaves no unhandled rejection when the cut-off call later fails on its own', async () => {
+    vi.useFakeTimers();
+    const unhandled = vi.fn();
+    process.on('unhandledRejection', unhandled);
+
+    try {
+      const tool = makeTool();
+      const extra = makeExtra(undefined, 60_000);
+
+      const pending = tool.logAndExecute({
+        extra,
+        args: { session: '31875' },
+        callback: () =>
+          new Promise((_resolve, reject) => {
+            setTimeout(() => reject(new Error('socket closed long after we gave up')), 90_000);
+          }),
+      });
+
+      await vi.advanceTimersByTimeAsync(60_000);
+      const result = await pending;
+      expect(result.isError).toBe(true);
+
+      await vi.advanceTimersByTimeAsync(60_000);
+      extra.deadline.dispose();
+
+      vi.useRealTimers();
+      await new Promise((resolve) => setImmediate(resolve));
+      expect(unhandled).not.toHaveBeenCalled();
+    } finally {
+      process.off('unhandledRejection', unhandled);
+    }
+  });
+
+  it('runs unchanged when no deadline is attached', async () => {
+    const tool = makeTool();
+    const base = getMockRequestHandlerExtra();
+
+    const result = await tool.logAndExecute({
+      extra: base,
+      args: { session: 'S1' },
+      callback: async () => new Ok({ ok: true }),
+    });
+
+    expect(result.isError).toBe(false);
+  });
+});


### PR DESCRIPTION
## What you are approving

Every Tableau Desktop tool call now runs against a clock. When Desktop stops answering, the call is cut and the agent is told what happened instead of waiting forever.

**This is a rule we keep, not a one-off.** A caller-supplied `AbortSignal` is a cancellation channel, never a clock. Any new code that talks to Desktop composes the two — it must not treat "the caller gave me a signal" as "I need no timeout." Both places that talk to Desktop now follow that rule, and new desktop tools inherit it for free because the deadline lives in the shared harness, not in each tool.

## The evidence

Across 309 episode logs and 1,175 timed tool calls:

| | duration | outcome |
|---|---|---|
| `tableau-execute-command` | 308,111 ms | failed |
| `tableau-list-worksheets` | 265,233 ms | succeeded |
| `tableau-apply-workbook` | 212,388 ms | succeeded |

Those three calls are **52.4% of all tool execution time**. Both hung read paths have sub-250 ms medians (212.5 ms and 220.1 ms), so this is not slow work — it is a hang. Excluding the three, the mean call is 609 ms.

There was no deadline anywhere. `ExternalApiClient.request()` did:

```ts
const signal = options.signal ?? AbortSignal.timeout(this.timeoutMs);
```

Every desktop tool passes `extra.signal`, which fires on client cancellation and never on a clock. So the `??` meant the 60s default was dead code in shipped builds. `AbortSignal.timeout` appeared exactly once in the whole desktop tree, on the branch that never ran.

## Why 60s

Not a round number — the gap in the data. Sorted by duration, the calls run 37,543 ms, then 212,388 ms. **Nothing falls between them.** Any ceiling inside that 5.7x band cuts all three hangs and zero real work.

| rank | duration | tool |
|---|---|---|
| 3rd | 212,388 ms | apply-workbook (hang) |
| **4th** | **37,543 ms** | **apply-workbook (real)** |
| 5th | 28,060 ms | apply-workbook (real) |
| 6th | 21,500 ms | apply-worksheet (real) |

60s sits in the band with 1.6x headroom over the largest legitimate call.

I chose **one ceiling over per-tool budgets** on purpose. Per-tool numbers keyed to 309 episodes on one machine would not carry to a bigger workbook, and a newly added tool would silently get no budget at all. One ceiling covers every tool, including tools nobody has written yet.

## What happens on timeout

The call aborts and the agent gets:

> Tableau Desktop did not respond within 60s and the call was aborted (tool: apply-workbook, session: 31875). Desktop is most likely showing a blocking dialog that a person has to dismiss, or the instance is wedged. Do not retry this call — it will hang against the same dialog. Tell the user to dismiss any open Tableau dialog, then call list-instances to confirm the session is still reachable and re-target if the pid changed.

Three properties this has to have, and a test for each:

- **Nothing retries it.** The one existing auto-retry (`withRescan`) fires on 401 only. The composed signal stays aborted, so a second attempt fails immediately rather than hanging against the same dialog. This matters because the live `/v0` image endpoints return HTTP 500 and raise a blocking Desktop modal.
- **The agent cannot paper over it.** It comes back `isError: true`, and the outer race means a multi-step tool cannot swallow a timed-out step and report partial success.
- **It is recorded as a failure.** `tool_error` and `tool_end{success:false}` are emitted, so this shows up in the latency data instead of vanishing.

## The second fix: a dead Desktop names itself

`SessionManager` caches one executor per pid and never re-checks it. When Desktop dies after that, calls went to the cached client and came back as a raw `TypeError: fetch failed` — nothing the agent could act on.

`ingest-csv-directory` already got this right. That message shape now lives in one module and is used everywhere:

> No Desktop instance found with PID 31875. Session 31875 is stale: that Tableau Desktop process is no longer reachable or was restarted. Call list-instances and retry with the current session. Cached XML from the old session may not match the current workbook — re-read before applying.

One correction while moving it: a pinned session does not register `list-instances`, so the pinned-unreachable message must not tell the agent to call it. That one keeps its relaunch instruction and gains the pid and the cache warning.

## Where it sits

| seam | file | what it does |
|---|---|---|
| mint the clock | `src/server.desktop.ts:244` | one deadline per call, composed into `extra.signal`, disposed in `finally` |
| catch tools that ignore the signal | `src/tools/desktop/tool.ts:61,142` | races the body; the loser's late rejection is swallowed |
| the wire | `src/desktop/externalApi/externalApiClient.ts:356` | compose caller signal with the clock instead of `??` |
| honest unreachable | `src/desktop/externalApi/externalApiToolExecutor.ts:581` | name the pid instead of leaking `fetch failed` |

## Residual risk

**A cap set too low cuts real work.** That is the whole danger here, and it is why the number is at the top of the safe band rather than the bottom. 60s clears the largest legitimate call by 1.6x. If a much larger workbook ever pushes a legitimate apply past 60s, we would cut it — so `TABLEAU_DESKTOP_CALL_TIMEOUT_MS` overrides it, with a 40s floor so nobody can set a value below the largest call we have actually measured.

Second risk: the 37.5s legitimate maximum comes from one machine's workbooks. If Desktop on a slower machine is systematically slower, the band moves. The env override is the release valve; the floor stops it being turned into a footgun.

## Validation

- `npx tsc` — clean
- `npm run lint` — clean
- `npx vitest run` — **347 files, 5,299 passed, 1 skipped, 0 failed**
- `npm run build` — succeeds

23 new tests. Two existing assertions changed from `pid 12345` to `PID 12345` to match the new message and gained a check that the recovery instruction is present — stricter than before, not weaker.

Co-Authored-By: Claude <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
