### PR TITLE
@W-23574817: Derive stable OAuth device_id per client to avoid duplicate device registrations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "3.6.1",
+  "version": "3.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "3.6.1",
+      "version": "3.6.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.7.2",
@@ -21,6 +21,7 @@
         "jose": "^6.0.12",
         "ssrfcheck": "^1.2.0",
         "ts-results-es": "^7.1.0",
+        "uuid": "^14.0.1",
         "xpath": "^0.0.34",
         "zod": "^3.24.3",
         "zod-validation-error": "^4.0.1"
@@ -8539,6 +8540,19 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
+      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/validate-npm-package-license": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "3.6.1",
+  "version": "3.6.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"
@@ -74,6 +74,7 @@
     "jose": "^6.0.12",
     "ssrfcheck": "^1.2.0",
     "ts-results-es": "^7.1.0",
+    "uuid": "^14.0.1",
     "xpath": "^0.0.34",
     "zod": "^3.24.3",
     "zod-validation-error": "^4.0.1"

--- a/src/server/oauth/authorize.ts
+++ b/src/server/oauth/authorize.ts
@@ -13,6 +13,7 @@ import { parseUrl } from '../../utils/parseUrl.js';
 import { retry } from '../../utils/retry.js';
 import { setLongTimeout } from '../../utils/setLongTimeout.js';
 import { clientMetadataCache } from './clientMetadataCache.js';
+import { getDeviceId, getDeviceName } from './device.js';
 import { getDnsResolver } from './dnsResolver.js';
 import { generateCodeChallenge } from './generateCodeChallenge.js';
 import { isValidRedirectUri } from './isValidRedirectUri.js';
@@ -167,9 +168,10 @@ export function authorize(
     oauthUrl.searchParams.set('response_type', 'code');
     oauthUrl.searchParams.set('redirect_uri', config.oauth.redirectUri);
     oauthUrl.searchParams.set('state', `${authKey}:${tableauState}`);
-    oauthUrl.searchParams.set('device_id', randomUUID());
+    const deviceName = getDeviceName(redirect_uri, state ?? '', clientName);
+    oauthUrl.searchParams.set('device_id', getDeviceId(deviceName));
     oauthUrl.searchParams.set('target_site', config.siteName);
-    oauthUrl.searchParams.set('device_name', getDeviceName(redirect_uri, state ?? '', clientName));
+    oauthUrl.searchParams.set('device_name', deviceName);
     oauthUrl.searchParams.set('client_type', 'tableau-mcp');
 
     if (config.oauth.lockSite) {
@@ -380,32 +382,3 @@ async function getClientFromMetadataDoc(
 
   return Ok(clientMetadataResult.data);
 }
-
-function getDeviceName(redirectUri: string, state: string, clientName: string | undefined): string {
-  if (clientName) {
-    return `tableau-mcp (${clientName})`;
-  }
-
-  const defaultDeviceName = 'tableau-mcp (Unknown agent)';
-
-  try {
-    const url = new URL(redirectUri);
-    if (url.protocol === 'https:' || url.protocol === 'http:') {
-      if (redirectUri === 'https://vscode.dev/redirect' && new URL(state).protocol === 'vscode:') {
-        // VS Code normally authenticates in a way that doesn't give any clues about who it is.
-        // It has a backup authentication method they call "URL Handler" that does though.
-        return 'tableau-mcp (VS Code)';
-      }
-
-      return defaultDeviceName;
-    } else if (url.protocol === 'cursor:') {
-      return 'tableau-mcp (Cursor)';
-    } else {
-      return `tableau-mcp (${url.protocol.slice(0, -1)})`;
-    }
-  } catch {
-    return defaultDeviceName;
-  }
-}
-
-export const exportedForTesting = { getDeviceName };

--- a/src/server/oauth/device.ts
+++ b/src/server/oauth/device.ts
@@ -1,0 +1,50 @@
+import { v5 as uuidv5 } from 'uuid';
+
+// Fixed namespace UUID for tableau-mcp device IDs. Combined with the device name via UUIDv5,
+// this yields a stable device_id per client type so repeat authorizations from the same client
+// reuse a single device entry in Tableau instead of registering a new device on every re-auth.
+const DEVICE_ID_NAMESPACE = 'e3b4f2a0-6c1d-4f8e-9a2b-7d5c1e0f3a6b';
+
+/**
+ * Derives a deterministic device ID from the device name using RFC 4122 v5 (namespace + name).
+ * Same device name always maps to the same UUID, making the device_id stable per client type
+ * without any server-side state (safe across restarts and horizontally scaled instances).
+ */
+export function getDeviceId(deviceName: string): string {
+  return uuidv5(deviceName, DEVICE_ID_NAMESPACE);
+}
+
+/**
+ * Derives a human-readable device name for the Tableau OAuth `device_name` param, identifying
+ * the MCP client (e.g. VS Code, Cursor) from the client metadata name or the redirect URI.
+ */
+export function getDeviceName(
+  redirectUri: string,
+  state: string,
+  clientName: string | undefined,
+): string {
+  if (clientName) {
+    return `tableau-mcp (${clientName})`;
+  }
+
+  const defaultDeviceName = 'tableau-mcp (Unknown agent)';
+
+  try {
+    const url = new URL(redirectUri);
+    if (url.protocol === 'https:' || url.protocol === 'http:') {
+      if (redirectUri === 'https://vscode.dev/redirect' && new URL(state).protocol === 'vscode:') {
+        // VS Code normally authenticates in a way that doesn't give any clues about who it is.
+        // It has a backup authentication method they call "URL Handler" that does though.
+        return 'tableau-mcp (VS Code)';
+      }
+
+      return defaultDeviceName;
+    } else if (url.protocol === 'cursor:') {
+      return 'tableau-mcp (Cursor)';
+    } else {
+      return `tableau-mcp (${url.protocol.slice(0, -1)})`;
+    }
+  } catch {
+    return defaultDeviceName;
+  }
+}

--- a/tests/oauth/embedded-authz/authorizationCodeFlow.test.ts
+++ b/tests/oauth/embedded-authz/authorizationCodeFlow.test.ts
@@ -66,7 +66,9 @@ describe('authorization code flow', () => {
     expect(location.searchParams.get('redirect_uri')).toBe('http://127.0.0.1:3927/Callback');
     expect(location.searchParams.get('state')).not.toBeNull();
     expect(location.searchParams.get('state')).toContain(':');
-    expect(location.searchParams.get('device_id')).not.toBeNull();
+    expect(location.searchParams.get('device_id')).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-5[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+    );
     expect(location.searchParams.get('target_site')).toBe('mcp-test');
     expect(location.searchParams.get('device_name')).toBe('tableau-mcp (Unknown agent)');
     expect(location.searchParams.get('client_type')).toBe('tableau-mcp');

--- a/tests/oauth/embedded-authz/getDeviceId.test.ts
+++ b/tests/oauth/embedded-authz/getDeviceId.test.ts
@@ -1,0 +1,26 @@
+import { getDeviceId, getDeviceName } from '../../../src/server/oauth/device.js';
+
+// RFC 4122 v5 UUID: 8-4-4-4-12 hex, version nibble 5, variant nibble 8/9/a/b.
+const UUID_V5_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-5[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+describe('getDeviceId', () => {
+  it('should produce a valid RFC 4122 v5 UUID', () => {
+    expect(getDeviceId('tableau-mcp (VS Code)')).toMatch(UUID_V5_REGEX);
+  });
+
+  it('should be deterministic for the same device name', () => {
+    expect(getDeviceId('tableau-mcp (Cursor)')).toBe(getDeviceId('tableau-mcp (Cursor)'));
+  });
+
+  it('should produce different IDs for different device names', () => {
+    expect(getDeviceId('tableau-mcp (VS Code)')).not.toBe(getDeviceId('tableau-mcp (Cursor)'));
+  });
+
+  it('should be stable across authorizations from the same client type regardless of ephemeral port', () => {
+    // Loopback clients use ephemeral ports in the redirect URI, but the derived device name
+    // is port-independent, so the device_id must remain stable across sessions.
+    const first = getDeviceId(getDeviceName('http://127.0.0.1:33418/', '', 'Visual Studio Code'));
+    const second = getDeviceId(getDeviceName('http://127.0.0.1:51027/', '', 'Visual Studio Code'));
+    expect(first).toBe(second);
+  });
+});

--- a/tests/oauth/embedded-authz/getDeviceName.test.ts
+++ b/tests/oauth/embedded-authz/getDeviceName.test.ts
@@ -1,6 +1,4 @@
-import { exportedForTesting } from '../../../src/server/oauth/authorize.js';
-
-const { getDeviceName } = exportedForTesting;
+import { getDeviceName } from '../../../src/server/oauth/device.js';
 
 describe('getDeviceName', () => {
   it('should use client_name from CIMD when provided', () => {


### PR DESCRIPTION
## Description

- Add `getDeviceId(deviceName)` in a new `src/server/oauth/device.ts` module that derives a deterministic RFC 4122 v5 UUID (namespace + device name) for the Tableau OAuth `device_id` param.
- Replace the previous `randomUUID()` call in `authorize.ts` so the same client type always maps to the same `device_id`.
- Move `getDeviceName` out of `authorize.ts` into the new `device.ts` module (single home for device-derivation logic); update imports/tests accordingly and drop the `exportedForTesting` shim.

## Motivation and Context

Embedded authz previously generated a brand-new random `device_id` on every authorization request. Because Tableau keys device registrations on `device_id`, each re-auth from the same client (e.g. VS Code, Cursor) registered a **new device**, cluttering the user's device list and defeating the purpose of a stable device identity.

Deriving `device_id` deterministically from the (already stable, port-independent) device name via UUIDv5 means repeat authorizations from the same client type reuse a single device entry — with no server-side state, so it's safe across restarts and horizontally scaled instances.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## How Has This Been Tested?

- New `tests/oauth/embedded-authz/getDeviceId.test.ts`: verifies the output is a valid v5 UUID, is deterministic for the same device name, differs across device names, and is stable across sessions despite ephemeral loopback ports.
- Updated `authorizationCodeFlow.test.ts` to assert `device_id` matches the v5 UUID shape.
- Updated `getDeviceName.test.ts` to import from the new `device.ts` module.

## Related Issues

W-23574817

## Checklist

- [x] I have updated the version in the package.json file (3.6.1 → 3.6.2).
- [ ] I have made any necessary changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have documented any breaking changes in the PR description. (None — the `device_id` is derived server-side; no config or API surface changes.)