### PR TITLE
feat(desktop): author real set actions, not parameter actions aimed at sets

### DIFF
--- a/src/server.desktop.test.ts
+++ b/src/server.desktop.test.ts
@@ -208,10 +208,10 @@ describe('desktop tools/list serialized surface', () => {
     // Dynamic authoring is the serving surface, so this is the real budget gate.
     // The full desktop surface is not what clients see by default; its looser cap
     // only catches runaway growth without forcing valuable full-profile tools to be trimmed.
-    // Honest wire measurements are 28,804 bytes dynamic and 44,286 bytes full.
+    // Honest wire measurements are 29,132 bytes dynamic and 44,614 bytes full.
     // Keep only a few bytes of ratchet headroom while staying well below the 46k cliff.
-    expect(dynamicAuthoringTotal).toBeLessThanOrEqual(28_820);
-    expect(fullSurfaceTotal).toBeLessThanOrEqual(44_300);
+    expect(dynamicAuthoringTotal).toBeLessThanOrEqual(29_148);
+    expect(fullSurfaceTotal).toBeLessThanOrEqual(44_630);
   });
 });
 
@@ -522,7 +522,7 @@ describe('selectToolsForProfile (TOOL_PROFILE, W60 spike lever 1 / preamble P1)'
     }
     // A lean surface must have generous headroom — this is a structural win, not a
     // describe-stub squeeze. If this ever approaches 46k something is very wrong.
-    expect(total).toBeLessThanOrEqual(28_820);
+    expect(total).toBeLessThanOrEqual(29_148);
   });
 
   it('unset ("") profile returns the lean dynamic-authoring native surface — the singer sings native by default', () => {

--- a/src/tools/desktop/data-source/authorAction.test.ts
+++ b/src/tools/desktop/data-source/authorAction.test.ts
@@ -14,8 +14,10 @@ const BASE_XML = [
   "<datasource hasconnection='false' inline='true' name='Parameters'>",
   "<column caption='p.Period' datatype='string' name='[Parameter 1]' param-domain-type='list' role='measure' type='nominal' value='&quot;Month&quot;'><calculation class='tableau' formula='&quot;Month&quot;' /></column>",
   '</datasource>',
-  "<datasource name='Sample - Superstore'>",
+  "<datasource caption='Sample - Superstore' name='federated.1syzfv90anwuu119p4zra1ga299n'>",
   "<column caption='Profit' datatype='real' name='[Profit]' role='measure' type='quantitative' />",
+  "<group caption='Category Set' name='[Category Set]' user:ui-builder='filter-group' />",
+  "<group caption='Ad Hoc Group' name='[Ad Hoc Group]' />",
   '</datasource>',
   '</datasources>',
   "<worksheets><worksheet name='Profit' /></worksheets>",
@@ -48,6 +50,8 @@ describe('authorActionTool', () => {
     const parsed = JSON.parse(result.content[0].text);
     expect(parsed.actionName).toBe('[Action1]');
     expect(parsed.caption).toBe('Set Period');
+    expect(parsed.mode).toBe('parameter');
+    expect(parsed.target).toBe('[Parameters].[Parameter 1]');
     expect(parsed.targetParameter).toBe('[Parameters].[Parameter 1]');
 
     const loaded = appliedDocumentXml(applyWorkbookDocument);
@@ -70,7 +74,7 @@ describe('authorActionTool', () => {
     );
     const readbackXml = withOne.replace(
       '</actions>',
-      "<edit-parameter-action caption='Second' name='[Action2]'></edit-parameter-action></actions>",
+      "<edit-parameter-action caption='Second' name='[Action2]'><params><param name='target-parameter' value='[Parameters].[Parameter 1]' /></params></edit-parameter-action></actions>",
     );
     const { result, applyWorkbookDocument } = await getToolResult({
       args: {
@@ -111,6 +115,342 @@ describe('authorActionTool', () => {
     expect(applyWorkbookDocument).not.toHaveBeenCalled();
   });
 
+  it('detects caption collisions with edit-group-action elements', async () => {
+    const xml = withActions(
+      BASE_XML,
+      "<edit-group-action caption='Dup' name='[Action1]'></edit-group-action>",
+    );
+    const { result, applyWorkbookDocument } = await getToolResult({
+      args: {
+        mode: 'set',
+        caption: 'Dup',
+        sourceWorksheet: 'Profit',
+        sourceField: '',
+        targetSet: 'Category Set',
+      },
+      initialXml: xml,
+    });
+
+    expect(result.isError).toBe(true);
+    invariant(result.content[0].type === 'text');
+    expect(result.content[0].text).toContain('caption collision');
+    expect(applyWorkbookDocument).not.toHaveBeenCalled();
+  });
+
+  it('emits a byte-faithful set action with children in XSD order', async () => {
+    const expectedAction =
+      "<edit-group-action caption='Expand Category' name='[Action1]'>" +
+      "<activation type='on-select' />" +
+      "<source type='sheet' worksheet='Profit' />" +
+      "<single-select value='true' />" +
+      "<add-or-remove-marks value='assign' />" +
+      "<params><param name='selection-clear-set-option' value='do-nothing' />" +
+      "<param name='target-group' value='[federated.1syzfv90anwuu119p4zra1ga299n].[Category Set]' /></params>" +
+      '</edit-group-action>';
+    const { result, applyWorkbookDocument } = await getToolResult({
+      args: {
+        mode: 'set',
+        caption: 'Expand Category',
+        sourceWorksheet: 'Profit',
+        sourceField: '',
+        targetSet: 'Category Set',
+        singleSelect: true,
+      },
+      readbackXml: withActions(BASE_XML, expectedAction),
+    });
+
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.mode).toBe('set');
+    expect(parsed.target).toBe('[federated.1syzfv90anwuu119p4zra1ga299n].[Category Set]');
+    expect(parsed.targetSet).toBe('[federated.1syzfv90anwuu119p4zra1ga299n].[Category Set]');
+
+    const loaded = appliedDocumentXml(applyWorkbookDocument);
+    expect(loaded).toContain(expectedAction);
+    const activationAt = loaded.indexOf("<activation type='on-select' />");
+    const sourceAt = loaded.indexOf("<source type='sheet' worksheet='Profit' />");
+    const singleAt = loaded.indexOf("<single-select value='true' />");
+    const membershipAt = loaded.indexOf("<add-or-remove-marks value='assign' />");
+    const paramsAt = loaded.indexOf('<params>', membershipAt);
+    expect(activationAt).toBeLessThan(sourceAt);
+    expect(sourceAt).toBeLessThan(singleAt);
+    expect(singleAt).toBeLessThan(membershipAt);
+    expect(membershipAt).toBeLessThan(paramsAt);
+  });
+
+  it('accepts set-action readback when Desktop backfills single-select', async () => {
+    const normalizedAction =
+      "<edit-group-action caption='Expand Category' name='[Action1]'>" +
+      "<activation type='on-select' />" +
+      "<source type='sheet' worksheet='Profit' />" +
+      "<single-select value='false' />" +
+      "<add-or-remove-marks value='assign' />" +
+      "<params><param name='selection-clear-set-option' value='do-nothing' />" +
+      "<param name='target-group' value='[federated.1syzfv90anwuu119p4zra1ga299n].[Category Set]' /></params>" +
+      '</edit-group-action>';
+    const { result } = await getToolResult({
+      args: {
+        mode: 'set',
+        caption: 'Expand Category',
+        sourceWorksheet: 'Profit',
+        targetSet: 'Category Set',
+      },
+      readbackXml: withActions(BASE_XML, normalizedAction),
+    });
+
+    expect(result.isError).toBe(false);
+  });
+
+  it.each([
+    ['assign', 'do-nothing'],
+    ['add', 'show-all'],
+    ['remove', 'exclude-all'],
+  ] as const)(
+    'emits set membership %s and clear selection %s in Tableau wire vocabulary',
+    async (setMembership, clearSelection) => {
+      const expectedAction =
+        "<edit-group-action caption='Map Options' name='[Action1]'>" +
+        "<activation type='on-select' />" +
+        "<source type='sheet' worksheet='Profit' />" +
+        `<add-or-remove-marks value='${setMembership}' />` +
+        `<params><param name='selection-clear-set-option' value='${clearSelection}' />` +
+        "<param name='target-group' value='[federated.1syzfv90anwuu119p4zra1ga299n].[Category Set]' /></params>" +
+        '</edit-group-action>';
+      const { result, applyWorkbookDocument } = await getToolResult({
+        args: {
+          mode: 'set',
+          caption: 'Map Options',
+          sourceWorksheet: 'Profit',
+          sourceField: '',
+          targetSet: '[Category Set]',
+          setMembership,
+          clearSelection,
+        },
+        readbackXml: withActions(BASE_XML, expectedAction),
+      });
+
+      expect(result.isError).toBe(false);
+      const loaded = appliedDocumentXml(applyWorkbookDocument);
+      expect(loaded).toContain(`<add-or-remove-marks value='${setMembership}' />`);
+      expect(loaded).toContain(
+        `<param name='selection-clear-set-option' value='${clearSelection}' />`,
+      );
+    },
+  );
+
+  it('rejects a missing targetSet and names available sets', async () => {
+    const { result, applyWorkbookDocument } = await getToolResult({
+      args: {
+        mode: 'set',
+        caption: 'Expand Category',
+        sourceWorksheet: 'Profit',
+        sourceField: '',
+      },
+    });
+
+    expect(result.isError).toBe(true);
+    invariant(result.content[0].type === 'text');
+    expect(result.content[0].text).toContain('targetSet');
+    expect(result.content[0].text).toContain('Category Set');
+    expect(applyWorkbookDocument).not.toHaveBeenCalled();
+  });
+
+  it('ignores non-set groups during target resolution and suggestions', async () => {
+    const { result, applyWorkbookDocument } = await getToolResult({
+      args: {
+        mode: 'set',
+        caption: 'Expand Group',
+        sourceWorksheet: 'Profit',
+        targetSet: 'Ad Hoc Group',
+      },
+    });
+
+    expect(result.isError).toBe(true);
+    invariant(result.content[0].type === 'text');
+    expect(result.content[0].text).toContain('Category Set');
+    expect(result.content[0].text).not.toContain('Ad Hoc Group (');
+    expect(applyWorkbookDocument).not.toHaveBeenCalled();
+  });
+
+  it('does not parse datasource-dependencies as a datasource', async () => {
+    const xml = BASE_XML.replace(
+      '</datasource>',
+      "<datasource-dependencies name='phantom'><group caption='Phantom Set' name='[Phantom Set]' user:ui-builder='filter-group' /></datasource-dependencies></datasource>",
+    );
+    const { result, applyWorkbookDocument } = await getToolResult({
+      args: {
+        mode: 'set',
+        caption: 'Expand Phantom',
+        sourceWorksheet: 'Profit',
+        targetSet: 'Phantom Set',
+        datasource: 'phantom',
+      },
+      initialXml: xml,
+    });
+
+    expect(result.isError).toBe(true);
+    invariant(result.content[0].type === 'text');
+    expect(result.content[0].text).toContain("datasource 'phantom' matched no datasource");
+    expect(applyWorkbookDocument).not.toHaveBeenCalled();
+  });
+
+  it('reports when a datasource filter matches no datasource', async () => {
+    const { result, applyWorkbookDocument } = await getToolResult({
+      args: {
+        mode: 'set',
+        caption: 'Expand Category',
+        sourceWorksheet: 'Profit',
+        targetSet: 'Category Set',
+        datasource: 'Missing Datasource',
+      },
+    });
+
+    expect(result.isError).toBe(true);
+    invariant(result.content[0].type === 'text');
+    expect(result.content[0].text).toContain(
+      "datasource 'Missing Datasource' matched no datasource; sets found in:",
+    );
+    expect(result.content[0].text).toContain('Category Set');
+    expect(applyWorkbookDocument).not.toHaveBeenCalled();
+  });
+
+  it('rejects an unqualified targetParameter with recovery guidance', async () => {
+    const { result, applyWorkbookDocument } = await getToolResult({
+      args: {
+        caption: 'Set Period',
+        sourceWorksheet: 'Profit',
+        sourceField: '',
+        targetParameter: 'Parameter 1',
+      },
+    });
+
+    expect(result.isError).toBe(true);
+    invariant(result.content[0].type === 'text');
+    expect(result.content[0].text).toContain('[Parameters].[X]');
+    expect(applyWorkbookDocument).not.toHaveBeenCalled();
+  });
+
+  it('requires sourceField in parameter mode', async () => {
+    const { result, applyWorkbookDocument } = await getToolResult({
+      args: {
+        caption: 'Set Period',
+        sourceWorksheet: 'Profit',
+        targetParameter: '[Parameters].[Parameter 1]',
+      },
+    });
+
+    expect(result.isError).toBe(true);
+    invariant(result.content[0].type === 'text');
+    expect(result.content[0].text).toContain('sourceField is required in parameter mode');
+    expect(applyWorkbookDocument).not.toHaveBeenCalled();
+  });
+
+  it('rejects mode-incompatible targets', async () => {
+    const { result } = await getToolResult({
+      args: {
+        mode: 'set',
+        caption: 'Expand Category',
+        sourceWorksheet: 'Profit',
+        sourceField: '',
+        targetSet: 'Category Set',
+        targetParameter: '[Parameters].[Parameter 1]',
+      },
+    });
+
+    expect(result.isError).toBe(true);
+    invariant(result.content[0].type === 'text');
+    expect(result.content[0].text).toContain('targetParameter');
+  });
+
+  it('treats a blank targetParameter as absent in set mode', async () => {
+    const action =
+      "<edit-group-action caption='Expand Category' name='[Action1]'>" +
+      "<activation type='on-select' /><source type='sheet' worksheet='Profit' />" +
+      "<add-or-remove-marks value='assign' />" +
+      "<params><param name='selection-clear-set-option' value='do-nothing' />" +
+      "<param name='target-group' value='[federated.1syzfv90anwuu119p4zra1ga299n].[Category Set]' /></params>" +
+      '</edit-group-action>';
+    const { result } = await getToolResult({
+      args: {
+        mode: 'set',
+        caption: 'Expand Category',
+        sourceWorksheet: 'Profit',
+        targetSet: 'Category Set',
+        targetParameter: '   ',
+      },
+      readbackXml: withActions(BASE_XML, action),
+    });
+
+    expect(result.isError).toBe(false);
+  });
+
+  it('treats a blank targetSet as absent in parameter mode', async () => {
+    const action =
+      "<edit-parameter-action caption='Set Period' name='[Action1]'>" +
+      "<activation type='on-select' /><source type='sheet' worksheet='Profit' />" +
+      "<agg-type type='attr' /><clear-option type='do-nothing' value='s:LROOT:' />" +
+      "<params><param name='source-field' value='[Profit]' />" +
+      "<param name='target-parameter' value='[Parameters].[Parameter 1]' /></params>" +
+      '</edit-parameter-action>';
+    const { result } = await getToolResult({
+      args: {
+        caption: 'Set Period',
+        sourceWorksheet: 'Profit',
+        sourceField: '[Profit]',
+        targetParameter: '[Parameters].[Parameter 1]',
+        targetSet: '\t ',
+      },
+      readbackXml: withActions(BASE_XML, action),
+    });
+
+    expect(result.isError).toBe(false);
+  });
+
+  it('fails set-action readback when the target-group param is absent', async () => {
+    const incompleteAction =
+      "<edit-group-action caption='Expand Category' name='[Action1]'>" +
+      "<activation type='on-select' /><source type='sheet' worksheet='Profit' />" +
+      "<add-or-remove-marks value='assign' />" +
+      "<params><param name='selection-clear-set-option' value='do-nothing' /></params>" +
+      '</edit-group-action>';
+    const { result } = await getToolResult({
+      args: {
+        mode: 'set',
+        caption: 'Expand Category',
+        sourceWorksheet: 'Profit',
+        sourceField: '',
+        targetSet: 'Category Set',
+      },
+      readbackXml: withActions(BASE_XML, incompleteAction),
+    });
+
+    expect(result.isError).toBe(true);
+    invariant(result.content[0].type === 'text');
+    expect(result.content[0].text).toContain('target-group');
+  });
+
+  it('fails parameter-action readback when the target-parameter param is absent', async () => {
+    const incompleteAction =
+      "<edit-parameter-action caption='Set Period' name='[Action1]'>" +
+      "<activation type='on-select' /><source type='sheet' worksheet='Profit' />" +
+      "<agg-type type='attr' /><clear-option type='do-nothing' value='s:LROOT:' />" +
+      '<params></params></edit-parameter-action>';
+    const { result } = await getToolResult({
+      args: {
+        caption: 'Set Period',
+        sourceWorksheet: 'Profit',
+        sourceField: '',
+        targetParameter: '[Parameters].[Parameter 1]',
+      },
+      readbackXml: withActions(BASE_XML, incompleteAction),
+    });
+
+    expect(result.isError).toBe(true);
+    invariant(result.content[0].type === 'text');
+    expect(result.content[0].text).toContain('target-parameter');
+  });
+
   it('rejects empty required primitives', async () => {
     const { result } = await getToolResult({
       args: {
@@ -133,10 +473,16 @@ function withActions(baseXml: string, actionXml: string): string {
 
 type AuthorActionArgs = {
   session?: string;
+  mode?: 'parameter' | 'set';
   caption: string;
   sourceWorksheet: string;
-  sourceField: string;
-  targetParameter: string;
+  sourceField?: string;
+  targetParameter?: string;
+  targetSet?: string;
+  datasource?: string;
+  setMembership?: 'assign' | 'add' | 'remove';
+  clearSelection?: 'do-nothing' | 'show-all' | 'exclude-all';
+  singleSelect?: boolean;
   activation?: 'on-select' | 'on-hover' | 'on-menu';
 };
 
@@ -182,7 +528,15 @@ async function getToolResult({
     {
       session: '12345',
       ...args,
+      mode: args.mode ?? 'parameter',
+      sourceField: args.sourceField,
+      targetParameter: args.targetParameter,
+      targetSet: args.targetSet,
+      datasource: args.datasource,
+      singleSelect: args.singleSelect,
       activation: args.activation ?? 'on-select',
+      setMembership: args.setMembership ?? 'assign',
+      clearSelection: args.clearSelection ?? 'do-nothing',
     },
     extra,
   );

--- a/src/tools/desktop/data-source/authorAction.ts
+++ b/src/tools/desktop/data-source/authorAction.ts
@@ -15,26 +15,60 @@ import { DesktopMcpServer } from '../../../server.desktop.js';
 import { DesktopTool } from '../tool.js';
 
 const activationSchema = z.enum(['on-select', 'on-hover', 'on-menu']);
+const modeSchema = z.enum(['parameter', 'set']);
+const setMembershipSchema = z.enum(['assign', 'add', 'remove']);
+const clearSelectionSchema = z.enum(['do-nothing', 'show-all', 'exclude-all']);
 
-// Primitives in, <edit-parameter-action> XML server-side, readback out. A parameter
-// -change action wires a mark interaction on a source sheet to a target parameter.
+// Primitives in, parameter/set action XML server-side, readback out. An action
+// wires a mark interaction on a source sheet to a target parameter or set.
 // PROVEN live 2026-07-19 (CODA): a workbook-level <actions> block MERGES via the
 // document round-trip — the action survived readback with the target-parameter link
 // intact. This is the interactivity layer over the key signature.
 const paramsSchema = {
   session: z.string().optional().describe(''),
+  mode: modeSchema.default('parameter').describe(''),
   caption: z.string().describe(''),
   sourceWorksheet: z.string().describe(''),
-  sourceField: z.string().describe(''),
-  targetParameter: z.string().describe(''),
+  sourceField: z.string().optional().describe(''),
+  targetParameter: z.string().optional().describe(''),
+  targetSet: z.string().optional().describe(''),
+  datasource: z.string().optional().describe(''),
+  setMembership: setMembershipSchema.default('assign').describe(''),
+  clearSelection: clearSelectionSchema.default('do-nothing').describe(''),
+  singleSelect: z.boolean().optional().describe(''),
   activation: activationSchema.default('on-select').describe(''),
 };
 
-type AuthorActionResult = {
+type AuthorActionResultBase = {
   actionName: string;
   caption: string;
-  targetParameter: string;
+  target: string;
   hint: string;
+};
+
+type AuthorActionResult = AuthorActionResultBase &
+  (
+    | {
+        mode: 'parameter';
+        targetParameter: string;
+      }
+    | {
+        mode: 'set';
+        targetSet: string;
+      }
+  );
+
+type DatasourceElement = {
+  name: string;
+  caption?: string;
+  xml: string;
+};
+
+type SetCandidate = {
+  datasourceName: string;
+  datasourceCaption?: string;
+  name: string;
+  caption?: string;
 };
 
 const title = 'Author Action';
@@ -52,12 +86,38 @@ export const getAuthorActionTool = (server: DesktopMcpServer): DesktopTool<typeo
       idempotentHint: false,
     },
     callback: async (
-      { session, caption, sourceWorksheet, sourceField, targetParameter, activation = 'on-select' },
+      {
+        session,
+        mode = 'parameter',
+        caption,
+        sourceWorksheet,
+        sourceField,
+        targetParameter,
+        targetSet,
+        datasource,
+        setMembership = 'assign',
+        clearSelection = 'do-nothing',
+        singleSelect,
+        activation = 'on-select',
+      },
       extra,
     ): Promise<CallToolResult> => {
       return await tool.logAndExecute<AuthorActionResult>({
         extra,
-        args: { session, caption, sourceWorksheet, sourceField, targetParameter, activation },
+        args: {
+          session,
+          mode,
+          caption,
+          sourceWorksheet,
+          sourceField,
+          targetParameter,
+          targetSet,
+          datasource,
+          setMembership,
+          clearSelection,
+          singleSelect,
+          activation,
+        },
         callback: async () => {
           if (caption.trim().length === 0) {
             return new ArgsValidationError('caption empty').toErr();
@@ -65,8 +125,30 @@ export const getAuthorActionTool = (server: DesktopMcpServer): DesktopTool<typeo
           if (sourceWorksheet.trim().length === 0) {
             return new ArgsValidationError('sourceWorksheet empty').toErr();
           }
-          if (targetParameter.trim().length === 0) {
-            return new ArgsValidationError('targetParameter empty').toErr();
+          if (mode === 'set' && (targetParameter?.trim().length ?? 0) > 0) {
+            return new ArgsValidationError(
+              'targetParameter is not allowed in set mode; use targetSet',
+            ).toErr();
+          }
+          if (mode === 'parameter') {
+            if ((targetSet?.trim().length ?? 0) > 0) {
+              return new ArgsValidationError(
+                'targetSet is not allowed in parameter mode; use targetParameter',
+              ).toErr();
+            }
+            if (sourceField === undefined) {
+              return new ArgsValidationError('sourceField is required in parameter mode').toErr();
+            }
+            if (targetParameter === undefined || targetParameter.trim().length === 0) {
+              return new ArgsValidationError(
+                'targetParameter is required in parameter mode',
+              ).toErr();
+            }
+            if (!/^\[.+\]\.\[.+\]$/.test(targetParameter.trim())) {
+              return new ArgsValidationError(
+                'targetParameter must be fully qualified like [Parameters].[X]; unqualified targets can cause a blocking Tableau modal',
+              ).toErr();
+            }
           }
 
           const sessionResult = resolveSession(session);
@@ -88,14 +170,35 @@ export const getAuthorActionTool = (server: DesktopMcpServer): DesktopTool<typeo
           }
 
           const actionName = nextActionName(liveXml);
-          const actionXml = renderParameterAction({
-            caption,
-            actionName,
-            sourceWorksheet,
-            sourceField,
-            targetParameter,
-            activation,
-          });
+          let target: string;
+          let actionXml: string;
+          if (mode === 'set') {
+            const targetResult = resolveTargetSet(liveXml, targetSet, datasource);
+            if (targetResult.isErr()) {
+              return targetResult.error.toErr();
+            }
+            target = targetResult.value;
+            actionXml = renderSetAction({
+              caption,
+              actionName,
+              sourceWorksheet,
+              targetSet: target,
+              setMembership,
+              clearSelection,
+              singleSelect,
+              activation,
+            });
+          } else {
+            target = targetParameter!.trim();
+            actionXml = renderParameterAction({
+              caption,
+              actionName,
+              sourceWorksheet,
+              sourceField: sourceField ?? '',
+              targetParameter: target,
+              activation,
+            });
+          }
           const editResult = spliceActionIntoWorkbook(liveXml, actionXml);
           if (editResult.isErr()) {
             return editResult.error.toErr();
@@ -121,16 +224,51 @@ export const getAuthorActionTool = (server: DesktopMcpServer): DesktopTool<typeo
           if (readbackResult.isErr()) {
             return new DesktopCommandExecutionError(readbackResult.error).toErr();
           }
-          if (!hasActionCaption(readbackResult.value, caption)) {
+          if (
+            mode === 'set' &&
+            !hasActionWithTargetParam(
+              readbackResult.value,
+              'edit-group-action',
+              caption,
+              'target-group',
+              target,
+            )
+          ) {
             return new XmlModificationError(
-              'load completed but did not apply: readback did not contain the new action',
+              'action applied but the target-group param did not survive readback',
+            ).toErr();
+          }
+          if (
+            mode === 'parameter' &&
+            !hasActionWithTargetParam(
+              readbackResult.value,
+              'edit-parameter-action',
+              caption,
+              'target-parameter',
+              target,
+            )
+          ) {
+            return new XmlModificationError(
+              'action applied but the target-parameter param did not survive readback',
             ).toErr();
           }
 
+          if (mode === 'set') {
+            return new Ok({
+              actionName,
+              caption,
+              mode,
+              target,
+              targetSet: target,
+              hint: 'readback verified the qualified target set; the source sheet must expose marks that can drive the action',
+            });
+          }
           return new Ok({
             actionName,
             caption,
-            targetParameter,
+            mode,
+            target,
+            targetParameter: target,
             hint: 'the source sheet must expose the source field; the target parameter must already exist (author it at open time)',
           });
         },
@@ -142,9 +280,31 @@ export const getAuthorActionTool = (server: DesktopMcpServer): DesktopTool<typeo
 };
 
 function hasActionCaption(xml: string, caption: string): boolean {
-  return [...xml.matchAll(/<(?:action|edit-parameter-action)\b[^>]*>/g)].some(
+  return [...xml.matchAll(/<(?:action|edit-parameter-action|edit-group-action)\b[^>]*>/g)].some(
     (match) => unescapeXml(getAttr(match[0], 'caption') ?? '') === caption,
   );
+}
+
+function hasActionWithTargetParam(
+  xml: string,
+  elementName: 'edit-group-action' | 'edit-parameter-action',
+  caption: string,
+  paramName: 'target-group' | 'target-parameter',
+  target: string,
+): boolean {
+  const actionPattern = new RegExp(`<${elementName}\\b[^>]*>[\\s\\S]*?</${elementName}>`, 'g');
+  return [...xml.matchAll(actionPattern)].some((actionMatch) => {
+    const actionXml = actionMatch[0];
+    const openingTag = actionXml.match(new RegExp(`^<${elementName}\\b[^>]*>`))?.[0];
+    if (openingTag === undefined || unescapeXml(getAttr(openingTag, 'caption') ?? '') !== caption) {
+      return false;
+    }
+    return [...actionXml.matchAll(/<param\b[^>]*>/g)].some(
+      (paramMatch) =>
+        getAttr(paramMatch[0], 'name') === paramName &&
+        unescapeXml(getAttr(paramMatch[0], 'value') ?? '') === target,
+    );
+  });
 }
 
 function nextActionName(xml: string): string {
@@ -186,6 +346,163 @@ function renderParameterAction({
     "<clear-option type='do-nothing' value='s:LROOT:' />" +
     `<params>${params.join('')}</params>` +
     '</edit-parameter-action>'
+  );
+}
+
+function resolveTargetSet(
+  liveXml: string,
+  targetSet: string | undefined,
+  datasource?: string,
+): Result<string, ArgsValidationError> {
+  const datasourceElements = findDatasourceElements(liveXml);
+  const allCandidates = datasourceElements.flatMap((element) =>
+    findGroupTags(element.xml).flatMap((tag): SetCandidate[] => {
+      const name = getAttr(tag, 'name');
+      if (name === undefined) {
+        return [];
+      }
+      const caption = getAttr(tag, 'caption');
+      return [
+        {
+          datasourceName: element.name,
+          datasourceCaption: element.caption,
+          name: unescapeXml(name),
+          caption: caption === undefined ? undefined : unescapeXml(caption),
+        },
+      ];
+    }),
+  );
+  const matchedDatasourceElements =
+    datasource === undefined
+      ? datasourceElements
+      : datasourceElements.filter(
+          (element) => element.name === datasource || element.caption === datasource,
+        );
+  if (datasource !== undefined && matchedDatasourceElements.length === 0) {
+    return new ArgsValidationError(
+      `datasource '${datasource}' matched no datasource; sets found in: ${formatSetCandidates(allCandidates)}`,
+    ).toErr();
+  }
+  const matchedDatasourceNames = new Set(matchedDatasourceElements.map((element) => element.name));
+  const candidates = allCandidates.filter((candidate) =>
+    matchedDatasourceNames.has(candidate.datasourceName),
+  );
+  const available = formatSetCandidates(candidates);
+
+  if (targetSet === undefined || targetSet.trim().length === 0) {
+    return new ArgsValidationError(
+      `targetSet is required in set mode. Available sets: ${available}`,
+    ).toErr();
+  }
+
+  const requested = normalizeReferenceToken(targetSet);
+  const matches = candidates.filter(
+    (candidate) =>
+      normalizeReferenceToken(candidate.name) === requested ||
+      (candidate.caption !== undefined && normalizeReferenceToken(candidate.caption) === requested),
+  );
+  if (matches.length === 0) {
+    return new ArgsValidationError(
+      `Set "${targetSet}" was not found. Available sets: ${available}`,
+    ).toErr();
+  }
+  if (matches.length > 1) {
+    return new ArgsValidationError(
+      `Set "${targetSet}" is ambiguous; specify datasource. Matches: ${formatSetCandidates(matches)}`,
+    ).toErr();
+  }
+
+  const match = matches[0];
+  return new Ok(`${bracketToken(match.datasourceName)}.${bracketToken(match.name)}`);
+}
+
+function findDatasourceElements(xml: string): DatasourceElement[] {
+  const elements: DatasourceElement[] = [];
+  const blockStart = xml.indexOf('<datasources>');
+  const blockEnd = xml.indexOf('</datasources>', blockStart);
+  const scanFrom = blockStart === -1 ? 0 : blockStart;
+  const scanTo = blockEnd === -1 ? xml.length : blockEnd;
+  for (const match of xml.matchAll(/<datasource(?=\s)[^>]*\bname=(?:'[^']*'|"[^"]*")[^>]*>/g)) {
+    if (match.index < scanFrom || match.index >= scanTo || /\/\s*>$/.test(match[0])) {
+      continue;
+    }
+    const name = getAttr(match[0], 'name');
+    if (name === undefined) {
+      continue;
+    }
+    const openEnd = match.index + match[0].length;
+    const closeStart = xml.indexOf('</datasource>', openEnd);
+    if (closeStart === -1 || closeStart > scanTo) {
+      continue;
+    }
+    const caption = getAttr(match[0], 'caption');
+    elements.push({
+      name: unescapeXml(name),
+      caption: caption === undefined ? undefined : unescapeXml(caption),
+      xml: xml.slice(match.index, closeStart + '</datasource>'.length),
+    });
+  }
+  return elements;
+}
+
+function findGroupTags(xml: string): string[] {
+  return [...xml.matchAll(/<group\b[^>]*>/g)]
+    .map((match) => match[0])
+    .filter((tag) => getAttr(tag, 'user:ui-builder') === 'filter-group');
+}
+
+function normalizeReferenceToken(value: string): string {
+  const trimmed = value.trim();
+  return trimmed.startsWith('[') && trimmed.endsWith(']') ? trimmed.slice(1, -1) : trimmed;
+}
+
+function bracketToken(value: string): string {
+  const trimmed = value.trim();
+  return trimmed.startsWith('[') && trimmed.endsWith(']') ? trimmed : `[${trimmed}]`;
+}
+
+function formatSetCandidates(candidates: SetCandidate[]): string {
+  if (candidates.length === 0) {
+    return 'none';
+  }
+  return candidates
+    .map(
+      (candidate) =>
+        `${candidate.caption ?? candidate.name} (${candidate.name}, datasource ${candidate.datasourceCaption ?? candidate.datasourceName})`,
+    )
+    .join(', ');
+}
+
+function renderSetAction({
+  caption,
+  actionName,
+  sourceWorksheet,
+  targetSet,
+  setMembership,
+  clearSelection,
+  singleSelect,
+  activation,
+}: {
+  caption: string;
+  actionName: string;
+  sourceWorksheet: string;
+  targetSet: string;
+  setMembership: z.infer<typeof setMembershipSchema>;
+  clearSelection: z.infer<typeof clearSelectionSchema>;
+  singleSelect: boolean | undefined;
+  activation: z.infer<typeof activationSchema>;
+}): string {
+  const singleSelectXml =
+    singleSelect === undefined ? '' : `<single-select value='${singleSelect}' />`;
+  return (
+    `<edit-group-action caption='${escapeXml(caption)}' name='${escapeXml(actionName)}'>` +
+    `<activation type='${activation}' />` +
+    `<source type='sheet' worksheet='${escapeXml(sourceWorksheet.trim())}' />` +
+    singleSelectXml +
+    `<add-or-remove-marks value='${setMembership}' />` +
+    `<params><param name='selection-clear-set-option' value='${clearSelection}' />` +
+    `<param name='target-group' value='${escapeXml(targetSet)}' /></params>` +
+    '</edit-group-action>'
   );
 }
 


### PR DESCRIPTION
## Decision
A set action is `<edit-group-action>`, and `author-action` now emits it directly via `mode: 'set'`. This is a rule we keep: when an ask needs set membership to change on click, tmcp authors a group action — it never aims a parameter action at a set.

Until now `author-action` could only write `<edit-parameter-action>`. Following our own drilldown knowledge, an agent aimed one at a set; Desktop stored it and then threw blocking modal CDEAC1A9 when the user clicked, and the + never expanded. Caught by a human looking at the screen during a WW eval leg on 2026-07-26.

## Scope
- `mode: 'set'` takes `targetSet`, `setMembership` (assign|add|remove), `clearSelection` (Tableau's own wire words: do-nothing|show-all|exclude-all). The target resolves against live workbook XML and is qualified with the datasource `name` attribute (`federated.*`), never the caption.
- Only groups carrying `user:ui-builder='filter-group'` count as sets, so an ad-hoc Tableau group can never be resolved as a set target.
- Two latent defects fixed in the existing parameter path: the action scan could not match `edit-group-action` at all, and an unqualified `target-parameter` was written verbatim — the same defect class as the modal above.
- Readback asserts the caption and the target param survived, and its failure message states only what it can observe.
- Deliberately out: creating the empty set itself (`author-set` still requires orderBy+count and emits only the Top-N triad — that gap is filed separately and still blocks the drilldown end to end).

## What future work must preserve
Resolve-before-send. Probed live on build 0000.26.0724.1117: a dangling `target-group` applies `SUCCEEDED` with empty warnings and survives readback, so Desktop will never tell us the target is bad. The client-side resolution is the only thing standing between a typo and a dead interaction. Child order follows the schema; an omitted `single-select` is not backfilled by Desktop (also probed), so readback stays honest on the default path.

## Evidence
- Element and grammar confirmed from Tableau's own writer fixtures and the published TWB schema, then round-tripped live through `/v0` apply + readback (byte-faithful).
- Sol-built, Opus-reviewed in andy format; all four must-fix findings applied (narrowed readback, wire vocabulary, blank-string tolerance across the mode split, filter-group filtering).
- Full suite 6208 passed / 332 skipped, `tsc --noEmit` clean, lint clean, desktop build clean — run firsthand, not taken from the builder's report.
- Note: repo CI does not run Build and Test on PRs targeting `claude/v11-fixes` (the workflow triggers only on `main` and `feature/desktop`), so local runs are the evidence here.

## Risk
The tool still parses workbook XML with regexes, consistent with its siblings. No live click test — proving membership actually changes on select needs a human at the UI or the `author-set` gap closed first.

## Approving this means
tmcp can author the set actions our knowledge already tells agents to build, and a bad set target fails as a typed error instead of a blocking dialog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)