### PR TITLE
fix(desktop): allow published-datasource (sqlproxy) connections through preflight

### DIFF
--- a/src/desktop/validation/rules/connectionsNotAuthorable.test.ts
+++ b/src/desktop/validation/rules/connectionsNotAuthorable.test.ts
@@ -50,6 +50,34 @@ describe('connections-not-authorable rule', () => {
     expect(offenders).toEqual([]);
   });
 
+  it('deliberately permits a hand-authored bare sqlproxy connection with suspicious attributes', () => {
+    // Desktop accepted this live (PR #101, 2026-06-22; see nawar-sqlproxy-report);
+    // preflight is not the acceptance gate.
+    const xml = `<?xml version="1.0"?>
+<workbook>
+  <datasources>
+    <datasource name="my-data">
+      <connection class="sqlproxy" dbname="guess" server="" />
+    </datasource>
+  </datasources>
+</workbook>`;
+    expect(connectionsNotAuthorableRule.validate(xml)).toEqual([]);
+  });
+
+  it('a top-level connection with no class attribute is rejected', () => {
+    const xml = `<?xml version="1.0"?>
+<workbook>
+  <datasources>
+    <datasource name="my-data">
+      <connection />
+    </datasource>
+  </datasources>
+</workbook>`;
+    const issues = connectionsNotAuthorableRule.validate(xml);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].xpath).toContain("@class='(none)'");
+  });
+
   it('a federated wrapper with a fabricated (non-Desktop-minted) named-connection id is rejected', () => {
     const xml = `<?xml version="1.0"?>
 <workbook>

--- a/src/desktop/validation/rules/connectionsNotAuthorable.test.ts
+++ b/src/desktop/validation/rules/connectionsNotAuthorable.test.ts
@@ -35,6 +35,21 @@ describe('connections-not-authorable rule', () => {
     expect(issues[0].message).not.toMatch(/^FIX/i);
   });
 
+  it('a published-datasource readback with a bare top-level sqlproxy connection passes', () => {
+    const xml = `<?xml version="1.0"?>
+<workbook>
+  <datasources>
+    <datasource caption="My Published DS" inline="true" name="federated.mypubds01">
+      <connection class="sqlproxy" dbname="MyDatasourceContentUrl"
+        server="https://10az.online.tableau.com/" site="mysitename" />
+    </datasource>
+  </datasources>
+</workbook>`;
+    const result = runValidation(xml, 'workbook');
+    const offenders = result.issues.filter((i) => i.ruleId === 'connections-not-authorable');
+    expect(offenders).toEqual([]);
+  });
+
   it('a federated wrapper with a fabricated (non-Desktop-minted) named-connection id is rejected', () => {
     const xml = `<?xml version="1.0"?>
 <workbook>

--- a/src/desktop/validation/rules/connectionsNotAuthorable.ts
+++ b/src/desktop/validation/rules/connectionsNotAuthorable.ts
@@ -66,8 +66,8 @@ export const connectionsNotAuthorableRule: ValidationRule = {
   id: 'connections-not-authorable',
   description:
     'Rejects hand-authored or structurally invalid <connection> XML with a terminal, ' +
-    'non-retryable error — only the exact shape Desktop itself serializes on a live ' +
-    'readback (federated + named-connection with a Desktop-minted id) ever applies.',
+    "non-retryable error — only Desktop's top-level readback allowlist (federated + " +
+    'sqlproxy) applies; named-connection ids must still be Desktop-minted.',
   contexts: ['workbook', 'datasource'],
 
   validate(xml: string): ValidationIssue[] {

--- a/src/desktop/validation/rules/connectionsNotAuthorable.ts
+++ b/src/desktop/validation/rules/connectionsNotAuthorable.ts
@@ -6,9 +6,9 @@
  * (~/.claude/state/w60-southard-containment-spec.md §3 layer 3, task card #2).
  *
  * WHY: Tableau Desktop only accepts the connection SHAPE it serializes itself on a
- * live readback — a modern datasource is `<connection class="federated">` wrapping
- * `<named-connections><named-connection name="<protocol>.<Desktop-minted-id>">` around
- * the real per-protocol `<connection class="excel-direct"|"hyper"|...>`. A model that
+ * live readback. The allowlist for a top-level `<connection>` is `federated` and
+ * `sqlproxy`: modern local datasources use a federated wrapper, while published
+ * datasources read back as a bare `<connection class="sqlproxy">`. A model that
  * hand-authors (or copies from a .tds) a bare `<connection class="excel-direct" .../>`
  * directly under `<datasource>` — or fabricates a `named-connection` name instead of
  * using Desktop's own minted id — produces XML that LOOKS plausible but fails at
@@ -86,11 +86,11 @@ export const connectionsNotAuthorableRule: ValidationRule = {
     // are authorable connection stanzas. Worksheet <view> datasource references and
     // datasource-dependencies are usage metadata, not connection rewrites.
     //
-    // 1. A bare/legacy top-level connection that is NOT the modern federated wrapper —
+    // 1. A top-level connection outside Desktop's federated/sqlproxy readback allowlist —
     // exactly the hand-authored-from-.tds shape (known-bad).
     const bareConnections = xpath.select(
-      "/workbook/datasources/datasource/connection[not(@class='federated')] | " +
-        "/datasource/connection[not(@class='federated')]",
+      "/workbook/datasources/datasource/connection[not(@class='federated' or @class='sqlproxy')] | " +
+        "/datasource/connection[not(@class='federated' or @class='sqlproxy')]",
       doc as unknown as Node,
     ) as Element[];
     for (const conn of bareConnections) {


### PR DESCRIPTION
## The decision

The `connections-not-authorable` preflight rule now allowlists `sqlproxy` alongside `federated` for top-level connections. This is a rule we keep: published datasources read back from Desktop as a bare `<connection class='sqlproxy'>`, and the rule was rejecting that unchanged readback on every save path — the exact case its own header promises to leave alone. This blocked a real user (Nawar) on every save against a Pulse/published datasource.

Approving this means accepting that preflight no longer distinguishes a hand-authored sqlproxy from a readback. That is deliberate: Desktop itself accepted a hand-authored bare sqlproxy live (PR #101, 2026-06-22), and preflight is not the acceptance gate. A test pins that decision so it is not silently re-tightened later.

## What changed

- `connectionsNotAuthorable.ts`: top-level branch rejects `not(federated or sqlproxy)` instead of `not(federated)`. Named-connections branch untouched. Description string updated to match.
- Tests: published-DS readback passes; hand-authored sqlproxy passes (decision-pinning); classless connection still rejects (pins XPath missing-attribute semantics); all existing rejections (excel-direct etc.) unchanged. 61/61 green.

## What this does not do

Desktop's live acceptance of an applied sqlproxy workbook is still unproven — the rule fired before the POST, so nothing has ever tested it. Follow-up: live probe against a published datasource (an `author-calc` call posts the whole workbook with no preflight, so the probe needs no special build), then replace the doc-derived test fixture with the live-captured stanza. The rule's other known false positive (short ingest-minted textscan ids) is out of scope here.

Opus-reviewed pre-push: no blockers; monotonic change (can only convert rejections into passes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)