### PR TITLE
feat(binder): unqualified time asks bind the only date field, or surface the choice

### DIFF
--- a/lockstep.hashes.json
+++ b/lockstep.hashes.json
@@ -1,6 +1,6 @@
 {
   "src/desktop/binder/calc-derivation.ts": "5105d466e3c31019affa91320edf3047259301ca5cd27aeb5883ba1faa251098",
-  "src/desktop/binder/classify.ts": "3dc1e888343c15cffa355dc2793bb15f4a6eee654ce4cd5f219e8ce9bccb4b81",
+  "src/desktop/binder/classify.ts": "e5d146c99648196054d6068e18c2d517f537ab28ba6506e348b7fdc6390d625f",
   "src/desktop/binder/escape.ts": "3c79bcf77c33fad64975e95ea57df5fb3e416008633e15dc7a585018fbc92d3f",
   "src/desktop/binder/manifest-types.ts": "22740b978fdf7f1f463aa9ccd94f1e2ae5d383e610bf9063bff37e1624d173f8",
   "src/desktop/binder/manifest-validation.ts": "fc46c7b874cb2bd5958a2ed40848d18f6b3654e2d8559cff90fb841ca8fdd8d6",

--- a/lockstep.hashes.json
+++ b/lockstep.hashes.json
@@ -1,6 +1,6 @@
 {
   "src/desktop/binder/calc-derivation.ts": "5105d466e3c31019affa91320edf3047259301ca5cd27aeb5883ba1faa251098",
-  "src/desktop/binder/classify.ts": "093aa6baa96b88a0c119c75a080ccf5de8614e05c8d9016c4664ea10f3ed70d0",
+  "src/desktop/binder/classify.ts": "bedd52d70e3b394ca6ba383373229e1196d580047a1ffdbf8b58a53c67e84844",
   "src/desktop/binder/escape.ts": "3c79bcf77c33fad64975e95ea57df5fb3e416008633e15dc7a585018fbc92d3f",
   "src/desktop/binder/manifest-types.ts": "22740b978fdf7f1f463aa9ccd94f1e2ae5d383e610bf9063bff37e1624d173f8",
   "src/desktop/binder/manifest-validation.ts": "fc46c7b874cb2bd5958a2ed40848d18f6b3654e2d8559cff90fb841ca8fdd8d6",

--- a/lockstep.hashes.json
+++ b/lockstep.hashes.json
@@ -1,6 +1,6 @@
 {
   "src/desktop/binder/calc-derivation.ts": "5105d466e3c31019affa91320edf3047259301ca5cd27aeb5883ba1faa251098",
-  "src/desktop/binder/classify.ts": "e5d146c99648196054d6068e18c2d517f537ab28ba6506e348b7fdc6390d625f",
+  "src/desktop/binder/classify.ts": "093aa6baa96b88a0c119c75a080ccf5de8614e05c8d9016c4664ea10f3ed70d0",
   "src/desktop/binder/escape.ts": "3c79bcf77c33fad64975e95ea57df5fb3e416008633e15dc7a585018fbc92d3f",
   "src/desktop/binder/manifest-types.ts": "22740b978fdf7f1f463aa9ccd94f1e2ae5d383e610bf9063bff37e1624d173f8",
   "src/desktop/binder/manifest-validation.ts": "fc46c7b874cb2bd5958a2ed40848d18f6b3654e2d8559cff90fb841ca8fdd8d6",

--- a/src/desktop/binder/classify.ts
+++ b/src/desktop/binder/classify.ts
@@ -194,16 +194,28 @@ const PLURALIZABLE_CHART_NOUNS: ReadonlySet<string> = new Set([
  * Scoped to chart nouns only — no stemming, no mid-token change, no broadening of
  * non-noun keywords; the singular still matches unchanged.
  */
-function phraseIndexInAsk(ask: string, phrase: string): number {
+interface PhraseMatch {
+  index: number;
+  start: number;
+  end: number;
+}
+
+function phraseMatchInAsk(ask: string, phrase: string): PhraseMatch | null {
   const p = phrase.toLowerCase().trim();
-  if (!p) return -1;
+  if (!p) return null;
   const body = escapeRegex(p).replace(/-/g, '[\\s-]+');
   const tokens = p.split(/[^a-z0-9]+/).filter(Boolean);
   const finalToken = tokens[tokens.length - 1];
   const pluralSuffix = finalToken && PLURALIZABLE_CHART_NOUNS.has(finalToken) ? 's?' : '';
-  const re = new RegExp(`(^|[^a-z0-9])${body}${pluralSuffix}([^a-z0-9]|$)`);
+  const re = new RegExp(`(^|[^a-z0-9])(${body}${pluralSuffix})([^a-z0-9]|$)`);
   const match = re.exec(ask.toLowerCase());
-  return match ? match.index : -1;
+  if (!match) return null;
+  const start = match.index + match[1].length;
+  return { index: match.index, start, end: start + match[2].length };
+}
+
+function phraseIndexInAsk(ask: string, phrase: string): number {
+  return phraseMatchInAsk(ask, phrase)?.index ?? -1;
 }
 
 /** Count of a template's intent_keywords that appear as whole tokens in the ask. */
@@ -989,13 +1001,21 @@ function fieldExactNames(fields: SchemaField[]): Set<string> {
  *     alias never claims a "Regions" span that a field literally named "Regions" owns
  *     by exact match.
  */
-function fieldNameMatchInAsk(ask: string, name: string, exactNames: ReadonlySet<string>): number {
-  const exact = phraseIndexInAsk(ask, name);
-  if (exact >= 0) return exact;
+function fieldNameMatchInAskSpan(
+  ask: string,
+  name: string,
+  exactNames: ReadonlySet<string>,
+): PhraseMatch | null {
+  const exact = phraseMatchInAsk(ask, name);
+  if (exact) return exact;
   const plural = naivePlural(name.toLowerCase().trim());
-  if (!plural) return -1; // one-way: an `s`-final (or empty) name gains no alias
-  if (exactNames.has(plural)) return -1; // exact-first: another field owns this token
-  return phraseIndexInAsk(ask, plural);
+  if (!plural) return null; // one-way: an `s`-final (or empty) name gains no alias
+  if (exactNames.has(plural)) return null; // exact-first: another field owns this token
+  return phraseMatchInAsk(ask, plural);
+}
+
+function fieldNameMatchInAsk(ask: string, name: string, exactNames: ReadonlySet<string>): number {
+  return fieldNameMatchInAskSpan(ask, name, exactNames)?.index ?? -1;
 }
 
 /**
@@ -1011,19 +1031,23 @@ const ACRONYM_EXPANSIONS: Readonly<Record<string, readonly string[]>> = {
 
 /**
  * Precision-first business nouns whose schema captions commonly use a different term.
- * Candidate patterns are whole-token caption fragments, not fuzzy stems. A noun contributes
- * a field match only when exactly one schema field contains any candidate pattern.
+ * Candidate patterns are whole-token caption fragments, not fuzzy stems. Partial matches are
+ * retained for proposals; auto-binding requires one candidate whose full normalized field
+ * name/caption/bare column name equals a pattern.
  */
 const BUSINESS_FIELD_SYNONYMS: ReadonlyArray<{
   nouns: readonly string[];
   captionPatterns: readonly string[];
 }> = [
   { nouns: ['revenue'], captionPatterns: ['sales', 'revenue', 'amount'] },
-  { nouns: ['customers'], captionPatterns: ['customer'] },
-  { nouns: ['products'], captionPatterns: ['product'] },
-  { nouns: ['orders'], captionPatterns: ['order'] },
-  { nouns: ['reps', 'salespeople'], captionPatterns: ['rep', 'sales person', 'owner'] },
-  { nouns: ['deals'], captionPatterns: ['deal', 'opportunity'] },
+  { nouns: ['customers'], captionPatterns: ['customer', 'customer name'] },
+  { nouns: ['products'], captionPatterns: ['product', 'product name'] },
+  { nouns: ['orders'], captionPatterns: ['order', 'order id'] },
+  {
+    nouns: ['reps', 'salespeople'],
+    captionPatterns: ['rep', 'rep name', 'sales rep', 'sales person', 'owner'],
+  },
+  { nouns: ['deals'], captionPatterns: ['deal', 'opportunity', 'opportunity name'] },
 ];
 
 /**
@@ -1084,6 +1108,25 @@ function fieldMatchesCaptionPattern(field: SchemaField, pattern: string): boolea
   );
 }
 
+function normalizeFieldPhrase(value: string): string {
+  return value
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter(Boolean)
+    .join(' ');
+}
+
+function fieldFullyMatchesCaptionPattern(field: SchemaField, pattern: string): boolean {
+  const normalizedPattern = normalizeFieldPhrase(pattern);
+  return [field.name, field.caption, bareName(field.columnName)].some((name) => {
+    if (!name) return false;
+    const normalizedName = normalizeFieldPhrase(name);
+    return (
+      normalizedName === normalizedPattern || naivePlural(normalizedName) === normalizedPattern
+    );
+  });
+}
+
 /**
  * Candidate fields for business nouns that the literal pass did not already resolve.
  * Literal/plural caption matches at the same ask position win, as do existing acronym
@@ -1093,20 +1136,40 @@ function businessSynonymCandidatesInAsk(
   ask: string,
   s: SchemaSummary,
   literalHits: readonly FieldMatch[],
-): Array<{ noun: string; index: number; candidates: SchemaField[] }> {
+): Array<{
+  noun: string;
+  index: number;
+  candidates: SchemaField[];
+  fullMatchCandidates: SchemaField[];
+}> {
   const exactNames = fieldExactNames(s.fields);
-  const matches: Array<{ noun: string; index: number; candidates: SchemaField[] }> = [];
+  const matches: Array<{
+    noun: string;
+    index: number;
+    candidates: SchemaField[];
+    fullMatchCandidates: SchemaField[];
+  }> = [];
 
   for (const entry of BUSINESS_FIELD_SYNONYMS) {
     for (const noun of entry.nouns) {
-      const nounIndex = phraseIndexInAsk(ask, noun);
-      if (nounIndex < 0) continue;
+      const nounMatch = phraseMatchInAsk(ask, noun);
+      if (!nounMatch) continue;
+      const nounIndex = nounMatch.index;
 
       const literalClaimsNoun = literalHits.some(({ field }) => {
         const names = [bareName(field.columnName), field.caption, field.name].filter(
           (name): name is string => !!name && name.length > 0,
         );
-        if (names.some((name) => fieldNameMatchInAsk(ask, name, exactNames) === nounIndex)) {
+        if (
+          names.some((name) => {
+            const literalMatch = fieldNameMatchInAskSpan(ask, name, exactNames);
+            return (
+              literalMatch !== null &&
+              nounMatch.start >= literalMatch.start &&
+              nounMatch.start < literalMatch.end
+            );
+          })
+        ) {
           return true;
         }
         return names.some((name) => {
@@ -1119,7 +1182,10 @@ function businessSynonymCandidatesInAsk(
       const candidates = s.fields.filter((field) =>
         entry.captionPatterns.some((pattern) => fieldMatchesCaptionPattern(field, pattern)),
       );
-      matches.push({ noun, index: nounIndex, candidates });
+      const fullMatchCandidates = candidates.filter((field) =>
+        entry.captionPatterns.some((pattern) => fieldFullyMatchesCaptionPattern(field, pattern)),
+      );
+      matches.push({ noun, index: nounIndex, candidates, fullMatchCandidates });
     }
   }
 
@@ -1127,8 +1193,8 @@ function businessSynonymCandidatesInAsk(
 }
 
 /**
- * Unambiguous business-synonym field matches. Zero candidates fall through; multiple
- * candidates are withheld so classifyNoLlm can fail closed and expose them in proposal fields.
+ * Unambiguous full-name business-synonym matches. Zero, partial-only, and multiple candidates
+ * are withheld so classifyNoLlm fails closed and exposes candidates in proposal fields.
  */
 function businessSynonymMatchesInAsk(
   ask: string,
@@ -1138,7 +1204,7 @@ function businessSynonymMatchesInAsk(
   return businessSynonymCandidatesInAsk(ask, s, literalHits)
     .filter(
       (match): match is typeof match & { candidates: [SchemaField] } =>
-        match.candidates.length === 1,
+        match.candidates.length === 1 && match.fullMatchCandidates.length === 1,
     )
     .map(({ noun, index, candidates }) => ({ noun, index, field: candidates[0] }));
 }

--- a/src/desktop/binder/classify.ts
+++ b/src/desktop/binder/classify.ts
@@ -1504,10 +1504,15 @@ const TIME_INTENT_CUES: readonly string[] = [
   'timeline',
   'time-series',
   'over-time',
+  'by-date',
   'by-month',
   'by-week',
   'by-quarter',
   'by-year',
+  'daily',
+  'monthly',
+  'quarterly',
+  'yearly',
   'calendar',
   'period',
   'change-over-time',
@@ -1516,9 +1521,19 @@ const TIME_INTENT_CUES: readonly string[] = [
   'yoy',
 ];
 
+/**
+ * A bounded relative window also names a time axis even when it does not repeat a
+ * static cue above. Keep the unit set narrow: these are the material calendar
+ * grains the temporal fallback contract admits.
+ */
+const LAST_N_TIME_WINDOW_RE = /\blast\s+[1-9]\d*\s+(?:months?|quarters?|years?)\b/i;
+
 /** True when the (masked) ask carries an explicit time-axis cue from the allowlist. */
 function askHasExplicitTimeIntent(maskedAsk: string): boolean {
-  return TIME_INTENT_CUES.some((cue) => phraseIndexInAsk(maskedAsk, cue) >= 0);
+  return (
+    TIME_INTENT_CUES.some((cue) => phraseIndexInAsk(maskedAsk, cue) >= 0) ||
+    LAST_N_TIME_WINDOW_RE.test(maskedAsk)
+  );
 }
 
 /**

--- a/src/desktop/binder/classify.ts
+++ b/src/desktop/binder/classify.ts
@@ -1010,6 +1010,23 @@ const ACRONYM_EXPANSIONS: Readonly<Record<string, readonly string[]>> = {
 };
 
 /**
+ * Precision-first business nouns whose schema captions commonly use a different term.
+ * Candidate patterns are whole-token caption fragments, not fuzzy stems. A noun contributes
+ * a field match only when exactly one schema field contains any candidate pattern.
+ */
+const BUSINESS_FIELD_SYNONYMS: ReadonlyArray<{
+  nouns: readonly string[];
+  captionPatterns: readonly string[];
+}> = [
+  { nouns: ['revenue'], captionPatterns: ['sales', 'revenue', 'amount'] },
+  { nouns: ['customers'], captionPatterns: ['customer'] },
+  { nouns: ['products'], captionPatterns: ['product'] },
+  { nouns: ['orders'], captionPatterns: ['order'] },
+  { nouns: ['reps', 'salespeople'], captionPatterns: ['rep', 'sales person', 'owner'] },
+  { nouns: ['deals'], captionPatterns: ['deal', 'opportunity'] },
+];
+
+/**
  * Return the earliest token index of a known acronym's full expansion, or -1.
  * Expansion tokens may appear in any order and punctuation (including hyphens)
  * is treated as a token boundary. Every token is required, preserving the
@@ -1036,6 +1053,96 @@ function acronymExpansionMatch(ask: string, field: SchemaField): number {
   return best;
 }
 
+interface FieldMatch {
+  field: SchemaField;
+  index: number;
+}
+
+/** Existing literal/plural/acronym field matches, before business synonyms are considered. */
+function literalFieldMatchesInAsk(ask: string, s: SchemaSummary): FieldMatch[] {
+  const exactNames = fieldExactNames(s.fields);
+  const hits: FieldMatch[] = [];
+  for (const field of s.fields) {
+    const names = [bareName(field.columnName), field.caption, field.name].filter(
+      (name): name is string => !!name && name.length > 0,
+    );
+    let best = -1;
+    for (const name of names) {
+      const index = fieldNameMatchInAsk(ask, name, exactNames);
+      if (index >= 0 && (best < 0 || index < best)) best = index;
+    }
+    if (best < 0) best = acronymExpansionMatch(ask, field);
+    if (best >= 0) hits.push({ field, index: best });
+  }
+  hits.sort((a, b) => a.index - b.index);
+  return hits;
+}
+
+function fieldMatchesCaptionPattern(field: SchemaField, pattern: string): boolean {
+  return [field.name, field.caption, bareName(field.columnName)].some(
+    (name) => !!name && phraseIndexInAsk(name, pattern) >= 0,
+  );
+}
+
+/**
+ * Candidate fields for business nouns that the literal pass did not already resolve.
+ * Literal/plural caption matches at the same ask position win, as do existing acronym
+ * expansions that claim that noun.
+ */
+function businessSynonymCandidatesInAsk(
+  ask: string,
+  s: SchemaSummary,
+  literalHits: readonly FieldMatch[],
+): Array<{ noun: string; index: number; candidates: SchemaField[] }> {
+  const exactNames = fieldExactNames(s.fields);
+  const matches: Array<{ noun: string; index: number; candidates: SchemaField[] }> = [];
+
+  for (const entry of BUSINESS_FIELD_SYNONYMS) {
+    for (const noun of entry.nouns) {
+      const nounIndex = phraseIndexInAsk(ask, noun);
+      if (nounIndex < 0) continue;
+
+      const literalClaimsNoun = literalHits.some(({ field }) => {
+        const names = [bareName(field.columnName), field.caption, field.name].filter(
+          (name): name is string => !!name && name.length > 0,
+        );
+        if (names.some((name) => fieldNameMatchInAsk(ask, name, exactNames) === nounIndex)) {
+          return true;
+        }
+        return names.some((name) => {
+          const expansion = ACRONYM_EXPANSIONS[name.trim().toLowerCase()];
+          return expansion?.includes(noun) && acronymExpansionMatch(ask, field) >= 0;
+        });
+      });
+      if (literalClaimsNoun) continue;
+
+      const candidates = s.fields.filter((field) =>
+        entry.captionPatterns.some((pattern) => fieldMatchesCaptionPattern(field, pattern)),
+      );
+      matches.push({ noun, index: nounIndex, candidates });
+    }
+  }
+
+  return matches;
+}
+
+/**
+ * Unambiguous business-synonym field matches. Zero candidates fall through; multiple
+ * candidates are withheld so classifyNoLlm can fail closed and expose them in proposal fields.
+ */
+function businessSynonymMatchesInAsk(
+  ask: string,
+  s: SchemaSummary,
+  literalHits: readonly FieldMatch[],
+): Array<FieldMatch & { noun: string }> {
+  return businessSynonymCandidatesInAsk(ask, s, literalHits)
+    .filter(
+      (match): match is typeof match & { candidates: [SchemaField] } =>
+        match.candidates.length === 1,
+    )
+    .map(({ noun, index, candidates }) => ({ noun, index, field: candidates[0] }));
+}
+
 /**
  * Blank out whole-token occurrences of every field name/caption/bare column name
  * in the ask (replaced by spaces so token boundaries are preserved). Used for
@@ -1048,6 +1155,7 @@ function acronymExpansionMatch(ask: string, field: SchemaField): number {
 function maskFieldNames(ask: string, s: SchemaSummary): string {
   let masked = ask;
   const exactNames = fieldExactNames(s.fields);
+  const literalHits = literalFieldMatchesInAsk(ask, s);
   // LONGEST FIELD NAME FIRST. Schema-order masking fragments a compound field:
   // masking "Region" before "Country/Region" turns it into "Country/      " so the
   // compound's own regex no longer matches, and the surviving "Country" token trips
@@ -1084,27 +1192,33 @@ function maskFieldNames(ask: string, s: SchemaSummary): string {
       );
     }
   }
+  // A uniquely resolved business noun is a field mention too: mask it before chart-family
+  // and aggregation scoring. Ambiguous/unknown nouns remain untouched and follow today's path.
+  for (const { noun } of businessSynonymMatchesInAsk(ask, s, literalHits)) {
+    const body = escapeRegex(noun).replace(/-/g, '[\\s-]+');
+    const re = new RegExp(`(^|[^a-z0-9])(${body})([^a-z0-9]|$)`, 'gi');
+    masked = masked.replace(
+      re,
+      (_whole, pre: string, mid: string, post: string) => pre + ' '.repeat(mid.length) + post,
+    );
+  }
   return masked;
 }
 
 /** Fields whose name/caption/bare column name appear in the ask, earliest-first. */
 function matchFieldsInAsk(ask: string, s: SchemaSummary): SchemaField[] {
-  const exactNames = fieldExactNames(s.fields);
-  const hits: Array<{ field: SchemaField; index: number }> = [];
-  for (const f of s.fields) {
-    const names = [bareName(f.columnName), f.caption, f.name].filter(
-      (n): n is string => !!n && n.length > 0,
-    );
-    let best = -1;
-    for (const n of names) {
-      const idx = fieldNameMatchInAsk(ask, n, exactNames);
-      if (idx >= 0 && (best < 0 || idx < best)) best = idx;
-    }
-    if (best < 0) best = acronymExpansionMatch(ask, f);
-    if (best >= 0) hits.push({ field: f, index: best });
-  }
+  const literalHits = literalFieldMatchesInAsk(ask, s);
+  const hits: FieldMatch[] = [
+    ...literalHits,
+    ...businessSynonymMatchesInAsk(ask, s, literalHits),
+  ];
   hits.sort((a, b) => a.index - b.index);
-  return hits.map((h) => h.field);
+  const seen = new Set<SchemaField>();
+  return hits.flatMap(({ field }) => {
+    if (seen.has(field)) return [];
+    seen.add(field);
+    return [field];
+  });
 }
 
 /** Whole-phrase test: does the ask NAME this field (by name, caption, or bare column)? */
@@ -1165,6 +1279,7 @@ function fieldFitsSlotKind(kind: SlotKind, f: SchemaField): boolean {
 /**
  * Field-narrowing for the propose prompt (stage 2B, adjudicated attack 1). A wide
  * schema (300–1000 fields) would blow the prompt, so rank and cap:
+ *   rank 0 — business-synonym candidates when that noun was not literally resolved;
  *   rank 1 — fields whose name/caption tokens overlap the ask (a field the ask
  *            NAMES is guaranteed rank-1, so it survives the cap);
  *   rank 2 — fields kind-compatible with any required slot of any candidate;
@@ -1182,6 +1297,16 @@ function narrowFields(
 
   const askTokens = contentTokens(ask);
   const exactNames = fieldExactNames(fields);
+  const synonymSummary: SchemaSummary = {
+    datasource: fields[0]?.datasource ?? '',
+    fields,
+  };
+  const literalHits = literalFieldMatchesInAsk(ask, synonymSummary);
+  const synonymCandidates = new Set(
+    businessSynonymCandidatesInAsk(ask, synonymSummary, literalHits).flatMap(
+      (match) => match.candidates,
+    ),
+  );
   const ranked = fields.map((f, index) => {
     const named = askNamesField(ask, f, exactNames);
     let overlap = 0;
@@ -1190,7 +1315,8 @@ function narrowFields(
     }
     const relevant = named || overlap > 0;
     const compatible = !relevant && [...kinds].some((k) => fieldFitsSlotKind(k, f));
-    const tier = relevant ? 2 : compatible ? 1 : 0;
+    const synonymCandidate = synonymCandidates.has(f);
+    const tier = synonymCandidate ? 3 : relevant ? 2 : compatible ? 1 : 0;
     return { f, index, tier, named, overlap };
   });
 
@@ -2522,6 +2648,18 @@ export function classifyNoLlm(
   // return null so the orchestrator escalates rather than risk a silent wrong bind on a
   // partial view. Checked at the TOP, before any field is touched, so cost stays bounded.
   if (summary.fields.length > MAX_CLASSIFIABLE_FIELDS) return null;
+
+  // A business noun with multiple caption-pattern candidates is materially ambiguous:
+  // deterministic binding could change the numbers. Fail closed before template selection;
+  // buildLlmInput ranks every candidate into the existing proposal field list.
+  const literalHits = literalFieldMatchesInAsk(ask, summary);
+  if (
+    businessSynonymCandidatesInAsk(ask, summary, literalHits).some(
+      ({ candidates }) => candidates.length > 1,
+    )
+  ) {
+    return null;
+  }
 
   // Mask field names before scoring so a field NAME can't select a template or
   // read as an aggregation word; field↔slot matching still uses the raw ask.

--- a/src/desktop/binder/manifest-encoding-corpus.test.ts
+++ b/src/desktop/binder/manifest-encoding-corpus.test.ts
@@ -1177,15 +1177,39 @@ const MATRIX = CORPUS.flatMap((row) =>
 );
 
 describe('binder/manifest-encoding-corpus — business-synonym field resolution', () => {
-  it('"revenue" uniquely resolves to Sales', () => {
+  it('"revenue by region" uniquely resolves to the full-name Sales match', () => {
     const summary = summarizeSchema(businessSynonymSchema(['Sales']));
 
-    const result = classifyNoLlm('Show me revenue by region', manifests, summary);
+    const result = classifyNoLlm('revenue by region', manifests, summary);
 
     expect(result).not.toBeNull();
     expect(result!.bindings).toEqual([
       { slot_id: 'category', field: 'Region' },
       { slot_id: 'measure', field: 'Sales' },
+    ]);
+  });
+
+  it('a lone partial-caption revenue candidate proposes instead of auto-binding', async () => {
+    const result = await bindTemplate({
+      ask: 'revenue by region',
+      workbookXml: businessSynonymSchema(['Sales Tax']),
+      manifests,
+    });
+
+    expect(result.status).toBe('propose');
+    if (result.status !== 'propose') throw new Error(`expected propose, got ${result.status}`);
+    expect(result.llm_input.fields.map((field) => field.name)).toContain('Sales Tax');
+  });
+
+  it('a compound literal field suppresses synonym ambiguity for a noun inside its span', () => {
+    const summary = summarizeSchema(businessSynonymSchema(['Net Revenue', 'Sales']));
+
+    const result = classifyNoLlm('show Net Revenue by Region', manifests, summary);
+
+    expect(result).not.toBeNull();
+    expect(result!.bindings).toEqual([
+      { slot_id: 'category', field: 'Region' },
+      { slot_id: 'measure', field: 'Net Revenue' },
     ]);
   });
 

--- a/src/desktop/binder/manifest-encoding-corpus.test.ts
+++ b/src/desktop/binder/manifest-encoding-corpus.test.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
 
-import { classifyNoLlm, summarizeSchema } from './binder.js';
+import { bindTemplate, classifyNoLlm, summarizeSchema } from './binder.js';
 import { hasDeterministicPathBlockingHazard } from './classify.js';
 import { loadManifests } from './manifest.js';
 import type { SlotSpec, TemplateManifest } from './manifest-types.js';
@@ -75,6 +75,19 @@ const NARROW = `<?xml version='1.0'?>
 <workbook><datasources><datasource name='Narrow'>
   <column name='[Order Date]' role='dimension' type='quantitative' datatype='date' />
   <column name='[Region]' role='dimension' type='nominal' datatype='string' />
+  <column name='[Sales]' role='measure' type='quantitative' datatype='real' />
+</datasource></datasources></workbook>`;
+
+const SINGLE_DATE = `<?xml version='1.0'?>
+<workbook><datasources><datasource name='SingleDate'>
+  <column name='[Order Date]' role='dimension' type='quantitative' datatype='date' />
+  <column name='[Sales]' role='measure' type='quantitative' datatype='real' />
+</datasource></datasources></workbook>`;
+
+const TWO_DATES = `<?xml version='1.0'?>
+<workbook><datasources><datasource name='TwoDates'>
+  <column name='[Order Date]' role='dimension' type='quantitative' datatype='date' />
+  <column name='[Ship Date]' role='dimension' type='quantitative' datatype='datetime' />
   <column name='[Sales]' role='measure' type='quantitative' datatype='real' />
 </datasource></datasources></workbook>`;
 
@@ -1046,6 +1059,83 @@ beforeAll(() => {
 beforeEach(() => {
   // A future early return must fail instead of manufacturing another green, assertion-free row.
   expect.hasAssertions();
+});
+
+describe('binder/manifest-encoding-corpus — temporal-slot fallback', () => {
+  const expectedExplicitDateClassification = {
+    template: 'trend-line-chart',
+    bindings: [
+      { slot_id: 'order_date', field: 'Order Date' },
+      { slot_id: 'sales', field: 'Sales' },
+    ],
+    encodings: { filled: [], unfilled: [] },
+  };
+
+  it('binds the only date field when a trend ask names no date field', () => {
+    const result = classifyNoLlm('sales over time', manifests, summarizeSchema(SINGLE_DATE));
+
+    expect(result).toEqual({
+      ...expectedExplicitDateClassification,
+      notes: [
+        "Using 'Order Date' for required temporal slot 'order_date' because it is the only date field in the datasource.",
+      ],
+    });
+  });
+
+  it.each([
+    'line chart of Sales by date',
+    'line chart of Sales by month',
+    'line chart of Sales by quarter',
+    'line chart of Sales by year',
+    'line chart of Sales monthly',
+    'line chart of Sales quarterly',
+    'line chart of Sales yearly',
+    'line chart of Sales daily',
+    'line chart of Sales over the last 6 months',
+    'line chart of Sales for the last 2 quarters',
+    'line chart of Sales across the last 3 years',
+  ])('recognizes the temporal cue in "%s"', (ask) => {
+    const trend = manifests.get('trend-line-chart')!;
+    const result = classifyNoLlm(
+      ask,
+      new Map([[trend.template, trend]]),
+      summarizeSchema(SINGLE_DATE),
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.bindings).toContainEqual({ slot_id: 'order_date', field: 'Order Date' });
+  });
+
+  it('proposes both date candidates instead of binding either when the choice is material', async () => {
+    const result = await bindTemplate({
+      ask: 'sales over time',
+      workbookXml: TWO_DATES,
+      manifests,
+    });
+
+    expect(result.status).toBe('propose');
+    if (result.status !== 'propose') return;
+    expect(
+      result.llm_input.candidate_templates
+        .find((candidate) => candidate.template === 'trend-line-chart')
+        ?.slots.find((slot) => slot.slot_id === 'order_date'),
+    ).toMatchObject({ kind: 'temporal', required: true });
+    expect(
+      result.llm_input.fields
+        .filter((field) => field.datatype === 'date' || field.datatype === 'datetime')
+        .map((field) => field.name),
+    ).toEqual(['Order Date', 'Ship Date']);
+  });
+
+  it('keeps an explicitly named date-field classification byte-identical', () => {
+    const result = classifyNoLlm(
+      'line chart of Sales by Order Date',
+      manifests,
+      summarizeSchema(SINGLE_DATE),
+    );
+
+    expect(JSON.stringify(result)).toBe(JSON.stringify(expectedExplicitDateClassification));
+  });
 });
 
 function bindableSlots(m: TemplateManifest): SlotSpec[] {

--- a/src/desktop/binder/manifest-encoding-corpus.test.ts
+++ b/src/desktop/binder/manifest-encoding-corpus.test.ts
@@ -91,6 +91,19 @@ const TWO_DATES = `<?xml version='1.0'?>
   <column name='[Sales]' role='measure' type='quantitative' datatype='real' />
 </datasource></datasources></workbook>`;
 
+function businessSynonymSchema(measures: readonly string[], dimension = 'Region'): string {
+  const columns = [
+    `<column name='[${dimension}]' role='dimension' type='nominal' datatype='string' />`,
+    ...measures.map(
+      (measure) =>
+        `<column name='[${measure}]' role='measure' type='quantitative' datatype='real' />`,
+    ),
+  ];
+  return `<?xml version='1.0'?><workbook><datasources><datasource name='BusinessSynonyms'>
+  ${columns.join('\n  ')}
+</datasource></datasources></workbook>`;
+}
+
 /**
  * One geo level (country) plus a NON-geographic spare dimension. This is the schema in which
  * the optional geo slots (`state`, `city`) can honestly be shown to stay unbound: Superstore
@@ -1162,6 +1175,88 @@ function slotIds(result: NonNullable<ReturnType<typeof classifyNoLlm>>): string[
 const MATRIX = CORPUS.flatMap((row) =>
   INTENTS.map(([intent, suffix]) => ({ row, intent, ask: row.ask + suffix })),
 );
+
+describe('binder/manifest-encoding-corpus — business-synonym field resolution', () => {
+  it('"revenue" uniquely resolves to Sales', () => {
+    const summary = summarizeSchema(businessSynonymSchema(['Sales']));
+
+    const result = classifyNoLlm('Show me revenue by region', manifests, summary);
+
+    expect(result).not.toBeNull();
+    expect(result!.bindings).toEqual([
+      { slot_id: 'category', field: 'Region' },
+      { slot_id: 'measure', field: 'Sales' },
+    ]);
+  });
+
+  it('literal Revenue wins over the Sales synonym candidate', () => {
+    const summary = summarizeSchema(businessSynonymSchema(['Sales', 'Revenue']));
+
+    const result = classifyNoLlm('Show me revenue by region', manifests, summary);
+
+    expect(result).not.toBeNull();
+    expect(result!.bindings).toEqual([
+      { slot_id: 'category', field: 'Region' },
+      { slot_id: 'measure', field: 'Revenue' },
+    ]);
+  });
+
+  it('ambiguous revenue candidates propose both Sales and Amount without binding', async () => {
+    const distractors = Array.from({ length: 25 }, (_, index) => `Metric ${index + 1}`);
+    const workbookXml = businessSynonymSchema(['Sales', 'Amount', ...distractors]);
+
+    const result = await bindTemplate({
+      ask: 'Show me revenue by region',
+      workbookXml,
+      manifests,
+    });
+
+    expect(result.status).toBe('propose');
+    if (result.status !== 'propose') throw new Error(`expected propose, got ${result.status}`);
+    expect(result.llm_input.fields.map((field) => field.name)).toEqual(
+      expect.arrayContaining(['Sales', 'Amount']),
+    );
+  });
+
+  it('"customers" uniquely resolves to Customer Name', () => {
+    const summary = summarizeSchema(businessSynonymSchema(['Sales'], 'Customer Name'));
+
+    const result = classifyNoLlm('top 10 customers by sales', manifests, summary);
+
+    expect(result).not.toBeNull();
+    expect(result!.template).toBe('ranking-ordered-bar');
+    expect(result!.bindings).toEqual([
+      { slot_id: 'region', field: 'Customer Name' },
+      { slot_id: 'sales', field: 'Sales' },
+    ]);
+    expect(result!.top_n).toBe(10);
+  });
+
+  it.each([
+    ['products', 'Product Name'],
+    ['orders', 'Order ID'],
+    ['reps', 'Sales Rep'],
+    ['salespeople', 'Sales Person'],
+    ['deals', 'Opportunity Name'],
+  ])('"%s" uniquely resolves to %s', (noun, dimension) => {
+    const summary = summarizeSchema(businessSynonymSchema(['Sales'], dimension));
+
+    const result = classifyNoLlm(`Show me Sales by ${noun}`, manifests, summary);
+
+    expect(result).not.toBeNull();
+    expect(result!.template).toBe('magnitude-simple-bar');
+    expect(result!.bindings).toEqual([
+      { slot_id: 'category', field: dimension },
+      { slot_id: 'measure', field: 'Sales' },
+    ]);
+  });
+
+  it('falls through when a business noun has no caption-pattern match', () => {
+    const summary = summarizeSchema(businessSynonymSchema(['Profit']));
+
+    expect(classifyNoLlm('Show me revenue by region', manifests, summary)).toBeNull();
+  });
+});
 
 describe('binder/manifest-encoding-corpus — census tripwires', () => {
   it('covers every manifest on disk exactly once', () => {


### PR DESCRIPTION
Stacks on #643. First class-campaign change under the fast-path constitution the owner ruled today: tiered binding, materiality splits the middle, zero-misbind floor.

The measured gap: real users say "over time," "monthly," "last 12 months" — almost never a date column's name — and those asks selected the right template but failed to bind. This was the single most common way real asks fell off the 0.3s path in the coverage audit, and Slack mining confirmed the phrasing pattern dominates.

The rule this sets: an unqualified time ask on a temporal-slot template binds the schema's ONLY date field (that choice cannot change the numbers); with several date fields it surfaces the candidates through the existing proposal shape and never silently picks — Order vs Ship Date is a materially different answer. Explicit-date asks are pinned byte-identical.

Precision floor evidence: corpus 521 → 535 passing, zero regressions, zero misbinds. Full suite 6072 passed / 332 skipped, tsc clean, lint clean, lockstep hashes regenerated (a2td twin re-sync on the port-debt ledger).

Not yet proven live against Desktop — the live probe rides the next eval board and will be reported as such.

🤖 Generated with [Claude Code](https://claude.com/claude-code)