### PR TITLE
fix(desktop): cap /v0 health checks at 10s and classify aborted requests as timeouts

### DIFF
--- a/src/desktop/externalApi/externalApiClient.ts
+++ b/src/desktop/externalApi/externalApiClient.ts
@@ -45,7 +45,7 @@ import {
 export type ExternalApiClientOptions = {
   /** Injectable fetch — defaults to the global. Tests pass real HTTP to a mock server. */
   fetchFn?: typeof fetch;
-  /** Per-request timeout used when the caller does not supply an AbortSignal. */
+  /** Global ceiling for each request; health remains capped at its shorter route budget. */
   timeoutMs?: number;
 };
 
@@ -63,6 +63,7 @@ export type WorksheetSummaryDataQuery = {
 };
 
 const DEFAULT_TIMEOUT_MS = 60_000;
+const DEFAULT_HEALTH_TIMEOUT_MS = 10_000;
 
 /**
  * Typed client for a single Tableau Desktop External Client API instance.
@@ -74,12 +75,12 @@ const DEFAULT_TIMEOUT_MS = 60_000;
 export class ExternalApiClient {
   private readonly instance: ExternalApiInstance;
   private readonly fetchFn: typeof fetch;
-  private readonly timeoutMs: number;
+  private readonly timeoutMs: number | undefined;
 
   constructor(instance: ExternalApiInstance, options: ExternalApiClientOptions = {}) {
     this.instance = instance;
     this.fetchFn = options.fetchFn ?? fetch;
-    this.timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    this.timeoutMs = options.timeoutMs;
   }
 
   get baseUrl(): string {
@@ -355,7 +356,7 @@ export class ExternalApiClient {
 
     // A caller signal is a cancellation channel, not a clock — compose, never replace. `??` here
     // meant the default timeout never applied, because every desktop tool passes extra.signal.
-    const signal = composeWithTimeout(options.signal, this.timeoutMs);
+    const signal = composeWithTimeout(options.signal, timeoutMsForRoute(route, this.timeoutMs));
 
     try {
       const res = await this.fetchFn(this.url(route), {
@@ -366,7 +367,7 @@ export class ExternalApiClient {
       });
       return Ok(res);
     } catch (error) {
-      return Err({ type: 'network', error });
+      return Err({ type: 'network', error, aborted: signal.aborted });
     }
   }
 
@@ -378,6 +379,13 @@ export class ExternalApiClient {
 function composeWithTimeout(signal: AbortSignal | undefined, timeoutMs: number): AbortSignal {
   const timeout = AbortSignal.timeout(timeoutMs);
   return signal ? AbortSignal.any([signal, timeout]) : timeout;
+}
+
+function timeoutMsForRoute(route: string, configuredTimeoutMs: number | undefined): number {
+  const globalTimeoutMs = configuredTimeoutMs ?? DEFAULT_TIMEOUT_MS;
+  return route === EXTERNAL_API_ROUTES.health
+    ? Math.min(globalTimeoutMs, DEFAULT_HEALTH_TIMEOUT_MS)
+    : globalTimeoutMs;
 }
 
 function buildWorksheetByIdRoute(worksheetId: string): string {

--- a/src/desktop/externalApi/externalApiClientTimeout.test.ts
+++ b/src/desktop/externalApi/externalApiClientTimeout.test.ts
@@ -23,6 +23,53 @@ function hangingFetch(): typeof fetch {
 }
 
 describe('ExternalApiClient request deadline', () => {
+  it('applies the health budget beneath the configured global ceiling', async () => {
+    const fetchFn = vi
+      .fn()
+      .mockResolvedValueOnce(new Response('{}', { status: 200 }))
+      .mockResolvedValueOnce(new Response('<workbook />', { status: 200 }))
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            id: 'op-1',
+            kind: 'command.invoke',
+            state: 'SUCCEEDED',
+          }),
+          { status: 200 },
+        ),
+      ) as unknown as typeof fetch;
+    const timeoutSpy = vi.spyOn(AbortSignal, 'timeout');
+    // Production always supplies this option from sessionManager.
+    const client = new ExternalApiClient(instance, { fetchFn, timeoutMs: 60_000 });
+
+    try {
+      await client.health();
+      await client.getWorkbookDocument();
+      await client.invokeCommand('tabdoc', 'undo');
+
+      expect(timeoutSpy.mock.calls.map(([budgetMs]) => budgetMs)).toEqual([10_000, 60_000, 60_000]);
+    } finally {
+      timeoutSpy.mockRestore();
+    }
+  });
+
+  it('creates a fresh deadline for every request', async () => {
+    const fetchFn = vi
+      .fn()
+      .mockResolvedValue(new Response('{}', { status: 200 })) as unknown as typeof fetch;
+    const timeoutSpy = vi.spyOn(AbortSignal, 'timeout');
+    const client = new ExternalApiClient(instance, { fetchFn });
+
+    try {
+      await client.health();
+      await client.health();
+
+      expect(timeoutSpy).toHaveBeenCalledTimes(2);
+    } finally {
+      timeoutSpy.mockRestore();
+    }
+  });
+
   it('applies its own clock even when the caller supplies a signal', async () => {
     // The `??` this replaces meant a caller signal removed the timeout entirely, and every
     // desktop tool supplies extra.signal — so the 60s default was unreachable in shipped code.

--- a/src/desktop/externalApi/externalApiToolExecutor.test.ts
+++ b/src/desktop/externalApi/externalApiToolExecutor.test.ts
@@ -454,6 +454,59 @@ describe('ExternalApiToolExecutor', () => {
     });
   });
 
+  describe('request deadline errors', () => {
+    const hangingFetch = (): typeof fetch =>
+      ((_url: string, init?: RequestInit): Promise<Response> =>
+        new Promise((_resolve, reject) => {
+          if (init?.signal?.aborted) {
+            reject(init.signal.reason);
+            return;
+          }
+          init?.signal?.addEventListener('abort', () => reject(init.signal?.reason), {
+            once: true,
+          });
+        })) as unknown as typeof fetch;
+
+    it('maps a request timeout to command-timed-out without rescanning discovery', async () => {
+      const discover = vi.fn(() => [instanceFor(server)]);
+      const executor = new ExternalApiToolExecutor({
+        discover,
+        clientOptions: { fetchFn: hangingFetch(), timeoutMs: 60 },
+      });
+      await executor.start();
+
+      const result = await executor.executeCommand({
+        namespace: 'tabdoc',
+        command: 'undo',
+        signal,
+      });
+
+      expect(result.unwrapErr().type).toBe('command-timed-out');
+      expect(discover).toHaveBeenCalledTimes(1);
+    });
+
+    it('respects caller aborts and maps them to command-timed-out', async () => {
+      const discover = vi.fn(() => [instanceFor(server)]);
+      const executor = new ExternalApiToolExecutor({
+        discover,
+        clientOptions: { fetchFn: hangingFetch(), timeoutMs: 60_000 },
+      });
+      await executor.start();
+      const controller = new AbortController();
+
+      const pending = executor.executeCommand({
+        namespace: 'tabdoc',
+        command: 'undo',
+        signal: controller.signal,
+      });
+      controller.abort();
+      const result = await pending;
+
+      expect(result.unwrapErr().type).toBe('command-timed-out');
+      expect(discover).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe('401 rescan-once', () => {
     it('rediscovers once on a 401 and retries with the fresh token', async () => {
       const discover = vi

--- a/src/desktop/externalApi/externalApiToolExecutor.ts
+++ b/src/desktop/externalApi/externalApiToolExecutor.ts
@@ -562,7 +562,7 @@ function mapClientError(
     case 'invalid-response':
       return { type: 'invalid-response', error: error.error };
     case 'network':
-      return mapNetworkFailure(error.error, pinnedPid);
+      return mapNetworkFailure(error.error, pinnedPid, error.aborted);
     case 'no-instance':
       return {
         type: 'unknown',
@@ -578,7 +578,11 @@ function mapClientError(
  * A dead-but-cached Desktop used to surface as a raw `fetch failed`, which the agent could not
  * act on. Name the instance so it can re-target, and keep a timeout honest as a timeout.
  */
-function mapNetworkFailure(cause: unknown, pinnedPid?: number): ExecuteCommandError {
+function mapNetworkFailure(
+  cause: unknown,
+  pinnedPid?: number,
+  aborted = false,
+): ExecuteCommandError {
   if (isDesktopCallTimeout(cause)) {
     return {
       type: 'command-timed-out',
@@ -586,8 +590,18 @@ function mapNetworkFailure(cause: unknown, pinnedPid?: number): ExecuteCommandEr
     };
   }
 
-  if (cause instanceof Error && cause.name === 'TimeoutError') {
-    return { type: 'command-timed-out', error: cause.message };
+  // Caller AbortError is reported as timed out for now; MCP cancellation discards this response.
+  if (
+    aborted ||
+    (cause instanceof Error && (cause.name === 'TimeoutError' || cause.name === 'AbortError'))
+  ) {
+    return {
+      type: 'command-timed-out',
+      error:
+        cause instanceof Error
+          ? cause.message
+          : 'External Client API request was aborted before completion.',
+    };
   }
 
   const detail = cause instanceof Error ? cause.message : undefined;

--- a/src/desktop/externalApi/types.ts
+++ b/src/desktop/externalApi/types.ts
@@ -369,4 +369,4 @@ export type ExternalApiError =
   | { type: 'unauthorized'; status: number }
   | { type: 'problem'; status: number; code?: string; title?: string; detail?: string }
   | { type: 'invalid-response'; error: unknown }
-  | { type: 'network'; error: unknown };
+  | { type: 'network'; error: unknown; aborted?: boolean };


### PR DESCRIPTION
## Decision
When a /v0 request dies by deadline or abort, the agent gets the typed `command-timed-out` error (which carries the "Desktop is likely showing a blocking dialog" guidance) instead of `unknown`. Health checks are capped at 10 seconds regardless of the global timeout; today only the `get-health` tool exercises that path, so the cap is defensive rather than a measured saving. This is a rule we keep: every /v0 route has a deadline, and a timeout is always reported as a timeout.

## Scope
- `externalApiClient`: the configured `desktopCallTimeoutMs` stays a global ceiling; health uses `min(ceiling, 10s)`. Network errors record whether the composed signal aborted.
- `externalApiToolExecutor`: AbortError / aborted requests map to `command-timed-out` (base already mapped TimeoutError; this closes the abort-shaped gap).
- Deliberately out: per-route budgets beyond health, and a distinct cancelled-vs-timed-out error type.

## What future work must preserve
The caller's AbortSignal is a cancellation channel, not the clock — it is always composed with the route deadline, never replaced by it. A timeout must never trigger the 401 discovery rescan.

## Evidence / risk
Sol-built, Opus-reviewed (finding fixed: the 10s health budget originally never ran in production because sessionManager always passes a global timeoutMs — now min-composed and regression-tested with a configured timeout). Full vitest, tsc, lint, desktop build green, run firsthand. Known tradeoff, commented in code: a caller-initiated cancel also reports as `command-timed-out`; MCP cancellation discards the response today, so this is cosmetic until an internal caller races two legs on its own controller.

## Approving this means
/v0 calls can no longer hang for the full global timeout on a dead health check, and wedged-Desktop failures arrive typed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
