### PR TITLE
test(surface): hunt the cannot-know class instead of fixing it one bug at a time

### DIFF
--- a/lockstep.hashes.json
+++ b/lockstep.hashes.json
@@ -1,6 +1,6 @@
 {
   "src/desktop/binder/calc-derivation.ts": "5105d466e3c31019affa91320edf3047259301ca5cd27aeb5883ba1faa251098",
-  "src/desktop/binder/classify.ts": "3dc1e888343c15cffa355dc2793bb15f4a6eee654ce4cd5f219e8ce9bccb4b81",
+  "src/desktop/binder/classify.ts": "e5d146c99648196054d6068e18c2d517f537ab28ba6506e348b7fdc6390d625f",
   "src/desktop/binder/escape.ts": "3c79bcf77c33fad64975e95ea57df5fb3e416008633e15dc7a585018fbc92d3f",
   "src/desktop/binder/manifest-types.ts": "22740b978fdf7f1f463aa9ccd94f1e2ae5d383e610bf9063bff37e1624d173f8",
   "src/desktop/binder/manifest-validation.ts": "fc46c7b874cb2bd5958a2ed40848d18f6b3654e2d8559cff90fb841ca8fdd8d6",

--- a/lockstep.hashes.json
+++ b/lockstep.hashes.json
@@ -1,6 +1,6 @@
 {
   "src/desktop/binder/calc-derivation.ts": "5105d466e3c31019affa91320edf3047259301ca5cd27aeb5883ba1faa251098",
-  "src/desktop/binder/classify.ts": "e5d146c99648196054d6068e18c2d517f537ab28ba6506e348b7fdc6390d625f",
+  "src/desktop/binder/classify.ts": "093aa6baa96b88a0c119c75a080ccf5de8614e05c8d9016c4664ea10f3ed70d0",
   "src/desktop/binder/escape.ts": "3c79bcf77c33fad64975e95ea57df5fb3e416008633e15dc7a585018fbc92d3f",
   "src/desktop/binder/manifest-types.ts": "22740b978fdf7f1f463aa9ccd94f1e2ae5d383e610bf9063bff37e1624d173f8",
   "src/desktop/binder/manifest-validation.ts": "fc46c7b874cb2bd5958a2ed40848d18f6b3654e2d8559cff90fb841ca8fdd8d6",

--- a/src/desktop/binder/classify.ts
+++ b/src/desktop/binder/classify.ts
@@ -1504,10 +1504,15 @@ const TIME_INTENT_CUES: readonly string[] = [
   'timeline',
   'time-series',
   'over-time',
+  'by-date',
   'by-month',
   'by-week',
   'by-quarter',
   'by-year',
+  'daily',
+  'monthly',
+  'quarterly',
+  'yearly',
   'calendar',
   'period',
   'change-over-time',
@@ -1516,9 +1521,19 @@ const TIME_INTENT_CUES: readonly string[] = [
   'yoy',
 ];
 
+/**
+ * A bounded relative window also names a time axis even when it does not repeat a
+ * static cue above. Keep the unit set narrow: these are the material calendar
+ * grains the temporal fallback contract admits.
+ */
+const LAST_N_TIME_WINDOW_RE = /\blast\s+[1-9]\d*\s+(?:months?|quarters?|years?)\b/i;
+
 /** True when the (masked) ask carries an explicit time-axis cue from the allowlist. */
 function askHasExplicitTimeIntent(maskedAsk: string): boolean {
-  return TIME_INTENT_CUES.some((cue) => phraseIndexInAsk(maskedAsk, cue) >= 0);
+  return (
+    TIME_INTENT_CUES.some((cue) => phraseIndexInAsk(maskedAsk, cue) >= 0) ||
+    LAST_N_TIME_WINDOW_RE.test(maskedAsk)
+  );
 }
 
 /**

--- a/src/desktop/binder/classify.ts
+++ b/src/desktop/binder/classify.ts
@@ -1010,6 +1010,23 @@ const ACRONYM_EXPANSIONS: Readonly<Record<string, readonly string[]>> = {
 };
 
 /**
+ * Precision-first business nouns whose schema captions commonly use a different term.
+ * Candidate patterns are whole-token caption fragments, not fuzzy stems. A noun contributes
+ * a field match only when exactly one schema field contains any candidate pattern.
+ */
+const BUSINESS_FIELD_SYNONYMS: ReadonlyArray<{
+  nouns: readonly string[];
+  captionPatterns: readonly string[];
+}> = [
+  { nouns: ['revenue'], captionPatterns: ['sales', 'revenue', 'amount'] },
+  { nouns: ['customers'], captionPatterns: ['customer'] },
+  { nouns: ['products'], captionPatterns: ['product'] },
+  { nouns: ['orders'], captionPatterns: ['order'] },
+  { nouns: ['reps', 'salespeople'], captionPatterns: ['rep', 'sales person', 'owner'] },
+  { nouns: ['deals'], captionPatterns: ['deal', 'opportunity'] },
+];
+
+/**
  * Return the earliest token index of a known acronym's full expansion, or -1.
  * Expansion tokens may appear in any order and punctuation (including hyphens)
  * is treated as a token boundary. Every token is required, preserving the
@@ -1036,6 +1053,96 @@ function acronymExpansionMatch(ask: string, field: SchemaField): number {
   return best;
 }
 
+interface FieldMatch {
+  field: SchemaField;
+  index: number;
+}
+
+/** Existing literal/plural/acronym field matches, before business synonyms are considered. */
+function literalFieldMatchesInAsk(ask: string, s: SchemaSummary): FieldMatch[] {
+  const exactNames = fieldExactNames(s.fields);
+  const hits: FieldMatch[] = [];
+  for (const field of s.fields) {
+    const names = [bareName(field.columnName), field.caption, field.name].filter(
+      (name): name is string => !!name && name.length > 0,
+    );
+    let best = -1;
+    for (const name of names) {
+      const index = fieldNameMatchInAsk(ask, name, exactNames);
+      if (index >= 0 && (best < 0 || index < best)) best = index;
+    }
+    if (best < 0) best = acronymExpansionMatch(ask, field);
+    if (best >= 0) hits.push({ field, index: best });
+  }
+  hits.sort((a, b) => a.index - b.index);
+  return hits;
+}
+
+function fieldMatchesCaptionPattern(field: SchemaField, pattern: string): boolean {
+  return [field.name, field.caption, bareName(field.columnName)].some(
+    (name) => !!name && phraseIndexInAsk(name, pattern) >= 0,
+  );
+}
+
+/**
+ * Candidate fields for business nouns that the literal pass did not already resolve.
+ * Literal/plural caption matches at the same ask position win, as do existing acronym
+ * expansions that claim that noun.
+ */
+function businessSynonymCandidatesInAsk(
+  ask: string,
+  s: SchemaSummary,
+  literalHits: readonly FieldMatch[],
+): Array<{ noun: string; index: number; candidates: SchemaField[] }> {
+  const exactNames = fieldExactNames(s.fields);
+  const matches: Array<{ noun: string; index: number; candidates: SchemaField[] }> = [];
+
+  for (const entry of BUSINESS_FIELD_SYNONYMS) {
+    for (const noun of entry.nouns) {
+      const nounIndex = phraseIndexInAsk(ask, noun);
+      if (nounIndex < 0) continue;
+
+      const literalClaimsNoun = literalHits.some(({ field }) => {
+        const names = [bareName(field.columnName), field.caption, field.name].filter(
+          (name): name is string => !!name && name.length > 0,
+        );
+        if (names.some((name) => fieldNameMatchInAsk(ask, name, exactNames) === nounIndex)) {
+          return true;
+        }
+        return names.some((name) => {
+          const expansion = ACRONYM_EXPANSIONS[name.trim().toLowerCase()];
+          return expansion?.includes(noun) && acronymExpansionMatch(ask, field) >= 0;
+        });
+      });
+      if (literalClaimsNoun) continue;
+
+      const candidates = s.fields.filter((field) =>
+        entry.captionPatterns.some((pattern) => fieldMatchesCaptionPattern(field, pattern)),
+      );
+      matches.push({ noun, index: nounIndex, candidates });
+    }
+  }
+
+  return matches;
+}
+
+/**
+ * Unambiguous business-synonym field matches. Zero candidates fall through; multiple
+ * candidates are withheld so classifyNoLlm can fail closed and expose them in proposal fields.
+ */
+function businessSynonymMatchesInAsk(
+  ask: string,
+  s: SchemaSummary,
+  literalHits: readonly FieldMatch[],
+): Array<FieldMatch & { noun: string }> {
+  return businessSynonymCandidatesInAsk(ask, s, literalHits)
+    .filter(
+      (match): match is typeof match & { candidates: [SchemaField] } =>
+        match.candidates.length === 1,
+    )
+    .map(({ noun, index, candidates }) => ({ noun, index, field: candidates[0] }));
+}
+
 /**
  * Blank out whole-token occurrences of every field name/caption/bare column name
  * in the ask (replaced by spaces so token boundaries are preserved). Used for
@@ -1048,6 +1155,7 @@ function acronymExpansionMatch(ask: string, field: SchemaField): number {
 function maskFieldNames(ask: string, s: SchemaSummary): string {
   let masked = ask;
   const exactNames = fieldExactNames(s.fields);
+  const literalHits = literalFieldMatchesInAsk(ask, s);
   // LONGEST FIELD NAME FIRST. Schema-order masking fragments a compound field:
   // masking "Region" before "Country/Region" turns it into "Country/      " so the
   // compound's own regex no longer matches, and the surviving "Country" token trips
@@ -1084,27 +1192,33 @@ function maskFieldNames(ask: string, s: SchemaSummary): string {
       );
     }
   }
+  // A uniquely resolved business noun is a field mention too: mask it before chart-family
+  // and aggregation scoring. Ambiguous/unknown nouns remain untouched and follow today's path.
+  for (const { noun } of businessSynonymMatchesInAsk(ask, s, literalHits)) {
+    const body = escapeRegex(noun).replace(/-/g, '[\\s-]+');
+    const re = new RegExp(`(^|[^a-z0-9])(${body})([^a-z0-9]|$)`, 'gi');
+    masked = masked.replace(
+      re,
+      (_whole, pre: string, mid: string, post: string) => pre + ' '.repeat(mid.length) + post,
+    );
+  }
   return masked;
 }
 
 /** Fields whose name/caption/bare column name appear in the ask, earliest-first. */
 function matchFieldsInAsk(ask: string, s: SchemaSummary): SchemaField[] {
-  const exactNames = fieldExactNames(s.fields);
-  const hits: Array<{ field: SchemaField; index: number }> = [];
-  for (const f of s.fields) {
-    const names = [bareName(f.columnName), f.caption, f.name].filter(
-      (n): n is string => !!n && n.length > 0,
-    );
-    let best = -1;
-    for (const n of names) {
-      const idx = fieldNameMatchInAsk(ask, n, exactNames);
-      if (idx >= 0 && (best < 0 || idx < best)) best = idx;
-    }
-    if (best < 0) best = acronymExpansionMatch(ask, f);
-    if (best >= 0) hits.push({ field: f, index: best });
-  }
+  const literalHits = literalFieldMatchesInAsk(ask, s);
+  const hits: FieldMatch[] = [
+    ...literalHits,
+    ...businessSynonymMatchesInAsk(ask, s, literalHits),
+  ];
   hits.sort((a, b) => a.index - b.index);
-  return hits.map((h) => h.field);
+  const seen = new Set<SchemaField>();
+  return hits.flatMap(({ field }) => {
+    if (seen.has(field)) return [];
+    seen.add(field);
+    return [field];
+  });
 }
 
 /** Whole-phrase test: does the ask NAME this field (by name, caption, or bare column)? */
@@ -1165,6 +1279,7 @@ function fieldFitsSlotKind(kind: SlotKind, f: SchemaField): boolean {
 /**
  * Field-narrowing for the propose prompt (stage 2B, adjudicated attack 1). A wide
  * schema (300–1000 fields) would blow the prompt, so rank and cap:
+ *   rank 0 — business-synonym candidates when that noun was not literally resolved;
  *   rank 1 — fields whose name/caption tokens overlap the ask (a field the ask
  *            NAMES is guaranteed rank-1, so it survives the cap);
  *   rank 2 — fields kind-compatible with any required slot of any candidate;
@@ -1182,6 +1297,16 @@ function narrowFields(
 
   const askTokens = contentTokens(ask);
   const exactNames = fieldExactNames(fields);
+  const synonymSummary: SchemaSummary = {
+    datasource: fields[0]?.datasource ?? '',
+    fields,
+  };
+  const literalHits = literalFieldMatchesInAsk(ask, synonymSummary);
+  const synonymCandidates = new Set(
+    businessSynonymCandidatesInAsk(ask, synonymSummary, literalHits).flatMap(
+      (match) => match.candidates,
+    ),
+  );
   const ranked = fields.map((f, index) => {
     const named = askNamesField(ask, f, exactNames);
     let overlap = 0;
@@ -1190,7 +1315,8 @@ function narrowFields(
     }
     const relevant = named || overlap > 0;
     const compatible = !relevant && [...kinds].some((k) => fieldFitsSlotKind(k, f));
-    const tier = relevant ? 2 : compatible ? 1 : 0;
+    const synonymCandidate = synonymCandidates.has(f);
+    const tier = synonymCandidate ? 3 : relevant ? 2 : compatible ? 1 : 0;
     return { f, index, tier, named, overlap };
   });
 
@@ -2522,6 +2648,18 @@ export function classifyNoLlm(
   // return null so the orchestrator escalates rather than risk a silent wrong bind on a
   // partial view. Checked at the TOP, before any field is touched, so cost stays bounded.
   if (summary.fields.length > MAX_CLASSIFIABLE_FIELDS) return null;
+
+  // A business noun with multiple caption-pattern candidates is materially ambiguous:
+  // deterministic binding could change the numbers. Fail closed before template selection;
+  // buildLlmInput ranks every candidate into the existing proposal field list.
+  const literalHits = literalFieldMatchesInAsk(ask, summary);
+  if (
+    businessSynonymCandidatesInAsk(ask, summary, literalHits).some(
+      ({ candidates }) => candidates.length > 1,
+    )
+  ) {
+    return null;
+  }
 
   // Mask field names before scoring so a field NAME can't select a template or
   // read as an aggregation word; field↔slot matching still uses the raw ask.

--- a/src/desktop/binder/manifest-encoding-corpus.test.ts
+++ b/src/desktop/binder/manifest-encoding-corpus.test.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
 
-import { classifyNoLlm, summarizeSchema } from './binder.js';
+import { bindTemplate, classifyNoLlm, summarizeSchema } from './binder.js';
 import { hasDeterministicPathBlockingHazard } from './classify.js';
 import { loadManifests } from './manifest.js';
 import type { SlotSpec, TemplateManifest } from './manifest-types.js';
@@ -75,6 +75,19 @@ const NARROW = `<?xml version='1.0'?>
 <workbook><datasources><datasource name='Narrow'>
   <column name='[Order Date]' role='dimension' type='quantitative' datatype='date' />
   <column name='[Region]' role='dimension' type='nominal' datatype='string' />
+  <column name='[Sales]' role='measure' type='quantitative' datatype='real' />
+</datasource></datasources></workbook>`;
+
+const SINGLE_DATE = `<?xml version='1.0'?>
+<workbook><datasources><datasource name='SingleDate'>
+  <column name='[Order Date]' role='dimension' type='quantitative' datatype='date' />
+  <column name='[Sales]' role='measure' type='quantitative' datatype='real' />
+</datasource></datasources></workbook>`;
+
+const TWO_DATES = `<?xml version='1.0'?>
+<workbook><datasources><datasource name='TwoDates'>
+  <column name='[Order Date]' role='dimension' type='quantitative' datatype='date' />
+  <column name='[Ship Date]' role='dimension' type='quantitative' datatype='datetime' />
   <column name='[Sales]' role='measure' type='quantitative' datatype='real' />
 </datasource></datasources></workbook>`;
 
@@ -1046,6 +1059,83 @@ beforeAll(() => {
 beforeEach(() => {
   // A future early return must fail instead of manufacturing another green, assertion-free row.
   expect.hasAssertions();
+});
+
+describe('binder/manifest-encoding-corpus — temporal-slot fallback', () => {
+  const expectedExplicitDateClassification = {
+    template: 'trend-line-chart',
+    bindings: [
+      { slot_id: 'order_date', field: 'Order Date' },
+      { slot_id: 'sales', field: 'Sales' },
+    ],
+    encodings: { filled: [], unfilled: [] },
+  };
+
+  it('binds the only date field when a trend ask names no date field', () => {
+    const result = classifyNoLlm('sales over time', manifests, summarizeSchema(SINGLE_DATE));
+
+    expect(result).toEqual({
+      ...expectedExplicitDateClassification,
+      notes: [
+        "Using 'Order Date' for required temporal slot 'order_date' because it is the only date field in the datasource.",
+      ],
+    });
+  });
+
+  it.each([
+    'line chart of Sales by date',
+    'line chart of Sales by month',
+    'line chart of Sales by quarter',
+    'line chart of Sales by year',
+    'line chart of Sales monthly',
+    'line chart of Sales quarterly',
+    'line chart of Sales yearly',
+    'line chart of Sales daily',
+    'line chart of Sales over the last 6 months',
+    'line chart of Sales for the last 2 quarters',
+    'line chart of Sales across the last 3 years',
+  ])('recognizes the temporal cue in "%s"', (ask) => {
+    const trend = manifests.get('trend-line-chart')!;
+    const result = classifyNoLlm(
+      ask,
+      new Map([[trend.template, trend]]),
+      summarizeSchema(SINGLE_DATE),
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.bindings).toContainEqual({ slot_id: 'order_date', field: 'Order Date' });
+  });
+
+  it('proposes both date candidates instead of binding either when the choice is material', async () => {
+    const result = await bindTemplate({
+      ask: 'sales over time',
+      workbookXml: TWO_DATES,
+      manifests,
+    });
+
+    expect(result.status).toBe('propose');
+    if (result.status !== 'propose') return;
+    expect(
+      result.llm_input.candidate_templates
+        .find((candidate) => candidate.template === 'trend-line-chart')
+        ?.slots.find((slot) => slot.slot_id === 'order_date'),
+    ).toMatchObject({ kind: 'temporal', required: true });
+    expect(
+      result.llm_input.fields
+        .filter((field) => field.datatype === 'date' || field.datatype === 'datetime')
+        .map((field) => field.name),
+    ).toEqual(['Order Date', 'Ship Date']);
+  });
+
+  it('keeps an explicitly named date-field classification byte-identical', () => {
+    const result = classifyNoLlm(
+      'line chart of Sales by Order Date',
+      manifests,
+      summarizeSchema(SINGLE_DATE),
+    );
+
+    expect(JSON.stringify(result)).toBe(JSON.stringify(expectedExplicitDateClassification));
+  });
 });
 
 function bindableSlots(m: TemplateManifest): SlotSpec[] {

--- a/src/desktop/binder/manifest-encoding-corpus.test.ts
+++ b/src/desktop/binder/manifest-encoding-corpus.test.ts
@@ -91,6 +91,19 @@ const TWO_DATES = `<?xml version='1.0'?>
   <column name='[Sales]' role='measure' type='quantitative' datatype='real' />
 </datasource></datasources></workbook>`;
 
+function businessSynonymSchema(measures: readonly string[], dimension = 'Region'): string {
+  const columns = [
+    `<column name='[${dimension}]' role='dimension' type='nominal' datatype='string' />`,
+    ...measures.map(
+      (measure) =>
+        `<column name='[${measure}]' role='measure' type='quantitative' datatype='real' />`,
+    ),
+  ];
+  return `<?xml version='1.0'?><workbook><datasources><datasource name='BusinessSynonyms'>
+  ${columns.join('\n  ')}
+</datasource></datasources></workbook>`;
+}
+
 /**
  * One geo level (country) plus a NON-geographic spare dimension. This is the schema in which
  * the optional geo slots (`state`, `city`) can honestly be shown to stay unbound: Superstore
@@ -1162,6 +1175,88 @@ function slotIds(result: NonNullable<ReturnType<typeof classifyNoLlm>>): string[
 const MATRIX = CORPUS.flatMap((row) =>
   INTENTS.map(([intent, suffix]) => ({ row, intent, ask: row.ask + suffix })),
 );
+
+describe('binder/manifest-encoding-corpus — business-synonym field resolution', () => {
+  it('"revenue" uniquely resolves to Sales', () => {
+    const summary = summarizeSchema(businessSynonymSchema(['Sales']));
+
+    const result = classifyNoLlm('Show me revenue by region', manifests, summary);
+
+    expect(result).not.toBeNull();
+    expect(result!.bindings).toEqual([
+      { slot_id: 'category', field: 'Region' },
+      { slot_id: 'measure', field: 'Sales' },
+    ]);
+  });
+
+  it('literal Revenue wins over the Sales synonym candidate', () => {
+    const summary = summarizeSchema(businessSynonymSchema(['Sales', 'Revenue']));
+
+    const result = classifyNoLlm('Show me revenue by region', manifests, summary);
+
+    expect(result).not.toBeNull();
+    expect(result!.bindings).toEqual([
+      { slot_id: 'category', field: 'Region' },
+      { slot_id: 'measure', field: 'Revenue' },
+    ]);
+  });
+
+  it('ambiguous revenue candidates propose both Sales and Amount without binding', async () => {
+    const distractors = Array.from({ length: 25 }, (_, index) => `Metric ${index + 1}`);
+    const workbookXml = businessSynonymSchema(['Sales', 'Amount', ...distractors]);
+
+    const result = await bindTemplate({
+      ask: 'Show me revenue by region',
+      workbookXml,
+      manifests,
+    });
+
+    expect(result.status).toBe('propose');
+    if (result.status !== 'propose') throw new Error(`expected propose, got ${result.status}`);
+    expect(result.llm_input.fields.map((field) => field.name)).toEqual(
+      expect.arrayContaining(['Sales', 'Amount']),
+    );
+  });
+
+  it('"customers" uniquely resolves to Customer Name', () => {
+    const summary = summarizeSchema(businessSynonymSchema(['Sales'], 'Customer Name'));
+
+    const result = classifyNoLlm('top 10 customers by sales', manifests, summary);
+
+    expect(result).not.toBeNull();
+    expect(result!.template).toBe('ranking-ordered-bar');
+    expect(result!.bindings).toEqual([
+      { slot_id: 'region', field: 'Customer Name' },
+      { slot_id: 'sales', field: 'Sales' },
+    ]);
+    expect(result!.top_n).toBe(10);
+  });
+
+  it.each([
+    ['products', 'Product Name'],
+    ['orders', 'Order ID'],
+    ['reps', 'Sales Rep'],
+    ['salespeople', 'Sales Person'],
+    ['deals', 'Opportunity Name'],
+  ])('"%s" uniquely resolves to %s', (noun, dimension) => {
+    const summary = summarizeSchema(businessSynonymSchema(['Sales'], dimension));
+
+    const result = classifyNoLlm(`Show me Sales by ${noun}`, manifests, summary);
+
+    expect(result).not.toBeNull();
+    expect(result!.template).toBe('magnitude-simple-bar');
+    expect(result!.bindings).toEqual([
+      { slot_id: 'category', field: dimension },
+      { slot_id: 'measure', field: 'Sales' },
+    ]);
+  });
+
+  it('falls through when a business noun has no caption-pattern match', () => {
+    const summary = summarizeSchema(businessSynonymSchema(['Profit']));
+
+    expect(classifyNoLlm('Show me revenue by region', manifests, summary)).toBeNull();
+  });
+});
 
 describe('binder/manifest-encoding-corpus — census tripwires', () => {
   it('covers every manifest on disk exactly once', () => {

--- a/src/tools/desktop/cannotKnowGate.test.ts
+++ b/src/tools/desktop/cannotKnowGate.test.ts
@@ -1,3 +1,8 @@
+/*
+ * Known limitations: this hunter does not correlate an observed identifier to the claim it
+ * supports (an unrelated `result` identifier can satisfy a receipt), and it does not inspect
+ * Boolean()/!! coercions whose assigned name falls outside FLAG_NAME. Both are follow-ups.
+ */
 import { readdirSync, readFileSync } from 'fs';
 import { join, relative } from 'path';
 import ts from 'typescript';
@@ -17,27 +22,48 @@ type Violation = {
 const RECEIPT_ALLOWLIST: Readonly<Record<string, string>> = {
   // WHY safe: this receipt describes a local retry-policy decision, not an external effect;
   // `reason` is the observed branch input and `unverified` disclaims permanence.
-  'src/tools/desktop/data-source/getSummaryData.ts#nextActionForSummaryError':
-    'Local terminal-policy receipt with no external mutation claim.',
+  [receiptExemptionKey(
+    'src/tools/desktop/data-source/getSummaryData.ts',
+    'nextActionForSummaryError',
+    ['stopped get-summary-data on a terminal " " failure'],
+  )]: 'Local terminal-policy receipt with no external mutation claim.',
   // WHY safe: callers pass this record only after rememberedSheetStillPresent re-read the live
   // workbook; the receipt limits its claim to name presence and disclaims field/content checks.
-  'src/tools/desktop/binder/bindTemplate.ts#reusedSheetResult':
-    'Live name presence is checked immediately before this result is constructed.',
+  [receiptExemptionKey(
+    'src/tools/desktop/binder/bindTemplate.ts',
+    'reusedSheetResult',
+    [
+      'matched this ask to the sheet " " this session already applied (template  )',
+      'authored calcs:  ',
+    ],
+  )]: 'Live name presence is checked immediately before this result is constructed.',
 };
 
 const BOOLEAN_FLAG_ALLOWLIST: Readonly<Record<string, string>> = {
   // WHY safe: `true` requires both an actual encoding report and zero reported gaps. Undefined
   // can only produce false, and the receipt separately reports that analysis as unverified.
-  'src/tools/desktop/binder/bindTemplate.ts#encodingAnalysisComplete':
-    'Undefined cannot produce a completed claim; it is explicitly disclosed as unverified.',
+  [booleanExemptionKey(
+    'src/tools/desktop/binder/bindTemplate.ts',
+    `encodingAnalysisComplete =
+    res.encodings !== undefined && res.encodings.unfilled.length === 0`,
+  )]: 'Undefined cannot produce a completed claim; it is explicitly disclosed as unverified.',
   // WHY safe: this flag means a known non-empty unfilled report exists. Undefined can only
   // contribute false and does not by itself assert that the overall bind is complete.
-  'src/tools/desktop/binder/bindTemplate.ts#incomplete':
-    'Presence is affirmative evidence of an incomplete bind, never evidence of completion.',
+  [booleanExemptionKey(
+    'src/tools/desktop/binder/bindTemplate.ts',
+    `incomplete =
+    waterfallReBindSlotUnfilled(res, schemaSummary) ||
+    unfilledEncodings !== undefined ||
+    spliced.warnings.length > 0 ||
+    promiseOutcome === 'failed'`,
+  )]: 'Presence is affirmative evidence of an incomplete bind, never evidence of completion.',
   // WHY safe: this is checked only after getWorkbookXml succeeds; true additionally requires
   // the read-back worksheet to contain the requested mark-label setting.
-  'src/tools/desktop/data-source/formatLabels.ts#applied':
-    'The optional worksheet is host readback, and true requires its requested setting.',
+  [booleanExemptionKey(
+    'src/tools/desktop/data-source/formatLabels.ts',
+    `applied =
+            worksheetXml !== undefined && hasMarkLabelsSetting(worksheetXml, showLabels)`,
+  )]: 'The optional worksheet is host readback, and true requires its requested setting.',
 };
 
 const CLAIM_EVIDENCE = [
@@ -86,20 +112,6 @@ function callName(node: ts.CallExpression): string | undefined {
   return undefined;
 }
 
-function containsCall(node: ts.Node | undefined, name: string): boolean {
-  if (!node) {
-    return false;
-  }
-  if (ts.isCallExpression(node) && callName(node) === name) {
-    return true;
-  }
-  let found = false;
-  node.forEachChild((child) => {
-    found ||= containsCall(child, name);
-  });
-  return found;
-}
-
 function unwrapExpression(expression: ts.Expression): ts.Expression {
   if (
     ts.isAsExpression(expression) ||
@@ -110,6 +122,14 @@ function unwrapExpression(expression: ts.Expression): ts.Expression {
     return unwrapExpression(expression.expression);
   }
   return expression;
+}
+
+function isDirectCall(node: ts.Expression | undefined, name: string): boolean {
+  if (!node) {
+    return false;
+  }
+  const expression = unwrapExpression(node);
+  return ts.isCallExpression(expression) && callName(expression) === name;
 }
 
 function stringValue(expression: ts.Expression): string | undefined {
@@ -153,12 +173,33 @@ function functionName(node: ts.FunctionLikeDeclaration, sourceFile: ts.SourceFil
   return `<anonymous@${lineOf(sourceFile, node)}>`;
 }
 
+function receiptExemptionKey(file: string, fn: string, claims: readonly string[]): string {
+  return JSON.stringify([file, fn, claims]);
+}
+
 function receiptAllowlistKey(
   file: string,
   fn: ts.FunctionLikeDeclaration,
   sourceFile: ts.SourceFile,
+  claims: readonly string[],
 ): string {
-  return `${normalizedRelative(file)}#${functionName(fn, sourceFile)}`;
+  return receiptExemptionKey(normalizedRelative(file), functionName(fn, sourceFile), claims);
+}
+
+function booleanExemptionKey(file: string, assignmentSource: string): string {
+  return JSON.stringify([file, assignmentSource]);
+}
+
+function useAllowlist(
+  allowlist: Readonly<Record<string, string>>,
+  key: string,
+  usedAllowlist: Set<string>,
+): boolean {
+  if (!allowlist[key] || usedAllowlist.has(key)) {
+    return false;
+  }
+  usedAllowlist.add(key);
+  return true;
 }
 
 function stringClaims(node: ts.Node): string[] {
@@ -210,12 +251,6 @@ function auditReceipt(
     ];
   }
 
-  const allowlistKey = receiptAllowlistKey(file, fn, sourceFile);
-  if (RECEIPT_ALLOWLIST[allowlistKey]) {
-    usedAllowlist.add(allowlistKey);
-    return [];
-  }
-
   const facts = call.arguments[0] && unwrapExpression(call.arguments[0]);
   const did =
     facts && ts.isObjectLiteralExpression(facts)
@@ -246,6 +281,11 @@ function auditReceipt(
         message: 'receipt.did has no statically reviewable claim text',
       },
     ];
+  }
+
+  const allowlistKey = receiptAllowlistKey(file, fn, sourceFile, claims);
+  if (useAllowlist(RECEIPT_ALLOWLIST, allowlistKey, usedAllowlist)) {
+    return [];
   }
 
   return claims.flatMap((claim) => {
@@ -356,9 +396,8 @@ function auditBooleanFlag(
     return [];
   }
 
-  const key = `${normalizedRelative(file)}#${assignment.name}`;
-  if (BOOLEAN_FLAG_ALLOWLIST[key]) {
-    usedAllowlist.add(key);
+  const key = booleanExemptionKey(normalizedRelative(file), node.getText(sourceFile));
+  if (useAllowlist(BOOLEAN_FLAG_ALLOWLIST, key, usedAllowlist)) {
     return [];
   }
   return [
@@ -446,7 +485,7 @@ function auditTerminal(node: ts.Node, file: string, sourceFile: ts.SourceFile): 
   }
 
   const envelope = enclosingCall(node, 'withNextAction');
-  if (envelope && containsCall(envelope.arguments[1], 'doneNextAction')) {
+  if (envelope && isDirectCall(envelope.arguments[1], 'doneNextAction')) {
     return [];
   }
   return [
@@ -455,7 +494,7 @@ function auditTerminal(node: ts.Node, file: string, sourceFile: ts.SourceFile): 
       line: lineOf(sourceFile, node),
       rule: 'TERMINAL_RECEIPT',
       message:
-        "status:'terminal' must be enveloped by withNextAction(..., doneNextAction(Receipt))",
+        "status:'terminal' must use doneNextAction(Receipt) as its unconditional next action",
     },
   ];
 }
@@ -551,5 +590,67 @@ describe('cannot-know hunter gate', () => {
       'RECEIPT_OBSERVATION',
       'TERMINAL_RECEIPT',
     ]);
+  });
+
+  it('does not exempt a new receipt in an allowlisted function', () => {
+    const file = join(DESKTOP_ROOT, 'data-source/getSummaryData.ts');
+    const source = readFileSync(file, 'utf-8');
+    const mutated = source.replace(
+      `function nextActionForSummaryError(
+  status: SummaryDataErrorStatus,
+  reason: SummaryDataErrorReason,
+): NextAction {
+`,
+      `function nextActionForSummaryError(
+  status: SummaryDataErrorStatus,
+  reason: SummaryDataErrorReason,
+): NextAction {
+  receipt({ did: ['applied an unobserved workbook change'], unverified: [] });
+`,
+    );
+    expect(mutated).not.toBe(source);
+
+    const violations = auditSource(file, mutated).violations.filter(
+      ({ rule }) => rule === 'RECEIPT_OBSERVATION',
+    );
+    expect(violations).toHaveLength(1);
+    expect(violations[0].message).toContain('applied an unobserved workbook change');
+  });
+
+  it('does not exempt a new same-named flag in an allowlisted file', () => {
+    const file = join(DESKTOP_ROOT, 'data-source/formatLabels.ts');
+    const source = `${readFileSync(file, 'utf-8')}
+      function syntheticFlag(optionalResult?: object) {
+        const applied = optionalResult !== undefined;
+        return applied;
+      }
+    `;
+
+    const violations = auditSource(file, source).violations.filter(
+      ({ rule }) => rule === 'BOOLEAN_FLAG',
+    );
+    expect(violations).toHaveLength(1);
+    expect(violations[0].message).toContain('"applied"');
+  });
+
+  it('rejects a conditional alternative to doneNextAction for terminal status', () => {
+    const synthetic = auditSource(
+      join(DESKTOP_ROOT, 'syntheticConditionalTerminal.ts'),
+      `
+        function conditionalTerminal(condition: boolean) {
+          return withNextAction(
+            { status: 'terminal' as const },
+            condition
+              ? prefillNextAction('Keep going')
+              : doneNextAction(receipt({
+                  did: ['stopped because status was terminal'],
+                  unverified: [],
+                })),
+          );
+        }
+      `,
+    );
+    const violations = synthetic.violations.filter(({ rule }) => rule === 'TERMINAL_RECEIPT');
+    expect(violations).toHaveLength(1);
   });
 });

--- a/src/tools/desktop/cannotKnowGate.test.ts
+++ b/src/tools/desktop/cannotKnowGate.test.ts
@@ -1,0 +1,555 @@
+import { readdirSync, readFileSync } from 'fs';
+import { join, relative } from 'path';
+import ts from 'typescript';
+
+const REPO_ROOT = join(__dirname, '../../..');
+const DESKTOP_ROOT = join(REPO_ROOT, 'src/tools/desktop');
+const FLAG_NAME = /(complete|success|applied|verified|loaded)/i;
+
+type Rule = 'BOOLEAN_FLAG' | 'RECEIPT_OBSERVATION' | 'TERMINAL_RECEIPT';
+type Violation = {
+  file: string;
+  line: number;
+  rule: Rule;
+  message: string;
+};
+
+const RECEIPT_ALLOWLIST: Readonly<Record<string, string>> = {
+  // WHY safe: this receipt describes a local retry-policy decision, not an external effect;
+  // `reason` is the observed branch input and `unverified` disclaims permanence.
+  'src/tools/desktop/data-source/getSummaryData.ts#nextActionForSummaryError':
+    'Local terminal-policy receipt with no external mutation claim.',
+  // WHY safe: callers pass this record only after rememberedSheetStillPresent re-read the live
+  // workbook; the receipt limits its claim to name presence and disclaims field/content checks.
+  'src/tools/desktop/binder/bindTemplate.ts#reusedSheetResult':
+    'Live name presence is checked immediately before this result is constructed.',
+};
+
+const BOOLEAN_FLAG_ALLOWLIST: Readonly<Record<string, string>> = {
+  // WHY safe: `true` requires both an actual encoding report and zero reported gaps. Undefined
+  // can only produce false, and the receipt separately reports that analysis as unverified.
+  'src/tools/desktop/binder/bindTemplate.ts#encodingAnalysisComplete':
+    'Undefined cannot produce a completed claim; it is explicitly disclosed as unverified.',
+  // WHY safe: this flag means a known non-empty unfilled report exists. Undefined can only
+  // contribute false and does not by itself assert that the overall bind is complete.
+  'src/tools/desktop/binder/bindTemplate.ts#incomplete':
+    'Presence is affirmative evidence of an incomplete bind, never evidence of completion.',
+  // WHY safe: this is checked only after getWorkbookXml succeeds; true additionally requires
+  // the read-back worksheet to contain the requested mark-label setting.
+  'src/tools/desktop/data-source/formatLabels.ts#applied':
+    'The optional worksheet is host readback, and true requires its requested setting.',
+};
+
+const CLAIM_EVIDENCE = [
+  {
+    claim: /\b(quer(?:y|ied)|return(?:ed)?|read|found)\b/i,
+    evidence: /\b(summaryResult|dataColumns|dataRows|readback|fetched\w*|response\w*|result\w*)\b/i,
+  },
+  {
+    claim:
+      /\b(appl(?:y|ied)|accept(?:ed)?|author(?:ed)?|bound|creat(?:e|ed)|updat(?:e|ed)|wrote|loaded|phase)\b/i,
+    evidence:
+      /\b(applyResult|readback\w*|verification|receiptInput|fetched\w*|response\w*|result\w*)\b/i,
+  },
+  {
+    claim: /\b(match(?:ed)?|reuse(?:d)?|remember(?:ed)?)\b/i,
+    evidence: /\b(readback\w*|fetched\w*|remembered\w*|result\w*|workbookXml)\b/i,
+  },
+  {
+    claim: /\b(stop(?:ped)?|terminal)\b/i,
+    evidence: /\b(reason|status|result\w*)\b/i,
+  },
+] as const;
+
+function sourceFiles(): string[] {
+  return readdirSync(DESKTOP_ROOT, { recursive: true })
+    .map(String)
+    .filter((file) => file.endsWith('.ts') && !file.endsWith('.test.ts'))
+    .map((file) => join(DESKTOP_ROOT, file));
+}
+
+function normalizedRelative(file: string): string {
+  return relative(REPO_ROOT, file).replaceAll('\\', '/');
+}
+
+function lineOf(sourceFile: ts.SourceFile, node: ts.Node): number {
+  return sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile)).line + 1;
+}
+
+function callName(node: ts.CallExpression): string | undefined {
+  if (ts.isIdentifier(node.expression)) {
+    return node.expression.text;
+  }
+  if (ts.isPropertyAccessExpression(node.expression)) {
+    return node.expression.name.text;
+  }
+  return undefined;
+}
+
+function containsCall(node: ts.Node | undefined, name: string): boolean {
+  if (!node) {
+    return false;
+  }
+  if (ts.isCallExpression(node) && callName(node) === name) {
+    return true;
+  }
+  let found = false;
+  node.forEachChild((child) => {
+    found ||= containsCall(child, name);
+  });
+  return found;
+}
+
+function unwrapExpression(expression: ts.Expression): ts.Expression {
+  if (
+    ts.isAsExpression(expression) ||
+    ts.isTypeAssertionExpression(expression) ||
+    ts.isParenthesizedExpression(expression) ||
+    ts.isSatisfiesExpression(expression)
+  ) {
+    return unwrapExpression(expression.expression);
+  }
+  return expression;
+}
+
+function stringValue(expression: ts.Expression): string | undefined {
+  const value = unwrapExpression(expression);
+  return ts.isStringLiteralLike(value) ? value.text : undefined;
+}
+
+function propertyName(node: ts.PropertyName): string | undefined {
+  return ts.isIdentifier(node) || ts.isStringLiteralLike(node) ? node.text : undefined;
+}
+
+function enclosingFunction(node: ts.Node): ts.FunctionLikeDeclaration | undefined {
+  let current = node.parent;
+  while (current) {
+    if (
+      ts.isFunctionDeclaration(current) ||
+      ts.isMethodDeclaration(current) ||
+      ts.isGetAccessorDeclaration(current) ||
+      ts.isSetAccessorDeclaration(current) ||
+      ts.isConstructorDeclaration(current) ||
+      ts.isFunctionExpression(current) ||
+      ts.isArrowFunction(current)
+    ) {
+      return current;
+    }
+    current = current.parent;
+  }
+  return undefined;
+}
+
+function functionName(node: ts.FunctionLikeDeclaration, sourceFile: ts.SourceFile): string {
+  if (node.name) {
+    return node.name.getText(sourceFile);
+  }
+  if (ts.isVariableDeclaration(node.parent) && ts.isIdentifier(node.parent.name)) {
+    return node.parent.name.text;
+  }
+  if (ts.isPropertyAssignment(node.parent)) {
+    return propertyName(node.parent.name) ?? `<anonymous@${lineOf(sourceFile, node)}>`;
+  }
+  return `<anonymous@${lineOf(sourceFile, node)}>`;
+}
+
+function receiptAllowlistKey(
+  file: string,
+  fn: ts.FunctionLikeDeclaration,
+  sourceFile: ts.SourceFile,
+): string {
+  return `${normalizedRelative(file)}#${functionName(fn, sourceFile)}`;
+}
+
+function stringClaims(node: ts.Node): string[] {
+  const claims: string[] = [];
+  function visit(child: ts.Node): void {
+    if (ts.isStringLiteralLike(child) || ts.isNoSubstitutionTemplateLiteral(child)) {
+      claims.push(child.text);
+      return;
+    }
+    if (ts.isTemplateExpression(child)) {
+      claims.push(
+        [child.head.text, ...child.templateSpans.map((span) => span.literal.text)].join(' '),
+      );
+      return;
+    }
+    child.forEachChild(visit);
+  }
+  visit(node);
+  return claims;
+}
+
+function identifierNames(node: ts.Node): string {
+  const names: string[] = [];
+  function visit(child: ts.Node): void {
+    if (ts.isIdentifier(child)) {
+      names.push(child.text);
+    }
+    child.forEachChild(visit);
+  }
+  visit(node);
+  return names.join(' ');
+}
+
+function auditReceipt(
+  call: ts.CallExpression,
+  file: string,
+  sourceFile: ts.SourceFile,
+  usedAllowlist: Set<string>,
+): Violation[] {
+  const fn = enclosingFunction(call);
+  if (!fn) {
+    return [
+      {
+        file: normalizedRelative(file),
+        line: lineOf(sourceFile, call),
+        rule: 'RECEIPT_OBSERVATION',
+        message: 'receipt() must be produced inside a function with observable evidence',
+      },
+    ];
+  }
+
+  const allowlistKey = receiptAllowlistKey(file, fn, sourceFile);
+  if (RECEIPT_ALLOWLIST[allowlistKey]) {
+    usedAllowlist.add(allowlistKey);
+    return [];
+  }
+
+  const facts = call.arguments[0] && unwrapExpression(call.arguments[0]);
+  const did =
+    facts && ts.isObjectLiteralExpression(facts)
+      ? facts.properties.find(
+          (property): property is ts.PropertyAssignment =>
+            ts.isPropertyAssignment(property) && propertyName(property.name) === 'did',
+        )
+      : undefined;
+  if (!did || !ts.isArrayLiteralExpression(unwrapExpression(did.initializer))) {
+    return [
+      {
+        file: normalizedRelative(file),
+        line: lineOf(sourceFile, call),
+        rule: 'RECEIPT_OBSERVATION',
+        message: 'receipt.did must be an inline array so its claims can be audited',
+      },
+    ];
+  }
+
+  const functionIdentifiers = identifierNames(fn);
+  const claims = stringClaims(did.initializer);
+  if (claims.length === 0) {
+    return [
+      {
+        file: normalizedRelative(file),
+        line: lineOf(sourceFile, did),
+        rule: 'RECEIPT_OBSERVATION',
+        message: 'receipt.did has no statically reviewable claim text',
+      },
+    ];
+  }
+
+  return claims.flatMap((claim) => {
+    const category = CLAIM_EVIDENCE.find(({ claim: claimWords }) => claimWords.test(claim));
+    if (!category) {
+      return [
+        {
+          file: normalizedRelative(file),
+          line: lineOf(sourceFile, did),
+          rule: 'RECEIPT_OBSERVATION' as const,
+          message: `did claim has no reviewed claim-word category: ${JSON.stringify(claim)}`,
+        },
+      ];
+    }
+    if (category.evidence.test(functionIdentifiers)) {
+      return [];
+    }
+    return [
+      {
+        file: normalizedRelative(file),
+        line: lineOf(sourceFile, did),
+        rule: 'RECEIPT_OBSERVATION' as const,
+        message: `did claim lacks a correlated observation in ${functionName(fn, sourceFile)}: ${JSON.stringify(claim)}`,
+      },
+    ];
+  });
+}
+
+function containsUndefinedComparison(node: ts.Node): boolean {
+  if (
+    ts.isBinaryExpression(node) &&
+    node.operatorToken.kind === ts.SyntaxKind.ExclamationEqualsEqualsToken &&
+    ((ts.isIdentifier(node.left) && node.left.text === 'undefined') ||
+      (ts.isIdentifier(node.right) && node.right.text === 'undefined'))
+  ) {
+    return true;
+  }
+  let found = false;
+  node.forEachChild((child) => {
+    found ||= containsUndefinedComparison(child);
+  });
+  return found;
+}
+
+function booleanFlagAssignment(
+  node: ts.Node,
+): { name: string; initializer: ts.Expression } | undefined {
+  if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.initializer) {
+    return { name: node.name.text, initializer: node.initializer };
+  }
+  if (ts.isPropertyAssignment(node)) {
+    const name = propertyName(node.name);
+    return name ? { name, initializer: node.initializer } : undefined;
+  }
+  if (
+    ts.isBinaryExpression(node) &&
+    node.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+    (ts.isIdentifier(node.left) || ts.isPropertyAccessExpression(node.left))
+  ) {
+    return {
+      name: ts.isIdentifier(node.left) ? node.left.text : node.left.name.text,
+      initializer: node.right,
+    };
+  }
+  return undefined;
+}
+
+function isBooleanExpression(expression: ts.Expression): boolean {
+  const value = unwrapExpression(expression);
+  if (value.kind === ts.SyntaxKind.TrueKeyword || value.kind === ts.SyntaxKind.FalseKeyword) {
+    return true;
+  }
+  if (ts.isPrefixUnaryExpression(value)) {
+    return value.operator === ts.SyntaxKind.ExclamationToken;
+  }
+  if (!ts.isBinaryExpression(value)) {
+    return false;
+  }
+  return [
+    ts.SyntaxKind.AmpersandAmpersandToken,
+    ts.SyntaxKind.BarBarToken,
+    ts.SyntaxKind.EqualsEqualsEqualsToken,
+    ts.SyntaxKind.ExclamationEqualsEqualsToken,
+    ts.SyntaxKind.EqualsEqualsToken,
+    ts.SyntaxKind.ExclamationEqualsToken,
+    ts.SyntaxKind.GreaterThanToken,
+    ts.SyntaxKind.GreaterThanEqualsToken,
+    ts.SyntaxKind.LessThanToken,
+    ts.SyntaxKind.LessThanEqualsToken,
+    ts.SyntaxKind.InKeyword,
+    ts.SyntaxKind.InstanceOfKeyword,
+  ].includes(value.operatorToken.kind);
+}
+
+function auditBooleanFlag(
+  node: ts.Node,
+  file: string,
+  sourceFile: ts.SourceFile,
+  usedAllowlist: Set<string>,
+): Violation[] {
+  const assignment = booleanFlagAssignment(node);
+  if (
+    !assignment ||
+    !FLAG_NAME.test(assignment.name) ||
+    !isBooleanExpression(assignment.initializer) ||
+    !containsUndefinedComparison(assignment.initializer)
+  ) {
+    return [];
+  }
+
+  const key = `${normalizedRelative(file)}#${assignment.name}`;
+  if (BOOLEAN_FLAG_ALLOWLIST[key]) {
+    usedAllowlist.add(key);
+    return [];
+  }
+  return [
+    {
+      file: normalizedRelative(file),
+      line: lineOf(sourceFile, node),
+      rule: 'BOOLEAN_FLAG',
+      message: `"${assignment.name}" derives a truth claim from optional-data presence (!== undefined)`,
+    },
+  ];
+}
+
+function enclosingCall(node: ts.Node, name: string): ts.CallExpression | undefined {
+  let current = node.parent;
+  while (current && !ts.isFunctionLike(current)) {
+    if (ts.isCallExpression(current) && callName(current) === name) {
+      return current;
+    }
+    current = current.parent;
+  }
+  return undefined;
+}
+
+function isBrandedDoneFactory(node: ts.PropertyAssignment, sourceFile: ts.SourceFile): boolean {
+  const fn = enclosingFunction(node);
+  if (!fn || functionName(fn, sourceFile) !== 'doneNextAction') {
+    return false;
+  }
+  const receiptParameter = fn.parameters.find(
+    (parameter) =>
+      ts.isIdentifier(parameter.name) &&
+      parameter.name.text === 'toolReceipt' &&
+      parameter.type?.getText(sourceFile) === 'Receipt',
+  );
+  const object = node.parent;
+  const receiptProperty =
+    ts.isObjectLiteralExpression(object) &&
+    object.properties.find(
+      (property): property is ts.PropertyAssignment =>
+        ts.isPropertyAssignment(property) && propertyName(property.name) === 'receipt',
+    );
+  return Boolean(
+    receiptParameter &&
+    receiptProperty &&
+    ts.isIdentifier(receiptProperty.initializer) &&
+    receiptProperty.initializer.text === 'toolReceipt',
+  );
+}
+
+function auditTerminal(node: ts.Node, file: string, sourceFile: ts.SourceFile): Violation[] {
+  if (ts.isCallExpression(node) && callName(node) === 'doneNextAction') {
+    const toolReceipt = node.arguments[0] && unwrapExpression(node.arguments[0]);
+    if (toolReceipt && ts.isCallExpression(toolReceipt) && callName(toolReceipt) === 'receipt') {
+      return [];
+    }
+    return [
+      {
+        file: normalizedRelative(file),
+        line: lineOf(sourceFile, node),
+        rule: 'TERMINAL_RECEIPT',
+        message: 'doneNextAction must receive a receipt() result directly',
+      },
+    ];
+  }
+  if (!ts.isPropertyAssignment(node)) {
+    return [];
+  }
+  const name = propertyName(node.name);
+  const value = stringValue(node.initializer);
+  if (name === 'kind' && value === 'done') {
+    if (isBrandedDoneFactory(node, sourceFile)) {
+      return [];
+    }
+    return [
+      {
+        file: normalizedRelative(file),
+        line: lineOf(sourceFile, node),
+        rule: 'TERMINAL_RECEIPT',
+        message: "kind:'done' may only be minted by doneNextAction(Receipt)",
+      },
+    ];
+  }
+  if (name !== 'status' || value !== 'terminal') {
+    return [];
+  }
+
+  const envelope = enclosingCall(node, 'withNextAction');
+  if (envelope && containsCall(envelope.arguments[1], 'doneNextAction')) {
+    return [];
+  }
+  return [
+    {
+      file: normalizedRelative(file),
+      line: lineOf(sourceFile, node),
+      rule: 'TERMINAL_RECEIPT',
+      message:
+        "status:'terminal' must be enveloped by withNextAction(..., doneNextAction(Receipt))",
+    },
+  ];
+}
+
+function auditSource(
+  file: string,
+  text = readFileSync(file, 'utf-8'),
+): {
+  violations: Violation[];
+  receiptAllowlist: Set<string>;
+  booleanAllowlist: Set<string>;
+} {
+  const sourceFile = ts.createSourceFile(file, text, ts.ScriptTarget.Latest, true);
+  const violations: Violation[] = [];
+  const receiptAllowlist = new Set<string>();
+  const booleanAllowlist = new Set<string>();
+
+  function visit(node: ts.Node): void {
+    if (ts.isCallExpression(node) && callName(node) === 'receipt') {
+      violations.push(...auditReceipt(node, file, sourceFile, receiptAllowlist));
+    }
+    violations.push(...auditTerminal(node, file, sourceFile));
+    violations.push(...auditBooleanFlag(node, file, sourceFile, booleanAllowlist));
+    ts.forEachChild(node, visit);
+  }
+  visit(sourceFile);
+  return { violations, receiptAllowlist, booleanAllowlist };
+}
+
+function formatViolations(violations: readonly Violation[]): string {
+  return violations
+    .map(({ file, line, rule, message }) => `${file}:${line} [${rule}] ${message}`)
+    .join('\n');
+}
+
+const treeAudit = sourceFiles()
+  .map((file) => auditSource(file))
+  .reduce(
+    (all, audit) => {
+      all.violations.push(...audit.violations);
+      audit.receiptAllowlist.forEach((key) => all.receiptAllowlist.add(key));
+      audit.booleanAllowlist.forEach((key) => all.booleanAllowlist.add(key));
+      return all;
+    },
+    {
+      violations: [] as Violation[],
+      receiptAllowlist: new Set<string>(),
+      booleanAllowlist: new Set<string>(),
+    },
+  );
+
+describe('cannot-know hunter gate', () => {
+  it('requires observable evidence for every receipt.did claim', () => {
+    const violations = treeAudit.violations.filter(({ rule }) => rule === 'RECEIPT_OBSERVATION');
+    expect(violations, `Cannot-know gate failed:\n${formatViolations(violations)}`).toEqual([]);
+    expect([...treeAudit.receiptAllowlist].sort()).toEqual(Object.keys(RECEIPT_ALLOWLIST).sort());
+  });
+
+  it('requires terminal results to flow through the branded Receipt factory', () => {
+    const violations = treeAudit.violations.filter(({ rule }) => rule === 'TERMINAL_RECEIPT');
+    expect(violations, `Cannot-know gate failed:\n${formatViolations(violations)}`).toEqual([]);
+  });
+
+  it('rejects truth flags derived from optional-data presence', () => {
+    const violations = treeAudit.violations.filter(({ rule }) => rule === 'BOOLEAN_FLAG');
+    expect(violations, `Cannot-know gate failed:\n${formatViolations(violations)}`).toEqual([]);
+    expect([...treeAudit.booleanAllowlist].sort()).toEqual(
+      Object.keys(BOOLEAN_FLAG_ALLOWLIST).sort(),
+    );
+  });
+
+  it('recognizes synthetic violations for all three rules', () => {
+    const synthetic = auditSource(
+      join(DESKTOP_ROOT, 'syntheticViolation.ts'),
+      `
+        function fakeApply(optionalResult?: object) {
+          const appliedComplete = optionalResult !== undefined;
+          return withNextAction(
+            { status: 'terminal' as const, appliedComplete },
+            prefillNextAction('Keep going'),
+          );
+        }
+        function fakeReceipt() {
+          return receipt({
+            did: ['applied the workbook'],
+            unverified: [],
+          });
+        }
+      `,
+    );
+    expect(synthetic.violations.map(({ rule }) => rule).sort()).toEqual([
+      'BOOLEAN_FLAG',
+      'RECEIPT_OBSERVATION',
+      'TERMINAL_RECEIPT',
+    ]);
+  });
+});

--- a/src/tools/desktop/data-source/getSummaryData.test.ts
+++ b/src/tools/desktop/data-source/getSummaryData.test.ts
@@ -111,7 +111,7 @@ describe('getSummaryDataTool', () => {
     }
   });
 
-  it('returns a terminal result without querying a worksheet that has no datasource', async () => {
+  it('requires action without querying a worksheet that has no datasource', async () => {
     const harness = await startHarness((server) => {
       server.setOverride('GET /v0/workbook/worksheets', {
         status: 200,
@@ -127,7 +127,7 @@ describe('getSummaryDataTool', () => {
 
       expect(result.isError).toBe(false);
       expect(parseJsonResult(result)).toEqual({
-        status: 'terminal',
+        status: 'action-required',
         reason: 'empty-sheet',
         worksheet: { id: 'sheet-empty', name: 'Empty Sheet' },
         maxRows: 200,
@@ -148,7 +148,7 @@ describe('getSummaryDataTool', () => {
     }
   });
 
-  it('returns a terminal result when the worksheet has no marks', async () => {
+  it('requires action when the worksheet has no marks', async () => {
     const harness = await startHarness((server) => {
       server.setOverride('GET /v0/workbook/worksheets/sheet-sales/summaryData', {
         status: 200,
@@ -162,7 +162,7 @@ describe('getSummaryDataTool', () => {
 
       expect(result.isError).toBe(false);
       expect(parseJsonResult(result)).toMatchObject({
-        status: 'terminal',
+        status: 'action-required',
         reason: 'empty-sheet',
         shape: '0 rows x 0 columns',
         summaryData: { columns: [], rows: [] },

--- a/src/tools/desktop/data-source/getSummaryData.ts
+++ b/src/tools/desktop/data-source/getSummaryData.ts
@@ -62,7 +62,12 @@ type SummaryDataCompletedBody =
   | ({ status: 'success' } & SummaryDataValue)
   | ({
       status: 'terminal';
-      reason: 'empty-sheet' | 'no-rows';
+      reason: 'no-rows';
+      guidance: string;
+    } & SummaryDataValue)
+  | ({
+      status: 'action-required';
+      reason: 'empty-sheet';
       guidance: string;
     } & SummaryDataValue);
 
@@ -346,7 +351,7 @@ function worksheetError(error: ArgsValidationError): SummaryDataResponseError {
 function emptySheetResult(worksheet: WorksheetItem, maxRows: number): SummaryDataCompletedResult {
   return withNextAction(
     {
-      status: 'terminal' as const,
+      status: 'action-required' as const,
       reason: 'empty-sheet' as const,
       worksheet: { id: worksheet.id, name: worksheet.name },
       maxRows,


### PR DESCRIPTION
Stacks on #644. The class campaign the owner ranked second: stop playing whack-a-mole with producer-written statuses that claim what they never observed (eight shipped instances this month), and build the hunter.

The rule this sets: a new cannot-know shape on the served surface fails CI — receipt claims need a correlated observation, terminal language needs the branded Receipt, and truth-flags may not derive from optional-data presence. The allowlist is the escape hatch and every entry carries its WHY; stale entries fail the gate.

Proof it hunts: calibration flushed a real instance (get-summary-data's empty-sheet result was terminal while prescribing a follow-up action — now action-required), and the report demonstrates the gate catching a synthetic violation on all three rules.

Honest limit: the observation-correlation is a heuristic, not semantic proof — it narrows the class; review still owns judgment.

Validation (run firsthand): full suite green, tsc clean, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)