### PR TITLE
feat(binder): at-least-one-of manifest slot groups free country from being force-required

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "2.60.2",
+  "version": "2.61.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "2.60.2",
+      "version": "2.61.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.7.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "2.60.2",
+  "version": "2.61.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/src/desktop/binder/binder.test.ts
+++ b/src/desktop/binder/binder.test.ts
@@ -241,6 +241,33 @@ describe('binder/classifyNoLlm', () => {
     expect(classifyNoLlm('Map the countries by Goals For', manifests, s)).toBeNull();
   });
 
+  it.each([
+    ['symbol map of Sales by City Tier', 'City Tier', 'Sales'],
+    ['filled map of Profit by State Tax Bracket', 'State Tax Bracket', 'Profit'],
+  ])(
+    'does not treat a geo token inside a non-geo field name as geo evidence',
+    (ask, dimension, measure) => {
+      const xml = `<workbook><datasources><datasource name='Probe'>
+  <column name='[${dimension}]' role='dimension' type='nominal' datatype='string' />
+  <column name='[${measure}]' role='measure' type='quantitative' datatype='real' />
+</datasource></datasources></workbook>`;
+
+      expect(classifyNoLlm(ask, manifests, summarizeSchema(xml))).toBeNull();
+    },
+  );
+
+  it('keeps a bare Region field eligible for the state geo concept', () => {
+    const xml = `<workbook><datasources><datasource name='Probe'>
+  <column name='[Region]' role='dimension' type='nominal' datatype='string' />
+  <column name='[Profit]' role='measure' type='quantitative' datatype='real' />
+</datasource></datasources></workbook>`;
+    const cls = classifyNoLlm('filled map of Profit by Region', manifests, summarizeSchema(xml));
+
+    expect(cls).not.toBeNull();
+    expect(cls!.template).toBe('spatial-choropleth-map');
+    expect(cls!.bindings).toContainEqual({ slot_id: 'state', field: 'Region' });
+  });
+
   it('still routes the s8 cross-table goals ambiguity through labeled proposals', async () => {
     const ask =
       'Map the countries by goals scored — bigger, warmer dots for the teams that scored more';
@@ -2010,14 +2037,14 @@ describe('binder/roleGreedyBind — single-candidate-per-slot schema fallback', 
 <workbook>
   <datasources>
     <datasource name='NoGeo'>
-      <column name='[region]' caption='Region' role='dimension' type='nominal' datatype='string' />
+      <column name='[department]' caption='Department' role='dimension' type='nominal' datatype='string' />
       <column name='[segment]' caption='Segment' role='dimension' type='nominal' datatype='string' />
       <column name='[sales]' caption='Sales' role='measure' type='quantitative' datatype='real' />
     </datasource>
   </datasources>
 </workbook>`;
     const result = await bindTemplate({
-      ask: 'map of sales by region',
+      ask: 'map of sales by department',
       workbookXml,
       manifests,
     });
@@ -2359,8 +2386,8 @@ describe('binder/bindTemplate — avoid_when consumption (H3.2)', () => {
   });
 });
 
-describe('binder/bindTemplate — W60 choropleth geo-slot completion', () => {
-  it("'choropleth of Profit by State/Province' one-shot binds; country auto-completes to Country/Region", async () => {
+describe('binder/bindTemplate — choropleth at-least-one geo constraint', () => {
+  it("'choropleth of Profit by State/Province' one-shot binds only the named state", async () => {
     const res = await bindTemplate({
       ask: 'choropleth of Profit by State/Province',
       workbookXml: WORKBOOK_XML,
@@ -2370,19 +2397,80 @@ describe('binder/bindTemplate — W60 choropleth geo-slot completion', () => {
     if (res.status === 'bound') {
       expect(res.used_llm).toBe(false);
       expect(res.args.template_name).toBe('spatial-choropleth-map');
-      // The required country slot was NOT named in the ask; it auto-completes to the
-      // unique country-affine field [Country/Region] (template_field 'Country'), while
-      // the ask-named [State/Province] fills the state slot (template_field 'State').
-      expect(res.args.field_mapping['Country']).toBe('[Superstore].[none:Country/Region:nk]');
-      expect(res.args.field_mapping['State']).toBe('[Superstore].[none:State/Province:nk]');
-      expect(res.args.optional_field_prunes).toBeUndefined();
-      // Provenance is surfaced so the agent can say "using Country/Region".
-      expect(res.warnings?.some((w) => /Country\/Region/.test(w))).toBe(true);
+      expect(res.args.field_mapping).toEqual({
+        State: '[Superstore].[none:State/Province:nk]',
+        Profit: '[Superstore].[sum:Profit:qk]',
+      });
+      expect(res.args.optional_field_prunes).toEqual([
+        { templateField: 'Country', derivation: 'none', role: 'nk' },
+      ]);
+    }
+  });
+
+  it('warns when a spatial bind cannot apply an ask-named categorical color field', async () => {
+    const xml = `<workbook><datasources><datasource name='Probe'>
+  <column name='[City]' role='dimension' type='nominal' datatype='string' semantic-role='[City].[Name]' />
+  <column name='[Segment]' role='dimension' type='nominal' datatype='string' />
+  <column name='[Sales]' role='measure' type='quantitative' datatype='real' />
+</datasource></datasources></workbook>`;
+    const res = await bindTemplate({
+      ask: 'symbol map of Sales by City colored by Segment',
+      workbookXml: xml,
+      manifests,
+    });
+
+    expect(res.status).toBe('bound');
+    if (res.status === 'bound') {
+      expect(res.args.field_mapping).not.toHaveProperty('Color');
+      expect(res.warnings?.join(' ')).toContain('Segment');
     }
   });
 });
 
 describe('binder/bindTemplate — country-only spatial maps', () => {
+  it('binds a state-only choropleth because one geo slot satisfies the group', async () => {
+    const proposal: BindingProposal = {
+      template: 'spatial-choropleth-map',
+      title: 'Profit by state',
+      bindings: [
+        { slot_id: 'state', field: 'State/Province' },
+        { slot_id: 'profit', field: 'Profit' },
+      ],
+    };
+    const res = await bindTemplate({
+      ask: 'choropleth of Profit by State/Province',
+      workbookXml: WORKBOOK_XML,
+      manifests,
+      proposal,
+    });
+    expect(res.status).toBe('bound');
+    if (res.status === 'bound') {
+      expect(res.args.field_mapping).toEqual({
+        State: '[Superstore].[none:State/Province:nk]',
+        Profit: '[Superstore].[sum:Profit:qk]',
+      });
+    }
+  });
+
+  it('escalates a spatial proposal that binds no geo slot', async () => {
+    const proposal: BindingProposal = {
+      template: 'spatial-choropleth-map',
+      title: 'Profit map',
+      bindings: [{ slot_id: 'profit', field: 'Profit' }],
+    };
+    const res = await bindTemplate({
+      ask: 'choropleth of Profit',
+      workbookXml: WORKBOOK_XML,
+      manifests,
+      proposal,
+    });
+    expect(res.status).toBe('escalate');
+    if (res.status === 'escalate') {
+      expect(res.reason).toBe('missing-required-slot');
+      expect(res.blockers.some((blocker) => /at least one/.test(blocker.detail))).toBe(true);
+    }
+  });
+
   it('binds a country-only choropleth and marks state for XML pruning', async () => {
     const res = await bindTemplate({
       ask: 'choropleth of Goals For by Country',

--- a/src/desktop/binder/classify.ts
+++ b/src/desktop/binder/classify.ts
@@ -19,6 +19,7 @@
 import Fuse from 'fuse.js';
 
 import { calcForcedSlotIds } from './calc-derivation.js';
+import { fieldSatisfiesSlotConstraint } from './manifest-validation.js';
 import type { Derivation, SlotKind, TemplateManifest } from './manifest-types.js';
 import { inferStringTemporal } from './stringTemporal.js';
 import {
@@ -34,7 +35,8 @@ import {
  * and a byte-identical copy resolves entirely within the shared lockstep-core set.
  * These MIRROR the schema module's exported `SchemaField`/`SchemaSummary` structurally;
  * the PRODUCER (`summarizeSchema`) still lives there — only the read-only shapes the
- * classifier consumes are declared here.
+ * classifier consumes are declared here. Group constraint evidence is shared with
+ * fixture binding through the equally-pure `manifest-validation.ts`.
  */
 interface SchemaField {
   name: string; // friendly name: caption ?? bare column name
@@ -2052,8 +2054,12 @@ function augmentGeoConceptMatches(
   schemaDims: SchemaField[],
 ): SchemaField[] {
   const augmented = [...matched];
+  const constrainedSlotIds = new Set((manifest.at_least_one_of ?? []).flat());
   const geoSlots = manifest.slots.filter(
-    (slot) => slot.bindable && slot.required && slot.kind === 'geo',
+    (slot) =>
+      slot.bindable &&
+      (slot.required || constrainedSlotIds.has(slot.slot_id)) &&
+      slot.kind === 'geo',
   );
 
   for (const slot of geoSlots) {
@@ -2242,6 +2248,7 @@ function roleGreedyBind(
 } | null {
   const used = new Set<SchemaField>();
   const bindings: Array<{ slot_id: string; field: string; derivation?: Derivation }> = [];
+  const boundFieldsBySlot = new Map<string, SchemaField>();
   // A REQUIRED calc forces its bindable input slots to bind even when the slot is
   // authored optional (H3) — otherwise the calc's formula ref would dangle and the
   // no-LLM path would needlessly escalate.
@@ -2479,6 +2486,23 @@ function roleGreedyBind(
     };
     if (slot.kind === 'quantitative' && aggOverride) binding.derivation = aggOverride;
     bindings.push(binding);
+    boundFieldsBySlot.set(slot.slot_id, chosen);
+  }
+
+  if (
+    (m.at_least_one_of ?? []).some(
+      (group) =>
+        !group.some((slotId) => {
+          const field = boundFieldsBySlot.get(slotId);
+          if (!field) return false;
+          const slot = m.slots.find((candidate) => candidate.slot_id === slotId);
+          return slot
+            ? fieldSatisfiesSlotConstraint(slotId, slot.kind, field)
+            : false;
+        }),
+    )
+  ) {
+    return null;
   }
 
   // Surface any geo slot AUTO-COMPLETED from the full schema (W60) as provenance, so the
@@ -3496,14 +3520,32 @@ export function classifyNoLlm(
   // its sole spare Product dimension. Exact-one cardinality keeps this fail-closed.
   const colorSeries = facet ? null : colorSeriesBinding(chosen, bindings, summary.fields);
   if (colorSeries) bindings.push(colorSeries);
-  // Attach provenance (e.g. W60 geo auto-completion) only when non-empty, so a
-  // non-geo / no-auto-complete ask returns the exact same {template, bindings} shape.
+  const appliedFieldNames = new Set([
+    ...bindings.map((binding) => binding.field),
+    ...filterCandidates.map((field) => field.name),
+  ]);
+  const droppedSpatialDimensions =
+    chosen.family === 'spatial'
+      ? matched.filter(
+          (field) => field.role === 'dimension' && !appliedFieldNames.has(field.name),
+        )
+      : [];
+  const notes = [...rgb.provenance];
+  if (droppedSpatialDimensions.length > 0) {
+    notes.push(
+      `Did not apply ask-named field${droppedSpatialDimensions.length === 1 ? '' : 's'} ` +
+        `${droppedSpatialDimensions.map((field) => `'${field.name}'`).join(', ')} because ` +
+        `the selected spatial template has no compatible open slot.`,
+    );
+  }
+  // Attach provenance and dropped-input warnings only when non-empty, so a clean
+  // non-spatial/no-auto-complete ask returns the same {template, bindings} shape.
   return attachAskModifiers(
     ask,
     {
       template: chosen.template,
       bindings,
-      ...(rgb.provenance.length > 0 ? { notes: rgb.provenance } : {}),
+      ...(notes.length > 0 ? { notes } : {}),
       encodings: symbolMapEncodings.encodings,
     },
     filterCandidates,

--- a/src/desktop/binder/manifest-encoding-corpus.test.ts
+++ b/src/desktop/binder/manifest-encoding-corpus.test.ts
@@ -586,8 +586,8 @@ const CORPUS: readonly CorpusRow[] = [
     schema: 'superstore',
     plain: {
       kind: 'binds',
-      slots: ['country', 'state', 'profit'],
-      why: 'the required country slot has no ask-named candidate so it widens to the schema and picks the unique country-affine field; the optional state slot fills from the ask-named State/Province',
+      slots: ['state', 'profit'],
+      why: 'the ask-named State/Province satisfies the at-least-one geo constraint, so the optional country slot stays unbound',
     },
   },
   {
@@ -768,17 +768,47 @@ const OPTIONAL_SLOTS: readonly OptionalSlotRow[] = [
   },
   {
     template: 'spatial-choropleth-map',
+    slot: 'country',
+    fills: {
+      ask: 'filled map of Profit by Country/Region',
+      schema: 'geo-minimal',
+      field: 'Country/Region',
+      why: 'the ask-named country field satisfies the at-least-one geo constraint',
+    },
+    staysUnbound: {
+      ask: 'filled map of Profit by State/Province',
+      schema: 'superstore',
+      why: 'the ask-named state field satisfies the group without auto-completing optional country',
+    },
+  },
+  {
+    template: 'spatial-choropleth-map',
     slot: 'state',
     fills: {
       ask: 'filled map of Profit by State/Province',
       schema: 'superstore',
       field: 'State/Province',
-      why: 'the optional sub-region slot fills from the geo field the ask names, while the required country slot widens to the schema',
+      why: 'the optional sub-region slot fills from the geo field the ask names',
     },
     staysUnbound: {
       ask: 'filled map of Profit by Country/Region',
       schema: 'geo-minimal',
       why: 'the ask names only the country level and the schema carries no sub-national field, so nothing may reach the optional state slot. Deliberately NOT run on Superstore: see the geo-slot characterisation suite below',
+    },
+  },
+  {
+    template: 'spatial-symbol-map',
+    slot: 'country',
+    fills: {
+      ask: 'symbol map of Sales by Country/Region',
+      schema: 'geo-minimal',
+      field: 'Country/Region',
+      why: 'the ask-named country field satisfies the at-least-one geo constraint',
+    },
+    staysUnbound: {
+      ask: 'symbol map of Sales by State/Province',
+      schema: 'superstore',
+      why: 'the ask-named state field satisfies the group without auto-completing optional country',
     },
   },
   {
@@ -1448,13 +1478,13 @@ describe('binder/manifest-encoding-corpus — census tripwires', () => {
       'correlation-scatter-plot-chart': ['customer_name'],
       'part-to-whole-waterfall': ['anchor_category'],
       'ranking-ordered-bar': ['facet_row'],
-      'spatial-choropleth-map': ['state'],
-      'spatial-symbol-map': ['city', 'color', 'state', 'tooltip'],
+      'spatial-choropleth-map': ['country', 'state'],
+      'spatial-symbol-map': ['city', 'color', 'country', 'state', 'tooltip'],
       'spatial-symbol-map-latlon': ['color', 'detail2', 'size', 'tooltip'],
       'trend-line-chart': ['color_series', 'facet_col'],
     });
     expect(Object.keys(inventory)).toHaveLength(8);
-    expect(Object.values(inventory).flat()).toHaveLength(15);
+    expect(Object.values(inventory).flat()).toHaveLength(17);
   });
 
   it('gives every optional bindable slot in the corpus a row in the optional-slot table', () => {
@@ -1465,7 +1495,7 @@ describe('binder/manifest-encoding-corpus — census tripwires', () => {
       .flatMap((m) => optionalSlotIds(m).map((slot) => `${m.template}.${slot}`))
       .sort();
     expect(declared).toEqual(actual);
-    expect(declared).toHaveLength(15);
+    expect(declared).toHaveLength(17);
   });
 
   it('pins how much of the manifest-intent matrix reaches a deterministic bind', () => {

--- a/src/desktop/binder/manifest-types.ts
+++ b/src/desktop/binder/manifest-types.ts
@@ -163,6 +163,13 @@ export interface SlotSpec {
   notes?: string;
 }
 
+/**
+ * Every group requires at least one of its named bindable slots to be bound.
+ * Individual slots remain optional, so the binder can use whichever compatible
+ * field the ask supplies without weakening the template's overall coverage.
+ */
+export type AtLeastOneOfSlotGroup = string[];
+
 /** A calc's OUTPUT role — measure|dimension — read from the calc <column role=…> in the XML. */
 export type CalcResultRole = 'measure' | 'dimension';
 
@@ -441,6 +448,8 @@ export interface TemplateManifest {
    */
   avoid_when?: string[];
   slots: SlotSpec[]; // bindable + non-bindable structural slots
+  /** Every group requires at least one named slot to be bound. */
+  at_least_one_of?: AtLeastOneOfSlotGroup[];
   calcs: CalcSlot[]; // template-owned calculated fields
   hazards: Hazard[];
   /**

--- a/src/desktop/binder/manifest-validation.test.ts
+++ b/src/desktop/binder/manifest-validation.test.ts
@@ -123,6 +123,69 @@ describe('binder/manifest-validation — the new superset fields are additive/pa
   });
 });
 
+describe('binder/manifest-validation — at_least_one_of slot constraints', () => {
+  function withAtLeastOneOf(groups: unknown): unknown {
+    const base = structuredClone(loadManifests().get('ranking-ordered-bar')!) as unknown as Record<
+      string,
+      unknown
+    >;
+    base.at_least_one_of = groups;
+    return base;
+  }
+
+  it('accepts a non-empty group of declared slot names', () => {
+    expect(validateManifest(withAtLeastOneOf([['region', 'sales']]))).toEqual([]);
+  });
+
+  it('rejects an empty group', () => {
+    expect(validateManifest(withAtLeastOneOf([[]])).join(' ')).toMatch(
+      /at_least_one_of.*non-empty/,
+    );
+  });
+
+  it('rejects an unknown slot name', () => {
+    expect(validateManifest(withAtLeastOneOf([['region', 'does-not-exist']])).join(' ')).toMatch(
+      /at_least_one_of.*does-not-exist/,
+    );
+  });
+
+  it('rejects a group that names a non-bindable slot', () => {
+    const manifest = withAtLeastOneOf([['region']]) as Record<string, unknown>;
+    const slots = manifest.slots as Array<Record<string, unknown>>;
+    slots.find((slot) => slot.slot_id === 'region')!.bindable = false;
+
+    expect(validateManifest(manifest).join(' ')).toMatch(
+      /at_least_one_of.*region.*must be bindable/,
+    );
+  });
+
+  it('uses the runtime geo-evidence rule for fixture group satisfaction', () => {
+    const manifest = structuredClone(loadManifests().get('spatial-symbol-map')!);
+    const sales = {
+      name: 'Sales',
+      role: 'measure' as const,
+      type: 'quantitative',
+      datatype: 'real',
+    };
+    const dimension = (
+      name: string,
+    ): {
+      name: string;
+      role: 'dimension';
+      type: string;
+      datatype: string;
+    } => ({
+      name,
+      role: 'dimension' as const,
+      type: 'nominal',
+      datatype: 'string',
+    });
+
+    expect(computeFixtureBind(manifest, [dimension('City Tier'), sales])).toBe(false);
+    expect(computeFixtureBind(manifest, [dimension('City'), sales])).toBe(true);
+  });
+});
+
 describe('binder/manifest-validation — validateManifest ENFORCES the DerivationContract shape (LR2-3)', () => {
   // Attach a derivation block to a known-valid bundled manifest to exercise the ported shape gate
   // (superset from A's manifest.ts). The facet-vocabulary / parent-existence cross-checks still

--- a/src/desktop/binder/manifest-validation.ts
+++ b/src/desktop/binder/manifest-validation.ts
@@ -127,6 +127,9 @@ function isStringArray(v: unknown): v is string[] {
  */
 export interface FixtureField {
   name: string;
+  caption?: string;
+  columnName?: string;
+  semanticRole?: string;
   role: 'dimension' | 'measure';
   type: string; // "quantitative" | "nominal" | "ordinal" | ...
   datatype: string; // "string" | "real" | "integer" | "date" | "datetime" | ...
@@ -157,6 +160,95 @@ function fixtureFieldFitsKind(kind: SlotKind, f: FixtureField): boolean {
   }
 }
 
+type GeoConcept = 'country' | 'state' | 'city' | 'zip';
+
+const GEO_CONSTRAINT_NAME_TOKENS: Readonly<Record<GeoConcept, readonly string[]>> = {
+  country: ['country', 'nation'],
+  state: ['state', 'province', 'region', 'admin'],
+  city: ['city'],
+  zip: ['zip', 'zipcode', 'postal'],
+};
+
+const GEO_CONSTRAINT_NAME_QUALIFIERS: Readonly<Record<GeoConcept, readonly string[]>> = {
+  country: ['region', 'code'],
+  state: ['code'],
+  city: ['code'],
+  zip: ['code'],
+};
+
+const GEO_TOKEN_CONCEPT: Readonly<Record<string, GeoConcept>> = {
+  country: 'country',
+  nation: 'country',
+  state: 'state',
+  province: 'state',
+  region: 'state',
+  admin: 'state',
+  city: 'city',
+  zip: 'zip',
+  zipcode: 'zip',
+  postal: 'zip',
+};
+
+const GEO_SEMANTIC_ROLE_CONCEPT: Readonly<Record<string, GeoConcept>> = {
+  '[Country].[ISO3166_2]': 'country',
+  '[Country].[Name]': 'country',
+  '[State].[Name]': 'state',
+  '[City].[Name]': 'city',
+  '[ZipCode].[Name]': 'zip',
+};
+
+function nameTokens(value: string): string[] {
+  return value
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter(Boolean);
+}
+
+function geoConceptFromSlotId(slotId: string): GeoConcept | null {
+  for (const token of nameTokens(slotId)) {
+    const concept = GEO_TOKEN_CONCEPT[token];
+    if (concept) return concept;
+  }
+  return null;
+}
+
+/**
+ * Shared runtime/fixture rule for whether a field can satisfy a slot-group member.
+ * Untagged geo fields need one complete field name made only of concept tokens and
+ * narrow geo qualifiers; a token buried in "City Tier" or "State Tax Bracket" is
+ * not geographic evidence.
+ */
+export function fieldSatisfiesSlotConstraint(
+  slotId: string,
+  kind: SlotKind,
+  field: Pick<FixtureField, 'name' | 'caption' | 'columnName' | 'semanticRole'>,
+): boolean {
+  if (kind !== 'geo') return true;
+  const slotConcept = geoConceptFromSlotId(slotId);
+  if (!slotConcept) return true;
+  const semanticConcept = field.semanticRole
+    ? (GEO_SEMANTIC_ROLE_CONCEPT[field.semanticRole] ?? null)
+    : null;
+  if (semanticConcept) return semanticConcept === slotConcept;
+
+  const conceptTokens = new Set(GEO_CONSTRAINT_NAME_TOKENS[slotConcept]);
+  const allowedTokens = new Set([
+    ...GEO_CONSTRAINT_NAME_TOKENS[slotConcept],
+    ...GEO_CONSTRAINT_NAME_QUALIFIERS[slotConcept],
+  ]);
+  const names = [field.name, field.caption, field.columnName?.replace(/^\[|\]$/g, '')].filter(
+    (name): name is string => !!name,
+  );
+  return names.some((name) => {
+    const tokens = nameTokens(name);
+    return (
+      tokens.length > 0 &&
+      tokens.some((token) => conceptTokens.has(token)) &&
+      tokens.every((token) => allowedTokens.has(token))
+    );
+  });
+}
+
 /**
  * Prove portability by binding: can every required, bindable slot — PLUS every
  * bindable slot a required calc's inputs force (H3) — be filled by a DISTINCT
@@ -166,11 +258,16 @@ function fixtureFieldFitsKind(kind: SlotKind, f: FixtureField): boolean {
  * the stored `portability_evidence.fixture_bind`.
  */
 export function computeFixtureBind(
-  m: { slots: TemplateManifest['slots']; calcs?: TemplateManifest['calcs'] },
+  m: {
+    slots: TemplateManifest['slots'];
+    at_least_one_of?: TemplateManifest['at_least_one_of'];
+    calcs?: TemplateManifest['calcs'];
+  },
   fields: FixtureField[],
 ): boolean {
   const forced = calcForcedSlotIds(m);
   const used = new Set<FixtureField>();
+  const boundSlotIds = new Set<string>();
   for (const slot of m.slots) {
     // Bind a slot when it is required, OR when a required calc's input forces it.
     if (!slot.bindable || !(slot.required || forced.has(slot.slot_id))) continue;
@@ -184,6 +281,28 @@ export function computeFixtureBind(
     }
     if (!picked) return false;
     used.add(picked);
+    boundSlotIds.add(slot.slot_id);
+  }
+  for (const group of m.at_least_one_of ?? []) {
+    if (group.some((slotId) => boundSlotIds.has(slotId))) continue;
+    let picked: { slotId: string; field: FixtureField } | null = null;
+    for (const slotId of group) {
+      const slot = m.slots.find((candidate) => candidate.slot_id === slotId);
+      if (!slot?.bindable) continue;
+      const field = fields.find(
+        (candidate) =>
+          !used.has(candidate) &&
+          fixtureFieldFitsKind(slot.kind, candidate) &&
+          fieldSatisfiesSlotConstraint(slotId, slot.kind, candidate),
+      );
+      if (field) {
+        picked = { slotId, field };
+        break;
+      }
+    }
+    if (!picked) return false;
+    used.add(picked.field);
+    boundSlotIds.add(picked.slotId);
   }
   return true;
 }
@@ -466,6 +585,7 @@ export function validateManifest(m: unknown): string[] {
   }
 
   const slotIds = new Set<string>();
+  const slotById = new Map<string, Record<string, unknown>>();
   if (!Array.isArray(m.slots)) {
     errors.push('slots must be an array');
   } else {
@@ -474,8 +594,34 @@ export function validateManifest(m: unknown): string[] {
       if (id) {
         if (slotIds.has(id)) errors.push(`slot[${i}]: duplicate slot_id '${id}'`);
         slotIds.add(id);
+        if (isRecord(s)) slotById.set(id, s);
       }
     });
+  }
+
+  if (m.at_least_one_of !== undefined) {
+    if (!Array.isArray(m.at_least_one_of)) {
+      errors.push('at_least_one_of must be an array of non-empty slot-name groups');
+    } else {
+      m.at_least_one_of.forEach((group, i) => {
+        const where = `at_least_one_of[${i}]`;
+        if (
+          !isStringArray(group) ||
+          group.length === 0 ||
+          group.some((slotId) => slotId.trim().length === 0)
+        ) {
+          errors.push(`${where} must be a non-empty string[] of slot names`);
+          return;
+        }
+        for (const slotId of group) {
+          if (!slotIds.has(slotId)) {
+            errors.push(`${where} references unknown slot_id '${slotId}'`);
+          } else if (slotById.get(slotId)?.bindable !== true) {
+            errors.push(`${where} member slot_id '${slotId}' must be bindable`);
+          }
+        }
+      });
+    }
   }
 
   if (!Array.isArray(m.calcs)) {

--- a/src/desktop/binder/portability-lane.test.ts
+++ b/src/desktop/binder/portability-lane.test.ts
@@ -155,7 +155,7 @@ describe('portability-lane — geo semantic-role picks (W2, the Territory-class 
     expect(cls!.template).toBe('spatial-choropleth-map');
     const byId = Object.fromEntries(cls!.bindings.map((b) => [b.slot_id, b.field]));
     expect(byId.state).toBe('Territory');
-    expect(byId.country).toBe('Country');
+    expect(byId.country).toBeUndefined();
   });
 
   it('a Country map ask stays country-level instead of auto-completing optional state', () => {

--- a/src/desktop/binder/validate.test.ts
+++ b/src/desktop/binder/validate.test.ts
@@ -97,6 +97,25 @@ describe('binder/validate — gate 1: slot coverage', () => {
       ).toBe(true);
   });
 
+  it('fire: an unsatisfied slot group identifies its repair slot', () => {
+    const m = manifests.get('spatial-choropleth-map')!;
+    const p: BindingProposal = {
+      template: m.template,
+      title: 'Profit map',
+      bindings: [{ slot_id: 'profit', field: 'Profit' }],
+    };
+    const r = validateBinding(m, p, SUMMARY);
+
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.blockers).toContainEqual({
+        code: 'missing-required-slot',
+        slot_id: 'country',
+        detail: 'at least one of slots [country, state] must have a binding',
+      });
+    }
+  });
+
   it('fire: binding to a template-owned calc slot → kind-mismatch', () => {
     const m = manifests.get('correlation-scatter-plot-chart')!;
     const p: BindingProposal = {

--- a/src/desktop/binder/validate.ts
+++ b/src/desktop/binder/validate.ts
@@ -450,6 +450,19 @@ export function validateBinding(
       });
     }
   }
+  for (const group of m.at_least_one_of ?? []) {
+    const satisfied = group.some(
+      (slotId) => slotById.get(slotId)?.bindable === true && boundBySlot.has(slotId),
+    );
+    if (!satisfied) {
+      const repairSlotId = group.find((slotId) => slotById.get(slotId)?.bindable === true);
+      blockers.push({
+        code: 'missing-required-slot',
+        ...(repairSlotId !== undefined ? { slot_id: repairSlotId } : {}),
+        detail: `at least one of slots [${group.join(', ')}] must have a binding`,
+      });
+    }
+  }
   for (const b of p.bindings) {
     const slot = slotById.get(b.slot_id);
     if (!slot) {

--- a/src/desktop/data/content-manifest.json
+++ b/src/desktop/data/content-manifest.json
@@ -2,11 +2,11 @@
   "_generated": true,
   "_generator": "src/scripts/buildTemplateManifests.ts",
   "_warning": "GENERATED FILE — do not hand-edit. Re-run `npx tsx src/scripts/buildTemplateManifests.ts`.",
-  "content_version": "2.59.1+content.2026-07-27",
+  "content_version": "2.60.2+content.2026-07-28",
   "schema_version": "2",
-  "generated": "2026-07-27",
+  "generated": "2026-07-28",
   "engine_compat": {
-    "server_min": "2.59.1",
+    "server_min": "2.60.2",
     "node": ">=22.7.5"
   },
   "resources": [
@@ -252,8 +252,8 @@
     },
     {
       "path": "template-manifests.index.json",
-      "sha256": "9a72ff66a3a4b9720cf2309c2a7793129d8b6bee120ad202316a8b1d214f5255",
-      "bytes": 283278
+      "sha256": "ee51eb6743a0ef27d87d83b551968ac3f1d66a173ec4eeae57e7163daa4158fa",
+      "bytes": 283488
     },
     {
       "path": "template-manifests/box-plot-chart.manifest.json",
@@ -442,8 +442,8 @@
     },
     {
       "path": "template-manifests/spatial-choropleth-map.manifest.json",
-      "sha256": "5bf42e221bb01d867a01c442a762503195898c320377febf9f2b0cfa9e4048dc",
-      "bytes": 5914
+      "sha256": "bc5ca874ec4a2be267fafe41940ee431647149dd27678a55dc9db626a0c48fc9",
+      "bytes": 5986
     },
     {
       "path": "template-manifests/spatial-symbol-map-latlon.manifest.json",
@@ -452,8 +452,8 @@
     },
     {
       "path": "template-manifests/spatial-symbol-map.manifest.json",
-      "sha256": "2b82774cb6da6f6c17c8932963ffe237a75ca3dd41b64a0605d7ced2eab0baf7",
-      "bytes": 5862
+      "sha256": "4883a2c54b0b550f1de41c1ddee830ffb3cdbd540e83494af18c27fd965e3131",
+      "bytes": 5948
     },
     {
       "path": "template-manifests/trend-line-chart.manifest.json",

--- a/src/desktop/data/template-manifests.index.json
+++ b/src/desktop/data/template-manifests.index.json
@@ -4076,6 +4076,12 @@
         "Regions differ wildly in physical size — large, low-value areas visually dominate (area is not magnitude); consider a symbol/bubble map sized by the measure instead.",
         "The dimension has no geographic semantic-role (not a Country/State/etc.) — a choropleth needs fields Tableau can resolve to a filled geometry."
       ],
+      "at_least_one_of": [
+        [
+          "country",
+          "state"
+        ]
+      ],
       "slots": [
         {
           "slot_id": "country",
@@ -4086,7 +4092,7 @@
           ],
           "kind": "geo",
           "bindable": true,
-          "required": true,
+          "required": false,
           "notes": "Geographic dimension on level-of-detail (outer region). Binds to a Country/Region-class field; XML column-instance [none:Country:nk]."
         },
         {
@@ -4327,6 +4333,13 @@
         "map"
       ],
       "description": "A point (symbol) map: one Circle mark per geographic member, placed on generated Lat/Long, sized by a measure. Distinct from a choropleth (which fills regions); use when magnitude is encoded by symbol size rather than region shading.",
+      "at_least_one_of": [
+        [
+          "country",
+          "state",
+          "city"
+        ]
+      ],
       "slots": [
         {
           "slot_id": "country",
@@ -4337,7 +4350,7 @@
           ],
           "kind": "geo",
           "bindable": true,
-          "required": true,
+          "required": false,
           "notes": "template column carries semantic-role='[Country].[ISO3166_2]'; the LOD level drives generated Lat/Long. Portability is 'across the committed fixture classes + render-verified', not a blanket 'any dataset'."
         },
         {

--- a/src/desktop/data/template-manifests/spatial-choropleth-map.manifest.json
+++ b/src/desktop/data/template-manifests/spatial-choropleth-map.manifest.json
@@ -48,6 +48,12 @@
     "Regions differ wildly in physical size — large, low-value areas visually dominate (area is not magnitude); consider a symbol/bubble map sized by the measure instead.",
     "The dimension has no geographic semantic-role (not a Country/State/etc.) — a choropleth needs fields Tableau can resolve to a filled geometry."
   ],
+  "at_least_one_of": [
+    [
+      "country",
+      "state"
+    ]
+  ],
   "slots": [
     {
       "slot_id": "country",
@@ -58,7 +64,7 @@
       ],
       "kind": "geo",
       "bindable": true,
-      "required": true,
+      "required": false,
       "notes": "Geographic dimension on level-of-detail (outer region). Binds to a Country/Region-class field; XML column-instance [none:Country:nk]."
     },
     {

--- a/src/desktop/data/template-manifests/spatial-symbol-map.manifest.json
+++ b/src/desktop/data/template-manifests/spatial-symbol-map.manifest.json
@@ -47,6 +47,13 @@
     "map"
   ],
   "description": "A point (symbol) map: one Circle mark per geographic member, placed on generated Lat/Long, sized by a measure. Distinct from a choropleth (which fills regions); use when magnitude is encoded by symbol size rather than region shading.",
+  "at_least_one_of": [
+    [
+      "country",
+      "state",
+      "city"
+    ]
+  ],
   "slots": [
     {
       "slot_id": "country",
@@ -57,7 +64,7 @@
       ],
       "kind": "geo",
       "bindable": true,
-      "required": true,
+      "required": false,
       "notes": "template column carries semantic-role='[Country].[ISO3166_2]'; the LOD level drives generated Lat/Long. Portability is 'across the committed fixture classes + render-verified', not a blanket 'any dataset'."
     },
     {

--- a/src/tools/desktop/binder/bindTemplate.test.ts
+++ b/src/tools/desktop/binder/bindTemplate.test.ts
@@ -479,6 +479,24 @@ const missingCountryEscalateResult: BinderResult = {
   ],
   proposal: missingCountryProposal,
 };
+const missingSpatialGroupProposal: BindingProposal & { confidence: number } = {
+  template: 'spatial-choropleth-map',
+  title: 'Profit map',
+  bindings: [{ slot_id: 'profit', field: 'Profit' }],
+  confidence: 0.9,
+};
+const missingSpatialGroupEscalateResult: BinderResult = {
+  status: 'escalate',
+  reason: 'missing-required-slot',
+  blockers: [
+    {
+      code: 'missing-required-slot',
+      slot_id: 'country',
+      detail: 'at least one of slots [country, state] must have a binding',
+    },
+  ],
+  proposal: missingSpatialGroupProposal,
+};
 
 // A Call-2 proposal that validated into a bound result is marked used_llm:true.
 // The auto-apply gate should preserve that field on non-applied results, but it no
@@ -1691,6 +1709,26 @@ describe('bindTemplateTool bind recovery gate', () => {
     });
     expect(getWorkbookXmlModule.getWorkbookXml).toHaveBeenCalledTimes(2);
     expect(binderModule.bindTemplate).toHaveBeenCalledTimes(2);
+  });
+
+  it('mints a repair allowance for an unsatisfied spatial slot group', async () => {
+    vi.mocked(externalDiscovery.discoverInstances).mockReturnValue([]);
+    vi.spyOn(getWorkbookXmlModule, 'getWorkbookXml').mockResolvedValue(Ok(XML));
+    vi.mocked(binderModule.bindTemplate).mockResolvedValueOnce(missingSpatialGroupEscalateResult);
+    const ask = 'choropleth of Profit';
+
+    const result = await getToolResult({ session: '1', ask });
+
+    invariant(result.content[0].type === 'text');
+    expect(JSON.parse(result.content[0].text).reason).toBe('missing-required-slot');
+    expect(sessionRouteState.getBindRecovery('1', normalizeAskForMatch(ask))).toMatchObject({
+      phase: 'terminal',
+      terminalRepairAllowance: {
+        template: 'spatial-choropleth-map',
+        slotId: 'country',
+        remaining: 1,
+      },
+    });
   });
 
   it('keeps the ask terminal when an admitted Tier-2 repair proposes again', async () => {


### PR DESCRIPTION
First work PR of the v12 train (base: `claude/v12-fixes`). Approving this adds a rule to the manifest grammar that all templates can now use: a slot group where at least one member must bind, replacing the workaround of force-requiring `country` on the spatial templates.

## What it does
- `at_least_one_of?: string[][]` on template manifests; spatial manifests mark geo slots individually optional under a group (choropleth `[country,state]`; symbol map `[country,state,city]`).
- Enforced in all four layers: `validateManifest` (grammar + members must be bindable), `computeFixtureBind` (portability evidence), `validateBinding` (blocker carries a repair `slot_id` so the E2 one-repair allowance still mints on spatial templates), `roleGreedyBind` (escalates when no member binds with real geo evidence).
- Geo evidence is one shared predicate (`fieldSatisfiesSlotConstraint`): semantic role wins; an untagged field counts only when a complete field name is concept tokens + narrow qualifiers — "Region" satisfies state, "City Tier" / "State Tax Bracket" satisfy nothing.

## Review
Opus review folded in full: 1 CRITICAL (name-token fallback let non-geo dimensions one-shot bind geo slots — now pinned by regression tests), 5 Please (repair slot_id, region/admin parity with GEO_CONCEPT_SYNONYMS, dropped-field warning beyond the temporal branch, bindable group members, one shared satisfaction predicate).

## What lands later
This touches lockstep-core files (classify, manifest-validation, manifest-types) — the a2td re-sync is owed after the v12 train merges, on the ledger.

## Validation (firsthand)
lint green; full vitest green (370 files, 6330 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)