### PR TITLE
docs(knowledge): prefer the name field for geographic roles; codes silently drop members

### DIFF
--- a/resources/desktop/knowledge/tactics/viz/marks-and-encodings.md
+++ b/resources/desktop/knowledge/tactics/viz/marks-and-encodings.md
@@ -451,12 +451,6 @@ Key requirements:
 - Mark class is `Automatic`
 - No lat/lon column defs needed — Tableau generates them
 
-### Choosing the geographic field
-
-When several fields could supply the same geographic role (country, state, or city), prefer the full name field over a code or ID. Tableau geocoding recognizes names and ISO-3166 country codes, not arbitrary sport or vendor code sets. If explicit latitude and longitude columns exist, prefer those over either field because they bypass geocoding.
-
-**Does NOT work:** assuming a code field is safe because most members render. In the 48-country World Cup data, FIFA codes `POR`, `SCO`, `ENG`, and `PAR` are not ISO-3166 codes and silently disappear from the map; the corresponding country names geocode all 48.
-
 ```xml
 <view>
   <datasources>
@@ -489,6 +483,12 @@ Rows/cols:
 <rows>[DS].[Latitude (generated)]</rows>
 <cols>[DS].[Longitude (generated)]</cols>
 ```
+
+### Choosing the geographic field
+
+When several fields could supply the same geographic role (country, state, or city), pick by what Tableau's geocoder recognizes: full names and ISO-3166 country codes both geocode; sport or vendor code sets (FIFA, IOC, internal IDs) do not. Prefer the name field unless the codes are known ISO-3166 — and never swap a valid ISO code field for a name field whose members are ambiguous on their own (e.g. "Congo"). If explicit latitude and longitude columns exist, prefer those over either because they bypass geocoding entirely. After binding, verify the map's rendered member count against the data's distinct count — unrecognized members drop silently, with no error or warning.
+
+**Does NOT work:** assuming a code field is safe because most members render. In the 48-country World Cup data, FIFA codes `POR`, `SCO`, `ENG`, and `PAR` are not ISO-3166 codes and silently disappear from the map; the corresponding country names geocode all 48.
 
 ---
 

--- a/resources/desktop/knowledge/tactics/viz/marks-and-encodings.md
+++ b/resources/desktop/knowledge/tactics/viz/marks-and-encodings.md
@@ -451,6 +451,12 @@ Key requirements:
 - Mark class is `Automatic`
 - No lat/lon column defs needed — Tableau generates them
 
+### Choosing the geographic field
+
+When several fields could supply the same geographic role (country, state, or city), prefer the full name field over a code or ID. Tableau geocoding recognizes names and ISO-3166 country codes, not arbitrary sport or vendor code sets. If explicit latitude and longitude columns exist, prefer those over either field because they bypass geocoding.
+
+**Does NOT work:** assuming a code field is safe because most members render. In the 48-country World Cup data, FIFA codes `POR`, `SCO`, `ENG`, and `PAR` are not ISO-3166 codes and silently disappear from the map; the corresponding country names geocode all 48.
+
 ```xml
 <view>
   <datasources>


### PR DESCRIPTION
One targeted knowledge entry, grounded in a live scored run from today: the agent bound a country code field for a symbol map and Tableau's geocoder silently dropped 4 of 48 countries (FIFA codes are not ISO-3166); the name field geocodes all 48. Five lines in `tactics/viz/marks-and-encodings.md` — names beat codes, explicit lat/long beats both, with the does-NOT-work example being the exact live miss.

Deliberately minimal: this corpus measurably regressed an eval when it grew indiscriminately, so the burst is one live-proven gap, not a sweep.

Validation: corpus integrity + section-read gates green, tsc clean, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)