### PR TITLE
@W-23584783: Add auth_type field to product telemetry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "3.6.0",
+      "version": "3.6.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.7.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/src/telemetry/authType.test.ts
+++ b/src/telemetry/authType.test.ts
@@ -1,0 +1,76 @@
+import { Config } from '../config.js';
+import { TableauAuthInfo } from '../server/oauth/schemas.js';
+import { getAuthTypeForTelemetry } from './authType.js';
+
+// The function only reads config.auth, so a minimal cast keeps these tests focused on the unit.
+const configWithAuth = (auth: Config['auth']): Config => ({ auth }) as unknown as Config;
+
+const xTableauAuthInfo: TableauAuthInfo = {
+  type: 'X-Tableau-Auth',
+  username: 'user@example.com',
+  server: 'https://my-tableau.example.com',
+  siteName: 'my-site',
+};
+
+const bearerAuthInfo: TableauAuthInfo = {
+  type: 'Bearer',
+  username: 'user@example.com',
+  server: 'https://my-tableau.example.com',
+  siteId: 'abc123',
+  siteName: 'my-site',
+  raw: 'fake-token',
+};
+
+const passthroughAuthInfo: TableauAuthInfo = {
+  type: 'Passthrough',
+  username: 'user@example.com',
+  userId: 'uid-1',
+  server: 'https://my-tableau.example.com',
+  siteId: 'abc123',
+  siteName: 'my-site',
+  raw: 'fake-token',
+};
+
+describe('getAuthTypeForTelemetry', () => {
+  it("returns 'unknown' when there is no tableauAuthInfo", () => {
+    expect(getAuthTypeForTelemetry(configWithAuth('pat'), undefined)).toBe('unknown');
+  });
+
+  it("returns 'passthrough' for Passthrough auth", () => {
+    expect(getAuthTypeForTelemetry(configWithAuth('pat'), passthroughAuthInfo)).toBe('passthrough');
+  });
+
+  it("returns 'tableau-oauth' for Bearer auth", () => {
+    expect(getAuthTypeForTelemetry(configWithAuth('pat'), bearerAuthInfo)).toBe('tableau-oauth');
+  });
+
+  it("returns 'pat' for X-Tableau-Auth with config.auth='pat'", () => {
+    expect(getAuthTypeForTelemetry(configWithAuth('pat'), xTableauAuthInfo)).toBe('pat');
+  });
+
+  it("returns 'uat' for X-Tableau-Auth with config.auth='uat'", () => {
+    expect(getAuthTypeForTelemetry(configWithAuth('uat'), xTableauAuthInfo)).toBe('uat');
+  });
+
+  it("returns 'direct-trust' for X-Tableau-Auth with config.auth='direct-trust'", () => {
+    expect(getAuthTypeForTelemetry(configWithAuth('direct-trust'), xTableauAuthInfo)).toBe(
+      'direct-trust',
+    );
+  });
+
+  it("returns 'embedded-oauth' for X-Tableau-Auth with config.auth='oauth'", () => {
+    expect(getAuthTypeForTelemetry(configWithAuth('oauth'), xTableauAuthInfo)).toBe(
+      'embedded-oauth',
+    );
+  });
+
+  it('lets Bearer win regardless of config.auth (external Tableau authz server)', () => {
+    expect(getAuthTypeForTelemetry(configWithAuth('oauth'), bearerAuthInfo)).toBe('tableau-oauth');
+  });
+
+  it('lets Passthrough win regardless of config.auth', () => {
+    expect(getAuthTypeForTelemetry(configWithAuth('oauth'), passthroughAuthInfo)).toBe(
+      'passthrough',
+    );
+  });
+});

--- a/src/telemetry/authType.test.ts
+++ b/src/telemetry/authType.test.ts
@@ -32,8 +32,28 @@ const passthroughAuthInfo: TableauAuthInfo = {
 };
 
 describe('getAuthTypeForTelemetry', () => {
-  it("returns 'unknown' when there is no tableauAuthInfo", () => {
-    expect(getAuthTypeForTelemetry(configWithAuth('pat'), undefined)).toBe('unknown');
+  it("returns 'unknown' for an unrecognized config.auth with no tableauAuthInfo", () => {
+    // Server-level modes leave tableauAuthInfo undefined, so 'unknown' only comes from an
+    // unrecognized config.auth. The AuthType union can't express that, so cast to hit the default.
+    expect(getAuthTypeForTelemetry(configWithAuth('bogus' as Config['auth']), undefined)).toBe(
+      'unknown',
+    );
+  });
+
+  it("returns 'pat' for config.auth='pat' with no tableauAuthInfo (server-level per-request sign-in)", () => {
+    expect(getAuthTypeForTelemetry(configWithAuth('pat'), undefined)).toBe('pat');
+  });
+
+  it("returns 'uat' for config.auth='uat' with no tableauAuthInfo", () => {
+    expect(getAuthTypeForTelemetry(configWithAuth('uat'), undefined)).toBe('uat');
+  });
+
+  it("returns 'direct-trust' for config.auth='direct-trust' with no tableauAuthInfo", () => {
+    expect(getAuthTypeForTelemetry(configWithAuth('direct-trust'), undefined)).toBe('direct-trust');
+  });
+
+  it("returns 'embedded-oauth' for config.auth='oauth' with no tableauAuthInfo", () => {
+    expect(getAuthTypeForTelemetry(configWithAuth('oauth'), undefined)).toBe('embedded-oauth');
   });
 
   it("returns 'passthrough' for Passthrough auth", () => {

--- a/src/telemetry/authType.ts
+++ b/src/telemetry/authType.ts
@@ -1,0 +1,29 @@
+import { Config } from '../config.js';
+import { TableauAuthInfo } from '../server/oauth/schemas.js';
+
+/**
+ * Derives the auth mode label for the product telemetry `tool_call` event.
+ *
+ * `TableauAuthInfo.type` disambiguates Bearer/Passthrough directly, but 'X-Tableau-Auth' is shared
+ * by pat/uat/direct-trust/embedded-oauth, so those split on the server's configured `config.auth`.
+ */
+export function getAuthTypeForTelemetry(
+  config: Config,
+  tableauAuthInfo: TableauAuthInfo | undefined,
+): string {
+  if (!tableauAuthInfo) return 'unknown';
+  if (tableauAuthInfo.type === 'Passthrough') return 'passthrough';
+  if (tableauAuthInfo.type === 'Bearer') return 'tableau-oauth'; // external Tableau authz server
+  switch (config.auth) {
+    case 'pat':
+      return 'pat';
+    case 'uat':
+      return 'uat';
+    case 'direct-trust':
+      return 'direct-trust';
+    case 'oauth':
+      return 'embedded-oauth';
+    default:
+      return 'unknown';
+  }
+}

--- a/src/telemetry/authType.ts
+++ b/src/telemetry/authType.ts
@@ -3,17 +3,17 @@ import { TableauAuthInfo } from '../server/oauth/schemas.js';
 
 /**
  * Derives the auth mode label for the product telemetry `tool_call` event.
- *
- * `TableauAuthInfo.type` disambiguates Bearer/Passthrough directly, but 'X-Tableau-Auth' is shared
- * by pat/uat/direct-trust/embedded-oauth, so those split on the server's configured `config.auth`.
  */
 export function getAuthTypeForTelemetry(
   config: Config,
   tableauAuthInfo: TableauAuthInfo | undefined,
 ): string {
-  if (!tableauAuthInfo) return 'unknown';
-  if (tableauAuthInfo.type === 'Passthrough') return 'passthrough';
-  if (tableauAuthInfo.type === 'Bearer') return 'tableau-oauth'; // external Tableau authz server
+  // Per-request types populated by HTTP auth middleware — check first when present.
+  if (tableauAuthInfo?.type === 'Passthrough') return 'passthrough';
+  if (tableauAuthInfo?.type === 'Bearer') return 'tableau-oauth';
+
+  // Server-level modes (pat/uat/direct-trust) and embedded oauth are identified by
+  // config.auth — tableauAuthInfo is undefined for the former, 'X-Tableau-Auth' for the latter.
   switch (config.auth) {
     case 'pat':
       return 'pat';

--- a/src/tools/web/tool.test.ts
+++ b/src/tools/web/tool.test.ts
@@ -389,7 +389,8 @@ describe('Tool', () => {
         expect.objectContaining({
           oauth_client_id: '',
           oauth_client_display_name: '',
-          auth_type: 'unknown',
+          // mockExtra has no tableauAuthInfo, so auth_type falls through to config.auth ('pat' in tests).
+          auth_type: 'pat',
         }),
       );
     });

--- a/src/tools/web/tool.test.ts
+++ b/src/tools/web/tool.test.ts
@@ -349,6 +349,7 @@ describe('Tool', () => {
         expect.objectContaining({
           oauth_client_id: clientId,
           oauth_client_display_name: 'Claude',
+          auth_type: 'tableau-oauth',
         }),
       );
     });
@@ -388,6 +389,7 @@ describe('Tool', () => {
         expect.objectContaining({
           oauth_client_id: '',
           oauth_client_display_name: '',
+          auth_type: 'unknown',
         }),
       );
     });

--- a/src/tools/web/tool.ts
+++ b/src/tools/web/tool.ts
@@ -6,6 +6,7 @@ import { ZodiosValidationError } from '../../errors/mcpToolError.js';
 import { log } from '../../logging/logger.js';
 import { WebMcpServer } from '../../server.web.js';
 import { getRequiredApiScopesForTool, TableauApiScope } from '../../server/oauth/scopes.js';
+import { getAuthTypeForTelemetry } from '../../telemetry/authType.js';
 import {
   getClientDisplayName,
   sanitizeClientIdForTelemetry,
@@ -240,6 +241,7 @@ export class WebTool<Args extends ZodRawShape | undefined = undefined> extends T
         oauth_client_id: sanitizeClientIdForTelemetry(oauthClientId),
         oauth_client_display_name:
           getClientDisplayName(oauthClientId) ?? sanitizeClientIdForTelemetry(oauthClientId),
+        auth_type: getAuthTypeForTelemetry(config, tableauAuthInfo),
       });
       // Record custom metric for this tool call
       const telemetry = getTelemetryProvider();


### PR DESCRIPTION
## Description

Emit an `auth_type` field on the `tool_call` product-telemetry event to identify which auth mode each tool call used: `pat`, `uat`, `direct-trust`, `embedded-oauth`, `tableau-oauth`, `passthrough`, or `unknown`.

Derived at the emission point from `config.auth` + `tableauAuthInfo.type` via a new `getAuthTypeForTelemetry` helper (`src/telemetry/authType.ts`). Complements the existing `oauth_client_id` field. Low-cardinality, non-PII.

## Motivation and Context

We want to segment tool-call telemetry by authentication mode.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## How Has This Been Tested?

Unit tests: new `src/telemetry/authType.test.ts` covers all 7 values and precedence edges; enhanced existing `src/tools/web/tool.test.ts` telemetry assertions verify the field is wired into the `tool_call` event. Full unit suite + lint + build + tsc pass locally.

## Related Issues

W-23584783

## Checklist

- [x] I have updated the version in the package.json file by using \`npm run version\`.
- [ ] I have made any necessary changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have documented any breaking changes in the PR description.