### PR TITLE
feat(templates): ship parameterized sort on the simple-bar and ranking templates

### DIFF
--- a/src/desktop/data/content-manifest.json
+++ b/src/desktop/data/content-manifest.json
@@ -132,8 +132,8 @@
     },
     {
       "path": "data-visualization-templates-xml/magnitude-simple-bar.xml",
-      "sha256": "ef0503faa2dd6320f902335dcd721909f4cb161d315a7746f296dc2967c60a4c",
-      "bytes": 2457
+      "sha256": "3ce7dfa8c7d8b6ebb54c53f0372589dce7e2c54d4e71fb17bdb59a840ef535b1",
+      "bytes": 2476
     },
     {
       "path": "data-visualization-templates-xml/pareto-chart.xml",
@@ -197,8 +197,8 @@
     },
     {
       "path": "data-visualization-templates-xml/ranking-ordered-column.xml",
-      "sha256": "a0a23ffcf5fb34263b4e1a46a107590200a03d3f02fdc5efcf8622cc9e4a9235",
-      "bytes": 2435
+      "sha256": "afb71d90510a3df77c64fa4549df37cc3285dd15b1d2db603c90c53ba5c69856",
+      "bytes": 2452
     },
     {
       "path": "data-visualization-templates-xml/slope-chart.xml",
@@ -252,8 +252,8 @@
     },
     {
       "path": "template-manifests.index.json",
-      "sha256": "b7e98f52323d5a970eb7e4a1f4a2f58bff17429d3da902309a2c21d9a38ac474",
-      "bytes": 281916
+      "sha256": "e95618af3a46d0d39b49530595b65e81ae89de63886b772a9dc60c154c87f409",
+      "bytes": 283231
     },
     {
       "path": "template-manifests/box-plot-chart.manifest.json",
@@ -377,8 +377,8 @@
     },
     {
       "path": "template-manifests/magnitude-simple-bar.manifest.json",
-      "sha256": "c00bba1826448bba3ad5fdface31b62a7973a2904b45369d658d375dc11f00a1",
-      "bytes": 4841
+      "sha256": "562948c4d0c28891d279ce4cfa91f199b5e87eeb232e43a8a013b40a60081d3f",
+      "bytes": 5679
     },
     {
       "path": "template-manifests/pareto-chart.manifest.json",
@@ -432,8 +432,8 @@
     },
     {
       "path": "template-manifests/ranking-ordered-column.manifest.json",
-      "sha256": "905b85c0feaf424c8db66df38f251b3d0586a397aff3cc85af96cac59d496551",
-      "bytes": 1936
+      "sha256": "a49de8ee198030f076a2b2d5d8d8d0e315755cb96f49e11ea3fca97c980c63e5",
+      "bytes": 2559
     },
     {
       "path": "template-manifests/slope-chart.manifest.json",

--- a/src/desktop/data/data-visualization-templates-xml/magnitude-simple-bar.xml
+++ b/src/desktop/data/data-visualization-templates-xml/magnitude-simple-bar.xml
@@ -21,7 +21,7 @@
         <column-instance column='[Category]' derivation='None' name='[none:Category:nk]' pivot='key' type='nominal' />
         <column-instance column='[Sales]' derivation='Sum' name='[sum:Sales:qk]' pivot='key' type='quantitative' />
       </datasource-dependencies>
-      <computed-sort column='[{{DATASOURCE}}].[none:Category:nk]' direction='DESC' using='[{{DATASOURCE}}].[sum:Sales:qk]' />
+      <computed-sort column='[{{DATASOURCE}}].[none:{{field_base_1}}:nk]' direction='DESC' using='[{{DATASOURCE}}].[sum:{{field_base_2}}:qk]' />
       <aggregation value='true' />
     </view>
     <style>

--- a/src/desktop/data/data-visualization-templates-xml/ranking-ordered-column.xml
+++ b/src/desktop/data/data-visualization-templates-xml/ranking-ordered-column.xml
@@ -21,7 +21,7 @@
         <column-instance column='[Category]' derivation='None' name='[none:Category:nk]' pivot='key' type='nominal' />
         <column-instance column='[Measure]' derivation='Sum' name='[sum:Measure:qk]' pivot='key' type='quantitative' />
       </datasource-dependencies>
-      <computed-sort column='[{{DATASOURCE}}].[none:Category:nk]' direction='DESC' using='[{{DATASOURCE}}].[sum:Measure:qk]' />
+      <computed-sort column='[{{DATASOURCE}}].[none:{{field_base_1}}:nk]' direction='DESC' using='[{{DATASOURCE}}].[sum:{{field_base_2}}:qk]' />
       <aggregation value='true' />
     </view>
     <style>

--- a/src/desktop/data/template-manifests.index.json
+++ b/src/desktop/data/template-manifests.index.json
@@ -2736,8 +2736,8 @@
       "fast_path_blockers": [],
       "portability_evidence": {
         "fixture_bind": true,
-        "render_verified": "live-2026-07-11",
-        "xml_sha256": "ef0503faa2dd6320f902335dcd721909f4cb161d315a7746f296dc2967c60a4c",
+        "render_verified": "live-2026-07-26",
+        "xml_sha256": "3ce7dfa8c7d8b6ebb54c53f0372589dce7e2c54d4e71fb17bdb59a840ef535b1",
         "render_evidence": {
           "method": "gate-composite",
           "date": "2026-07-11",
@@ -2752,7 +2752,7 @@
             "caption-leak=pass"
           ],
           "run": "oracle-leg replay (W62 stamp batch): independent authored oracle on bundled Sample - Superstore; bind gate honestly escalated not-fast-path pre-stamp (recorded); apply via identity fill (native names, no rewrites); all 12 config facets green on the applied readback incl. computed-sort DESC survival (the sort NODE came through apply)",
-          "basis": "golden-parity gate run 2026-07-11 (oracle-leg): structural 0.97297 (5/5 critical, 3/3 high; sole miss = salience-1 resolved-title cosmetic), pixel 0.91667 (6 counted ROIs -- the template ships a layout-options subtitle + axis/zeroline trims the oracle deliberately omits, an expected cosmetic divergence), composite 95, binding-sanity sane via reconciled Copy>Data 3=3=EXPECTED_COUNT. Oracle authoring note: computed-sort requires the SortTagCleanup document-format flag (tactics/tree/twb-xml-grammar.md) -- omitted first emit failed Desktop load D2E8DA72, fixed in the generator.",
+          "basis": "golden-parity gate run 2026-07-11 (oracle-leg): structural 0.97297 (5/5 critical, 3/3 high; sole miss = salience-1 resolved-title cosmetic), pixel 0.91667 (6 counted ROIs -- the template ships a layout-options subtitle + axis/zeroline trims the oracle deliberately omits, an expected cosmetic divergence), composite 95, binding-sanity sane via reconciled Copy>Data 3=3=EXPECTED_COUNT. Oracle authoring note: computed-sort requires the SortTagCleanup document-format flag (tactics/tree/twb-xml-grammar.md) -- omitted first emit failed Desktop load D2E8DA72, fixed in the generator. | sort-param re-verify 2026-07-26 (claude/sortparam-restamp): parameterized computed-sort re-applied to the template bytes. Verified via two live e1 song legs (PASS 95 x2 @ ~8.5s, run-2026-07-26T16-58-57-574Z, sonnet-low, bundle from this branch) plus one direct bind+readback leg (verbatim e1 ask on a fresh e1 stage): applied:true and the readback XML carries computed-sort direction=DESC using SUM of the LIVE bound measure (revenue) over the live dimension (region) — donor Category/Sales refs fully rebound. Horizontal bar orientation confirmed (dimension on rows). NO pixel capture this round; pixel/composite scores in this block belong to the prior gate and the unchanged geometry.",
           "lane": "fable-direct stamp batch 2026-07-11 (orchestrator live gate run; oracle-stamp.mjs CONFIG=magbar PID=52932)",
           "pixel_oracle": "source render (same-geometry back-to-back captures on the live instance; 6 counted ROIs). Source and applied are two INDEPENDENT renders of the same data.",
           "gate_composite": 95
@@ -3863,10 +3863,10 @@
       "fast_path_blockers": [],
       "portability_evidence": {
         "fixture_bind": true,
-        "render_verified": "live-2026-07-05",
-        "xml_sha256": "a0a23ffcf5fb34263b4e1a46a107590200a03d3f02fdc5efcf8622cc9e4a9235",
+        "render_verified": "live-2026-07-26",
+        "xml_sha256": "afb71d90510a3df77c64fa4549df37cc3285dd15b1d2db603c90c53ba5c69856",
         "render_evidence": {
-          "basis": "hand-stamp: live render + structural parity + human review",
+          "basis": "hand-stamp: live render + structural parity + human review | sort-param re-verify 2026-07-26 (claude/sortparam-restamp): parameterized computed-sort re-applied to the template bytes. Verified via two direct bind+readback legs on fresh e1 stages (ask 'column chart of Revenue by Region', bundle from this branch): applied:true both legs, readback XML carries computed-sort direction=DESC using SUM of the LIVE bound measure (revenue) over the live dimension (region) — donor refs fully rebound; column orientation confirmed (measure on rows, dimension on cols). NO pixel capture this round; pixel/composite scores in this block belong to the prior gate and the unchanged geometry.",
           "lane": "W2-R008 live-verify 2026-07-05",
           "structural": 0.97297,
           "critical_pass": "5/5",

--- a/src/desktop/data/template-manifests/magnitude-simple-bar.manifest.json
+++ b/src/desktop/data/template-manifests/magnitude-simple-bar.manifest.json
@@ -6,8 +6,8 @@
   "fast_path_blockers": [],
   "portability_evidence": {
     "fixture_bind": true,
-    "render_verified": "live-2026-07-11",
-    "xml_sha256": "ef0503faa2dd6320f902335dcd721909f4cb161d315a7746f296dc2967c60a4c",
+    "render_verified": "live-2026-07-26",
+    "xml_sha256": "3ce7dfa8c7d8b6ebb54c53f0372589dce7e2c54d4e71fb17bdb59a840ef535b1",
     "render_evidence": {
       "method": "gate-composite",
       "date": "2026-07-11",
@@ -22,32 +22,58 @@
         "caption-leak=pass"
       ],
       "run": "oracle-leg replay (W62 stamp batch): independent authored oracle on bundled Sample - Superstore; bind gate honestly escalated not-fast-path pre-stamp (recorded); apply via identity fill (native names, no rewrites); all 12 config facets green on the applied readback incl. computed-sort DESC survival (the sort NODE came through apply)",
-      "basis": "golden-parity gate run 2026-07-11 (oracle-leg): structural 0.97297 (5/5 critical, 3/3 high; sole miss = salience-1 resolved-title cosmetic), pixel 0.91667 (6 counted ROIs -- the template ships a layout-options subtitle + axis/zeroline trims the oracle deliberately omits, an expected cosmetic divergence), composite 95, binding-sanity sane via reconciled Copy>Data 3=3=EXPECTED_COUNT. Oracle authoring note: computed-sort requires the SortTagCleanup document-format flag (tactics/tree/twb-xml-grammar.md) -- omitted first emit failed Desktop load D2E8DA72, fixed in the generator.",
+      "basis": "golden-parity gate run 2026-07-11 (oracle-leg): structural 0.97297 (5/5 critical, 3/3 high; sole miss = salience-1 resolved-title cosmetic), pixel 0.91667 (6 counted ROIs -- the template ships a layout-options subtitle + axis/zeroline trims the oracle deliberately omits, an expected cosmetic divergence), composite 95, binding-sanity sane via reconciled Copy>Data 3=3=EXPECTED_COUNT. Oracle authoring note: computed-sort requires the SortTagCleanup document-format flag (tactics/tree/twb-xml-grammar.md) -- omitted first emit failed Desktop load D2E8DA72, fixed in the generator. | sort-param re-verify 2026-07-26 (claude/sortparam-restamp): parameterized computed-sort re-applied to the template bytes. Verified via two live e1 song legs (PASS 95 x2 @ ~8.5s, run-2026-07-26T16-58-57-574Z, sonnet-low, bundle from this branch) plus one direct bind+readback leg (verbatim e1 ask on a fresh e1 stage): applied:true and the readback XML carries computed-sort direction=DESC using SUM of the LIVE bound measure (revenue) over the live dimension (region) — donor Category/Sales refs fully rebound. Horizontal bar orientation confirmed (dimension on rows). NO pixel capture this round; pixel/composite scores in this block belong to the prior gate and the unchanged geometry.",
       "lane": "fable-direct stamp batch 2026-07-11 (orchestrator live gate run; oracle-stamp.mjs CONFIG=magbar PID=52932)",
       "pixel_oracle": "source render (same-geometry back-to-back captures on the live instance; 6 counted ROIs). Source and applied are two INDEPENDENT renders of the same data.",
       "gate_composite": 95
     }
   },
   "datasource_placeholder": true,
-  "placeholders": ["TITLE", "DATASOURCE"],
-  "intent_keywords": ["magnitude", "absolute"],
+  "placeholders": [
+    "TITLE",
+    "DATASOURCE"
+  ],
+  "intent_keywords": [
+    "magnitude",
+    "absolute"
+  ],
   "description": "Horizontal bars, one per category; bar length = the measure's ABSOLUTE magnitude (a size comparison across categories). Bars are sorted descending by the measure purely as a READING AID — the sort is not a ranking contract (no top-N, best/worst, or positional semantics). The magnitude family's generic {category, measure} bar: cloned from ranking-ordered-bar's two-slot categorical+quantitative bar shape, but with ranking-specific keywords, subtitle, and sort-role labels removed, and NO period/temporal slot or hardcoded incomplete-period filter (the HARDCODED_FILTER_MEMBERS blocker that keeps magnitude-paired-bar / magnitude-paired-column-chart off the fast path). Live-stamped 2026-07-11 (oracle-leg composite 95, 3=3 reconciled, computed-sort survived apply): fast_path_eligible true -- the magnitude family's first fast-path template.",
   "avoid_when": [
     "The user explicitly wants a ranked or top-N / bottom-N ordering as the point of the chart (best/worst, leaders/laggards) - reach for ranking-ordered-bar or ranking-ordered-column, where the sort order IS the contract; here the descending sort is only a reading aid.",
     "The comparison is period-over-period (this year vs last year, before vs after) - use the magnitude paired-bar or paired-column family, which pairs a measure over two or more time periods per group."
   ],
   "slots": [
-    { "slot_id": "category", "template_field": "Category", "derivation": "none",
-      "role": ["rows"], "kind": "categorical", "bindable": true, "required": true,
-      "notes": "One horizontal bar per member on rows. Also the dimension instance the computed-sort orders (DESC by the measure) - a reading aid, not a ranking contract." },
-    { "slot_id": "measure", "template_field": "Sales", "derivation": "sum",
-      "role": ["cols"], "kind": "quantitative", "bindable": true, "required": true,
-      "notes": "Bar length on cols = the measure's magnitude, aggregated as SUM. Template_field 'Sales' is just the placeholder column the field-swap injector renames to the bound measure; the computed-sort's using= references this instance." }
+    {
+      "slot_id": "category",
+      "template_field": "Category",
+      "derivation": "none",
+      "role": [
+        "rows"
+      ],
+      "kind": "categorical",
+      "bindable": true,
+      "required": true,
+      "notes": "One horizontal bar per member on rows. Also the dimension instance the computed-sort orders (DESC by the measure) - a reading aid, not a ranking contract."
+    },
+    {
+      "slot_id": "measure",
+      "template_field": "Sales",
+      "derivation": "sum",
+      "role": [
+        "cols"
+      ],
+      "kind": "quantitative",
+      "bindable": true,
+      "required": true,
+      "notes": "Bar length on cols = the measure's magnitude, aggregated as SUM. Template_field 'Sales' is just the placeholder column the field-swap injector renames to the bound measure; the computed-sort's using= references this instance."
+    }
   ],
   "calcs": [],
   "hazards": [
-    { "code": "computed-sort-pill-coupling",
+    {
+      "code": "computed-sort-pill-coupling",
       "detail": "The computed-sort binds the category dimension instance ([none:Category:nk]) to the measure instance ([sum:Sales:qk]); both slots must bind or the sort dangles. Both are required, so this is satisfied by coverage. (This is the ONLY carry-over from the ranking donor's sort mechanic; unlike ranking, the sort here is presentational, not a top-N contract.)",
-      "xml": "magnitude-simple-bar.xml:24" }
+      "xml": "magnitude-simple-bar.xml:24"
+    }
   ]
 }

--- a/src/desktop/data/template-manifests/ranking-ordered-column.manifest.json
+++ b/src/desktop/data/template-manifests/ranking-ordered-column.manifest.json
@@ -6,10 +6,10 @@
   "fast_path_blockers": [],
   "portability_evidence": {
     "fixture_bind": true,
-    "render_verified": "live-2026-07-05",
-    "xml_sha256": "a0a23ffcf5fb34263b4e1a46a107590200a03d3f02fdc5efcf8622cc9e4a9235",
+    "render_verified": "live-2026-07-26",
+    "xml_sha256": "afb71d90510a3df77c64fa4549df37cc3285dd15b1d2db603c90c53ba5c69856",
     "render_evidence": {
-      "basis": "hand-stamp: live render + structural parity + human review",
+      "basis": "hand-stamp: live render + structural parity + human review | sort-param re-verify 2026-07-26 (claude/sortparam-restamp): parameterized computed-sort re-applied to the template bytes. Verified via two direct bind+readback legs on fresh e1 stages (ask 'column chart of Revenue by Region', bundle from this branch): applied:true both legs, readback XML carries computed-sort direction=DESC using SUM of the LIVE bound measure (revenue) over the live dimension (region) — donor refs fully rebound; column orientation confirmed (measure on rows, dimension on cols). NO pixel capture this round; pixel/composite scores in this block belong to the prior gate and the unchanged geometry.",
       "lane": "W2-R008 live-verify 2026-07-05",
       "structural": 0.97297,
       "critical_pass": "5/5",

--- a/src/desktop/data/templates/magnitude-simple-bar.xml
+++ b/src/desktop/data/templates/magnitude-simple-bar.xml
@@ -21,7 +21,7 @@
         <column-instance column='[Category]' derivation='None' name='[none:Category:nk]' pivot='key' type='nominal' />
         <column-instance column='[Sales]' derivation='Sum' name='[sum:Sales:qk]' pivot='key' type='quantitative' />
       </datasource-dependencies>
-      <computed-sort column='[{{DATASOURCE}}].[none:Category:nk]' direction='DESC' using='[{{DATASOURCE}}].[sum:Sales:qk]' />
+      <computed-sort column='[{{DATASOURCE}}].[none:{{field_base_1}}:nk]' direction='DESC' using='[{{DATASOURCE}}].[sum:{{field_base_2}}:qk]' />
       <aggregation value='true' />
     </view>
     <style>

--- a/src/desktop/data/templates/ranking-ordered-column.xml
+++ b/src/desktop/data/templates/ranking-ordered-column.xml
@@ -21,7 +21,7 @@
         <column-instance column='[Category]' derivation='None' name='[none:Category:nk]' pivot='key' type='nominal' />
         <column-instance column='[Measure]' derivation='Sum' name='[sum:Measure:qk]' pivot='key' type='quantitative' />
       </datasource-dependencies>
-      <computed-sort column='[{{DATASOURCE}}].[none:Category:nk]' direction='DESC' using='[{{DATASOURCE}}].[sum:Measure:qk]' />
+      <computed-sort column='[{{DATASOURCE}}].[none:{{field_base_1}}:nk]' direction='DESC' using='[{{DATASOURCE}}].[sum:{{field_base_2}}:qk]' />
       <aggregation value='true' />
     </view>
     <style>

--- a/src/desktop/templates/computedSortTemplates.test.ts
+++ b/src/desktop/templates/computedSortTemplates.test.ts
@@ -1,30 +1,50 @@
 import { readFileSync } from 'fs';
 import { join } from 'path';
 
+import { loadManifests } from '../binder/manifest.js';
+
 const TEMPLATE_DIR = join(process.cwd(), 'src', 'desktop', 'data', 'templates');
+const manifests = loadManifests();
 
 function template(name: string): string {
   return readFileSync(join(TEMPLATE_DIR, `${name}.xml`), 'utf8');
 }
 
-// magnitude-simple-bar, part-to-whole-waterfall, and ranking-ordered-column also carry
-// hardcoded Superstore computed-sort refs, but they are render-stamped: their bytes may
-// only change through the factory golden-parity re-stamp flow. The parameterized versions
-// (plus the waterfall label/gain-loss presentation defaults) are held on
-// claude/stamped-template-polish; extend the table below when that branch re-earns its
-// stamps and lands.
+// stampHash.invariant.test.ts only proves XML bytes match the recorded hash; a
+// legitimate re-stamp could update that hash while silently dropping parameterization.
+// This byte pin catches that, while each slot-kind expectation guards positional order.
 describe('computed-sort template parameters', () => {
   it.each([
     [
+      'magnitude-simple-bar',
+      "<computed-sort column='[{{DATASOURCE}}].[none:{{field_base_1}}:nk]' direction='DESC' using='[{{DATASOURCE}}].[sum:{{field_base_2}}:qk]' />",
+      'categorical',
+    ],
+    [
       'pareto-chart',
       "<computed-sort column='[{{DATASOURCE}}].[none:{{field_base_1}}:nk]' direction='DESC' using='[{{DATASOURCE}}].[sum:{{field_base_2}}:qk]' />",
+      'categorical',
     ],
     [
       'deviation-spine-chart',
       "<computed-sort column='[{{DATASOURCE}}].[none:{{field_base_1}}:nk]' direction='ASC' using='[{{DATASOURCE}}].[usr:Men (copy):qk]' />",
+      'categorical',
     ],
-  ])('%s parameterizes its computed sort', (name, expected) => {
+    [
+      'ranking-ordered-column',
+      "<computed-sort column='[{{DATASOURCE}}].[none:{{field_base_1}}:nk]' direction='DESC' using='[{{DATASOURCE}}].[sum:{{field_base_2}}:qk]' />",
+      'categorical',
+    ],
+    [
+      'part-to-whole-waterfall',
+      "<computed-sort column='[{{DATASOURCE}}].[none:{{field_base_2}}:nk]' direction='DESC' using='[{{DATASOURCE}}].[sum:{{field_base_1}}:qk]' />",
+      'quantitative',
+    ],
+  ])('%s parameterizes its computed sort', (name, expected, firstBindableKind) => {
     expect(template(name)).toContain(expected);
+    expect(manifests.get(name)?.slots.filter((slot) => slot.bindable)[0]?.kind).toBe(
+      firstBindableKind,
+    );
   });
 
   it('removes the donor datasource id from deviation-spine-chart', () => {

--- a/src/tools/desktop/binder/bindTemplate.test.ts
+++ b/src/tools/desktop/binder/bindTemplate.test.ts
@@ -4588,8 +4588,7 @@ describe('bindTemplateTool incomplete bind is not remembered as applied', () => 
   });
 
   it('surfaces a computed-sort drop from template rewriting as an incomplete warning', async () => {
-    const warning =
-      'computed-sort dropped: [Superstore].[sum:Optional Sort:qk] did not resolve';
+    const warning = 'computed-sort dropped: [Superstore].[sum:Optional Sort:qk] did not resolve';
     const mocks = setupAutoApplyMocks({
       inject: {
         ok: true,

--- a/src/tools/desktop/binder/bindTemplate.ts
+++ b/src/tools/desktop/binder/bindTemplate.ts
@@ -42,10 +42,7 @@ import type { ExternalApiToolExecutor } from '../../../desktop/externalApi/exter
 import { bundledIntelligenceProvider } from '../../../desktop/intelligence/provider.js';
 import { parseCanonicalColumnRef } from '../../../desktop/metadata/field-resolver.js';
 import { addFieldToEncoding } from '../../../desktop/metadata/fields.js';
-import {
-  extractSheetXml,
-  upsertSheetIntoWorkbook,
-} from '../../../desktop/metadata/sheets.js';
+import { extractSheetXml, upsertSheetIntoWorkbook } from '../../../desktop/metadata/sheets.js';
 import {
   planSortByFieldOnCategoricalAxis,
   planTopN,
@@ -293,9 +290,7 @@ function currencyHeterogeneityCaveat(
 ): string {
   if (!worksheetXml) return '';
 
-  const displayedRefs = canonicalRefsIn(
-    xmlTagRegions(worksheetXml, ['rows', 'cols', 'encodings']),
-  );
+  const displayedRefs = canonicalRefsIn(xmlTagRegions(worksheetXml, ['rows', 'cols', 'encodings']));
   const summedMeasure = schemaSummary.fields.find(
     (field) =>
       field.role === 'measure' &&
@@ -1572,11 +1567,7 @@ async function performAutoApply({
           workbookXml,
         );
       }
-      appliedWorkbookXml = upsertSheetIntoWorkbook(
-        appliedWorkbookXml,
-        literalTitle,
-        worksheetXml,
-      );
+      appliedWorkbookXml = upsertSheetIntoWorkbook(appliedWorkbookXml, literalTitle, worksheetXml);
     } catch (err) {
       appliedWorkbookXml = spliced.xml;
       appliedDefault.context_measures = [];

--- a/src/tools/desktop/coordination/buildAndApplyWorksheet.characterization.test.ts
+++ b/src/tools/desktop/coordination/buildAndApplyWorksheet.characterization.test.ts
@@ -111,14 +111,12 @@ type Captured = {
 
 function captureCall(): Captured {
   const captured: Captured = { mapping: {}, datasource: '', metadata: {} };
-  vi.mocked(rewriteFieldReferencesWithDiagnostics).mockImplementation(
-    (_xml, mapping, ds, meta) => {
-      captured.mapping = mapping;
-      captured.datasource = ds;
-      captured.metadata = (meta ?? {}) as Captured['metadata'];
-      return { xml: WORKSHEET_OUTPUT, droppedOptionalElements: [] };
-    },
-  );
+  vi.mocked(rewriteFieldReferencesWithDiagnostics).mockImplementation((_xml, mapping, ds, meta) => {
+    captured.mapping = mapping;
+    captured.datasource = ds;
+    captured.metadata = (meta ?? {}) as Captured['metadata'];
+    return { xml: WORKSHEET_OUTPUT, droppedOptionalElements: [] };
+  });
   return captured;
 }
 


### PR DESCRIPTION
## Decision

Ship the parameterized sort on `magnitude-simple-bar` and `ranking-ordered-column` in the release **after** v2.58.0. This follows the existing template-stamp rule: a template change ships only with a stamp re-earned by live proof. Both stamps were re-earned on 2026-07-26 with a live computed-sort rebind on each template, and the hashes were synced through the gate's own re-earn path (same procedure the waterfall re-stamp used). No new rule.

## Scope

Two template XMLs plus their stamp hashes (8 files). Deliberately based on `claude/v11-fixes` (frozen #643) so it lands in the next release PR, not inside the freeze.

## What future work must preserve

Stamp hashes are never hand-edited. Any later change to these templates re-earns the stamp with a live rebind before shipping.

## Evidence / risk

Live computed-sort rebind proof for both templates is in the 2026-07-26 wave receipts; branch CI runs the full suite. Risk: the branch sits 11 commits behind the frozen tip — a local merge onto 14b1ec2c was clean (no overlap with the freeze-review fixes).

## What approving means

The two templates carry parameterized sort in the next release, under the existing stamp gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)