### PR TITLE
@W-23585136: Fix list-users omitting lastLogin and leaking non-requested fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ coverage/
 test-logs/
 config.json
 env.list
+*.env.list
 manifest.json
 sea-prep.blob
 tableau-mcp
@@ -41,3 +42,7 @@ src/web/apps/dist/
 !.work/**/.gitkeep
 
 .worktrees/
+
+# Loose local report / probe artifacts (never commit)
+*.tsv
+stale-*.md

--- a/docs/docs/tools/users/list-users.md
+++ b/docs/docs/tools/users/list-users.md
@@ -4,7 +4,7 @@ sidebar_position: 1
 
 # List Users
 
-Retrieves a list of users on the Tableau site. Each user includes profile information such as site role, email, last login time, and authentication settings.
+Retrieves a list of users on the Tableau site. Each user includes profile information such as site role, email, full name, and last login time.
 
 :::warning[Admin Only]
 This tool is restricted to Tableau site administrators and requires the `ADMIN_TOOLS_ENABLED` environment variable to be enabled.
@@ -54,6 +54,10 @@ See also: [Environment Variables](../../configuration/mcp-config/env-vars.md)
 The Tableau REST API does not support server-side filtering or pagination for users. All users are fetched and filtering is performed client-side by this tool.
 :::
 
+:::note[Never-logged-in users]
+Tableau emits no `lastLogin` value for users who were provisioned but have never signed in. Because these users are the most inactive, a `lastLogin:lt:<date>` or `lastLogin:lte:<date>` (inactivity) filter **includes** them, while `lastLogin:gt:`/`gte:`/`eq:` filters exclude them. This makes never-logged-in users discoverable as license-reclamation candidates.
+:::
+
 ## Filterable Fields
 
 | Field | Type | Operators | Example |
@@ -64,9 +68,8 @@ The Tableau REST API does not support server-side filtering or pagination for us
 | `email` | string | `eq`, `in` | `email:eq:user@example.com` |
 | `fullName` | string | `eq`, `in` | `fullName:eq:John Smith` |
 | `lastLogin` | string (ISO 8601) | `eq`, `gt`, `gte`, `lt`, `lte` | `lastLogin:lt:2025-01-01T00:00:00Z` |
-| `authSetting` | string | `eq`, `in` | `authSetting:eq:SAML` |
-| `locale` | string | `eq`, `in` | `locale:eq:en_US` |
-| `language` | string | `eq`, `in` | `language:eq:en` |
+
+Only the fields above are filterable — they match the attributes this tool requests from Tableau. Filtering on any other field (e.g. `authSetting`, `locale`, `language`) is rejected with a validation error.
 
 ### Site Roles
 
@@ -81,13 +84,6 @@ Common values for `siteRole`:
 - `Unlicensed` - No active license
 - `Guest` - Guest user (limited access)
 
-### Authentication Settings
-
-Common values for `authSetting`:
-- `ServerDefault` - Uses server's default authentication
-- `SAML` - SAML-based SSO
-- `OpenID` - OpenID Connect authentication
-
 ### Filter Examples
 
 - Find all Creators: `siteRole:eq:Creator`
@@ -95,7 +91,6 @@ Common values for `authSetting`:
 - Inactive users (no login in 6 months): `lastLogin:lt:2025-12-01T00:00:00Z`
 - Unlicensed users: `siteRole:eq:Unlicensed`
 - Combined filter for license reclamation: `siteRole:eq:Unlicensed,lastLogin:lt:2025-01-01T00:00:00Z`
-- Users with SAML auth: `authSetting:eq:SAML`
 - Find specific user by email: `email:eq:john.smith@example.com`
 
 ## Response structure
@@ -108,10 +103,10 @@ Each user includes:
 - `email` – user email address
 - `fullName` – user's full display name
 - `lastLogin` – timestamp of last login (ISO 8601 format)
-- `authSetting` – authentication method
-- `locale` – user's locale setting (e.g., `en_US`, `en_GB`)
-- `language` – user's language preference (e.g., `en`, `fr`, `de`)
-- `externalAuthUserId` – ID from external authentication provider (if applicable)
+
+:::note[Output fields]
+This tool returns a lean, fixed field set: `id`, `name`, `fullName`, `siteRole`, `email`, and `lastLogin`. Tableau's REST API may return additional attributes (such as `authSetting`, `locale`, `language`), but the tool strips them from its output; only the six fields above appear.
+:::
 
 ## Example result
 
@@ -123,10 +118,7 @@ Each user includes:
     "siteRole": "Creator",
     "email": "john.smith@example.com",
     "fullName": "John Smith",
-    "lastLogin": "2026-05-20T10:30:00Z",
-    "authSetting": "SAML",
-    "locale": "en_US",
-    "language": "en"
+    "lastLogin": "2026-05-20T10:30:00Z"
   },
   {
     "id": "user-def456",
@@ -134,10 +126,7 @@ Each user includes:
     "siteRole": "Viewer",
     "email": "alice.smith@example.com",
     "fullName": "Alice Smith",
-    "lastLogin": "2026-05-15T08:00:00Z",
-    "authSetting": "ServerDefault",
-    "locale": "en_GB",
-    "language": "en"
+    "lastLogin": "2026-05-15T08:00:00Z"
   },
   {
     "id": "user-ghi789",
@@ -145,10 +134,7 @@ Each user includes:
     "siteRole": "Unlicensed",
     "email": "bob.jones@example.com",
     "fullName": "Bob Jones",
-    "lastLogin": "2024-12-01T12:00:00Z",
-    "authSetting": "SAML",
-    "locale": "en_US",
-    "language": "en"
+    "lastLogin": "2024-12-01T12:00:00Z"
   }
 ]
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "3.6.0",
+      "version": "3.6.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.7.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/src/prompts/userLicenseReclamation/inform.test.ts
+++ b/src/prompts/userLicenseReclamation/inform.test.ts
@@ -105,15 +105,22 @@ describe('user-license-reclamation-inform prompt', () => {
     expect(text).toContain('ETL lag');
   });
 
-  it('includes instruction to fetch null-lastLogin users', async () => {
+  it('covers never-signed-in users in the single list-users call without a second fetch', async () => {
     const prompt = getUserLicenseReclamationInformPrompt(new WebMcpServer());
     const result = await prompt.callback({});
     if (result.messages[0].content.type !== 'text') {
       throw new Error('expected text content');
     }
     const { text } = result.messages[0].content;
+    // Never-signed-in users are still surfaced as candidates...
     expect(text).toContain('never signed in');
     expect(text).toContain('Never');
+    // ...but only ONE list-users call is made. The `lastLogin:lt` filter already
+    // matches null-lastLogin users, so a second call would double-count them.
+    expect(text).not.toContain('a second time');
+    expect(text).toContain('Do not issue a second `list-users` call');
+    const listUsersCalls = text.match(/`list-users`/g) ?? [];
+    expect(listUsersCalls.length).toBe(2); // one in the Step 1 instruction, one in the "do not" note
   });
 
   it('reads LICENSE_RECLAIM_INACTIVE_DAYS from env when no arg provided', async () => {

--- a/src/prompts/userLicenseReclamation/inform.ts
+++ b/src/prompts/userLicenseReclamation/inform.ts
@@ -76,6 +76,12 @@ export const getUserLicenseReclamationInformPrompt: WebPromptFactory = () => ({
     // it returns no additional data and would cause false positives.
     const activityLookbackDays = Math.min(inactiveDays, TS_EVENTS_LOOKBACK_MAX_DAYS);
 
+    // A single `lastLogin:lt` filter already captures never-signed-in users:
+    // `list-users` treats an undefined `lastLogin` as matching `lt`/`lte` (see
+    // usersFilterUtils `matchesFilter`), so they come back as the most-inactive
+    // candidates. Do NOT add a second `list-users` call to fetch null-`lastLogin`
+    // users separately — it would re-return the same rows and inflate the
+    // rendered "total candidates" count (double-count).
     const listUsersFilter = `siteRole:in:${roles.join('|')},lastLogin:lt:${cutoffIso}`;
 
     // Field captions verified against live TS Events VDS schema (2026-07-19).
@@ -117,7 +123,7 @@ export const getUserLicenseReclamationInformPrompt: WebPromptFactory = () => ({
       '',
       `This returns users with site roles [${roles.join(', ')}] whose \`lastLogin\` is before ${cutoffIso} (inactive ≥ ${inactiveDays} days).`,
       '',
-      'Then call `list-users` a second time with the same `siteRole` filter but **without** the `lastLogin` filter, and include only users whose `lastLogin` is empty/null (never signed in). These are also reclamation candidates — licensed users who were provisioned but never logged in.',
+      'This single call **also** includes users who have never signed in (empty/null `lastLogin`): the `lastLogin:lt` filter treats them as the most-inactive candidates. Do not issue a second `list-users` call for them — they are already in these results. Render never-signed-in users with Days Inactive = "Never".',
       '',
       '## Step 2 — Cross-reference recent activity',
       '',

--- a/src/prompts/userLicenseReclamation/inform.ts
+++ b/src/prompts/userLicenseReclamation/inform.ts
@@ -132,7 +132,7 @@ export const getUserLicenseReclamationInformPrompt: WebPromptFactory = () => ({
       '## Step 3 — Render the report',
       '',
       '1. Print a header line: `License reclamation candidates (threshold = <inactiveDays> days, roles = [<roles>], total candidates = <count>)`.',
-      '2. Render the final candidates (those NOT seen in TS Events) as a Markdown table with columns: `User Name | Email | Site Role | Last Login | Days Inactive | Auth Setting`.',
+      '2. Render the final candidates (those NOT seen in TS Events) as a Markdown table with columns: `User Name | Email | Site Role | Last Login | Days Inactive`.',
       '   - Sort by Days Inactive descending. Users with null `lastLogin` (never signed in) go at the top with Days Inactive = "Never".',
       '   - Days Inactive = number of days between now and their `lastLogin`, or "Never" if null.',
       '3. If no candidates remain after the TS Events cross-reference, state: "No reclamation candidates found above the threshold." and stop.',

--- a/src/sdks/tableau/apis/usersApi.ts
+++ b/src/sdks/tableau/apis/usersApi.ts
@@ -58,6 +58,17 @@ const listUsersEndpoint = makeEndpoint({
       schema: z.boolean().optional(),
     },
     {
+      // Comma-separated list of user attributes to return, e.g.
+      // `id,name,fullName,siteRole,email,lastLogin`. Callers should name every
+      // field explicitly rather than relying on Tableau's default set, which on
+      // some sites silently omits lastLogin. Also accepts the special value
+      // `_all_`, though that pulls the more expensive SSO/authSetting path.
+      // @see https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_concepts_fields.htm
+      name: 'fields',
+      type: 'Query',
+      schema: z.string().optional(),
+    },
+    {
       name: 'includeUserCount',
       type: 'Query',
       schema: z.boolean().optional(),

--- a/src/sdks/tableau/methods/usersMethods.test.ts
+++ b/src/sdks/tableau/methods/usersMethods.test.ts
@@ -136,6 +136,30 @@ describe('UsersMethods', () => {
       });
     });
 
+    it('should forward the fields query param to the API client', async () => {
+      const mockApiClient = {
+        listUsers: vi.fn().mockResolvedValue({
+          users: { user: [] },
+        }),
+      };
+
+      const usersMethods = new UsersMethods('http://test', { type: 'Bearer', token: 'test' }, {});
+      // @ts-expect-error - Mocking private property
+      usersMethods._apiClient = mockApiClient;
+
+      await usersMethods.listUsers({
+        siteId: 'site-1',
+        fields: 'id,name,fullName,siteRole,email,lastLogin',
+      });
+
+      expect(mockApiClient.listUsers).toHaveBeenCalledWith(
+        expect.objectContaining({
+          params: { siteId: 'site-1' },
+          queries: expect.objectContaining({ fields: 'id,name,fullName,siteRole,email,lastLogin' }),
+        }),
+      );
+    });
+
     it('should handle users with different site roles', async () => {
       const mockApiClient = {
         listUsers: vi.fn().mockResolvedValue({

--- a/src/sdks/tableau/methods/usersMethods.ts
+++ b/src/sdks/tableau/methods/usersMethods.ts
@@ -35,6 +35,10 @@ export default class UsersMethods extends AuthenticatedMethods<typeof usersApis>
    * @param includeUserCount - Include total user count in pagination metadata
    * @param includeSSOInfo - Include SSO/SAML info per user
    * @param includeGroups - Include group memberships per user
+   * @param fields - Comma-separated attribute list (e.g.
+   *   `id,name,fullName,siteRole,email,lastLogin`). Name every field explicitly;
+   *   relying on Tableau's default set can silently omit `lastLogin`. The special
+   *   value `_all_` is also accepted but pulls the more expensive SSO path.
    * @link https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref_users_and_groups.htm#get_users_on_site
    */
   listUsers = async ({
@@ -44,6 +48,7 @@ export default class UsersMethods extends AuthenticatedMethods<typeof usersApis>
     includeUserCount,
     includeSSOInfo,
     includeGroups,
+    fields,
   }: {
     siteId: string;
     pageSize?: number;
@@ -51,6 +56,7 @@ export default class UsersMethods extends AuthenticatedMethods<typeof usersApis>
     includeUserCount?: boolean;
     includeSSOInfo?: boolean;
     includeGroups?: boolean;
+    fields?: string;
   }): Promise<ListUsersResult> => {
     const response = await this._apiClient.listUsers({
       params: { siteId },
@@ -60,6 +66,7 @@ export default class UsersMethods extends AuthenticatedMethods<typeof usersApis>
         includeUserCount,
         includeSSOInfo,
         includeGroups,
+        fields,
       },
       ...this.authHeader,
     });

--- a/src/tools/web/users/listUsers.test.ts
+++ b/src/tools/web/users/listUsers.test.ts
@@ -67,7 +67,18 @@ describe('listUsersTool', () => {
     expect(result.isError).toBe(false);
     invariant(result.content[0].type === 'text');
     const parsed = JSON.parse(`${result.content[0].text}`);
-    expect(parsed.users).toEqual(mockUsers);
+    // mockUser carries extra fields (authSetting/locale/language); the tool
+    // projects output down to the 6 advertised fields, so compare against that.
+    expect(parsed.users).toEqual([
+      {
+        id: mockUser.id,
+        name: mockUser.name,
+        fullName: mockUser.fullName,
+        siteRole: mockUser.siteRole,
+        email: mockUser.email,
+        lastLogin: mockUser.lastLogin,
+      },
+    ]);
     expect(parsed.totalAvailable).toBe(mockUsers.length);
     expect(mocks.mockListUsers).toHaveBeenCalled();
   });
@@ -117,6 +128,96 @@ describe('listUsersTool', () => {
     expect(parsed.users[0].lastLogin).toBe('2026-05-20T10:30:00Z');
   });
 
+  it('should project output to only the 6 advertised fields, stripping extras Tableau still returns', async () => {
+    // CRITICAL: Tableau's `fields=...` param is only an "include at least" hint —
+    // the raw REST response STILL contains authSetting/locale/language/
+    // externalAuthUserId, and userSchema keeps them as known optional keys so Zod
+    // does not strip them. The tool must project them out at its boundary. Mock the
+    // REALISTIC FULL response so this guard actually exercises the projection.
+    const fullUser = {
+      id: 'user-full',
+      name: 'dsmith',
+      fullName: 'Dana Smith',
+      siteRole: 'Explorer',
+      email: 'dsmith@example.com',
+      lastLogin: '2026-05-20T10:30:00Z',
+      authSetting: 'SAML',
+      locale: 'en_US',
+      language: 'en',
+      externalAuthUserId: 'ext-123',
+    };
+    mocks.mockListUsers.mockResolvedValue({
+      users: [fullUser],
+      pagination: { pageNumber: 1, pageSize: 100, totalAvailable: 1 },
+    });
+    const result = await getToolResult({});
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+    const parsed = JSON.parse(`${result.content[0].text}`);
+    expect(parsed.users).toHaveLength(1);
+    const out = parsed.users[0];
+    // The 6 advertised fields survive.
+    expect(out).toEqual({
+      id: 'user-full',
+      name: 'dsmith',
+      fullName: 'Dana Smith',
+      siteRole: 'Explorer',
+      email: 'dsmith@example.com',
+      lastLogin: '2026-05-20T10:30:00Z',
+    });
+    // Everything Tableau leaks is stripped.
+    expect(out).not.toHaveProperty('authSetting');
+    expect(out).not.toHaveProperty('locale');
+    expect(out).not.toHaveProperty('language');
+    expect(out).not.toHaveProperty('externalAuthUserId');
+    expect(Object.keys(out).sort()).toEqual(
+      ['email', 'fullName', 'id', 'lastLogin', 'name', 'siteRole'].sort(),
+    );
+  });
+
+  it('should omit lastLogin (not emit null) for never-logged-in users after projection', async () => {
+    // A full response where lastLogin is absent (never signed in) but extras present.
+    const neverUser = {
+      id: 'user-never',
+      name: 'nlogin',
+      fullName: 'No Login',
+      siteRole: 'Creator',
+      email: 'nlogin@example.com',
+      authSetting: 'SAML',
+      locale: 'en_US',
+    };
+    mocks.mockListUsers.mockResolvedValue({
+      users: [neverUser],
+      pagination: { pageNumber: 1, pageSize: 100, totalAvailable: 1 },
+    });
+    const result = await getToolResult({});
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+    const parsed = JSON.parse(`${result.content[0].text}`);
+    const out = parsed.users[0];
+    expect(out).not.toHaveProperty('lastLogin'); // omitted, not null
+    expect(out).not.toHaveProperty('authSetting');
+    expect(out.id).toBe('user-never');
+  });
+
+  it('should request an explicit lean field set (not _all_, and not authSetting)', async () => {
+    // Regression guard for the lastLogin bug: we must name every field explicitly
+    // rather than relying on Tableau's silent default set. We deliberately do NOT
+    // request _all_ (avoids the expensive SSO/authSetting path).
+    mocks.mockListUsers.mockResolvedValue({
+      users: [mockUser],
+      pagination: { pageNumber: 1, pageSize: 100, totalAvailable: 1 },
+    });
+    await getToolResult({});
+    expect(mocks.mockListUsers).toHaveBeenCalledWith(
+      expect.objectContaining({ fields: 'id,name,fullName,siteRole,email,lastLogin' }),
+    );
+    const requestedFields: string = mocks.mockListUsers.mock.calls[0][0].fields;
+    expect(requestedFields).not.toContain('_all_');
+    expect(requestedFields).not.toContain('authSetting');
+    expect(requestedFields).toContain('lastLogin');
+  });
+
   it('should handle users with different site roles', async () => {
     const users = [
       { ...mockUser, id: 'u1', siteRole: 'ServerAdministrator' },
@@ -137,25 +238,6 @@ describe('listUsersTool', () => {
     expect(parsed.users[3].siteRole).toBe('Unlicensed');
   });
 
-  it('should handle users with different auth settings', async () => {
-    const users = [
-      { ...mockUser, id: 'u1', authSetting: 'SAML' },
-      { ...mockUser, id: 'u2', authSetting: 'ServerDefault' },
-      { ...mockUser, id: 'u3', authSetting: 'OpenID' },
-    ];
-    mocks.mockListUsers.mockResolvedValue({
-      users,
-      pagination: { pageNumber: 1, pageSize: 100, totalAvailable: users.length },
-    });
-    const result = await getToolResult({});
-    expect(result.isError).toBe(false);
-    invariant(result.content[0].type === 'text');
-    const parsed = JSON.parse(`${result.content[0].text}`);
-    expect(parsed.users[0].authSetting).toBe('SAML');
-    expect(parsed.users[1].authSetting).toBe('ServerDefault');
-    expect(parsed.users[2].authSetting).toBe('OpenID');
-  });
-
   it('should error when user is not admin', async () => {
     mocks.mockAssertAdmin.mockResolvedValue(new Err('Your site role is: Viewer'));
     const result = await getToolResult({});
@@ -171,6 +253,20 @@ describe('listUsersTool', () => {
     });
     const result = await getToolResult({ filter: 'invalidField:eq:value' });
     expect(result.isError).toBe(true);
+  });
+
+  it('should reject a filter on an un-fetched field (isError), not silently return empty', async () => {
+    // authSetting is no longer fetched, so it is no longer filterable. The tool
+    // must surface a clean validation error rather than "No users were found".
+    mocks.mockListUsers.mockResolvedValue({
+      users: [mockUser],
+      pagination: { pageNumber: 1, pageSize: 100, totalAvailable: 1 },
+    });
+    const result = await getToolResult({ filter: 'authSetting:eq:SAML' });
+    expect(result.isError).toBe(true);
+    invariant(result.content[0].type === 'text');
+    expect(result.content[0].text).toContain('authSetting');
+    expect(result.content[0].text).not.toContain('No users were found');
   });
 
   it('should respect limit parameter', async () => {

--- a/src/tools/web/users/listUsers.ts
+++ b/src/tools/web/users/listUsers.ts
@@ -25,13 +25,12 @@ export const getListUsersTool = (server: WebMcpServer): WebTool<typeof paramsSch
     name: 'list-users',
     disabled: !config.adminToolsEnabled,
     description: `
-  Retrieves a list of users on the Tableau site. Each user includes profile information such as site role, email, last login time, and authentication settings.
+  Retrieves a list of users on the Tableau site. Each user includes profile information such as site role, email, full name, and last login time.
 
   Use this tool when you need to:
   - Identify inactive users for license reclamation
   - Audit user site roles and permissions
   - Find users by email, name, or site role
-  - Review user authentication settings
   - Analyze user activity based on last login times
 
   **Parameters:**
@@ -49,10 +48,8 @@ export const getListUsersTool = (server: WebMcpServer): WebTool<typeof paramsSch
   | \`email\` | string | \`eq\`, \`in\` | \`email:eq:user@example.com\` |
   | \`fullName\` | string | \`eq\`, \`in\` | \`fullName:eq:John Smith\` |
   | \`lastLogin\` | string (ISO 8601) | \`eq\`, \`gt\`, \`gte\`, \`lt\`, \`lte\` | \`lastLogin:lt:2025-01-01T00:00:00Z\` |
-  | \`authSetting\` | string | \`eq\`, \`in\` | \`authSetting:eq:SAML\` |
-  | \`locale\` | string | \`eq\`, \`in\` | \`locale:eq:en_US\` |
-  | \`language\` | string | \`eq\`, \`in\` | \`language:eq:en\` |
-  | \`externalAuthUserId\` | string | \`eq\`, \`in\` | \`externalAuthUserId:eq:ext-123\` |
+
+  Never-signed-in users have no \`lastLogin\`: they MATCH \`lt\`/\`lte\` (counted as most-inactive) and are EXCLUDED from \`gt\`/\`gte\`/\`eq\`.
 
   **Filter Examples:**
   - Single filter: \`siteRole:eq:Creator\`
@@ -67,10 +64,6 @@ export const getListUsersTool = (server: WebMcpServer): WebTool<typeof paramsSch
   - \`email\` – user email address
   - \`fullName\` – user's full display name
   - \`lastLogin\` – timestamp of last login (ISO 8601)
-  - \`authSetting\` – ServerDefault, SAML, or OpenID
-  - \`locale\` – user's locale setting
-  - \`language\` – user's language preference
-  - \`externalAuthUserId\` – ID from external authentication provider
   `,
     paramsSchema,
     annotations: {
@@ -114,8 +107,14 @@ export const getListUsersTool = (server: WebMcpServer): WebTool<typeof paramsSch
                     pageSize: pageConfig.pageSize,
                     pageNumber: pageConfig.pageNumber,
                     includeUserCount: true,
-                    includeSSOInfo: false,
                     includeGroups: false,
+                    // Request an explicit, lean field set. Every field must be named
+                    // — do NOT rely on Tableau's "default" set: on some sites the
+                    // default silently omits lastLogin (the original bug), even though
+                    // the REST docs call it a default field. We deliberately avoid
+                    // `_all_` because it pulls the expensive SSO/authSetting path we
+                    // don't need. See rest_api_concepts_fields.htm.
+                    fields: 'id,name,fullName,siteRole,email,lastLogin',
                   });
 
                   const pagination = result.pagination ?? {
@@ -134,11 +133,19 @@ export const getListUsersTool = (server: WebMcpServer): WebTool<typeof paramsSch
             },
           });
 
-          // Apply client-side filtering
+          // Apply client-side filtering (may reference any of the fetched fields).
           const filteredUsers = applyUserFilters(users, args.filter);
 
+          // Project to exactly the fields this tool advertises. The `fields` query
+          // param is only an "include at least" hint on this endpoint — Tableau
+          // still returns authSetting/locale/language/externalAuthUserId, and
+          // userSchema declares them as known optional keys so Zod does NOT strip
+          // them. This projection is what actually enforces the lean output. Runs
+          // AFTER filtering (order: fetch → filter → project → serialize).
+          const projectedUsers = filteredUsers.map(projectLeanUser);
+
           const toolResult: ListUsersToolResult = {
-            users: filteredUsers,
+            users: projectedUsers,
             totalAvailable: siteTotalAvailable,
           };
           return new Ok(toolResult);
@@ -152,8 +159,29 @@ export const getListUsersTool = (server: WebMcpServer): WebTool<typeof paramsSch
   return listUsersTool;
 };
 
+/**
+ * The exact set of user fields this tool returns. Kept in sync with the `fields`
+ * query param and the documented output. Every key is optional except `id`/`name`
+ * because Tableau may omit them (e.g. `lastLogin` for never-logged-in users).
+ */
+type LeanUser = Pick<User, 'id' | 'name' | 'fullName' | 'siteRole' | 'email' | 'lastLogin'>;
+
+/**
+ * Project a full Tableau user down to the lean, advertised field set. Optional
+ * keys that are absent on the source are omitted entirely (not emitted as null),
+ * matching the tool's prior serialization behavior for never-logged-in users.
+ */
+function projectLeanUser(user: User): LeanUser {
+  const lean: LeanUser = { id: user.id, name: user.name };
+  if (user.fullName !== undefined) lean.fullName = user.fullName;
+  if (user.siteRole !== undefined) lean.siteRole = user.siteRole;
+  if (user.email !== undefined) lean.email = user.email;
+  if (user.lastLogin !== undefined) lean.lastLogin = user.lastLogin;
+  return lean;
+}
+
 interface ListUsersToolResult {
-  users: Array<User>;
+  users: Array<LeanUser>;
   totalAvailable?: number;
 }
 
@@ -161,7 +189,7 @@ export function constrainUsers({
   users,
   totalAvailable,
 }: {
-  users: Array<User>;
+  users: Array<LeanUser>;
   totalAvailable?: number;
 }): ConstrainedResult<ListUsersToolResult> {
   if (users.length === 0) {

--- a/src/tools/web/users/usersFilterUtils.test.ts
+++ b/src/tools/web/users/usersFilterUtils.test.ts
@@ -57,12 +57,6 @@ describe('usersFilterUtils', () => {
       expect(getFieldValue(mockUser, 'lastLogin')).toBe('2026-05-20T10:30:00Z');
     });
 
-    it('should get authentication and locale fields', () => {
-      expect(getFieldValue(mockUser, 'authSetting')).toBe('SAML');
-      expect(getFieldValue(mockUser, 'locale')).toBe('en_US');
-      expect(getFieldValue(mockUser, 'language')).toBe('en');
-    });
-
     it('should return undefined for missing optional fields', () => {
       const minimalUser: User = { id: 'user-456', name: 'test' };
       expect(getFieldValue(minimalUser, 'email')).toBeUndefined();
@@ -153,6 +147,24 @@ describe('usersFilterUtils', () => {
       expect(matchesFilter(undefined, 'eq', 'value', 'name')).toBe(false);
       expect(matchesFilter(null as any, 'eq', 'value', 'name')).toBe(false);
     });
+
+    describe('missing lastLogin (never signed in)', () => {
+      const cutoff = '2025-01-01T00:00:00Z';
+
+      it('should MATCH lt/lte — never-logged-in users are the most inactive', () => {
+        expect(matchesFilter(undefined, 'lt', cutoff, 'lastLogin')).toBe(true);
+        expect(matchesFilter(undefined, 'lte', cutoff, 'lastLogin')).toBe(true);
+      });
+
+      it('should NOT match gt/gte — they never logged in after any date', () => {
+        expect(matchesFilter(undefined, 'gt', cutoff, 'lastLogin')).toBe(false);
+        expect(matchesFilter(undefined, 'gte', cutoff, 'lastLogin')).toBe(false);
+      });
+
+      it('should NOT match eq — there is no date to equal', () => {
+        expect(matchesFilter(undefined, 'eq', cutoff, 'lastLogin')).toBe(false);
+      });
+    });
   });
 
   describe('applyUserFilters', () => {
@@ -201,7 +213,7 @@ describe('usersFilterUtils', () => {
     });
 
     it('should filter by multiple conditions (AND)', () => {
-      const result = applyUserFilters(users, 'siteRole:eq:Creator,authSetting:eq:SAML');
+      const result = applyUserFilters(users, 'siteRole:eq:Creator,email:eq:john.smith@example.com');
       expect(result).toHaveLength(1);
       expect(result[0].id).toBe('user-123');
     });
@@ -223,16 +235,23 @@ describe('usersFilterUtils', () => {
       expect(result[0].id).toBe('user-789');
     });
 
-    it('should filter by locale', () => {
-      const result = applyUserFilters(users, 'locale:eq:en_US');
-      expect(result).toHaveLength(2);
+    it('should filter by fullName', () => {
+      const result = applyUserFilters(users, 'fullName:eq:Alice Smith');
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('user-456');
     });
 
-    it('should filter by authSetting', () => {
-      const result = applyUserFilters(users, 'authSetting:eq:SAML');
-      expect(result).toHaveLength(2);
-      expect(result[0].authSetting).toBe('SAML');
-      expect(result[1].authSetting).toBe('SAML');
+    it('should reject a filter on an unsupported (un-fetched) field, not silently return empty', () => {
+      // authSetting/locale/language/externalAuthUserId are no longer fetched, so
+      // they are no longer filterable. Filtering on them must be REJECTED with a
+      // validation error rather than silently matching nothing (which was the
+      // original lastLogin bug class).
+      expect(() => applyUserFilters(users, 'authSetting:eq:SAML')).toThrow(/authSetting/);
+      expect(() => applyUserFilters(users, 'locale:eq:en_US')).toThrow(/locale/);
+      // Rejection also flows through the shared parse/validate entrypoint.
+      expect(() => parseAndValidateUsersFilterString('authSetting:eq:SAML')).toThrow(
+        /Invalid enum value/,
+      );
     });
 
     it('should handle complex inactive user query', () => {
@@ -242,6 +261,50 @@ describe('usersFilterUtils', () => {
       );
       expect(result).toHaveLength(1);
       expect(result[0].id).toBe('user-789');
+    });
+
+    it('should include never-logged-in users in lastLogin:lt (inactivity) queries', () => {
+      const neverLoggedIn: User = {
+        id: 'user-never',
+        name: 'nlogin',
+        siteRole: 'Explorer',
+        email: 'never.login@example.com',
+        // no lastLogin — provisioned but never signed in
+      };
+      const usersWithNever = [...users, neverLoggedIn];
+      const result = applyUserFilters(usersWithNever, 'lastLogin:lt:2025-01-01T00:00:00Z');
+      // user-789 (2024-12-01) plus the never-logged-in user
+      expect(result.map((u) => u.id).sort()).toEqual(['user-789', 'user-never']);
+    });
+
+    it('should include never-logged-in users in lastLogin:lte queries', () => {
+      const neverLoggedIn: User = { id: 'user-never', name: 'nlogin', siteRole: 'Explorer' };
+      const result = applyUserFilters([neverLoggedIn], 'lastLogin:lte:2025-01-01T00:00:00Z');
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('user-never');
+    });
+
+    it('should exclude never-logged-in users from lastLogin:gt queries', () => {
+      const neverLoggedIn: User = { id: 'user-never', name: 'nlogin', siteRole: 'Explorer' };
+      const usersWithNever = [...users, neverLoggedIn];
+      const result = applyUserFilters(usersWithNever, 'lastLogin:gt:2025-01-01T00:00:00Z');
+      expect(result.map((u) => u.id)).not.toContain('user-never');
+    });
+
+    it('should find never-logged-in reclamation candidates by role and inactivity', () => {
+      const neverLoggedIn: User = {
+        id: 'user-never',
+        name: 'nlogin',
+        siteRole: 'Creator',
+      };
+      const usersWithNever = [...users, neverLoggedIn];
+      const result = applyUserFilters(
+        usersWithNever,
+        'siteRole:eq:Creator,lastLogin:lt:2025-01-01T00:00:00Z',
+      );
+      // Only the never-logged-in Creator qualifies; user-123 (Creator) logged in recently.
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('user-never');
     });
 
     it('should support date range with same-field multiple conditions', () => {

--- a/src/tools/web/users/usersFilterUtils.ts
+++ b/src/tools/web/users/usersFilterUtils.ts
@@ -10,18 +10,11 @@ import {
 // === Field and Operator Definitions ===
 // Client-side filtering for users (API doesn't support server-side filtering)
 
-const FilterFieldSchema = z.enum([
-  'id',
-  'name',
-  'siteRole',
-  'email',
-  'fullName',
-  'lastLogin',
-  'authSetting',
-  'locale',
-  'language',
-  'externalAuthUserId',
-]);
+// Only fields we actually request from Tableau (see listUsers.ts `fields`) are
+// filterable. Filtering on an un-fetched field would silently match nothing —
+// the same class of bug as the original lastLogin defect — so unsupported
+// fields are rejected at parse time with a clear validation error instead.
+const FilterFieldSchema = z.enum(['id', 'name', 'siteRole', 'email', 'fullName', 'lastLogin']);
 
 type FilterField = z.infer<typeof FilterFieldSchema>;
 
@@ -32,10 +25,6 @@ const allowedOperatorsByField: Record<FilterField, FilterOperator[]> = {
   email: ['eq', 'in'],
   fullName: ['eq', 'in'],
   lastLogin: ['eq', 'gt', 'gte', 'lt', 'lte'],
-  authSetting: ['eq', 'in'],
-  locale: ['eq', 'in'],
-  language: ['eq', 'in'],
-  externalAuthUserId: ['eq', 'in'],
 };
 
 const dateFields: Set<FilterField> = new Set(['lastLogin']);
@@ -112,14 +101,6 @@ function getFieldValue(user: User, field: FilterField): string | number | undefi
       return user.fullName;
     case 'lastLogin':
       return user.lastLogin;
-    case 'authSetting':
-      return user.authSetting;
-    case 'locale':
-      return user.locale;
-    case 'language':
-      return user.language;
-    case 'externalAuthUserId':
-      return user.externalAuthUserId;
     default:
       return undefined;
   }
@@ -132,6 +113,18 @@ function matchesFilter(
   field: FilterField,
 ): boolean {
   if (fieldValue === undefined || fieldValue === null) {
+    // A missing date field means the event never happened. For `lastLogin`,
+    // Tableau emits no value for users who have never signed in. Such users are
+    // the *most* inactive, and the user-license-reclamation prompt explicitly
+    // treats them as reclamation candidates, so an "older than X" filter must
+    // include them:
+    //   - lt / lte (older than / on-or-before X)  → MATCH  (never < any date)
+    //   - gt / gte (newer than / on-or-after X)    → NO MATCH (they logged in after nothing)
+    //   - eq (equals a specific date)              → NO MATCH (no date to equal)
+    // Non-date fields keep the original "missing → no match" behavior.
+    if (dateFields.has(field)) {
+      return operator === 'lt' || operator === 'lte';
+    }
     return false;
   }
 

--- a/tests/e2e/users/listUsers.test.ts
+++ b/tests/e2e/users/listUsers.test.ts
@@ -1,0 +1,165 @@
+import { z } from 'zod';
+
+import { userSchema } from '../../../src/sdks/tableau/types/user.js';
+import { getDefaultEnv, resetEnv, setEnv } from '../../testEnv.js';
+import { McpClient } from '../mcpClient.js';
+
+/**
+ * E2E coverage for the admin-only, read-only `list-users` tool.
+ *
+ * This tier catches the exact regression unit tests could not: `list-users` must request an
+ * explicit lean field set (`id,name,fullName,siteRole,email,lastLogin`) from Tableau's "Get Users
+ * on Site" endpoint so that `lastLogin` comes back populated. Relying on Tableau's default set
+ * silently omits `lastLogin` on some sites, which (a) dropped it from output and (b) made the
+ * client-side `lastLogin` filter match nothing. These assertions hit the real server and prove
+ * lastLogin arrives end-to-end.
+ *
+ * The filter surface is narrowed to exactly those fetched fields; `authSetting` (and locale,
+ * language, externalAuthUserId) are no longer requested or filterable — a filter on any of them
+ * must be REJECTED with a validation error, NOT silently return an empty result.
+ *
+ * The site's PAT owner is a site admin who has signed in, so at least one returned user is
+ * guaranteed to carry a real `lastLogin`.
+ */
+const listUsersResultSchema = z.object({
+  users: z.array(userSchema),
+  totalAvailable: z.number().optional(),
+});
+
+describe('list-users', () => {
+  let client: McpClient;
+  let toolsAvailable = false;
+
+  beforeAll(setEnv);
+  afterAll(resetEnv);
+
+  beforeAll(async () => {
+    client = new McpClient({
+      env: { ...getDefaultEnv(), ADMIN_TOOLS_ENABLED: 'true' },
+    });
+    await client.connect();
+    const tools = await client.listTools();
+    toolsAvailable = tools.includes('list-users');
+    if (!toolsAvailable) {
+      console.warn(
+        'Skipping list-users e2e tests — admin tools not registered. ' +
+          'Ensure ADMIN_TOOLS_ENABLED=true in tests/.env and the caller is a site admin.',
+      );
+    }
+  });
+
+  afterAll(async () => {
+    await client.close();
+  });
+
+  it('should register the tool only when admin tools are enabled', async () => {
+    const defaultClient = new McpClient({ env: getDefaultEnv() });
+    await defaultClient.connect();
+    try {
+      const tools = await defaultClient.listTools();
+      expect(tools.includes('list-users')).toBe(false);
+    } finally {
+      await defaultClient.close();
+    }
+  });
+
+  it('should return users with a populated lastLogin (lean explicit field set regression guard)', async () => {
+    if (!toolsAvailable) {
+      return;
+    }
+
+    // The site has ~27k users; fetching every page (default pageSize 100) is ~271 sequential
+    // REST calls and blows the e2e timeout. Bound to a single 1000-user page — that page already
+    // contains admins/service accounts with real lastLogin values, which is all this guard needs.
+    const result = await client.callTool('list-users', {
+      schema: listUsersResultSchema,
+      toolArgs: { pageSize: 1000, limit: 1000 },
+    });
+
+    expect(result.users.length).toBeGreaterThan(0);
+
+    // At least one user must carry a real lastLogin timestamp. Before the fix the lean field set
+    // was never requested, so on the reproducing site EVERY user's lastLogin was undefined — this
+    // assertion would fail.
+    const usersWithLastLogin = result.users.filter((u) => u.lastLogin !== undefined);
+    expect(usersWithLastLogin.length).toBeGreaterThan(0);
+    // The populated value must be a parseable ISO 8601 timestamp.
+    expect(Number.isNaN(new Date(usersWithLastLogin[0].lastLogin!).getTime())).toBe(false);
+
+    // The tool projects output to exactly 6 fields. Tableau's `fields` param does NOT restrict the
+    // response (it still returns authSetting/locale/language/externalAuthUserId), and userSchema
+    // keeps those as known optional keys — so the tool-local projection is what strips them. Assert
+    // NONE of the four extras survive on ANY returned user, and that only the 6 keys appear.
+    const allowedKeys = ['id', 'name', 'fullName', 'siteRole', 'email', 'lastLogin'].sort();
+    for (const user of result.users) {
+      expect(user).not.toHaveProperty('authSetting');
+      expect(user).not.toHaveProperty('locale');
+      expect(user).not.toHaveProperty('language');
+      expect(user).not.toHaveProperty('externalAuthUserId');
+      // Every key present must be one of the 6 advertised fields (id/name always present).
+      const keys = Object.keys(user).sort();
+      expect(keys.every((k) => allowedKeys.includes(k))).toBe(true);
+    }
+  });
+
+  it('should return rows for a lastLogin filter, proving the filter is not silently empty', async () => {
+    if (!toolsAvailable) {
+      return;
+    }
+
+    // `gt` excludes never-logged-in users (undefined lastLogin), so any row returned here MUST
+    // have a real lastLogin — this is a stronger proof that lastLogin is populated end-to-end.
+    // The site's admin PAT owner has logged in well after 2020 and appears in the first page, so
+    // this is guaranteed non-empty. Bound to one page — client-side filtering otherwise fetches
+    // all ~27k users first (the filter is applied after pagination) and blows the timeout.
+    const result = await client.callTool('list-users', {
+      schema: listUsersResultSchema,
+      toolArgs: { pageSize: 1000, limit: 1000, filter: 'lastLogin:gt:2020-01-01T00:00:00Z' },
+    });
+
+    expect(result.users.length).toBeGreaterThan(0);
+    // Every returned user must have a real lastLogin newer than the cutoff.
+    for (const user of result.users) {
+      expect(user.lastLogin).toBeDefined();
+      expect(new Date(user.lastLogin!).getTime()).toBeGreaterThan(
+        new Date('2020-01-01T00:00:00Z').getTime(),
+      );
+    }
+  });
+
+  it('should reject a filter on a now-removed field (authSetting) with an enum error, not silent-empty', async () => {
+    if (!toolsAvailable) {
+      return;
+    }
+
+    // authSetting is no longer fetched, so it is no longer filterable. The tool must surface a
+    // clean enum-validation error rather than silently returning "No users were found" — the same
+    // silent-match failure class as the original lastLogin bug. Bound to one page: filter
+    // validation runs AFTER pagination, so an unbounded call would page all ~27k users first.
+    const result = await client.client.callTool({
+      name: 'list-users',
+      arguments: { pageSize: 1000, limit: 1000, filter: 'authSetting:eq:SAML' },
+    });
+
+    expect(result.isError).toBe(true);
+    const content = Array.isArray(result.content) ? result.content[0] : undefined;
+    const text = content && content.type === 'text' ? content.text : '';
+    expect(text).toContain('authSetting');
+    expect(text).not.toContain('No users were found');
+  });
+
+  it('should reject an unknown filter field with a structured error', async () => {
+    if (!toolsAvailable) {
+      return;
+    }
+
+    // Filter validation runs AFTER pagination (applyUserFilters), so bound the fetch to one page
+    // — an unbounded call would page through all ~27k users before rejecting and blow the timeout.
+    const result = await client.client.callTool({
+      name: 'list-users',
+      arguments: { pageSize: 1000, limit: 1000, filter: 'notAField:eq:x' },
+    });
+
+    expect(result.isError).toBe(true);
+  });
+});


### PR DESCRIPTION


list-users sent fields=_all_ to Get Users on Site, which (1) on some sites returned a default set omitting lastLogin — and the client-side lastLogin filter then dropped every row, silently breaking user-license-reclamation-inform — and (2) pulled the expensive SSO/authSetting path, leaking authSetting, locale, language, externalAuthUserId into output.

Key gotcha: Tableau's `fields` param on this endpoint is "include at least", not a projection, so restricting it does not shape the response.

Fix:
- Plumb a `fields` query param through usersApi -> usersMethods; call site requests the lean set id,name,fullName,siteRole,email,lastLogin.
- Add a tool-local projection (projectLeanUser, a Pick of User to the 6 fields) applied AFTER filtering. Absent optionals are omitted, not null. Shared userSchema is left intact (update-user and others depend on it).
- Narrow the filter surface to the 6 fetched fields, so filtering a dropped field returns a clean enum error instead of silently matching nothing.
- Never-logged-in semantics: undefined lastLogin matches lt/lte, excluded from gt/gte/eq.
- Docs + tool description trimmed to the 6 fields; add *.env.list and loose report artifacts to .gitignore.

Tests: unit guard mocks the full Tableau response and asserts output is exactly the 6 keys; new e2e asserts no extras survive on any user. Version bump 3.6.0 -> 3.6.1.

**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of
the pull request._

# Pull Request Template

<!-- Thank you for your contribution! Please fill out the following template to help us review your pull
request! -->

## Description

<!-- Please include a summary of the change. -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## How Has This Been Tested?

<!-- Please describe the tests that you performed to verify your changes. -->

## Related Issues

<!-- List any related issues, pull requests, or discussions. -->

## Checklist

- [x] I have updated the version in the package.json file by using `npm run version`. For example,
      use `npm run version:patch` for a patch version bump.
- [x] I have made any necessary changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have documented any breaking changes in the PR description. For example, renaming a config
      environment variable or changing its default value.

## Contributor Agreement

By submitting this pull request, I confirm that:

- [x] I have read the [CONTRIBUTING guidelines](../../CONTRIBUTING.md) for this project and followed
      its Contribution Checklist.
