### PR TITLE
fix(desktop): report raw command failures instead of inventing causes

### DIFF
--- a/src/desktop/commands/workbook/applyFailureClassifier.test.ts
+++ b/src/desktop/commands/workbook/applyFailureClassifier.test.ts
@@ -52,6 +52,49 @@ describe('classifyApplyFailure', () => {
     expect(c.guidance).toContain('command name');
   });
 
+  it('classifies a bare command failure without inventing a cause', () => {
+    const c = classifyApplyFailure({
+      context: 'workbook',
+      serverError: 'Command tabui:load-underlying-metadata failed',
+    });
+    expect(c.failure_class).toBe('command-failed-bare');
+    expect(c.evidence).toEqual(['Command tabui:load-underlying-metadata failed']);
+    expect(c.guidance).toContain('raw error verbatim');
+    expect(c.guidance).toContain('Do not name, guess, or imply a cause');
+  });
+
+  it('keeps a detailed command failure classified as worksheet-not-found', () => {
+    const c = classifyApplyFailure({
+      context: 'worksheet',
+      serverError: 'Command tabdoc:load-workbook failed: worksheet "Sales" not found',
+    });
+    expect(c.failure_class).toBe('worksheet-not-found');
+  });
+
+  it('keeps a detailed command failure classified as xml-grammar', () => {
+    const c = classifyApplyFailure({
+      context: 'workbook',
+      serverError: 'Command tabdoc:load-workbook failed: Qualified Name Parse Error',
+    });
+    expect(c.failure_class).toBe('xml-grammar');
+  });
+
+  it('keeps a detailed command failure classified as field-binding', () => {
+    const c = classifyApplyFailure({
+      context: 'worksheet',
+      serverError: 'Command tabdoc:apply failed: unknown field [Profit Ratio]',
+    });
+    expect(c.failure_class).toBe('field-binding');
+  });
+
+  it('keeps a detailed command failure classified as timeout-or-transport', () => {
+    const c = classifyApplyFailure({
+      context: 'workbook',
+      serverError: 'Command tabui:x failed: request timed out',
+    });
+    expect(c.failure_class).toBe('timeout-or-transport');
+  });
+
   it('falls back to unknown with low confidence on a generic wrapper', () => {
     const c = classifyApplyFailure({
       context: 'workbook',
@@ -61,6 +104,9 @@ describe('classifyApplyFailure', () => {
     expect(c.confidence).toBe(0.2);
     // The honest fallback must forbid blind retrying and force evidence-gathering.
     expect(c.guidance).toContain('blind-retry');
+    expect(c.guidance).toContain('raw error verbatim');
+    expect(c.guidance).toContain('Do not name, guess, or imply a cause');
+    expect(c.guidance).toContain('cause is unknown');
     expect(c.evidence.join(' ')).toContain('an unexpected error occurred');
   });
 

--- a/src/desktop/commands/workbook/applyFailureClassifier.ts
+++ b/src/desktop/commands/workbook/applyFailureClassifier.ts
@@ -5,6 +5,7 @@ export type ApplyFailureClass =
   | 'field-binding'
   | 'dashboard-composition'
   | 'command-rejected'
+  | 'command-failed-bare'
   | 'worksheet-not-found'
   | 'timeout-or-transport'
   | 'unknown';
@@ -23,6 +24,10 @@ export interface ClassifyApplyFailureInput {
   context: ApplyFailureContext;
 }
 
+export const BARE_COMMAND_FAILURE_PATTERN = /^Command\s+[\w.-]+:[\w.-]+\s+failed\s*$/im;
+export const BARE_COMMAND_FAILURE_GUIDANCE =
+  'Report the raw error verbatim. Do not name, guess, or imply a cause the tooling did not report. Offer next diagnostic steps only: retry, check the workbook state, and gather logs.';
+
 const GUIDANCE: Record<ApplyFailureClass, string> = {
   'xml-grammar':
     'The document was structurally rejected at load. Do not regenerate the workbook. Re-read the current known-good content, diff it against your payload, and apply the smallest XML patch that fixes the structural delta before re-applying.',
@@ -32,12 +37,13 @@ const GUIDANCE: Record<ApplyFailureClass, string> = {
     'The dashboard linkage was rejected. Verify every zone references a real worksheet included in the workbook, avoid guessed ids/window pairings, and patch the specific dashboard zone instead of rebuilding unrelated sheets.',
   'command-rejected':
     'The External Client API rejected the command or verb. Check the command name and required params; do not retry the same command unchanged.',
+  'command-failed-bare': BARE_COMMAND_FAILURE_GUIDANCE,
   'worksheet-not-found':
     'The target worksheet does not exist. List the live worksheets, verify the actual sheet name, then target or rename the real sheet before applying. Do not regenerate the workbook.',
   'timeout-or-transport':
     'Transport failed before Tableau could evaluate the payload. Confirm Tableau Desktop and the External Client API are reachable, then re-issue the same payload once instead of rewriting the XML.',
   unknown:
-    'Only a generic wrapper survived. Do not blind-retry. First gather evidence: inspect the command result/logs, re-read the current known-good content, structural-diff it against your payload, then retry with a minimal patch.',
+    'Only a generic wrapper survived. Report the raw error verbatim and say the cause is unknown. Do not name, guess, or imply a cause the tooling did not report. Do not blind-retry. First gather evidence: inspect the command result/logs, re-read the current known-good content, structural-diff it against your payload, then retry with a minimal patch.',
 };
 
 interface Rule {
@@ -121,6 +127,11 @@ const RULES: Rule[] = [
     failure_class: 'timeout-or-transport',
     confidence: 0.65,
     patterns: [/timed out/i, /\btimeout\b/i, /null response/i, /no response/i],
+  },
+  {
+    failure_class: 'command-failed-bare',
+    confidence: 0.7,
+    patterns: [BARE_COMMAND_FAILURE_PATTERN],
   },
 ];
 

--- a/src/errors/mcpToolError.test.ts
+++ b/src/errors/mcpToolError.test.ts
@@ -1,0 +1,17 @@
+import { DesktopCommandExecutionError } from './mcpToolError.js';
+
+describe('DesktopCommandExecutionError', () => {
+  it('forbids invented causes for a bare command failure', () => {
+    const error = new DesktopCommandExecutionError({
+      type: 'command-failed',
+      error: {
+        code: 'ERROR',
+        message: 'Command tabui:load-underlying-metadata failed',
+        recoverable: false,
+      },
+    });
+
+    expect(error.message).toContain('Command tabui:load-underlying-metadata failed');
+    expect(error.message).toContain('Do not name, guess, or imply a cause');
+  });
+});

--- a/src/errors/mcpToolError.ts
+++ b/src/errors/mcpToolError.ts
@@ -2,6 +2,10 @@ import { ZodiosError } from '@zodios/core';
 import { Err } from 'ts-results-es';
 import { fromError } from 'zod-validation-error/v3';
 
+import {
+  BARE_COMMAND_FAILURE_GUIDANCE,
+  BARE_COMMAND_FAILURE_PATTERN,
+} from '../desktop/commands/workbook/applyFailureClassifier.js';
 import type { GetDashboardXmlError } from '../desktop/commands/workbook/getDashboardXml.js';
 import type { GetWorksheetXmlError } from '../desktop/commands/workbook/getWorksheetXml.js';
 import type { LoadDashboardXmlError } from '../desktop/commands/workbook/loadDashboardXml.js';
@@ -15,10 +19,7 @@ import {
 } from '../tools/desktop/structuredContent.js';
 import { getExceptionMessage } from '../utils/getExceptionMessage.js';
 
-// The load-*-xml error union carries Desktop's own rejection text on its message-bearing
-// variants (load-rejected / readback-failed), already formatted for the agent by
-// applyFailureClassifier. Surface that text directly instead of JSON.stringify-wrapping it;
-// fall back to JSON only for the structural variants that carry no message string.
+// Load XML errors preserve Desktop's message when present; otherwise serialize structural errors.
 function xmlLoadErrorMessage(
   error: LoadWorkbookXmlError | LoadWorksheetXmlError | LoadDashboardXmlError,
 ): string {
@@ -320,9 +321,13 @@ function formatDesktopCommandExecutionError(error: ExecuteCommandError): string 
   }
 
   const tableauErrorCode = commandError['tableau-error-code'];
-  return typeof tableauErrorCode === 'string' && tableauErrorCode.length > 0
-    ? `${message}\ntableau-error-code: ${tableauErrorCode}`
-    : message;
+  const formattedMessage =
+    typeof tableauErrorCode === 'string' && tableauErrorCode.length > 0
+      ? `${message}\ntableau-error-code: ${tableauErrorCode}`
+      : message;
+  return BARE_COMMAND_FAILURE_PATTERN.test(message)
+    ? `${formattedMessage}\n${BARE_COMMAND_FAILURE_GUIDANCE}`
+    : formattedMessage;
 }
 
 export class WorkbookXmlLoadFailedError extends McpToolError {


### PR DESCRIPTION
## Decision
A rule we now keep: when a command fails without a disclosed cause, the agent gets the raw error verbatim plus a prohibition on naming a cause the tooling did not report. Twin fix: agent-to-tableau-desktop #284 (merged there under the a2td grant).

## Scope
- `command-failed-bare` classifier class for the exact shape `Command <ns>:<cmd> failed` — strictly bare, last in rule order; four regression tests pin the richer classes (worksheet-not-found, xml-grammar, field-binding, timeout-or-transport) a looser match displaced in review.
- The `unknown` fallback guidance carries the same prohibition.
- The live path: nothing imports the classifier today, so `formatDesktopCommandExecutionError` appends the guidance when the bare pattern matches — this is the path the live incident took. The stale comment claiming the classifier already formats load errors is corrected.
- Deliberately out: wiring the classifier itself into the executor path (bigger decision, not needed to stop the confabulation).

## What future work must preserve
The bare class stays last and strictly bare; the formatter guidance survives any refactor of the executor error path; class id and prohibition wording stay byte-identical to the a2td twin (eval tooling keys on failure_class strings).

## Evidence / risk
The incident's exact string is pinned in tests. Full vitest, tsc, lint green, run firsthand. Risk: mocked, not exercised against live Desktop.

## Approving this means
An unclassifiable command failure reaches the user as the raw error plus diagnostic next steps — never an invented cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)