### PR TITLE
fix(desktop): declare column-instance dependencies for template-bound encodings

### DIFF
--- a/src/desktop/metadata/fields.test.ts
+++ b/src/desktop/metadata/fields.test.ts
@@ -3,6 +3,7 @@ import {
   addFieldToCols,
   addFieldToEncoding,
   addFieldToRows,
+  ensureEncodingFieldDependencies,
   listFields,
   moveFieldInCols,
   moveFieldInEncoding,
@@ -43,6 +44,33 @@ const WORKSHEET_XML = `<?xml version="1.0" encoding="UTF-8"?>
     </panes>
   </table>
 </worksheet>`;
+
+describe('ensureEncodingFieldDependencies', () => {
+  it('returns byte-identical XML when every encoding instance is already declared', () => {
+    expect(ensureEncodingFieldDependencies(WORKSHEET_XML)).toBe(WORKSHEET_XML);
+  });
+
+  it('returns byte-identical XML for a non-worksheet fragment', () => {
+    const dashboardXml = '<dashboard name="Dashboard 1"><zones /></dashboard>';
+
+    expect(ensureEncodingFieldDependencies(dashboardXml)).toBe(dashboardXml);
+  });
+
+  it('adds one declaration for repeated references to the same missing instance', () => {
+    const missingRepeatedXml = WORKSHEET_XML.replace(
+      '        <column-instance name="[none:Category:nk]" column="[Category]" derivation="None" pivot="key" type="nominal"/>\n',
+      '',
+    ).replace(
+      '          <color column="[Sample].[none:Category:nk]"/>',
+      '          <color column="[Sample].[none:Category:nk]"/>\n' +
+        '          <tooltip column="[Sample].[none:Category:nk]"/>',
+    );
+
+    const result = ensureEncodingFieldDependencies(missingRepeatedXml);
+
+    expect(result.match(/name="\[none:Category:nk\]"/g)).toHaveLength(1);
+  });
+});
 
 describe('listFields', () => {
   it('should return fields from all locations', () => {

--- a/src/desktop/metadata/fields.ts
+++ b/src/desktop/metadata/fields.ts
@@ -9,7 +9,11 @@ import {
   inferFieldTypeFromType,
   inferRoleFromType,
 } from './field-builder.js';
-import { parseColumnInstanceRef, parseDatasourceQualifiedColumnRef } from './field-resolver.js';
+import {
+  parseCanonicalColumnRef,
+  parseColumnInstanceRef,
+  parseDatasourceQualifiedColumnRef,
+} from './field-resolver.js';
 import { emitFieldRewrite } from './field-rewrite-listener.js';
 import { normalizeArray, parseXML, serializeXML } from './parser.js';
 import type { EncodingType, FieldInfo, ParsedEncoding, ParsedWorksheet } from './types.js';
@@ -214,6 +218,65 @@ export function addFieldToEncoding(
   }
 
   return serializeXML(parsed);
+}
+
+/**
+ * Ensure every canonical field reference already present under <encodings> has
+ * the datasource-dependencies declarations addFieldToEncoding would create.
+ * Tableau-generated refs have no derivation/role instance shape and are skipped.
+ */
+export function ensureEncodingFieldDependencies(
+  worksheetXml: string,
+  workbookXml?: string,
+): string {
+  const parsed = parseXML(worksheetXml);
+  const worksheet = getWorksheet(parsed);
+
+  if (!worksheet) {
+    return worksheetXml;
+  }
+
+  const declared = new Set<string>();
+  for (const dependency of normalizeArray(worksheet.table?.view?.['datasource-dependencies'])) {
+    const datasource = dependency?.['@_datasource'];
+    if (typeof datasource !== 'string') continue;
+    for (const instance of normalizeArray(dependency['column-instance'])) {
+      const name = instance?.['@_name'];
+      if (typeof name === 'string') declared.add(`${datasource}::${name}`);
+    }
+  }
+
+  let changed = false;
+  const added = new Set<string>();
+  for (const pane of normalizeArray(worksheet.table?.panes?.pane)) {
+    for (const encodings of Object.values(pane.encodings ?? {})) {
+      for (const encoding of normalizeArray<ParsedEncoding>(encodings)) {
+        const columnRef = encoding?.['@_column'];
+        if (typeof columnRef !== 'string') continue;
+
+        const parsedRef = parseCanonicalColumnRef(columnRef);
+        if (!parsedRef) continue;
+        const requestedKey = `${parsedRef.datasource}::${parsedRef.columnInstanceName}`;
+        if (declared.has(requestedKey)) continue;
+
+        const correctedColumnInstanceName = ensureColumnInstanceInDependencies(
+          worksheet,
+          parsedRef.datasource,
+          parsedRef.columnInstanceName,
+          workbookXml,
+        );
+        const correctedKey = `${parsedRef.datasource}::${correctedColumnInstanceName}`;
+        if (declared.has(correctedKey) && !added.has(correctedKey)) continue;
+
+        encoding['@_column'] = `[${parsedRef.datasource}].${correctedColumnInstanceName}`;
+        declared.add(correctedKey);
+        added.add(correctedKey);
+        changed = true;
+      }
+    }
+  }
+
+  return changed ? serializeXML(parsed) : worksheetXml;
 }
 
 /**

--- a/src/desktop/templates/injectTemplateCore.test.ts
+++ b/src/desktop/templates/injectTemplateCore.test.ts
@@ -419,6 +419,49 @@ describe('buildInjectedWorkbookXml — optional geo LOD pruning', () => {
   );
   const SYMBOL_SLOTS = loadManifests().get('spatial-symbol-map')!.slots;
 
+  it('declares a worldcup-shaped measure bound to the optional color slot', () => {
+    const worldCupWorkbook = `<workbook>
+      <datasources>
+        <datasource name='federated.worldcup' caption='worldcup'>
+          <column caption='Team Name' datatype='string' name='[team_name]' role='dimension' type='nominal' />
+          <column caption='Goals' datatype='integer' name='[goals]' role='measure' type='quantitative' />
+          <column caption='Goal Difference' datatype='integer' name='[goal_difference]' role='measure' type='quantitative' />
+        </datasource>
+      </datasources>
+      <worksheets />
+      <windows />
+    </workbook>`;
+    const result = buildInjectedWorkbookXml({
+      workbookXml: worldCupWorkbook,
+      templateXml: SYMBOL_TEMPLATE,
+      title: 'World Cup goals',
+      sheetType: 'worksheet',
+      templateParameters: { DATASOURCE: 'federated.worldcup' },
+      fieldMapping: {
+        country: '[federated.worldcup].[none:team_name:nk]',
+        sales: '[federated.worldcup].[sum:goals:qk]',
+        color: '[federated.worldcup].[sum:goal_difference:qk]',
+      },
+      optionalFieldPrunes: [
+        { templateField: 'State/Province', derivation: 'none', role: 'nk' },
+        { templateField: 'City', derivation: 'none', role: 'nk' },
+      ],
+      templateSlots: SYMBOL_SLOTS,
+      applyNonce: 'worldcup-color',
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const colorInstance = result.xml.match(
+      /<column-instance\b[^>]*\bname="\[sum:goal_difference:qk\]"[^>]*>/,
+    )?.[0];
+    expect(colorInstance).toBeDefined();
+    expect(colorInstance).toContain('column="[goal_difference]"');
+    expect(colorInstance).toContain('derivation="Sum"');
+    expect(colorInstance).toContain('pivot="key"');
+    expect(colorInstance).toContain('type="quantitative"');
+  });
+
   it('removes an unbound optional state LOD from a country-only choropleth', () => {
     const result = buildInjectedWorkbookXml({
       workbookXml: EMPTY_WORKBOOK,
@@ -494,6 +537,46 @@ describe('buildInjectedWorkbookXml — optional geo LOD pruning', () => {
     expect(result.xml).toContain('[Football].[none:Country:nk]');
     expect(result.xml).toContain('[Football].[none:State:nk]');
     expect(result.xml).toContain('[Football].[none:City:nk]');
+  });
+});
+
+describe('buildInjectedWorkbookXml — declared calculated encoding dependencies', () => {
+  const TEMPLATE = readFileSync(
+    join(__dirname, '../data/templates/part-to-whole-proportional-stacked-bar.xml'),
+    'utf-8',
+  );
+  const manifest = loadManifests().get('part-to-whole-proportional-stacked-bar')!;
+  const slotsWithOptionalColor = manifest.slots.map((slot) =>
+    slot.slot_id === 'category' ? { ...slot, required: false } : slot,
+  );
+
+  it('does not rewrite or redeclare a bound optional-slot template calc instance', () => {
+    const result = buildInjectedWorkbookXml({
+      workbookXml: "<?xml version='1.0'?><workbook><worksheets/><windows/></workbook>",
+      templateXml: TEMPLATE,
+      title: 'Regional mix',
+      sheetType: 'worksheet',
+      templateParameters: { DATASOURCE: 'Superstore' },
+      fieldMapping: {
+        region: '[Superstore].[none:Region:nk]',
+        sales: '[Superstore].[sum:Sales:qk]',
+        category: '[Superstore].[none:Category:nk]',
+      },
+      templateSlots: slotsWithOptionalColor,
+      applyNonce: 'declared-calc',
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.xml).not.toContain('[usr:Calculation_3630088501878784');
+    expect(
+      result.xml.match(
+        /<column-instance\b[^>]*\bcolumn="\[Calculation_3630088501878784_tpl_[^"]+\]"[^>]*>/g,
+      ),
+    ).toHaveLength(1);
+    expect(result.xml).toMatch(
+      /<size column="\[Superstore\]\.\[sum:Calculation_3630088501878784_tpl_[^:\]]+:qk\]"><\/size>/,
+    );
   });
 });
 

--- a/src/desktop/templates/injectTemplateCore.ts
+++ b/src/desktop/templates/injectTemplateCore.ts
@@ -12,6 +12,7 @@
 // inject-template tool passes agent-supplied raw strings; bind-template passes the
 // binder's args as-is (matching what the manual inject-template call would receive).
 
+import { ensureEncodingFieldDependencies } from '../metadata/fields.js';
 import { normalizeArray, parseXML, serializeXML } from '../metadata/parser.js';
 import { ParsedWindow, ParsedWorkbook, ParsedWorksheet } from '../metadata/types.js';
 import { wellFormedXmlRule } from '../validation/rules/wellFormedXml.js';
@@ -253,6 +254,7 @@ export function buildInjectedWorkbookXml({
     );
     processed = rewrite.xml;
     rewriteWarnings.push(...rewrite.droppedOptionalElements);
+    processed = ensureEncodingFieldDependencies(processed, workbookXml);
     processed = spliceWaterfallAnchorFilter(processed, fieldMapping ?? {});
   }
 

--- a/src/desktop/validation/rules/rules.ts
+++ b/src/desktop/validation/rules/rules.ts
@@ -29,6 +29,7 @@ import { setCountMalformedParameterRule } from './setCountMalformedParameter.js'
 import { tooltipDimensionRequiresAttrRule } from './tooltipDimensionRequiresAttr.js';
 import { undeclaredAggregateOkRefRule } from './undeclaredAggregateOkRef.js';
 import { undeclaredCalcReferenceRule } from './undeclaredCalcReference.js';
+import { undeclaredEncodingColumnInstanceRule } from './undeclaredEncodingColumnInstance.js';
 import { undeclaredSetReferenceRule } from './undeclaredSetReference.js';
 import { unsubstitutedTemplateTokenRule } from './unsubstitutedTemplateToken.js';
 import { wellFormedXmlRule } from './wellFormedXml.js';
@@ -44,6 +45,7 @@ export const validationRules = [
   undeclaredCalcReferenceRule,
   undeclaredSetReferenceRule,
   undeclaredAggregateOkRefRule,
+  undeclaredEncodingColumnInstanceRule,
   dashboardZonesReferenceIncludedWorksheetsRule,
   qualifiedNameBracketsRule,
   worksheetMissingWindowRule,

--- a/src/desktop/validation/rules/undeclaredEncodingColumnInstance.test.ts
+++ b/src/desktop/validation/rules/undeclaredEncodingColumnInstance.test.ts
@@ -1,0 +1,82 @@
+import { runValidation } from '../registry.js';
+import { undeclaredEncodingColumnInstanceRule } from './undeclaredEncodingColumnInstance.js';
+
+function worksheetWith(encoding: string, dependencies: string): string {
+  return `<workbook><worksheets><worksheet name="Sheet 1"><table><view>
+    ${dependencies}
+  </view><panes><pane><encodings>${encoding}</encodings></pane></panes>
+  <rows>[Orders].[sum:Sales:qk]</rows>
+  </table></worksheet></worksheets></workbook>`;
+}
+
+const ORDERS_DEPENDENCIES = `<datasource-dependencies datasource="Orders">
+  <column-instance column="[Sales]" derivation="Sum" name="[sum:Sales:qk]" pivot="key" type="quantitative" />
+</datasource-dependencies>`;
+
+describe('undeclared-encoding-column-instance rule', () => {
+  it('errors on an undeclared canonical encoding reference', () => {
+    const issues = undeclaredEncodingColumnInstanceRule.validate(
+      worksheetWith('<color column="[Orders].[sum:Profit:qk]" />', ORDERS_DEPENDENCIES),
+    );
+
+    expect(issues).toHaveLength(1);
+    expect(issues[0]).toMatchObject({
+      ruleId: 'undeclared-encoding-column-instance',
+      severity: 'error',
+    });
+    expect(issues[0].message).toContain('[Orders].[sum:Profit:qk]');
+  });
+
+  it('stays silent when the owning datasource declares the instance', () => {
+    expect(
+      undeclaredEncodingColumnInstanceRule.validate(
+        worksheetWith('<color column="[Orders].[sum:Sales:qk]" />', ORDERS_DEPENDENCIES),
+      ),
+    ).toHaveLength(0);
+  });
+
+  it('does not accept a declaration owned by another datasource', () => {
+    const otherDependencies = ORDERS_DEPENDENCIES.replace(
+      'datasource="Orders"',
+      'datasource="Returns"',
+    );
+
+    expect(
+      undeclaredEncodingColumnInstanceRule.validate(
+        worksheetWith('<color column="[Orders].[sum:Sales:qk]" />', otherDependencies),
+      ),
+    ).toHaveLength(1);
+  });
+
+  it('ignores undeclared shelf references', () => {
+    const shelfOnlyXml = worksheetWith('', ORDERS_DEPENDENCIES).replace(
+      '[Orders].[sum:Sales:qk]</rows>',
+      '[Orders].[sum:Profit:qk]</rows>',
+    );
+
+    expect(undeclaredEncodingColumnInstanceRule.validate(shelfOnlyXml)).toHaveLength(0);
+  });
+
+  it('dedupes repeated undeclared encoding references', () => {
+    const issues = undeclaredEncodingColumnInstanceRule.validate(
+      worksheetWith(
+        '<color column="[Orders].[sum:Profit:qk]" /><tooltip column="[Orders].[sum:Profit:qk]" />',
+        ORDERS_DEPENDENCIES,
+      ),
+    );
+
+    expect(issues).toHaveLength(1);
+  });
+
+  it('blocks worksheet preflight through the registry', () => {
+    const result = runValidation(
+      worksheetWith('<color column="[Orders].[sum:Profit:qk]" />', ORDERS_DEPENDENCIES),
+      'worksheet',
+    );
+
+    expect(result.valid).toBe(false);
+    expect(
+      result.issues.some((issue) => issue.ruleId === 'undeclared-encoding-column-instance'),
+    ).toBe(true);
+  });
+});

--- a/src/desktop/validation/rules/undeclaredEncodingColumnInstance.ts
+++ b/src/desktop/validation/rules/undeclaredEncodingColumnInstance.ts
@@ -1,0 +1,72 @@
+/**
+ * Validation rule: undeclared-encoding-column-instance
+ *
+ * Tableau can silently drop a Marks-card encoding whose canonical column reference
+ * has no matching column-instance declaration in its datasource-dependencies block.
+ * Shelves are intentionally excluded because Desktop can derive some shelf instances.
+ */
+import { parseCanonicalColumnRef } from '../../metadata/field-resolver.js';
+import type { ValidationIssue, ValidationRule } from '../types.js';
+
+const DEPENDENCIES = /<datasource-dependencies\b([^>]*)>([\s\S]*?)<\/datasource-dependencies\s*>/gi;
+const ENCODINGS = /<encodings\b[^>]*>([\s\S]*?)<\/encodings\s*>/gi;
+const COLUMN_TAG = /<[A-Za-z][^>]*\bcolumn\s*=\s*(?:'([^']*)'|"([^"]*)")[^>]*>/gi;
+const COLUMN_INSTANCE_TAG = /<column-instance\b[^>]*>/gi;
+
+function attribute(tag: string, name: string): string {
+  const match = new RegExp(`\\b${name}\\s*=\\s*(?:'([^']*)'|"([^"]*)")`, 'i').exec(tag);
+  return match ? (match[1] ?? match[2] ?? '') : '';
+}
+
+function declarationKey(datasource: string, instance: string): string {
+  return `${datasource.toLowerCase()}::${instance.toLowerCase()}`;
+}
+
+export const undeclaredEncodingColumnInstanceRule: ValidationRule = {
+  id: 'undeclared-encoding-column-instance',
+  description:
+    'Errors when a canonical Marks-card encoding reference has no matching column-instance declaration in its datasource.',
+  contexts: ['workbook', 'worksheet'],
+
+  validate(xml: string): ValidationIssue[] {
+    const source = String(xml ?? '');
+    const declared = new Set<string>();
+
+    for (const dependencies of source.matchAll(DEPENDENCIES)) {
+      const datasource = attribute(dependencies[1], 'datasource');
+      if (!datasource) continue;
+      for (const instanceTag of dependencies[2].matchAll(COLUMN_INSTANCE_TAG)) {
+        const name = attribute(instanceTag[0], 'name');
+        if (name) declared.add(declarationKey(datasource, name));
+      }
+    }
+
+    const issues: ValidationIssue[] = [];
+    const issued = new Set<string>();
+    for (const encodings of source.matchAll(ENCODINGS)) {
+      for (const encoding of encodings[1].matchAll(COLUMN_TAG)) {
+        const columnRef = encoding[1] ?? encoding[2] ?? '';
+        const parsed = parseCanonicalColumnRef(columnRef);
+        if (!parsed) continue;
+
+        const key = declarationKey(parsed.datasource, parsed.columnInstanceName);
+        if (declared.has(key) || issued.has(key)) continue;
+        issued.add(key);
+        issues.push({
+          ruleId: 'undeclared-encoding-column-instance',
+          severity: 'error',
+          message:
+            `Encoding reference ${columnRef} has no matching ` +
+            `<column-instance name="${parsed.columnInstanceName}"> in datasource-dependencies ` +
+            `for "${parsed.datasource}"; Desktop may silently drop the encoding.`,
+          xpath: `//encodings/*[@column='${columnRef}']`,
+          suggestion:
+            `Declare ${parsed.columnInstanceName} in the "${parsed.datasource}" ` +
+            'datasource-dependencies block before applying the worksheet.',
+        });
+      }
+    }
+
+    return issues;
+  },
+};


### PR DESCRIPTION
Second work PR of the v12 train. Approving this makes the template bind path emit the same datasource-dependencies declarations add-field emits — add-only, never rewriting an existing declaration — and adds a preflight rule that blocks undeclared encoding refs at apply time.

## The defect (B1, root-caused live 2026-07-27)
Encodings bound via optional manifest slots shipped without `<column>`/`<column-instance>` declarations; Desktop silently dropped the color encoding on worldcup-shaped datasources. Superstore never reproduced it, so the regression tests are worldcup-shaped by design. Evidence: work-os vault `receipts/b1-evidence-2026-07-27/`.

## Review
Opus review folded: the CRITICAL (repair could rewrite a declared `[sum:]` calc ref to `[usr:]` — wrong math — and duplicate declarations) is fixed with a pinning test; the useless containment gate is deleted (repair is unconditional, idempotent); vacuous assertion groups removed.

## Follow-up on the train (deliberate, not forgotten)
The root-cause data fix — three template XMLs missing declarations for `{{field_base_N}}` refs — is deferred to its own small PR after this and #663 merge: those templates' byte-mirrors and stamped hashes collide with #663's files. Done-signature: the three templates declare the instances, `applyCopyMirror` and content-manifest hashes regenerated, and the runtime repair becomes a no-op for them.

No version bump here: open train PRs would collide on the version line; the train stamps at assembly (v11 precedent).

## Validation (firsthand)
lint green; full vitest green (371 files, 6324 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)