### PR TITLE
ci: run Build and Test on PRs that target claude/* branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - feature/desktop
+      - 'claude/**'
 
 jobs:
   build:


### PR DESCRIPTION
## Decision
A rule we now keep: every PR gets the full Build and Test run, including PRs that target a `claude/*` integration branch. Until now ci.yml only triggered for `main` and `feature/desktop` bases, so stacked PRs (like the seven that fed #643) merged with only cosmetic checks.

One line: add `claude/**` to the `pull_request` branch filter.

## What approving means
Stacked-PR CI cost goes up (one full matrix run per stacked PR). That is the point — a stack should never again land with untested tips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)