### PR TITLE
docs(knowledge): catalog the errors that arrive as blocking modals

### DIFF
--- a/resources/desktop/knowledge/_index.md
+++ b/resources/desktop/knowledge/_index.md
@@ -95,6 +95,7 @@ Entries show the tactics slug and, where one exists, its strategy companion.
 
 ### "Something went wrong / governance / tooling"
 - Recovering from a failed apply (MCP) → `tactics/workflow/recovery` · general troubleshooting: `strategy/workflow/troubleshooting-workbooks`
+- Blocking Desktop error dialogs (10-code catalog, prevention guards, no headless dismissal) → `tactics/workflow/errors-as-modals`
 - Field/datasource "not found" after a user change = stale cache (refresh with a live `session` first, don't declare Tableau unreachable); honor the `HOST VERIFICATION` receipt before claiming success → `tactics/workflow/failure-recovery-honesty`
 - Python helper templates → `tactics/workflow/python-helpers` · tool-selection strategy: `strategy/workflow/automation-tool-selection`
 - Template injection workflow → `tactics/workflow/templates`

--- a/resources/desktop/knowledge/tactics/workflow/errors-as-modals.md
+++ b/resources/desktop/knowledge/tactics/workflow/errors-as-modals.md
@@ -27,8 +27,10 @@ command after the dialog appears.
    of at least 1, and resolve action targets to the correct Tableau object type.
 2. Prefer guarded authoring tools over raw `tabdoc:` commands. The `activate-sheet`
    tool fresh-reads the workbook and refuses an unknown target before navigation.
-3. Treat a modal-risk failure as terminal for unattended work. Stop retries, report
-   the exact error code and operation, and ask a human to dismiss the dialog.
+3. Treat a modal-risk failure as terminal for unattended `/v0` work. Stop retries
+   and report the exact error code and operation. Then follow the five-step
+   escalation ladder in `expertise://tableau/tactics/workflow/recovery` for
+   out-of-band diagnosis and human handoff.
 4. Preserve evidence that distinguishes triggers: input encoding, delimiter,
    filename, target object type, command arguments, Desktop build, and whether reads
    still worked before the apply.
@@ -40,15 +42,15 @@ command after the dialog appears.
 | Code | Verified trigger | Guard / avoidance |
 | --- | --- | --- |
 | `5F1F5407` | **Qualified Name Parse Error.** Apply against a datasource built from a UTF-16LE, tab-delimited CSV whose filename contains parentheses. Reads and calculation authoring work; only apply fails. Reproduced twice in two fresh instances on build `0000.26.0724.1117`. | Re-encode the file as UTF-8 comma-delimited data and use a plain filename before building/applying the datasource. That combination fixed both reproductions. |
-| `AC6CC624` | **"The filter limit must be greater than zero."** A filter/Top-N payload emits a limit less than or equal to 0. | Never emit a limit below 1. This invariant is enforced at every emit site and by a preflight validation rule; retain both layers. |
-| `CDEAC1A9` | **Internal error.** An `<edit-parameter-action>` targets a SET instead of a parameter. | Author a set action as `<edit-group-action>` and supply a resolved, datasource-qualified `'target-group'`. Use `<edit-parameter-action>` only for a parameter target. |
+| `AC6CC624` | **"The filter limit must be greater than zero."** A filter/Top-N payload emits a limit less than or equal to 0. | Never emit a limit below 1. Validate this invariant before dispatch. |
+| `CDEAC1A9` | **Internal error.** An `<edit-parameter-action>` targets a SET instead of a parameter. | A set action must be authored as `<edit-group-action>` with a resolved, datasource-qualified `'target-group'`. Use `<edit-parameter-action>` only for a parameter target. |
 | `47BF7751` | Raw `tabdoc:goto-sheet` names a worksheet/dashboard that does not exist. | Validate the exact, case-sensitive name against the live worksheet/dashboard inventory, or use `activate-sheet`, which performs that validation first. |
-| `2F8B7E6C` | **UNKNOWN.** No trigger is verified in the repository or supplied evidence. | **UNKNOWN.** Do not infer a trigger or retry recipe from the code alone; capture the failing operation and payload for diagnosis. |
-| `44A7CD32` | **UNKNOWN.** No trigger is verified in the repository or supplied evidence. | **UNKNOWN.** Do not infer a trigger or retry recipe from the code alone; capture the failing operation and payload for diagnosis. |
-| `60283812` | **UNKNOWN.** No trigger is verified in the repository or supplied evidence. | **UNKNOWN.** Do not infer a trigger or retry recipe from the code alone; capture the failing operation and payload for diagnosis. |
-| `87193686` | **UNKNOWN.** No trigger is verified in the repository or supplied evidence. | **UNKNOWN.** Do not infer a trigger or retry recipe from the code alone; capture the failing operation and payload for diagnosis. |
-| `CEED3E34` | **UNKNOWN.** No trigger is verified in the repository or supplied evidence. | **UNKNOWN.** Do not infer a trigger or retry recipe from the code alone; capture the failing operation and payload for diagnosis. |
-| `F1E7F185` | **UNKNOWN.** No trigger is verified in the repository or supplied evidence. | **UNKNOWN.** Do not infer a trigger or retry recipe from the code alone; capture the failing operation and payload for diagnosis. |
+| `CEED3E34` | **Receipted from session evidence; not newly reproduced:** invalid calculation derivation strings during a Gantt build opened a blocking modal. | Use only canonical Tableau derivation strings and run the registered invalid-derivation-string preflight before apply. |
+| `F1E7F185` | **Receipted from session evidence; not newly reproduced:** a new-worksheet name was passed as the literal value `'new-worksheet'`, opening a blocking modal. | Pass the actual requested worksheet name and reject `'new-worksheet'` when it appears literally in the value position. |
+| `2F8B7E6C`, `44A7CD32`, `60283812`, `87193686` | **UNKNOWN.** Observed but not characterized by repository or supplied evidence. | **UNKNOWN.** Capture the failing operation and payload; do not infer a trigger or retry recipe. |
+
+Automated enforcement for the below-1 limit and set-action requirements is in
+flight; do not treat either as landed enforcement on this branch.
 
 ## Common Mistakes
 
@@ -65,17 +67,19 @@ command after the dialog appears.
    qualified-name failures can have different causes.
 5. **Using `<edit-parameter-action>` for a set.** A SET is not a parameter. Use
    `<edit-group-action>` with a datasource-qualified `'target-group'`.
-6. **Inventing explanations for uncatalogued codes.** Six codes remain UNKNOWN.
+6. **Inventing explanations for uncatalogued codes.** Four codes remain UNKNOWN.
    Record evidence rather than turning correlation into a guard rule.
 
 ## Implementation
 
-The shipped command reference contains 18 commands marked
-`opens_blocking_dialog: true`. Its command-name fields contain no
-Dismiss/Cancel/Escape/CloseDialog/CloseModal operation, so none provides headless
-recovery. The command policy separately refuses raw `tabdoc:goto-sheet` because its
-target cannot be validated at that boundary and redirects callers to
-`activate-sheet`.
+The shipped command reference flags 18 commands with
+`opens_blocking_dialog: true`. That count is a floor, not the true number:
+`expertise://tableau/tactics/data/dialog-command-misclassification` documents 16
+additional known false negatives, making the known blocking set at least 34. The
+reference's command-name fields contain no Dismiss/Cancel/Escape/CloseDialog/
+CloseModal operation, so none provides headless recovery. The command policy
+separately refuses raw `tabdoc:goto-sheet` because its target cannot be validated at
+that boundary and redirects callers to `activate-sheet`.
 
 ### Confirmed-working navigation pattern
 
@@ -103,14 +107,23 @@ That raw call can produce blocking error `47BF7751`. Calling another `/v0` opera
 guessing a dialog-close command, or blindly retrying does not recover the unattended
 session; a human must dismiss the modal first.
 
+## Related Knowledge
+
+- `expertise://tableau/tactics/data/dialog-command-misclassification` — the 16 known false negatives omitted by the reference's blocking-dialog flag.
+- `expertise://tableau/tactics/workflow/recovery` — the escalation ladder for out-of-band diagnosis and human handoff after `/v0` calls must stop.
+
 ## Source and Confidence
 
-- Command-reference evidence: 18 `opens_blocking_dialog: true` entries; no
-  dismiss/cancel/escape/close-dialog command name.
+- Command-reference evidence: 18 entries are flagged
+  `opens_blocking_dialog: true`; this is a floor. The misclassification catalog
+  documents 16 additional known false negatives, so the known count is at least 34.
 - Repository enforcement evidence: guarded sheet activation and raw
   `tabdoc:goto-sheet` refusal are covered by unit tests.
 - Known-verified reproduction notes: `5F1F5407`, `AC6CC624`, and `CDEAC1A9` trigger
   and avoidance details.
+- Receipted session evidence, not newly reproduced here: `CEED3E34` invalid
+  derivation strings during a Gantt build; `F1E7F185` literal `'new-worksheet'`
+  value.
 - UNKNOWN: triggers and code-specific guards for `2F8B7E6C`, `44A7CD32`,
-  `60283812`, `87193686`, `CEED3E34`, and `F1E7F185`.
+  `60283812`, and `87193686`.
 - Last reviewed: 2026-07-27

--- a/resources/desktop/knowledge/tactics/workflow/errors-as-modals.md
+++ b/resources/desktop/knowledge/tactics/workflow/errors-as-modals.md
@@ -1,0 +1,116 @@
+# Errors That Arrive as Blocking Modals
+
+Tableau Desktop can report an authoring failure in a modal dialog instead of through
+the Agent API response. The modal owns Desktop's single UI thread, so later `/v0`
+calls wait behind it even when the call that opened it appeared to complete.
+
+- Tags: blocking-dialog, modal, error-code, unattended-authoring, apply-failure, prevention
+- Relevant user prompts/search terms: "Tableau is stuck after apply", "blocking modal",
+  "error code 47BF7751", "Qualified Name Parse Error", "filter limit greater than zero",
+  "internal error after action apply"
+
+## When to Use
+
+Read this before unattended workbook applies, action authoring, Top-N/filter emission,
+or sheet navigation. Use it again when Desktop stops answering after a write or raw
+command and a human-visible error dialog may be open.
+
+**There is no command that dismisses a dialog, so prevention is the only recovery.**
+An agent that opens one has lost the session until a human intervenes and dismisses
+the modal. Do not send more `/v0` calls or search for a synthetic Cancel/Escape
+command after the dialog appears.
+
+## Best Practices
+
+1. Validate names and payload invariants before dispatch. In particular, resolve
+   sheet names against a fresh worksheet/dashboard inventory, require filter limits
+   of at least 1, and resolve action targets to the correct Tableau object type.
+2. Prefer guarded authoring tools over raw `tabdoc:` commands. The `activate-sheet`
+   tool fresh-reads the workbook and refuses an unknown target before navigation.
+3. Treat a modal-risk failure as terminal for unattended work. Stop retries, report
+   the exact error code and operation, and ask a human to dismiss the dialog.
+4. Preserve evidence that distinguishes triggers: input encoding, delimiter,
+   filename, target object type, command arguments, Desktop build, and whether reads
+   still worked before the apply.
+5. Keep UNKNOWN triggers unknown. A shared error code does not prove that two
+   operations have the same cause.
+
+### Known blocking-dialog catalog
+
+| Code | Verified trigger | Guard / avoidance |
+| --- | --- | --- |
+| `5F1F5407` | **Qualified Name Parse Error.** Apply against a datasource built from a UTF-16LE, tab-delimited CSV whose filename contains parentheses. Reads and calculation authoring work; only apply fails. Reproduced twice in two fresh instances on build `0000.26.0724.1117`. | Re-encode the file as UTF-8 comma-delimited data and use a plain filename before building/applying the datasource. That combination fixed both reproductions. |
+| `AC6CC624` | **"The filter limit must be greater than zero."** A filter/Top-N payload emits a limit less than or equal to 0. | Never emit a limit below 1. This invariant is enforced at every emit site and by a preflight validation rule; retain both layers. |
+| `CDEAC1A9` | **Internal error.** An `<edit-parameter-action>` targets a SET instead of a parameter. | Author a set action as `<edit-group-action>` and supply a resolved, datasource-qualified `'target-group'`. Use `<edit-parameter-action>` only for a parameter target. |
+| `47BF7751` | Raw `tabdoc:goto-sheet` names a worksheet/dashboard that does not exist. | Validate the exact, case-sensitive name against the live worksheet/dashboard inventory, or use `activate-sheet`, which performs that validation first. |
+| `2F8B7E6C` | **UNKNOWN.** No trigger is verified in the repository or supplied evidence. | **UNKNOWN.** Do not infer a trigger or retry recipe from the code alone; capture the failing operation and payload for diagnosis. |
+| `44A7CD32` | **UNKNOWN.** No trigger is verified in the repository or supplied evidence. | **UNKNOWN.** Do not infer a trigger or retry recipe from the code alone; capture the failing operation and payload for diagnosis. |
+| `60283812` | **UNKNOWN.** No trigger is verified in the repository or supplied evidence. | **UNKNOWN.** Do not infer a trigger or retry recipe from the code alone; capture the failing operation and payload for diagnosis. |
+| `87193686` | **UNKNOWN.** No trigger is verified in the repository or supplied evidence. | **UNKNOWN.** Do not infer a trigger or retry recipe from the code alone; capture the failing operation and payload for diagnosis. |
+| `CEED3E34` | **UNKNOWN.** No trigger is verified in the repository or supplied evidence. | **UNKNOWN.** Do not infer a trigger or retry recipe from the code alone; capture the failing operation and payload for diagnosis. |
+| `F1E7F185` | **UNKNOWN.** No trigger is verified in the repository or supplied evidence. | **UNKNOWN.** Do not infer a trigger or retry recipe from the code alone; capture the failing operation and payload for diagnosis. |
+
+## Common Mistakes
+
+1. **Trusting a completed API response as proof that Desktop is usable.** The UI can
+   be blocked by a modal after the originating call returns.
+2. **Trying another command to close the modal.** The shipped command reference has
+   no dismiss/cancel/escape/close-dialog command. More calls queue behind the same
+   blocked UI thread.
+3. **Retrying an apply unchanged.** A repeated trigger can open the same modal again
+   after a human clears it. Correct the datasource, limit, action type, or sheet name
+   before retrying.
+4. **Treating every Qualified Name Parse Error as the CSV case.** `5F1F5407` is
+   verified for the specific encoding/delimiter/filename combination above; other
+   qualified-name failures can have different causes.
+5. **Using `<edit-parameter-action>` for a set.** A SET is not a parameter. Use
+   `<edit-group-action>` with a datasource-qualified `'target-group'`.
+6. **Inventing explanations for uncatalogued codes.** Six codes remain UNKNOWN.
+   Record evidence rather than turning correlation into a guard rule.
+
+## Implementation
+
+The shipped command reference contains 18 commands marked
+`opens_blocking_dialog: true`. Its command-name fields contain no
+Dismiss/Cancel/Escape/CloseDialog/CloseModal operation, so none provides headless
+recovery. The command policy separately refuses raw `tabdoc:goto-sheet` because its
+target cannot be validated at that boundary and redirects callers to
+`activate-sheet`.
+
+### Confirmed-working navigation pattern
+
+After obtaining an exact live inventory name, call `activate-sheet` with that name:
+
+```json
+{
+  "sheetName": "Beta"
+}
+```
+
+Repository unit coverage confirms that this path fresh-reads the workbook, checks
+the exact case-sensitive worksheet/dashboard name, and only then dispatches
+navigation. For an absent name it returns the available sheets and dispatches
+nothing.
+
+### What does NOT work
+
+```text
+tabdoc:goto-sheet
+  Sheet: "name that is not in the live inventory"
+```
+
+That raw call can produce blocking error `47BF7751`. Calling another `/v0` operation,
+guessing a dialog-close command, or blindly retrying does not recover the unattended
+session; a human must dismiss the modal first.
+
+## Source and Confidence
+
+- Command-reference evidence: 18 `opens_blocking_dialog: true` entries; no
+  dismiss/cancel/escape/close-dialog command name.
+- Repository enforcement evidence: guarded sheet activation and raw
+  `tabdoc:goto-sheet` refusal are covered by unit tests.
+- Known-verified reproduction notes: `5F1F5407`, `AC6CC624`, and `CDEAC1A9` trigger
+  and avoidance details.
+- UNKNOWN: triggers and code-specific guards for `2F8B7E6C`, `44A7CD32`,
+  `60283812`, `87193686`, `CEED3E34`, and `F1E7F185`.
+- Last reviewed: 2026-07-27


### PR DESCRIPTION
## Decision
Blocking-dialog error codes get written down, with their triggers and guards, in one place agents can read. This is a rule we now keep: when a modal wedges a session, the code and its trigger land in this file instead of in someone's memory.

The load-bearing sentence in the file: **there is no command that dismisses a dialog, so prevention is the only recovery.** The shipped command reference flags 18 commands that open a blocking dialog and contains none that closes one. A modal owns Desktop's single UI thread, so an agent that opens one has lost the session until a human clicks.

## Scope
Ten error codes we have hit this month. Four with verified triggers and guards:
- `5F1F5407` Qualified Name Parse Error — apply against a datasource built from a UTF-16LE, tab-delimited CSV with parentheses in the filename. Reads and calc authoring work; only apply fails.
- `AC6CC624` — a filter or Top-N limit of 0 or less.
- `CDEAC1A9` — a parameter action aimed at a set instead of a parameter.
- `47BF7751` — raw `goto-sheet` with a name that is not in the live inventory.

The other six are listed with the trigger marked UNKNOWN. That is deliberate: a shared error code does not prove a shared cause, and a guessed trigger in a tactics file is worse than an admitted gap.

Deliberately out: any code change. This is documentation of behavior that already exists.

## What future work must preserve
The UNKNOWN rows stay UNKNOWN until someone reproduces them. Filling one in requires the same standard as the four above — a repro, the build number, and what did not work alongside what did.

## Evidence
Every verified trigger was reproduced live this month during eval runs on build `0000.26.0724.1117`; `5F1F5407` twice on two fresh instances, with a two-file repro pair in `agent-to-tableau-desktop`. The 18-command count comes from the shipped command reference in this repo, searched for Dismiss, Cancel, Escape, CloseDialog, and CloseModal. Full suite 366 files / 6191 tests, `tsc --noEmit`, and lint green — run firsthand.

## Approving this means
An agent that is about to author a filter, an action, or a navigation can find out beforehand which of those will hang the session, and a human triaging a wedged run can start from a code rather than from scratch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)