### PR TITLE
fix(binder): bind scatter asks at the asked grain and stop inventing grains the user never named

### DIFF
--- a/lockstep.hashes.json
+++ b/lockstep.hashes.json
@@ -1,6 +1,6 @@
 {
   "src/desktop/binder/calc-derivation.ts": "5105d466e3c31019affa91320edf3047259301ca5cd27aeb5883ba1faa251098",
-  "src/desktop/binder/classify.ts": "d2ef8ed64a34e0f1325fa0e918c3b6aee05f47482bae7ad34814c3e560d88c5d",
+  "src/desktop/binder/classify.ts": "4869c6f2fb189074ae97c5520c43baf9a21fae921020df797c80c4a69b6376d5",
   "src/desktop/binder/escape.ts": "3c79bcf77c33fad64975e95ea57df5fb3e416008633e15dc7a585018fbc92d3f",
   "src/desktop/binder/manifest-types.ts": "22740b978fdf7f1f463aa9ccd94f1e2ae5d383e610bf9063bff37e1624d173f8",
   "src/desktop/binder/manifest-validation.ts": "fc46c7b874cb2bd5958a2ed40848d18f6b3654e2d8559cff90fb841ca8fdd8d6",

--- a/lockstep.hashes.json
+++ b/lockstep.hashes.json
@@ -1,6 +1,6 @@
 {
   "src/desktop/binder/calc-derivation.ts": "5105d466e3c31019affa91320edf3047259301ca5cd27aeb5883ba1faa251098",
-  "src/desktop/binder/classify.ts": "4869c6f2fb189074ae97c5520c43baf9a21fae921020df797c80c4a69b6376d5",
+  "src/desktop/binder/classify.ts": "52d865378a968bb14b0ba6b2d7dda329350c1f03fde5b7291f961bb3f7c9fc47",
   "src/desktop/binder/escape.ts": "3c79bcf77c33fad64975e95ea57df5fb3e416008633e15dc7a585018fbc92d3f",
   "src/desktop/binder/manifest-types.ts": "22740b978fdf7f1f463aa9ccd94f1e2ae5d383e610bf9063bff37e1624d173f8",
   "src/desktop/binder/manifest-validation.ts": "fc46c7b874cb2bd5958a2ed40848d18f6b3654e2d8559cff90fb841ca8fdd8d6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "2.59.1",
+  "version": "2.59.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "2.59.1",
+      "version": "2.59.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.7.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "2.59.0",
+  "version": "2.59.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "2.59.0",
+      "version": "2.59.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.7.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "2.59.1",
+  "version": "2.59.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "2.59.0",
+  "version": "2.59.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/src/desktop/binder/binder.test.ts
+++ b/src/desktop/binder/binder.test.ts
@@ -1319,6 +1319,18 @@ describe('binder/bindTemplate — Call 1 miss (propose)', () => {
       );
     }
   });
+
+  it('routes the single token scatterplot to the correlation scatter candidate', () => {
+    const input = buildLlmInput(
+      'Show me a scatterplot of Sales and Profit by Region',
+      manifests,
+      summarizeSchema(WORKBOOK_XML),
+    );
+
+    expect(input.candidate_templates.map((candidate) => candidate.template)).toContain(
+      'correlation-scatter-plot-chart',
+    );
+  });
 });
 
 describe('binder/bindTemplate — Call 2 (agent proposal)', () => {

--- a/src/desktop/binder/classify.ts
+++ b/src/desktop/binder/classify.ts
@@ -2288,6 +2288,7 @@ function roleGreedyBind(
     pred: (f: SchemaField) => boolean,
   ): SchemaField | null => {
     if (!temporalCompletion) return null;
+    if (slot.required && slot.kind === 'categorical' && !matched.some(isCategorical)) return null;
     const candidates = temporalCompletion.schemaFields.filter((f) => !used.has(f) && pred(f));
     if (candidates.length === 0) return null;
 
@@ -2396,7 +2397,6 @@ function roleGreedyBind(
   for (const [i, slot] of activeSlots.entries()) {
     if (isOptionalCategoricalDetail(slot)) {
       const compatible = matched.filter((field) => !used.has(field) && isCategorical(field));
-      const hasNameMatch = compatible.some((field) => fieldNameMatchesSlot(field, slot));
       const laterRequired = activeSlots
         .slice(i + 1)
         .filter(
@@ -2404,7 +2404,7 @@ function roleGreedyBind(
             (candidate.required || forced.has(candidate.slot_id)) &&
             candidate.kind === 'categorical',
         ).length;
-      if (!hasNameMatch && compatible.length <= laterRequired) continue;
+      if (compatible.length <= laterRequired) continue;
     }
     let chosen: SchemaField | null = null;
     switch (slot.kind) {

--- a/src/desktop/binder/classify.ts
+++ b/src/desktop/binder/classify.ts
@@ -2272,6 +2272,17 @@ function roleGreedyBind(
     }
     return tokens;
   };
+  const normalizedName = (name: string): string => name.toLowerCase().replace(/[^a-z0-9]+/g, '');
+  const fieldNameMatchesSlot = (
+    field: SchemaField,
+    slot: TemplateManifest['slots'][number],
+  ): boolean => {
+    if (slot.template_field.includes('{{')) return false;
+    const templateFieldName = normalizedName(slot.template_field);
+    return [field.name, field.caption ?? '', bareName(field.columnName)]
+      .map(normalizedName)
+      .some((name) => name === templateFieldName);
+  };
   const schemaFallback = (
     slot: TemplateManifest['slots'][number],
     pred: (f: SchemaField) => boolean,
@@ -2312,6 +2323,15 @@ function roleGreedyBind(
     pred: (f: SchemaField) => boolean,
     allowSchemaFallback = true,
   ): SchemaField | null => {
+    if (slot.kind === 'categorical') {
+      const affine = matched.filter(
+        (field) => !used.has(field) && pred(field) && fieldNameMatchesSlot(field, slot),
+      );
+      if (affine.length === 1) {
+        used.add(affine[0]);
+        return affine[0];
+      }
+    }
     for (const f of matched) {
       if (!used.has(f) && pred(f)) {
         used.add(f);
@@ -2324,9 +2344,20 @@ function roleGreedyBind(
     return fallback;
   };
 
+  const isOptionalCategoricalDetail = (
+    slot: TemplateManifest['slots'][number],
+  ): boolean =>
+    slot.bindable &&
+    !slot.required &&
+    slot.kind === 'categorical' &&
+    slot.role.includes('detail');
   const isActive = (slot: TemplateManifest['slots'][number]): boolean =>
     slot.bindable &&
-    (slot.required || forced.has(slot.slot_id) || optionalAskNamedGeoSlots.has(slot.slot_id));
+    (slot.required ||
+      forced.has(slot.slot_id) ||
+      optionalAskNamedGeoSlots.has(slot.slot_id) ||
+      isOptionalCategoricalDetail(slot));
+  const activeSlots = m.slots.filter(isActive);
   const geoSlots = m.slots.filter((s) => isActive(s) && s.kind === 'geo');
   let geoPicks: Map<string, SchemaField> | null = null;
   let geoAutoCompleted = new Map<string, SchemaField>();
@@ -2362,15 +2393,26 @@ function roleGreedyBind(
     return unconsumedNonTemporalDims.length > capacity;
   };
 
-  for (const [i, slot] of m.slots.entries()) {
-    if (!isActive(slot)) continue;
+  for (const [i, slot] of activeSlots.entries()) {
+    if (isOptionalCategoricalDetail(slot)) {
+      const compatible = matched.filter((field) => !used.has(field) && isCategorical(field));
+      const hasNameMatch = compatible.some((field) => fieldNameMatchesSlot(field, slot));
+      const laterRequired = activeSlots
+        .slice(i + 1)
+        .filter(
+          (candidate) =>
+            (candidate.required || forced.has(candidate.slot_id)) &&
+            candidate.kind === 'categorical',
+        ).length;
+      if (!hasNameMatch && compatible.length <= laterRequired) continue;
+    }
     let chosen: SchemaField | null = null;
     switch (slot.kind) {
       case 'quantitative':
         chosen = take(slot, isMeasure);
         break;
       case 'categorical':
-        chosen = take(slot, isCategorical);
+        chosen = take(slot, isCategorical, slot.required || forced.has(slot.slot_id));
         break;
       case 'quantitative-or-categorical':
         chosen = take(slot, (field) => isMeasure(field) || isCategorical(field));
@@ -2399,7 +2441,7 @@ function roleGreedyBind(
           !chosen &&
           temporalCompletion &&
           temporalSlots.length === 1 &&
-          !hasUnslottedNonTemporalDimension(m.slots.slice(i + 1))
+          !hasUnslottedNonTemporalDimension(activeSlots.slice(i + 1))
         ) {
           const completed = completeTemporalSlot(
             temporalCompletion.maskedAsk,
@@ -2436,6 +2478,7 @@ function roleGreedyBind(
       default:
         chosen = null;
     }
+    if (!chosen && isOptionalCategoricalDetail(slot)) continue;
     if (!chosen) return null; // required slot unfilled / geo affinity ambiguous → fail closed
     const binding: { slot_id: string; field: string; derivation?: Derivation } = {
       slot_id: slot.slot_id,

--- a/src/desktop/binder/explicit-bind.test.ts
+++ b/src/desktop/binder/explicit-bind.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { bindExplicitTemplate, schemaSummaryFromAvailableFields } from './explicit-bind.js';
+import { loadManifests } from './manifest.js';
 import type { TemplateManifest } from './manifest-types.js';
 import type { SchemaField, SchemaSummary } from './schema-summary.js';
 
@@ -174,6 +175,90 @@ describe('bindExplicitTemplate', () => {
     if (!result.ok) {
       expect(result.blockers.some((b) => b.code === 'missing-required-slot')).toBe(true);
       expect(result.errors.every((e) => e.fix.length > 0)).toBe(true);
+    }
+  });
+
+  it('warns which fields landed on swappable categorical slots', () => {
+    const scatterSummary: SchemaSummary = {
+      datasource: 'Superstore',
+      fields: [
+        field({ name: 'Sales', role: 'measure', type: 'quantitative', datatype: 'real' }),
+        field({ name: 'Profit', role: 'measure', type: 'quantitative', datatype: 'real' }),
+        field({ name: 'City', role: 'dimension', type: 'nominal', datatype: 'string' }),
+        field({ name: 'Segment', role: 'dimension', type: 'nominal', datatype: 'string' }),
+      ],
+    };
+
+    const result = bindExplicitTemplate(
+      'correlation-scatter-plot-chart',
+      scatterSummary.fields.map((candidate) => candidate.column_ref),
+      scatterSummary,
+      { manifests: loadManifests() },
+    );
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.warnings).toContain(
+        "Ambiguous categorical assignment: field 'City' landed on slot 'customer_name'; field 'Segment' landed on slot 'region'. These categorical sources fit either slot and could swap when field order changes.",
+      );
+    }
+  });
+
+  it('uses categorical name affinity when both scatter detail fields are supplied', () => {
+    const scatterSummary: SchemaSummary = {
+      datasource: 'Superstore',
+      fields: [
+        field({ name: 'Profit', role: 'measure', type: 'quantitative', datatype: 'real' }),
+        field({ name: 'Sales', role: 'measure', type: 'quantitative', datatype: 'real' }),
+        field({
+          name: 'Customer Name',
+          role: 'dimension',
+          type: 'nominal',
+          datatype: 'string',
+        }),
+        field({ name: 'Region', role: 'dimension', type: 'nominal', datatype: 'string' }),
+      ],
+    };
+
+    const result = bindExplicitTemplate(
+      'correlation-scatter-plot-chart',
+      scatterSummary.fields.map((candidate) => candidate.column_ref),
+      scatterSummary,
+      { manifests: loadManifests() },
+    );
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.fieldMapping['Customer Name']).toBe('[Superstore].[none:Customer Name:nk]');
+      expect(result.fieldMapping.Region).toBe('[Superstore].[none:Region:nk]');
+      expect(result.optionalFieldPrunes).toEqual([]);
+    }
+  });
+
+  it('reserves a lone categorical field for the required scatter detail slot', () => {
+    const scatterSummary: SchemaSummary = {
+      datasource: 'Superstore',
+      fields: [
+        field({ name: 'Sales', role: 'measure', type: 'quantitative', datatype: 'real' }),
+        field({ name: 'Profit', role: 'measure', type: 'quantitative', datatype: 'real' }),
+        field({ name: 'Region', role: 'dimension', type: 'nominal', datatype: 'string' }),
+      ],
+    };
+
+    const result = bindExplicitTemplate(
+      'correlation-scatter-plot-chart',
+      scatterSummary.fields.map((candidate) => candidate.column_ref),
+      scatterSummary,
+      { manifests: loadManifests() },
+    );
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.fieldMapping.Region).toBe('[Superstore].[none:Region:nk]');
+      expect(result.fieldMapping).not.toHaveProperty('Customer Name');
+      expect(result.optionalFieldPrunes).toEqual([
+        { templateField: 'Customer Name', derivation: 'none', role: ['nk', 'ok'] },
+      ]);
     }
   });
 

--- a/src/desktop/binder/explicit-bind.test.ts
+++ b/src/desktop/binder/explicit-bind.test.ts
@@ -232,6 +232,9 @@ describe('bindExplicitTemplate', () => {
       expect(result.fieldMapping['Customer Name']).toBe('[Superstore].[none:Customer Name:nk]');
       expect(result.fieldMapping.Region).toBe('[Superstore].[none:Region:nk]');
       expect(result.optionalFieldPrunes).toEqual([]);
+      expect(
+        result.warnings.some((warning) => warning.startsWith('Ambiguous categorical assignment:')),
+      ).toBe(false);
     }
   });
 
@@ -255,6 +258,38 @@ describe('bindExplicitTemplate', () => {
     expect(result.ok).toBe(true);
     if (result.ok) {
       expect(result.fieldMapping.Region).toBe('[Superstore].[none:Region:nk]');
+      expect(result.fieldMapping).not.toHaveProperty('Customer Name');
+      expect(result.optionalFieldPrunes).toEqual([
+        { templateField: 'Customer Name', derivation: 'none', role: ['nk', 'ok'] },
+      ]);
+    }
+  });
+
+  it('reserves a lone Customer Name field for the required scatter detail slot', () => {
+    const scatterSummary: SchemaSummary = {
+      datasource: 'Superstore',
+      fields: [
+        field({ name: 'Sales', role: 'measure', type: 'quantitative', datatype: 'real' }),
+        field({ name: 'Profit', role: 'measure', type: 'quantitative', datatype: 'real' }),
+        field({
+          name: 'Customer Name',
+          role: 'dimension',
+          type: 'nominal',
+          datatype: 'string',
+        }),
+      ],
+    };
+
+    const result = bindExplicitTemplate(
+      'correlation-scatter-plot-chart',
+      scatterSummary.fields.map((candidate) => candidate.column_ref),
+      scatterSummary,
+      { manifests: loadManifests() },
+    );
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.fieldMapping.Region).toBe('[Superstore].[none:Customer Name:nk]');
       expect(result.fieldMapping).not.toHaveProperty('Customer Name');
       expect(result.optionalFieldPrunes).toEqual([
         { templateField: 'Customer Name', derivation: 'none', role: ['nk', 'ok'] },

--- a/src/desktop/binder/explicit-bind.ts
+++ b/src/desktop/binder/explicit-bind.ts
@@ -68,6 +68,11 @@ interface ProposalBuild {
   warnings: string[];
 }
 
+interface GreedyAssignment {
+  slot: SlotSpec;
+  field: SchemaField;
+}
+
 export function schemaSummaryFromAvailableFields(fields: AvailableFieldLike[]): SchemaSummary {
   const summaryFields: SchemaField[] = fields.map((f) => {
     const bare = bareName(f.columnName);
@@ -195,21 +200,44 @@ function buildProposalFromOrderedRefs(
   const reusableByTemplateField = new Map<string, ResolvedSource>();
   const fieldBySlot = new Map<string, SchemaField>();
   const bindings: BindingProposal['bindings'] = [];
+  const greedyAssignments: GreedyAssignment[] = [];
 
-  for (const slot of manifest.slots) {
-    if (!slot.bindable) continue;
+  const orderedSlots = manifest.slots.filter((slot) => slot.bindable);
+  for (const [index, slot] of orderedSlots.entries()) {
+    if (shouldReserveCategoricalSource(slot, orderedSlots.slice(index + 1), sources, used)) {
+      continue;
+    }
     const source = takeCompatibleSource(slot, sources, used, reusableByTemplateField);
     if (!source) continue;
     reusableByTemplateField.set(slot.template_field, source);
     fieldBySlot.set(slot.slot_id, source.field);
     bindings.push({ slot_id: slot.slot_id, field: source.field.name });
+    greedyAssignments.push({ slot, field: source.field });
   }
+  appendCategoricalSwapWarning(warnings, greedyAssignments);
 
   return {
     proposal: { template: manifest.template, title: title ?? manifest.template, bindings },
     fieldBySlot,
     warnings,
   };
+}
+
+function shouldReserveCategoricalSource(
+  slot: SlotSpec,
+  laterSlots: SlotSpec[],
+  sources: ResolvedSource[],
+  used: Set<SchemaField>,
+): boolean {
+  if (slot.required || slot.kind !== 'categorical') return false;
+  const compatible = sources.filter(
+    (source) => !used.has(source.field) && kindCompatible(slot.kind, source.field),
+  );
+  if (compatible.some((source) => fieldNameMatchesSlot(source.field, slot))) return false;
+  const laterRequired = laterSlots.filter(
+    (candidate) => candidate.required && candidate.kind === 'categorical',
+  ).length;
+  return compatible.length <= laterRequired;
 }
 
 function buildProposalFromFieldMapping(
@@ -223,6 +251,7 @@ function buildProposalFromFieldMapping(
   const usedFields = new Set<SchemaField>();
   const fieldBySlot = new Map<string, SchemaField>();
   const bindings: BindingProposal['bindings'] = [];
+  const greedyAssignments: GreedyAssignment[] = [];
 
   for (const slot of manifest.slots) {
     if (!slot.bindable) continue;
@@ -255,7 +284,9 @@ function buildProposalFromFieldMapping(
     usedFields.add(source.field);
     fieldBySlot.set(slot.slot_id, source.field);
     bindings.push({ slot_id: slot.slot_id, field: source.field.name });
+    greedyAssignments.push({ slot, field: source.field });
   }
+  appendCategoricalSwapWarning(warnings, greedyAssignments);
 
   return {
     proposal: { template: manifest.template, title: title ?? manifest.template, bindings },
@@ -273,6 +304,19 @@ function takeCompatibleSource(
   const reusable = reusableByTemplateField.get(slot.template_field);
   if (reusable && kindCompatible(slot.kind, reusable.field)) return reusable;
 
+  if (slot.kind === 'categorical') {
+    const affine = sources.filter(
+      (source) =>
+        !used.has(source.field) &&
+        kindCompatible(slot.kind, source.field) &&
+        fieldNameMatchesSlot(source.field, slot),
+    );
+    if (affine.length === 1) {
+      used.add(affine[0].field);
+      return affine[0];
+    }
+  }
+
   for (const source of sources) {
     if (used.has(source.field)) continue;
     if (!kindCompatible(slot.kind, source.field)) continue;
@@ -281,6 +325,19 @@ function takeCompatibleSource(
   }
 
   return null;
+}
+
+function fieldNameMatchesSlot(field: SchemaField, slot: SlotSpec): boolean {
+  if (slot.template_field.includes('{{')) return false;
+  const templateFieldName = normalizeComparableName(slot.template_field);
+  return [field.name, field.caption, bareName(field.columnName)]
+    .filter((name): name is string => typeof name === 'string')
+    .map(normalizeComparableName)
+    .some((name) => name === templateFieldName);
+}
+
+function normalizeComparableName(name: string): string {
+  return name.toLowerCase().replace(/[^a-z0-9]+/g, '');
 }
 
 function mappingKeyForSlot(
@@ -388,6 +445,25 @@ function kindCompatible(kind: SlotSpec['kind'], f: SchemaField): boolean {
   }
 }
 
+function appendCategoricalSwapWarning(warnings: string[], assignments: GreedyAssignment[]): void {
+  const categorical = assignments.filter(
+    ({ slot, field }) =>
+      slot.kind === 'categorical' &&
+      field.role === 'dimension' &&
+      assignments
+        .filter((candidate) => candidate.slot.kind === 'categorical')
+        .every((candidate) => kindCompatible(candidate.slot.kind, field)),
+  );
+  if (categorical.length < 2) return;
+
+  const landed = categorical
+    .map(({ slot, field }) => `field '${field.name}' landed on slot '${slot.slot_id}'`)
+    .join('; ');
+  warnings.push(
+    `Ambiguous categorical assignment: ${landed}. These categorical sources fit either slot and could swap when field order changes.`,
+  );
+}
+
 function suffixFor(derivation: Derivation, type: string): string {
   if (TRUNCATION_DERIVATIONS.has(derivation)) return 'qk';
   if (type === 'quantitative') return 'qk';
@@ -459,14 +535,14 @@ function optionalFieldPrunesFor(
       (slot) =>
         slot.bindable &&
         !slot.required &&
-        slot.kind === 'geo' &&
-        slot.role.includes('lod') &&
+        (slot.kind === 'geo' || slot.kind === 'categorical') &&
+        (slot.role.includes('lod') || slot.role.includes('detail')) &&
         !fieldBySlot.has(slot.slot_id),
     )
     .map((slot) => ({
       templateField: slot.template_field,
       derivation: slot.derivation,
-      role: 'nk',
+      role: slot.kind === 'categorical' ? ['nk', 'ok'] : 'nk',
     }));
 }
 

--- a/src/desktop/binder/explicit-bind.ts
+++ b/src/desktop/binder/explicit-bind.ts
@@ -71,6 +71,12 @@ interface ProposalBuild {
 interface GreedyAssignment {
   slot: SlotSpec;
   field: SchemaField;
+  affinityPlaced: boolean;
+}
+
+interface CompatibleSourceSelection {
+  source: ResolvedSource;
+  affinityPlaced: boolean;
 }
 
 export function schemaSummaryFromAvailableFields(fields: AvailableFieldLike[]): SchemaSummary {
@@ -207,12 +213,13 @@ function buildProposalFromOrderedRefs(
     if (shouldReserveCategoricalSource(slot, orderedSlots.slice(index + 1), sources, used)) {
       continue;
     }
-    const source = takeCompatibleSource(slot, sources, used, reusableByTemplateField);
-    if (!source) continue;
+    const selection = takeCompatibleSource(slot, sources, used, reusableByTemplateField);
+    if (!selection) continue;
+    const { source, affinityPlaced } = selection;
     reusableByTemplateField.set(slot.template_field, source);
     fieldBySlot.set(slot.slot_id, source.field);
     bindings.push({ slot_id: slot.slot_id, field: source.field.name });
-    greedyAssignments.push({ slot, field: source.field });
+    greedyAssignments.push({ slot, field: source.field, affinityPlaced });
   }
   appendCategoricalSwapWarning(warnings, greedyAssignments);
 
@@ -233,7 +240,6 @@ function shouldReserveCategoricalSource(
   const compatible = sources.filter(
     (source) => !used.has(source.field) && kindCompatible(slot.kind, source.field),
   );
-  if (compatible.some((source) => fieldNameMatchesSlot(source.field, slot))) return false;
   const laterRequired = laterSlots.filter(
     (candidate) => candidate.required && candidate.kind === 'categorical',
   ).length;
@@ -279,12 +285,13 @@ function buildProposalFromFieldMapping(
 
   for (const slot of manifest.slots) {
     if (!slot.bindable || !slot.required || fieldBySlot.has(slot.slot_id)) continue;
-    const source = takeCompatibleSource(slot, remainingSources, usedFields, new Map());
-    if (!source) continue;
+    const selection = takeCompatibleSource(slot, remainingSources, usedFields, new Map());
+    if (!selection) continue;
+    const { source, affinityPlaced } = selection;
     usedFields.add(source.field);
     fieldBySlot.set(slot.slot_id, source.field);
     bindings.push({ slot_id: slot.slot_id, field: source.field.name });
-    greedyAssignments.push({ slot, field: source.field });
+    greedyAssignments.push({ slot, field: source.field, affinityPlaced });
   }
   appendCategoricalSwapWarning(warnings, greedyAssignments);
 
@@ -300,9 +307,11 @@ function takeCompatibleSource(
   sources: ResolvedSource[],
   used: Set<SchemaField>,
   reusableByTemplateField: Map<string, ResolvedSource>,
-): ResolvedSource | null {
+): CompatibleSourceSelection | null {
   const reusable = reusableByTemplateField.get(slot.template_field);
-  if (reusable && kindCompatible(slot.kind, reusable.field)) return reusable;
+  if (reusable && kindCompatible(slot.kind, reusable.field)) {
+    return { source: reusable, affinityPlaced: false };
+  }
 
   if (slot.kind === 'categorical') {
     const affine = sources.filter(
@@ -313,7 +322,7 @@ function takeCompatibleSource(
     );
     if (affine.length === 1) {
       used.add(affine[0].field);
-      return affine[0];
+      return { source: affine[0], affinityPlaced: true };
     }
   }
 
@@ -321,7 +330,7 @@ function takeCompatibleSource(
     if (used.has(source.field)) continue;
     if (!kindCompatible(slot.kind, source.field)) continue;
     used.add(source.field);
-    return source;
+    return { source, affinityPlaced: false };
   }
 
   return null;
@@ -447,12 +456,8 @@ function kindCompatible(kind: SlotSpec['kind'], f: SchemaField): boolean {
 
 function appendCategoricalSwapWarning(warnings: string[], assignments: GreedyAssignment[]): void {
   const categorical = assignments.filter(
-    ({ slot, field }) =>
-      slot.kind === 'categorical' &&
-      field.role === 'dimension' &&
-      assignments
-        .filter((candidate) => candidate.slot.kind === 'categorical')
-        .every((candidate) => kindCompatible(candidate.slot.kind, field)),
+    ({ slot, field, affinityPlaced }) =>
+      !affinityPlaced && slot.kind === 'categorical' && field.role === 'dimension',
   );
   if (categorical.length < 2) return;
 

--- a/src/desktop/binder/manifest-encoding-corpus.test.ts
+++ b/src/desktop/binder/manifest-encoding-corpus.test.ts
@@ -679,6 +679,21 @@ interface OptionalSlotRow {
 
 const OPTIONAL_SLOTS: readonly OptionalSlotRow[] = [
   {
+    template: 'correlation-scatter-plot-chart',
+    slot: 'customer_name',
+    fills: {
+      ask: 'scatter plot of Profit and Sales by Customer Name and Region',
+      schema: 'superstore',
+      field: 'Customer Name',
+      why: 'a second ask-named categorical fills the optional fine-grain detail slot by name affinity',
+    },
+    staysUnbound: {
+      ask: 'scatter plot of Profit and Sales by Region',
+      schema: 'superstore',
+      why: 'the lone categorical is reserved for required Region, leaving Customer Name prunable',
+    },
+  },
+  {
     template: 'box-plot-chart',
     slot: 'facet',
     fills: {
@@ -1437,6 +1452,7 @@ describe('binder/manifest-encoding-corpus — census tripwires', () => {
     }
     expect(inventory).toEqual({
       'box-plot-chart': ['facet'],
+      'correlation-scatter-plot-chart': ['customer_name'],
       'part-to-whole-waterfall': ['anchor_category'],
       'ranking-ordered-bar': ['facet_row'],
       'spatial-choropleth-map': ['state'],
@@ -1444,8 +1460,8 @@ describe('binder/manifest-encoding-corpus — census tripwires', () => {
       'spatial-symbol-map-latlon': ['color', 'detail2', 'size', 'tooltip'],
       'trend-line-chart': ['color_series', 'facet_col'],
     });
-    expect(Object.keys(inventory)).toHaveLength(7);
-    expect(Object.values(inventory).flat()).toHaveLength(14);
+    expect(Object.keys(inventory)).toHaveLength(8);
+    expect(Object.values(inventory).flat()).toHaveLength(15);
   });
 
   it('gives every optional bindable slot in the corpus a row in the optional-slot table', () => {
@@ -1456,7 +1472,7 @@ describe('binder/manifest-encoding-corpus — census tripwires', () => {
       .flatMap((m) => optionalSlotIds(m).map((slot) => `${m.template}.${slot}`))
       .sort();
     expect(declared).toEqual(actual);
-    expect(declared).toHaveLength(14);
+    expect(declared).toHaveLength(15);
   });
 
   it('pins how much of the manifest-intent matrix reaches a deterministic bind', () => {

--- a/src/desktop/binder/manifest-encoding-corpus.test.ts
+++ b/src/desktop/binder/manifest-encoding-corpus.test.ts
@@ -997,13 +997,6 @@ const CUE_DEGRADATION: ReadonlyArray<{
     why: 'same spatial contention. The choropleth has no colour slot (colour IS the required measure), so a bind would have dropped the directive; the softer natural cue ("warmer colours") still binds and is covered in the matrix',
   },
   {
-    base: 'connected scatterplot of Profit vs Sales by Customer Name and Region',
-    cued: 'connected scatterplot of Profit vs Sales by Customer Name and Region, top 5',
-    schema: 'superstore',
-    boundTemplate: 'connected-scatterplot',
-    why: 'the top-N cue pulls the ranking family into contention with the connected scatterplot',
-  },
-  {
     base: 'scatter plot of Profit and Sales by Customer Name and Region',
     cued: 'scatter plot of Profit and Sales by Customer Name and Region, top 5',
     schema: 'superstore',
@@ -1481,8 +1474,8 @@ describe('binder/manifest-encoding-corpus — census tripwires', () => {
     const failedClosed = outcomes.length - bound;
 
     expect({ bound, failedClosed, total: outcomes.length }).toEqual({
-      bound: 230,
-      failedClosed: 166,
+      bound: 231,
+      failedClosed: 165,
       total: 396,
     });
   });
@@ -1502,8 +1495,8 @@ describe('binder/manifest-encoding-corpus — census tripwires', () => {
     }
 
     expect({ comparable, failedClosed, rerouted, total: cued.length }).toEqual({
-      comparable: 188,
-      failedClosed: 158,
+      comparable: 189,
+      failedClosed: 157,
       rerouted: 6,
       total: 352,
     });
@@ -1760,6 +1753,19 @@ describe('binder/manifest-encoding-corpus — cue degradation (fail-closed pins)
     // Fails closed, so the LLM propose path handles it. What must never happen is a silent
     // bind to some other template that drops the cue.
     expect(classify(row.cued, row.schema), row.why).toBeNull();
+  });
+});
+
+describe('binder/manifest-encoding-corpus — connected scatter intent retention', () => {
+  it('keeps an explicit connected scatterplot on its template with a top-N modifier', () => {
+    const result = classify(
+      'connected scatterplot of Profit vs Sales by Customer Name and Region, top 5',
+      'superstore',
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.template).toBe('connected-scatterplot');
+    expect(result!.top_n).toBe(5);
   });
 });
 

--- a/src/desktop/binder/portability-lane.test.ts
+++ b/src/desktop/binder/portability-lane.test.ts
@@ -1,12 +1,6 @@
 import { beforeAll, describe, expect, it } from 'vitest';
 
-import {
-  type BindingProposal,
-  bindTemplate,
-  classifyNoLlm,
-  PROPOSAL_OUTPUT_SCHEMA,
-  summarizeSchema,
-} from './binder.js';
+import { type BindingProposal, bindTemplate, classifyNoLlm, summarizeSchema } from './binder.js';
 import { loadManifests } from './manifest.js';
 import type { TemplateManifest } from './manifest-types.js';
 
@@ -248,18 +242,25 @@ describe('portability-lane — histogram bin-width refusal (W3)', () => {
   });
 });
 
-describe('portability-lane — under-specified scatter proposes with only bindable slots', () => {
-  it('healthcare scatter with too few fields → propose payload exposes the PROPOSAL_OUTPUT_SCHEMA', async () => {
+describe('portability-lane — coarse-grain scatter omits its optional detail slot', () => {
+  it('healthcare scatter binds with the schema-affine required region and prunes customer detail', async () => {
     const res = await bindTemplate({
       ask: 'scatter of Paid Amount vs Allowed Amount',
       workbookXml: HEALTHCARE_CLAIMS_WORKBOOK_XML,
       manifests: withForcedEligible(['correlation-scatter-plot-chart']),
     });
-    expect(res.status).toBe('propose');
-    if (res.status === 'propose') {
-      expect(res.output_schema).toBe(PROPOSAL_OUTPUT_SCHEMA);
-      expect(res.llm_input.fields.some((f) => f.name === 'Paid Amount')).toBe(true);
-      expect(res.llm_input.fields.some((f) => f.name === 'Payer')).toBe(true);
+    expect(res.status).toBe('bound');
+    if (res.status === 'bound') {
+      expect(res.used_llm).toBe(false);
+      expect(res.args.template_name).toBe('correlation-scatter-plot-chart');
+      expect(res.args.field_mapping).toEqual({
+        Sales: '[HealthcareClaimsDS].[sum:Paid Amount:qk]',
+        Profit: '[HealthcareClaimsDS].[sum:Allowed Amount:qk]',
+        Region: '[HealthcareClaimsDS].[none:Provider Region:nk]',
+      });
+      expect(res.args.optional_field_prunes).toEqual([
+        { templateField: 'Customer Name', derivation: 'none', role: ['nk', 'ok'] },
+      ]);
     }
   });
 });

--- a/src/desktop/binder/portability-lane.test.ts
+++ b/src/desktop/binder/portability-lane.test.ts
@@ -243,12 +243,23 @@ describe('portability-lane — histogram bin-width refusal (W3)', () => {
 });
 
 describe('portability-lane — coarse-grain scatter omits its optional detail slot', () => {
-  it('healthcare scatter binds with the schema-affine required region and prunes customer detail', async () => {
+  it('keeps a dimension-less healthcare scatter on the propose path', async () => {
     const res = await bindTemplate({
       ask: 'scatter of Paid Amount vs Allowed Amount',
       workbookXml: HEALTHCARE_CLAIMS_WORKBOOK_XML,
       manifests: withForcedEligible(['correlation-scatter-plot-chart']),
     });
+
+    expect(res.status).toBe('propose');
+  });
+
+  it('binds a healthcare scatter at an ask-named region grain and prunes customer detail', async () => {
+    const res = await bindTemplate({
+      ask: 'scatter of Paid Amount vs Allowed Amount by Provider Region',
+      workbookXml: HEALTHCARE_CLAIMS_WORKBOOK_XML,
+      manifests: withForcedEligible(['correlation-scatter-plot-chart']),
+    });
+
     expect(res.status).toBe('bound');
     if (res.status === 'bound') {
       expect(res.used_llm).toBe(false);

--- a/src/desktop/binder/validate.test.ts
+++ b/src/desktop/binder/validate.test.ts
@@ -1,7 +1,9 @@
+import { DOMParser } from '@xmldom/xmldom';
 import * as fs from 'fs';
 import * as path from 'path';
 import { beforeAll, describe, expect, it } from 'vitest';
 
+import { pruneUnboundOptionalFields } from '../templates/optionalFieldPrune.js';
 import { loadManifests } from './manifest.js';
 import type { TemplateManifest } from './manifest-types.js';
 import type { SchemaField, SchemaSummary } from './schema-summary.js';
@@ -1288,6 +1290,44 @@ describe('binder/validate — field_mapping covers calc inputs (H3, item 4)', ()
 });
 
 describe('binder/validate — gate 7: full scatter emission', () => {
+  it('prunes every authored Customer Name node when the optional detail slot is unbound', () => {
+    const m = manifests.get('correlation-scatter-plot-chart')!;
+    const p: BindingProposal = {
+      template: m.template,
+      title: 'Scatter',
+      bindings: [
+        { slot_id: 'sales', field: 'Sales' },
+        { slot_id: 'profit', field: 'Profit' },
+        { slot_id: 'region', field: 'Region' },
+      ],
+    };
+    const r = validateBinding(m, p, SUMMARY);
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.optional_field_prunes).toEqual([
+      {
+        templateField: 'Customer Name',
+        derivation: 'none',
+        role: ['nk', 'ok'],
+      },
+    ]);
+
+    const template = fs.readFileSync(
+      path.join(__dirname, '../data/templates/correlation-scatter-plot-chart.xml'),
+      'utf8',
+    );
+    const pruned = pruneUnboundOptionalFields(template, r.optional_field_prunes);
+    expect(pruned).not.toContain('name="[Customer Name]"');
+    expect(pruned).not.toContain('column="[Customer Name]"');
+    expect(pruned).not.toContain('].[none:Customer Name:nk]');
+    const parsed = new DOMParser().parseFromString(pruned, 'text/xml');
+    expect(parsed.getElementsByTagName('parsererror')).toHaveLength(0);
+
+    const ordinalTemplate = template.replaceAll('none:Customer Name:nk', 'none:Customer Name:ok');
+    const prunedOrdinal = pruneUnboundOptionalFields(ordinalTemplate, r.optional_field_prunes);
+    expect(prunedOrdinal).not.toContain('Customer Name');
+  });
+
   it('emits the exact 4-slot field_mapping (calc excluded)', () => {
     const m = manifests.get('correlation-scatter-plot-chart')!;
     const p: BindingProposal = {

--- a/src/desktop/binder/validate.ts
+++ b/src/desktop/binder/validate.ts
@@ -418,14 +418,17 @@ function optionalFieldPrunesFor(
       (slot) =>
         slot.bindable &&
         !slot.required &&
-        slot.kind === 'geo' &&
-        slot.role.includes('lod') &&
+        (slot.kind === 'geo' || slot.kind === 'categorical') &&
+        (slot.role.includes('lod') || slot.role.includes('detail')) &&
         !resolved.has(slot.slot_id),
     )
     .map((slot) => ({
       templateField: slot.template_field,
       derivation: slot.derivation,
-      role: 'nk',
+      // An unbound categorical slot has no target field whose type can choose suffixFor.
+      // Match both authored dimension suffixes so ordinal (:ok) templates prune as safely
+      // as nominal (:nk) templates; geo slots retain their existing nominal-only contract.
+      role: slot.kind === 'categorical' ? ['nk', 'ok'] : 'nk',
     }));
 }
 

--- a/src/desktop/data/content-manifest.json
+++ b/src/desktop/data/content-manifest.json
@@ -2,11 +2,11 @@
   "_generated": true,
   "_generator": "src/scripts/buildTemplateManifests.ts",
   "_warning": "GENERATED FILE — do not hand-edit. Re-run `npx tsx src/scripts/buildTemplateManifests.ts`.",
-  "content_version": "2.59.0+content.2026-07-27",
+  "content_version": "2.59.1+content.2026-07-27",
   "schema_version": "2",
   "generated": "2026-07-27",
   "engine_compat": {
-    "server_min": "2.59.0",
+    "server_min": "2.59.1",
     "node": ">=22.7.5"
   },
   "resources": [
@@ -252,8 +252,8 @@
     },
     {
       "path": "template-manifests.index.json",
-      "sha256": "fd0eade17d4a16b3a337c58c4ef798103da6f53ce50951cd463ccd623b3020e9",
-      "bytes": 283232
+      "sha256": "9a72ff66a3a4b9720cf2309c2a7793129d8b6bee120ad202316a8b1d214f5255",
+      "bytes": 283278
     },
     {
       "path": "template-manifests/box-plot-chart.manifest.json",
@@ -282,8 +282,8 @@
     },
     {
       "path": "template-manifests/connected-scatterplot.manifest.json",
-      "sha256": "e6a1f201d46669834604285f594ad4f7ccc716c04615680bb7308db1cb308841",
-      "bytes": 5372
+      "sha256": "cdfde5d2f4bd44a5dd1b7628d186f0fbb91a66379eaee616cc01469423aaf938",
+      "bytes": 5391
     },
     {
       "path": "template-manifests/control-chart-xmr.manifest.json",
@@ -307,8 +307,8 @@
     },
     {
       "path": "template-manifests/correlation-scatter-plot-chart.manifest.json",
-      "sha256": "32d760330cd48166ba8b118e52e4ed089b0b6a7fc6ee6a095f16ec573ea10617",
-      "bytes": 4774
+      "sha256": "858ddd80c02fa40d54a50e35e1792fcff3d91263a29cdb97106713570a0e0b74",
+      "bytes": 4793
     },
     {
       "path": "template-manifests/deviation-arrow.manifest.json",

--- a/src/desktop/data/content-manifest.json
+++ b/src/desktop/data/content-manifest.json
@@ -2,11 +2,11 @@
   "_generated": true,
   "_generator": "src/scripts/buildTemplateManifests.ts",
   "_warning": "GENERATED FILE — do not hand-edit. Re-run `npx tsx src/scripts/buildTemplateManifests.ts`.",
-  "content_version": "2.57.2+content.2026-07-26",
+  "content_version": "2.59.0+content.2026-07-27",
   "schema_version": "2",
-  "generated": "2026-07-26",
+  "generated": "2026-07-27",
   "engine_compat": {
-    "server_min": "2.57.2",
+    "server_min": "2.59.0",
     "node": ">=22.7.5"
   },
   "resources": [
@@ -252,8 +252,8 @@
     },
     {
       "path": "template-manifests.index.json",
-      "sha256": "e95618af3a46d0d39b49530595b65e81ae89de63886b772a9dc60c154c87f409",
-      "bytes": 283231
+      "sha256": "fd0eade17d4a16b3a337c58c4ef798103da6f53ce50951cd463ccd623b3020e9",
+      "bytes": 283232
     },
     {
       "path": "template-manifests/box-plot-chart.manifest.json",
@@ -307,8 +307,8 @@
     },
     {
       "path": "template-manifests/correlation-scatter-plot-chart.manifest.json",
-      "sha256": "061577ae88b915061e36daed6db0fed00f0607f8e6f7a61b0b4317eb49e9527e",
-      "bytes": 4773
+      "sha256": "32d760330cd48166ba8b118e52e4ed089b0b6a7fc6ee6a095f16ec573ea10617",
+      "bytes": 4774
     },
     {
       "path": "template-manifests/deviation-arrow.manifest.json",

--- a/src/desktop/data/template-manifests.index.json
+++ b/src/desktop/data/template-manifests.index.json
@@ -1167,7 +1167,7 @@
           ],
           "kind": "categorical",
           "bindable": true,
-          "required": true
+          "required": false
         },
         {
           "slot_id": "region",

--- a/src/desktop/data/template-manifests.index.json
+++ b/src/desktop/data/template-manifests.index.json
@@ -507,6 +507,7 @@
       "intent_keywords": [
         "connected-scatterplot",
         "connected-scatter",
+        "scatterplot",
         "trajectory",
         "path",
         "relationship"
@@ -1126,6 +1127,7 @@
       ],
       "intent_keywords": [
         "scatter",
+        "scatterplot",
         "correlation",
         "relationship",
         "vs",

--- a/src/desktop/data/template-manifests/connected-scatterplot.manifest.json
+++ b/src/desktop/data/template-manifests/connected-scatterplot.manifest.json
@@ -36,6 +36,7 @@
   "intent_keywords": [
     "connected-scatterplot",
     "connected-scatter",
+    "scatterplot",
     "trajectory",
     "path",
     "relationship"

--- a/src/desktop/data/template-manifests/correlation-scatter-plot-chart.manifest.json
+++ b/src/desktop/data/template-manifests/correlation-scatter-plot-chart.manifest.json
@@ -36,6 +36,7 @@
   ],
   "intent_keywords": [
     "scatter",
+    "scatterplot",
     "correlation",
     "relationship",
     "vs",

--- a/src/desktop/data/template-manifests/correlation-scatter-plot-chart.manifest.json
+++ b/src/desktop/data/template-manifests/correlation-scatter-plot-chart.manifest.json
@@ -77,7 +77,7 @@
       ],
       "kind": "categorical",
       "bindable": true,
-      "required": true
+      "required": false
     },
     {
       "slot_id": "region",

--- a/src/desktop/route/route-state.ts
+++ b/src/desktop/route/route-state.ts
@@ -124,6 +124,12 @@ export interface BindRecoveryRecord {
   lastProposalSignature?: string;
   proposalContext?: BindRecoveryProposalContext;
   consecutiveBareResubmitCount?: number;
+  /** One repair may re-enter a Tier-2 terminal record by binding its sole missing slot. */
+  terminalRepairAllowance?: {
+    template: string;
+    slotId: string;
+    remaining: 0 | 1;
+  };
   /** One-shot retry for an apply failure proven to have occurred before mutation dispatch. */
   preDispatchRetryAllowance?: {
     proposalSignature: string;
@@ -138,6 +144,7 @@ export interface BindRecoveryAttemptInput {
   proposalSignature?: string;
   proposalContext?: BindRecoveryProposalContext;
   reservationId?: number;
+  terminalRepairAllowance?: BindRecoveryRecord['terminalRepairAllowance'];
   /** Explicit terminal-done marker; callers use this only after final bind processing concludes. */
   terminal?: boolean;
 }
@@ -608,6 +615,15 @@ export class SessionRouteStateStore {
       : {};
   }
 
+  private withTerminalRepairAllowance(
+    previous: BindRecoveryRecord | undefined,
+    next?: BindRecoveryRecord['terminalRepairAllowance'],
+  ): Pick<BindRecoveryRecord, 'terminalRepairAllowance'> {
+    // Once consumed, the same ask cannot mint a fresh allowance by escalating again.
+    const allowance = previous?.terminalRepairAllowance ?? next;
+    return allowance ? { terminalRepairAllowance: allowance } : {};
+  }
+
   private withProposalContext(
     previous: BindRecoveryRecord | undefined,
     proposalContext: BindRecoveryProposalContext | undefined,
@@ -723,6 +739,7 @@ export class SessionRouteStateStore {
         admission.proposalSignature === undefined ? previous?.consecutiveBareResubmitCount : 0,
       ),
       ...this.withPreDispatchRetryAllowance(previous, nextProposalSignature),
+      ...this.withTerminalRepairAllowance(previous),
       ...this.withUncorrelatedOutcomeCount(previous, false),
     };
 
@@ -788,6 +805,7 @@ export class SessionRouteStateStore {
         attempt.proposalSignature === undefined ? previous?.consecutiveBareResubmitCount : 0,
       ),
       ...this.withPreDispatchRetryAllowance(previous, nextProposalSignature),
+      ...this.withTerminalRepairAllowance(previous),
       ...this.withUncorrelatedOutcomeCount(previous, upgraded.uncorrelated),
     };
 
@@ -843,11 +861,37 @@ export class SessionRouteStateStore {
         attempt.proposalSignature === undefined ? previous?.consecutiveBareResubmitCount : 0,
       ),
       ...this.withPreDispatchRetryAllowance(previous, nextProposalSignature),
+      ...this.withTerminalRepairAllowance(previous, attempt.terminalRepairAllowance),
       ...this.withUncorrelatedOutcomeCount(previous, upgraded.uncorrelated),
     };
 
     this.touchBindRecovery(state, ask, record);
     return state;
+  }
+
+  consumeTerminalRepairAllowance(
+    sessionId: string | undefined,
+    ask: string,
+    template: string,
+    slotId: string,
+  ): boolean {
+    const state = this.get(sessionId);
+    const record = state?.bindRecoveryByAsk.get(ask);
+    const allowance = record?.terminalRepairAllowance;
+    if (
+      !state ||
+      !record ||
+      record.phase !== 'terminal' ||
+      allowance?.remaining !== 1 ||
+      allowance.template !== template ||
+      allowance.slotId !== slotId
+    ) {
+      return false;
+    }
+    return this.touchBindRecovery(state, ask, {
+      ...record,
+      terminalRepairAllowance: { ...allowance, remaining: 0 },
+    });
   }
 
   grantPreDispatchRetryAllowance(

--- a/src/desktop/templates/optionalFieldPrune.ts
+++ b/src/desktop/templates/optionalFieldPrune.ts
@@ -3,7 +3,8 @@ import { DOMParser, XMLSerializer } from '@xmldom/xmldom';
 export interface OptionalFieldPruneSpec {
   templateField: string;
   derivation: string;
-  role: string;
+  /** Authored column-instance suffix(es); categorical templates may be nominal or ordinal. */
+  role: string | string[];
 }
 
 const ELEMENT_NODE = 1;
@@ -18,16 +19,16 @@ function removeElement(element: Element): void {
   element.parentNode?.removeChild(element);
 }
 
-function qualifiedInstanceSuffix(spec: OptionalFieldPruneSpec): string {
-  return `].[${spec.derivation}:${spec.templateField}:${spec.role}]`;
+function roles(spec: OptionalFieldPruneSpec): string[] {
+  return Array.isArray(spec.role) ? spec.role : [spec.role];
 }
 
 /**
  * Remove unbound optional template fields that are safe to omit structurally.
  *
  * This is intentionally narrow: callers pass only manifest-approved optional geo LOD
- * slots, and this helper removes exactly their LOD pill, matching column-instance,
- * and base column declaration before the normal field-reference rewrite runs.
+ * or categorical detail slots, and this helper removes exactly their LOD pill, matching
+ * column-instance, and base column declaration before normal field-reference rewriting.
  */
 export function pruneUnboundOptionalFields(
   templateXml: string,
@@ -40,11 +41,17 @@ export function pruneUnboundOptionalFields(
 
   for (const spec of specs) {
     const baseColumn = `[${spec.templateField}]`;
-    const instanceName = `[${spec.derivation}:${spec.templateField}:${spec.role}]`;
-    const qualifiedSuffix = qualifiedInstanceSuffix(spec);
+    const instanceNames = roles(spec).map(
+      (role) => `[${spec.derivation}:${spec.templateField}:${role}]`,
+    );
+    const qualifiedSuffixes = instanceNames.map((instanceName) => `].${instanceName}`);
 
     for (const lod of elementsByTag(doc, 'lod')) {
-      if (lod.getAttribute('column')?.endsWith(qualifiedSuffix)) {
+      if (
+        qualifiedSuffixes.some((qualifiedSuffix) =>
+          lod.getAttribute('column')?.endsWith(qualifiedSuffix),
+        )
+      ) {
         removeElement(lod);
       }
     }
@@ -52,7 +59,7 @@ export function pruneUnboundOptionalFields(
     for (const columnInstance of elementsByTag(doc, 'column-instance')) {
       if (
         columnInstance.getAttribute('column') === baseColumn &&
-        columnInstance.getAttribute('name') === instanceName
+        instanceNames.includes(columnInstance.getAttribute('name') ?? '')
       ) {
         removeElement(columnInstance);
       }

--- a/src/tools/desktop/binder/bindTemplate.test.ts
+++ b/src/tools/desktop/binder/bindTemplate.test.ts
@@ -1666,6 +1666,52 @@ describe('bindTemplateTool bind recovery gate', () => {
     expect(binderModule.bindTemplate).toHaveBeenCalledTimes(2);
   });
 
+  it('keeps the ask terminal when an admitted Tier-2 repair proposes again', async () => {
+    vi.mocked(externalDiscovery.discoverInstances).mockReturnValue([]);
+    vi.spyOn(getWorkbookXmlModule, 'getWorkbookXml').mockResolvedValue(Ok(XML));
+    vi.mocked(binderModule.bindTemplate)
+      .mockResolvedValueOnce(missingCountryEscalateResult)
+      .mockResolvedValueOnce(proposeResult)
+      .mockResolvedValueOnce(proposeResult);
+    const ask = 'symbol map of Sales by State';
+    const differentRepair = {
+      ...repairedCountryProposal,
+      bindings: repairedCountryProposal.bindings.map((binding) =>
+        binding.slot_id === 'val' ? { ...binding, field: 'Profit' } : binding,
+      ),
+    };
+
+    await getToolResult({ session: '1', ask });
+    const admittedRepair = await getToolResult({
+      session: '1',
+      ask,
+      proposal: repairedCountryProposal,
+    });
+    const blocked = await getToolResult({
+      session: '1',
+      ask,
+      proposal: differentRepair,
+    });
+
+    invariant(admittedRepair.content[0].type === 'text');
+    invariant(blocked.content[0].type === 'text');
+    expect(JSON.parse(admittedRepair.content[0].text).status).toBe('propose');
+    expect(sessionRouteState.getBindRecovery('1', normalizeAskForMatch(ask))).toMatchObject({
+      phase: 'terminal',
+      terminalRepairAllowance: {
+        template: missingCountryProposal.template,
+        slotId: 'country',
+        remaining: 0,
+      },
+    });
+    expect(blocked.isError).toBe(true);
+    expect(JSON.parse(blocked.content[0].text)).toMatchObject({
+      status: 'blocked',
+      reason: 'fallback_required',
+    });
+    expect(binderModule.bindTemplate).toHaveBeenCalledTimes(2);
+  });
+
   it('clears the recovery record after a terminal bound result', async () => {
     vi.spyOn(getWorkbookXmlModule, 'getWorkbookXml').mockResolvedValue(Ok(XML));
     vi.mocked(binderModule.bindTemplate)

--- a/src/tools/desktop/binder/bindTemplate.test.ts
+++ b/src/tools/desktop/binder/bindTemplate.test.ts
@@ -459,6 +459,26 @@ const changedProposalAgain: BindingProposal & { confidence: number } = {
   ...changedProposal,
   sort: { by: 'Profit', direction: 'desc' },
 };
+const missingCountryProposal: BindingProposal & { confidence: number } = {
+  ...sampleProposal,
+  bindings: sampleProposal.bindings.filter((binding) => binding.slot_id !== 'country'),
+};
+const repairedCountryProposal: BindingProposal & { confidence: number } = {
+  ...missingCountryProposal,
+  bindings: [...missingCountryProposal.bindings, { slot_id: 'country', field: 'Country' }],
+};
+const missingCountryEscalateResult: BinderResult = {
+  status: 'escalate',
+  reason: 'missing-required-slot',
+  blockers: [
+    {
+      code: 'missing-required-slot',
+      slot_id: 'country',
+      detail: "required slot 'country' has no binding",
+    },
+  ],
+  proposal: missingCountryProposal,
+};
 
 // A Call-2 proposal that validated into a bound result is marked used_llm:true.
 // The auto-apply gate should preserve that field on non-applied results, but it no
@@ -794,6 +814,72 @@ describe('bindTemplateTool', () => {
       2,
     );
     expect(body.call_2_contract.proposal_choices[0].slots[0]).not.toHaveProperty('field');
+  });
+
+  it('keeps every manifest bindable slot kind reachable in the Call-2 contract', async () => {
+    const manifests = [...loadManifests().values()];
+    const llmInput = {
+      ask: 'reachability probe',
+      candidate_templates: manifests.map((manifest) => ({
+        template: manifest.template,
+        description: manifest.description,
+        intent_keywords: manifest.intent_keywords,
+        slots: manifest.slots
+          .filter((slot) => slot.bindable)
+          .map((slot) => ({
+            slot_id: slot.slot_id,
+            role: slot.role,
+            kind: slot.kind,
+            required: slot.required,
+            ...(slot.temporal_from_string === true ? { temporal_from_string: true } : {}),
+          })),
+      })),
+      // One nominal date dimension reaches categorical, temporal, and geo; one measure
+      // reaches quantitative. Together they must cover every bindable manifest SlotKind.
+      fields: [
+        { name: 'Dimension', role: 'dimension', type: 'nominal', datatype: 'date' },
+        { name: 'Measure', role: 'measure', type: 'quantitative', datatype: 'real' },
+      ],
+    } as Extract<BinderResult, { status: 'propose' }>['llm_input'];
+    vi.spyOn(getWorkbookXmlModule, 'getWorkbookXml').mockResolvedValue(Ok(XML));
+    vi.mocked(binderModule.bindTemplate).mockResolvedValue({
+      ...proposeResult,
+      llm_input: llmInput,
+    });
+
+    const result = await getToolResult({ session: '1', ask: llmInput.ask });
+
+    invariant(result.content[0].type === 'text');
+    const body = JSON.parse(result.content[0].text);
+    const choices = body.call_2_contract.proposal_choices as Array<{
+      template: string;
+      slots: Array<{ slot_id: string; compatible_field_names: string[] }>;
+    }>;
+    const choiceByTemplate = new Map(choices.map((choice) => [choice.template, choice]));
+    const compatibilityCountsByKind = new Map<string, number[]>();
+    for (const manifest of manifests) {
+      const choice = choiceByTemplate.get(manifest.template);
+      invariant(choice);
+      for (const slot of manifest.slots.filter((candidate) => candidate.bindable)) {
+        const contractSlot = choice.slots.find((candidate) => candidate.slot_id === slot.slot_id);
+        invariant(contractSlot);
+        const counts = compatibilityCountsByKind.get(slot.kind) ?? [];
+        counts.push(contractSlot.compatible_field_names.length);
+        compatibilityCountsByKind.set(slot.kind, counts);
+      }
+    }
+    for (const [kind, counts] of compatibilityCountsByKind) {
+      expect(
+        counts.some((count) => count > 0),
+        `bindable manifest slot kind '${kind}' must have a compatible Call-2 field`,
+      ).toBe(true);
+    }
+
+    const symbolMap = choiceByTemplate.get('spatial-symbol-map');
+    invariant(symbolMap);
+    const color = symbolMap.slots.find((slot) => slot.slot_id === 'color');
+    invariant(color);
+    expect(color.compatible_field_names.length).toBeGreaterThan(0);
   });
 
   it('keeps the ask-named dimension in a synonym-heavy Call-2 categorical slot', async () => {
@@ -1535,6 +1621,47 @@ describe('bindTemplateTool bind recovery gate', () => {
     expect(blockedBody.reason).toBe('fallback_required');
     expect(blockedBody.guidance).toContain('not recoverable in the fast path');
     expectStructuredBlock(blocked, { label: 'Use fallback authoring path', kind: 'prefill' });
+    expect(getWorkbookXmlModule.getWorkbookXml).toHaveBeenCalledTimes(2);
+    expect(binderModule.bindTemplate).toHaveBeenCalledTimes(2);
+  });
+
+  it('admits exactly one Tier-2 repair that names the sole blocked slot', async () => {
+    vi.spyOn(getWorkbookXmlModule, 'getWorkbookXml').mockResolvedValue(Ok(XML));
+    vi.mocked(binderModule.bindTemplate)
+      .mockResolvedValueOnce(missingCountryEscalateResult)
+      .mockResolvedValueOnce(boundResult);
+    const ask = 'symbol map of Sales by State';
+
+    const tier2 = await getToolResult({ session: '1', ask });
+    const admittedRepair = await getToolResult({
+      session: '1',
+      ask,
+      proposal: repairedCountryProposal,
+    });
+    const terminal = await getToolResult({
+      session: '1',
+      ask,
+      proposal: repairedCountryProposal,
+    });
+
+    invariant(tier2.content[0].type === 'text');
+    invariant(admittedRepair.content[0].type === 'text');
+    invariant(terminal.content[0].type === 'text');
+    expect(JSON.parse(tier2.content[0].text).reason).toBe('missing-required-slot');
+    expect(JSON.parse(admittedRepair.content[0].text).status).toBe('bound');
+    expect(terminal.isError).toBe(true);
+    expect(JSON.parse(terminal.content[0].text)).toMatchObject({
+      status: 'blocked',
+      reason: 'fallback_required',
+    });
+    expect(sessionRouteState.getBindRecovery('1', normalizeAskForMatch(ask))).toMatchObject({
+      phase: 'terminal',
+      terminalRepairAllowance: {
+        template: missingCountryProposal.template,
+        slotId: 'country',
+        remaining: 0,
+      },
+    });
     expect(getWorkbookXmlModule.getWorkbookXml).toHaveBeenCalledTimes(2);
     expect(binderModule.bindTemplate).toHaveBeenCalledTimes(2);
   });

--- a/src/tools/desktop/binder/bindTemplate.ts
+++ b/src/tools/desktop/binder/bindTemplate.ts
@@ -51,6 +51,7 @@ import {
 import {
   type AppliedSheetRecord,
   type BindRecoveryProposalContext,
+  type BindRecoveryRecord,
   classifyBindProposalProgress,
   MAX_CONSECUTIVE_BIND_RECOVERY_BARE_RESUBMITS,
   sessionRouteState,
@@ -211,6 +212,7 @@ type BindTemplateToolResult =
 type StructuredBindTemplateToolResult = StructuredResult<BindTemplateToolResult>;
 
 type Call2Contract = BindRecoveryProposalContext;
+type TerminalRepairAllowance = NonNullable<BindRecoveryRecord['terminalRepairAllowance']>;
 
 /** Escalation reasons that route back to the general (non-fast-path) authoring flow. */
 const TIER2_REASONS: ReadonlySet<EscalateReason> = new Set<EscalateReason>([
@@ -471,6 +473,7 @@ function bareResubmitFallbackResult(
 function recoveryGateBlock(
   record: ReturnType<typeof sessionRouteState.getBindRecovery>,
   currentProposalSignature: string | undefined,
+  currentProposal: BindingProposal | undefined,
   session: string,
   askKey: string,
   targetWorksheet: string | undefined,
@@ -486,6 +489,20 @@ function recoveryGateBlock(
   }
 
   if (record.phase === 'terminal') {
+    const repair = record.terminalRepairAllowance;
+    if (
+      repair?.remaining === 1 &&
+      currentProposal?.template === repair.template &&
+      currentProposal.bindings.some((binding) => binding.slot_id === repair.slotId) &&
+      sessionRouteState.consumeTerminalRepairAllowance(
+        session,
+        askKey,
+        repair.template,
+        repair.slotId,
+      )
+    ) {
+      return undefined;
+    }
     if (
       (record.consecutiveBareResubmitCount ?? 0) >= MAX_CONSECUTIVE_BIND_RECOVERY_BARE_RESUBMITS
     ) {
@@ -824,6 +841,11 @@ function fieldFitsProposedSlot(
       return field.role === 'measure';
     case 'categorical':
       return field.role === 'dimension' && (field.type === 'nominal' || field.type === 'ordinal');
+    case 'quantitative-or-categorical':
+      return (
+        field.role === 'measure' ||
+        (field.role === 'dimension' && (field.type === 'nominal' || field.type === 'ordinal'))
+      );
     case 'temporal':
       return (
         field.datatype === 'date' ||
@@ -1808,6 +1830,7 @@ function recordBindRecoveryAttemptFailOpen({
   currentProposalSignature,
   proposalContext,
   reservationId,
+  terminalRepairAllowance,
   terminal = false,
   terminalFallback = false,
 }: {
@@ -1817,6 +1840,7 @@ function recordBindRecoveryAttemptFailOpen({
   currentProposalSignature?: string;
   proposalContext?: BindRecoveryProposalContext;
   reservationId?: number;
+  terminalRepairAllowance?: TerminalRepairAllowance;
   terminal?: boolean;
   terminalFallback?: boolean;
 }): void {
@@ -1828,12 +1852,22 @@ function recordBindRecoveryAttemptFailOpen({
         : {}),
       ...(proposalContext !== undefined ? { proposalContext } : {}),
       ...(reservationId !== undefined ? { reservationId } : {}),
+      ...(terminalRepairAllowance !== undefined ? { terminalRepairAllowance } : {}),
     };
     if (outcome === 'escalate' && currentProposalSignature === undefined && !terminalFallback) {
       sessionRouteState.clearBindRecovery(session, askKey);
       return;
     }
     if (terminalFallback) {
+      sessionRouteState.recordBindRecoveryTerminal(session, askKey, attempt);
+      return;
+    }
+    if (
+      terminal &&
+      sessionRouteState.getBindRecovery(session, askKey)?.terminalRepairAllowance?.remaining === 0
+    ) {
+      // A successful repair used its sole terminal escape. Keep the ask terminal instead
+      // of clearing recovery state, so an identical second repair cannot re-enter.
       sessionRouteState.recordBindRecoveryTerminal(session, askKey, attempt);
       return;
     }
@@ -1844,6 +1878,26 @@ function recordBindRecoveryAttemptFailOpen({
   } catch {
     /* fail-open */
   }
+}
+
+function terminalRepairAllowanceFor(result: BinderResult): TerminalRepairAllowance | undefined {
+  if (
+    result.status !== 'escalate' ||
+    result.reason !== 'missing-required-slot' ||
+    result.proposal === undefined ||
+    result.blockers.length !== 1
+  ) {
+    return undefined;
+  }
+  const blocker = result.blockers[0];
+  if (blocker.code !== 'missing-required-slot' || blocker.slot_id === undefined) {
+    return undefined;
+  }
+  return {
+    template: result.proposal.template,
+    slotId: blocker.slot_id,
+    remaining: 1,
+  };
 }
 
 /**
@@ -2003,6 +2057,7 @@ export const getBindTemplateTool = (server: DesktopMcpServer): DesktopTool<typeo
             const blocked = recoveryGateBlock(
               sessionRouteState.getBindRecovery(resolvedSession, askKey),
               currentProposalSignature,
+              proposal as BindingProposal | undefined,
               resolvedSession,
               askKey,
               target_worksheet,
@@ -2268,6 +2323,7 @@ export const getBindTemplateTool = (server: DesktopMcpServer): DesktopTool<typeo
                 ...(call2Contract !== undefined ? { proposalContext: call2Contract } : {}),
                 reservationId: bindRecoveryReservationId,
                 terminalFallback: TIER2_REASONS.has(res.reason),
+                terminalRepairAllowance: terminalRepairAllowanceFor(res),
               });
             }
           } catch {

--- a/src/tools/desktop/binder/bindTemplate.ts
+++ b/src/tools/desktop/binder/bindTemplate.ts
@@ -1863,11 +1863,10 @@ function recordBindRecoveryAttemptFailOpen({
       return;
     }
     if (
-      terminal &&
       sessionRouteState.getBindRecovery(session, askKey)?.terminalRepairAllowance?.remaining === 0
     ) {
-      // A successful repair used its sole terminal escape. Keep the ask terminal instead
-      // of clearing recovery state, so an identical second repair cannot re-enter.
+      // An admitted repair used its sole terminal escape. Keep the ask terminal regardless
+      // of outcome, so no later proposal can re-enter after the allowance is consumed.
       sessionRouteState.recordBindRecoveryTerminal(session, askKey, attempt);
       return;
     }


### PR DESCRIPTION
## Decision

A rule we now keep: **the binder never binds a categorical field the user did not name.** An ask that names zero dimensions escalates to the proposal/fallback path instead of deterministically picking a grain by token affinity (the old behavior bound Provider Region to a scatter nobody scoped, purely because the slot was called 'region'). The reviewer accepts that dimension-less asks trade the 0.3s deterministic bind for an escalation — reversible with one gate in `classify.ts` if the product call goes the other way.

## What this fixes (Zach's live defects)

- **D:** `customer_name` on the correlation scatter is optional; a scatter asked at Region grain binds at Region grain with no Customer Name pill.
- **A1:** proposal contracts advertise compatible fields for every slot kind, including `quantitative-or-categorical` (the symbol-map color slot was empty).
- **E2:** an escalated ask admits exactly one repair (same template + the named missing slot); the allowance re-terminalizes on every outcome, so an identical resubmit or template swap stays blocked.
- **Routing:** one-word "scatterplot" asks now reach `correlation-scatter-plot-chart`; connected asks still route to `connected-scatterplot`.

## Evidence

Suite 6587 green + lint clean, run firsthand. Live re-smoked on a fresh Desktop instance: the verbatim ask that previously landed at Customer Name grain now binds deterministically at Region grain (4 rows, Circle marks, zero Customer Name occurrences in the applied XML); the two-word "scatter plot" ask did not regress; a connected-scatterplot ask still routes connected. Corpus behavior lock moved 230→231 bound because connected top-N now binds while preserving `top_n`.

## Known observations, not fixed here

- Repeating a same-template ask returns `reused:true` and points at the existing sheet instead of applying a copy — surfaced during the smoke, plausibly correct, nobody specified it.
- Duplicate "Profit Ratio" entries in Call-2 `compatible_field_names` are indistinguishable when template-minted calcs accumulate (cosmetic).
- `classify.ts` is lockstep-core: a2td re-sync owes this delta.

## Approving this PR means

Zach's three binder defects are fixed and the no-invented-grain rule is in force.

🤖 Generated with [Claude Code](https://claude.com/claude-code)