### PR TITLE
fix(desktop): require a single-line message before classifying a command failure as bare

### DIFF
--- a/src/desktop/commands/workbook/applyFailureClassifier.test.ts
+++ b/src/desktop/commands/workbook/applyFailureClassifier.test.ts
@@ -59,8 +59,16 @@ describe('classifyApplyFailure', () => {
     });
     expect(c.failure_class).toBe('command-failed-bare');
     expect(c.evidence).toEqual(['Command tabui:load-underlying-metadata failed']);
-    expect(c.guidance).toContain('raw error verbatim');
-    expect(c.guidance).toContain('Do not name, guess, or imply a cause');
+    expect(c.guidance).toContain('raw error VERBATIM');
+    expect(c.guidance).toContain('Do NOT name, guess, or imply a cause');
+  });
+
+  it('does not classify a multi-line command failure with cause evidence as bare', () => {
+    const c = classifyApplyFailure({
+      context: 'workbook',
+      serverError: 'Command tabdoc:apply failed\nAccess denied to workbook',
+    });
+    expect(c.failure_class).toBe('unknown');
   });
 
   it('keeps a detailed command failure classified as worksheet-not-found', () => {

--- a/src/desktop/commands/workbook/applyFailureClassifier.ts
+++ b/src/desktop/commands/workbook/applyFailureClassifier.ts
@@ -26,7 +26,14 @@ export interface ClassifyApplyFailureInput {
 
 export const BARE_COMMAND_FAILURE_PATTERN = /^Command\s+[\w.-]+:[\w.-]+\s+failed\s*$/im;
 export const BARE_COMMAND_FAILURE_GUIDANCE =
-  'Report the raw error verbatim. Do not name, guess, or imply a cause the tooling did not report. Offer next diagnostic steps only: retry, check the workbook state, and gather logs.';
+  'Report the raw error VERBATIM. Do NOT name, guess, or imply a cause the tooling did not report. Offer next diagnostic steps only: retry once, check the workbook state, and gather logs.';
+
+// With multiline mode, `$` can stop before a newline. The bare wrapper class is valid only
+// when the entire preserved server error is that one line; any additional error line is cause
+// evidence that this intentionally cause-free class must not swallow.
+export function isBareCommandFailure(message: string): boolean {
+  return message.trim().split(/\r?\n/).length === 1 && BARE_COMMAND_FAILURE_PATTERN.test(message);
+}
 
 const GUIDANCE: Record<ApplyFailureClass, string> = {
   'xml-grammar':
@@ -205,6 +212,7 @@ export function classifyApplyFailure(input: ClassifyApplyFailureInput): ApplyFai
   const text = [toText(input.serverError), toText(input.applyResponse)].filter(Boolean).join('\n');
 
   for (const rule of RULES) {
+    if (rule.failure_class === 'command-failed-bare' && !isBareCommandFailure(text)) continue;
     const evidence = collectEvidence(text, rule.patterns);
     if (evidence.length === 0) continue;
     const confidence =

--- a/src/errors/mcpToolError.test.ts
+++ b/src/errors/mcpToolError.test.ts
@@ -12,6 +12,20 @@ describe('DesktopCommandExecutionError', () => {
     });
 
     expect(error.message).toContain('Command tabui:load-underlying-metadata failed');
-    expect(error.message).toContain('Do not name, guess, or imply a cause');
+    expect(error.message).toContain('Do NOT name, guess, or imply a cause');
+  });
+
+  it('preserves multi-line cause evidence without bare-failure guidance', () => {
+    const error = new DesktopCommandExecutionError({
+      type: 'command-failed',
+      error: {
+        code: 'ERROR',
+        message: 'Command tabdoc:apply failed\nAccess denied to workbook',
+        recoverable: false,
+      },
+    });
+
+    expect(error.message).toContain('Access denied to workbook');
+    expect(error.message).not.toContain('Do NOT name, guess, or imply a cause');
   });
 });

--- a/src/errors/mcpToolError.ts
+++ b/src/errors/mcpToolError.ts
@@ -4,7 +4,7 @@ import { fromError } from 'zod-validation-error/v3';
 
 import {
   BARE_COMMAND_FAILURE_GUIDANCE,
-  BARE_COMMAND_FAILURE_PATTERN,
+  isBareCommandFailure,
 } from '../desktop/commands/workbook/applyFailureClassifier.js';
 import type { GetDashboardXmlError } from '../desktop/commands/workbook/getDashboardXml.js';
 import type { GetWorksheetXmlError } from '../desktop/commands/workbook/getWorksheetXml.js';
@@ -325,7 +325,7 @@ function formatDesktopCommandExecutionError(error: ExecuteCommandError): string 
     typeof tableauErrorCode === 'string' && tableauErrorCode.length > 0
       ? `${message}\ntableau-error-code: ${tableauErrorCode}`
       : message;
-  return BARE_COMMAND_FAILURE_PATTERN.test(message)
+  return isBareCommandFailure(message)
     ? `${formattedMessage}\n${BARE_COMMAND_FAILURE_GUIDANCE}`
     : formattedMessage;
 }


### PR DESCRIPTION
## Decision

A rule we now keep, at both call sites: **a command failure is "bare" only when the entire message is one line.** Under `/m`, the bare regex matched any multi-line message whose first line is bare, so the live formatter appended "do not name, guess, or imply a cause the tooling did not report" to messages that name the cause on line 2 — the inverse of what #659 set out to fix. The a2td twin already carries this guard; this port brings it over via a shared `isBareCommandFailure` helper used by the classifier rule and the live formatter, with multi-line regression tests in both test files.

Also re-syncs the guidance string byte-identical to the twin, restoring **"retry once"** — the unbounded "retry" contradicted the sibling `unknown` class's "Do not blind-retry", and #659's byte-identity claim is now true.

## Scope

Follow-up to the merged #659, from its retroactive review (below). Deliberately deferred from that review: the module-relocation question, test placement for the not-yet-wired classifier, and the `tableau-error-code` wording — they ride until the next touch. No version bump: #643 sets the released number.

## Evidence

Lint clean, tsc clean, full suite 363 files / 6080 passed firsthand. Whether Desktop ever emits multi-line command-failure messages is unverified live — the guard is correct either way, matching the twin's reasoning.

## Approving this PR means

The bare-failure class can never swallow a cause Desktop reported.

---

<details>
<summary><b>The retroactive review of #659 that produced this fix</b> (written by MattGPT, Matt's review automation running Claude Opus 5, posted on Matt's behalf)</summary>

# Andy-lens review: tableau/tableau-mcp #659 (HEAD f4c2be09)

`fix(desktop): report raw command failures instead of inventing causes` · `claude/*` → `feature/desktop` · 4 files, +87/-8
Reviewed at head **f4c2be0912c3dc31081a4fe40066d45327dd540b**, merge commit **6a66568975a68ef034ca8ab56edd49c610fca425** (merged 2026-07-27). CI on the head is fully green (both build matrices, SAST, credential scan, CLA). **Retroactive — already merged; findings below are follow-up guidance, not a merge gate.**

Matt, the shape of this is right and the honesty in the PR body is the best part of it: naming that the classifier has no runtime consumer, and that the live path is the formatter, is exactly the disclosure that makes this reviewable in five minutes instead of thirty. The four "keeps a detailed failure classified as X" regression tests are the right instinct — you noticed a looser match could displace richer classes and pinned all four. Credit also for deleting the stale comment in `mcpToolError.ts` that claimed `applyFailureClassifier` had already formatted the load-XML text; that comment was actively lying about a call that doesn't exist.

One real finding, and it's the one the twin already solved.

### Please (address before merge)

- **[applyFailureClassifier.ts:27 / mcpToolError.ts:330] The pattern is not "strictly bare," and the live path has nothing else protecting it.** `/^Command\s+[\w.-]+:[\w.-]+\s+failed\s*$/im` — under `/m`, `\s*$` stops at a line boundary, so any *multi-line* message whose first line is bare matches. Probed:

  ```
  'Command tabdoc:load-workbook failed\nQualified Name Parse Error at line 12'  => true
  'Command tabdoc:apply failed\nunknown field [Profit Ratio]'                   => true
  'Some prefix\nCommand tabui:x failed\nrequest timed out'                      => true
  ```

  In the classifier this is masked — the bare rule is last, so `xml-grammar` / `field-binding` / `timeout-or-transport` fire first, which is why the four new regression tests pass. But a multi-line message whose cause line matches no existing rule (`Command tabdoc:apply failed\nAccess denied to workbook`) reaches the bare rule and gets classified `command-failed-bare`, swallowing a cause Desktop *did* report. And `formatDesktopCommandExecutionError` has no rule ordering at all: it tests the raw pattern first-and-only, so it appends *"Do not name, guess, or imply a cause the tooling did not report"* to a message that names the cause on line 2. That is the exact inverse of the bug this PR set out to fix, on the exact path the PR body identifies as the live one.

  This is not a hypothetical I invented — the a2td twin (#284, `src/server/apply-failure-classifier.ts:363`) already found it and guards it, with a comment saying so verbatim:

  ```ts
  // With multiline mode, `$` can stop before a newline. The bare wrapper class is valid only
  // when the entire preserved server error is that one line; any additional error line is cause
  // evidence that this intentionally cause-free class must not swallow.
  if (rule.failure_class === "command-failed-bare") {
    const serverEvidence = collectEvidence(serverErrorText, rule.patterns);
    if (serverEvidence.length === 0 || serverErrorText.trim().split(/\r?\n/).length !== 1) continue;
  }
  ```

  The port took the pattern and the class id but left the guard behind. Cheapest fix on both call sites: a `isBareCommandFailure(message)` helper that requires `message.trim().split(/\r?\n/).length === 1` before the regex, used by the rule and by the formatter. Add the multi-line case to both test files — every current test is single-line, which is why this passed green.

  **Follow-up: yes, fix PR now.** The formatter is shipping code on the live path, the guard is ~3 lines, and the twin already has the reference implementation to copy.

- **[applyFailureClassifier.ts:28] "Byte-identical to the a2td twin" isn't true, and one of the drifts is the safety word.** PR body: *"class id and prohibition wording stay byte-identical to the a2td twin."* The class id matches (`command-failed-bare` — that's the part eval tooling keys on, so the load-bearing claim holds). The wording does not:

  | | a2td #284 | tmcp #659 |
  |---|---|---|
  | | `Report the raw error VERBATIM.` | `Report the raw error verbatim.` |
  | | `Do NOT name, guess, or imply…` | `Do not name, guess, or imply…` |
  | | `next diagnostic steps only: retry once, …` | `next diagnostic steps only: retry, …` |

  Casing I'd wont-fix. Losing **"once"** I would not: this same diff's `unknown` guidance says *"Do not blind-retry"*, so the two sibling classes now disagree — the *more* confident class (0.7) offers unbounded retry while the *less* confident one (0.2) forbids it. Given the wall-time-is-call-count work happening next door, an unbounded "retry" in an error string is the wrong nudge. And `applyFailureClassifier.test.ts` asserts `toContain('Do not name, guess, or imply a cause')` case-sensitively, which pins the diverged copy — a future re-sync toward the twin now breaks a test.

  **Follow-up: fold into the same fix PR** — restore `once`, and either relax the assertion to case-insensitive or state plainly in the PR that tmcp's copy is intentionally its own string.

### Questions (your call)

- **[mcpToolError.ts:8] Where do these two constants actually live?** They're exported from `desktop/commands/workbook/applyFailureClassifier.ts` — a *workbook-apply* classifier — and consumed by `formatDesktopCommandExecutionError`, which formats *any* command failure and has nothing to do with workbook apply. (The module boundary itself is fine: `mcpToolError.ts` already value-imports `ExecuteCommandError` and `wireStructuredContent` from the desktop tree, so nothing new is crossed. It's the naming that will mislead the next reader.) Worth a small `desktop/errors/bareCommandFailure.ts` that both import, or is the coupling cheap enough to leave?

- **[applyFailureClassifier.ts:131] Five of the six new tests guard a function nothing calls.** `classifyApplyFailure` / `formatApplyFailureForAgent` have zero product consumers at the merge commit — only the test file. The behavior that actually shipped is the six lines in `formatDesktopCommandExecutionError`, guarded by exactly one test (`mcpToolError.test.ts`). I'm not calling the classifier dead code — the PR body is upfront that wiring it is a separate decision, and that's the right call. But the regression insurance is sitting mostly on the unreachable half. Should the multi-line cases go in `mcpToolError.test.ts` first, where the live path is?

- **[mcpToolError.ts:325] `tableau-error-code` and "the tooling did not report a cause."** The pattern is tested against `message`, then the guidance is appended after `formattedMessage`, which may already carry `tableau-error-code: …`. So a bare message that *did* come back with an error code tells the agent no cause was reported, on the same output where a code is printed. Defensible — a code isn't a cause — but is it what you want the model to read, or should the code's presence suppress the prohibition?

### nits (optional polish)

- [mcpToolError.ts:22] The replacement comment — *"Load XML errors preserve Desktop's message when present; otherwise serialize structural errors"* — restates the two-line function directly below it. Deleting the wrong comment was right; this one doesn't earn its line. Drop it, or keep the *why* (why not `JSON.stringify` the whole thing).
- [applyFailureClassifier.test.ts:55] `'Command tabui:load-underlying-metadata failed'` is a real incident string, which is good, but nothing in the test says so. One line naming the incident makes it obvious to the next person why this exact command appears twice across two files.

### Fine as-is / noted tradeoffs

- **No version bump.** Andy normally treats a missing `npm run version:patch` as a "Please," but the PR immediately before this one on `feature/desktop` (#632, `deca09cd`) also shipped without one, and #643 is the stack that actually sets the released number — flagging it here would just add a fourth version to the pile #643's review already complains about. Leave it; make sure #643's single chosen number is the one that ships.
- **Confidence 0.7 for the bare class, last in `RULES`.** Right ordering, right number — more confident than `unknown` (0.2), less than the classes that read an actual cause.
- **The longer `unknown` guidance string.** It grew ~120 chars, and error guidance does cost tokens on every failure. It stays actionable rather than explanatory, so it earns the length.

### Out of lens

- **Interaction with #643:** none, verified. `claude/v11-fixes` at `b23f48d2` touches none of these four files (empty diff-stat against #659's parent), and #659 is not yet an ancestor of it. When #643 picks up the new `feature/desktop`, this merges clean. Nothing here duplicates a finding in the #643 review, and nothing on `claude/v11-andy-fold` needs to absorb it.
- **Not exercised against live Desktop.** The PR body says so plainly, and I can't close that gap from here — whether Desktop's `commandError.message` is ever multi-line is **UNKNOWN** without a live probe. That's the variable that decides whether the finding above is a latent bug or an active one; the a2td twin's author evidently thought it was worth guarding blind, which is the right call either way.

### Follow-up recommendation

One fix packet, small, worth doing now:

1. **Add the single-line guard to both call sites** (`RULES`' bare entry and `formatDesktopCommandExecutionError`) via a shared `isBareCommandFailure(message)` helper. Copy the a2td twin's logic at `src/server/apply-failure-classifier.ts:363`. Add multi-line regression tests to *both* `applyFailureClassifier.test.ts` and `mcpToolError.test.ts`. — the only item with real live impact.
2. **Restore `retry once`** in `BARE_COMMAND_FAILURE_GUIDANCE`, so it stops contradicting `unknown`'s "Do not blind-retry." One word, same PR.
3. **Correct the byte-identity claim** — either re-sync the string to the twin exactly, or say in the follow-up PR body that tmcp's copy diverges deliberately and only `failure_class` is contractual.

Everything else (constant placement, comment nit, the `tableau-error-code` question) can ride until the next touch of this file. If a live probe shows Desktop never emits multi-line command-failure messages, item 1 drops from "bug" to "hardening" — but it's three lines with a working reference implementation, so I'd land it regardless rather than spend a probe deciding.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)