### PR TITLE
fix(desktop): compose-dashboard verifies through workbook XML and dashboard tools stop navigating to missing windows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "2.60.2",
+  "version": "2.62.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "2.60.2",
+      "version": "2.62.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.7.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "2.60.2",
+  "version": "2.62.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/resources/desktop/knowledge/tactics/workflow/failure-recovery-honesty.md
+++ b/resources/desktop/knowledge/tactics/workflow/failure-recovery-honesty.md
@@ -7,7 +7,7 @@ These two rules cover the moments an agent is most tempted to report the wrong t
 ## When to Use
 
 - **A field or datasource lookup returns `not_found`** (from `resolve-field`, `list-available-fields`, or a field tool), *especially* right after the user changed the workbook — connected a new data source, renamed a field, swapped an extract, or added a sheet in Tableau.
-- **You are about to report a change is finished** after any apply-style call (`apply-worksheet`, `apply-workbook`, `apply-dashboard`, `apply-dashboard-with-viewpoints`, `build-and-apply-dashboard`, `dashboard-auto-apply`). Read the `HOST VERIFICATION` line *before* you narrate success.
+- **You are about to report a change is finished** after any apply-style call (`apply-worksheet`, `apply-workbook`, `apply-dashboard`, `apply-dashboard-with-viewpoints`, `build-and-apply-dashboard`, `dashboard-auto-apply`, `compose-dashboard`). Read the `HOST VERIFICATION` line *before* you narrate success.
 
 ## Best Practices
 
@@ -30,7 +30,7 @@ HOST VERIFICATION — <status>: <checks> . <claim guard>
 ```
 
 - `status` is one of **`verified`**, **`unverified`**, **`failed`**. **`verified` is the only status that backs a "done" claim.**
-- Worksheet applies get a real structural readback, so they can reach `verified`. **Whole-workbook and dashboard applies are `unverified` by construction** — there is no structural readback for them yet, so the receipt says so plainly.
+- Worksheet applies get a real structural readback, so they can reach `verified`. `compose-dashboard` can also reach `verified` when workbook-XML readback matches both its dashboard zone tree and all requested dashboard-window viewpoints (viewpoint order does not matter). Whole-workbook applies remain `unverified` by construction, and other dashboard paths remain unverified unless they perform equivalent structural readback.
 - If the receipt says `unverified` or `failed` for something you claimed — a sort, a filter, an encoding, or the change as a whole — **re-read the artifact and correct your answer before reporting completion**: `get-worksheet-xml` for a sheet, `get-dashboard-xml` for a dashboard, `get-workbook-xml` for the whole workbook (or worksheet-list readback / `check-for-user-changes` to confirm survival).
 - Never report success that contradicts the receipt. Report only the evidence the host gives you.
 
@@ -41,7 +41,7 @@ What does **NOT** work:
 - **Declaring "Tableau is unreachable" or "that datasource is gone" on the first `not_found`** without a session refresh. The far more common cause is a stale cache from before the user's change.
 - **Re-reading the same stale cache repeatedly** — calling `resolve-field` again against an un-refreshed `workbookFile` and expecting a different answer. `resolve-field` reads the file as-is; nothing changes until you refresh the file.
 - **Narrating success over a failed/unverified receipt** — e.g. answering "Done — sorted descending and filtered to Top 10" when the line reads `HOST VERIFICATION — failed: … readback FAILED (nodes dropped).` The nodes were dropped; the claim is false.
-- **Treating a whole-workbook or dashboard `unverified` receipt as confirmation.** `unverified` means "not re-verified," not "verified." Read the sheet back before claiming the intent landed.
+- **Treating a whole-workbook or dashboard `unverified` receipt as confirmation.** `unverified` means "not re-verified," not "verified." A `compose-dashboard` receipt is verified only after workbook XML confirms its zone tree and dashboard-window viewpoints.
 - **Inventing problems that nothing measured** when the receipt is `verified` — the guard text explicitly says not to report unlisted issues.
 
 ## Implementation
@@ -82,14 +82,14 @@ apply-worksheet({ ... }) →
 3. apply-worksheet(...) → HOST VERIFICATION — verified: … readback clean.       # only NOW report "done"
 ```
 
-For a whole-workbook or dashboard apply, the receipt is `unverified` by design:
+For a whole-workbook apply, or a dashboard path without structural readback, the receipt is `unverified` by design:
 
 ```
 HOST VERIFICATION — unverified: preflight clean · apply completed · full workbook intent NOT re-verified.
 Treat sheet-level state as unconfirmed until read back; do not report problems without host evidence.
 ```
 
-Read the affected sheets back (`get-worksheet-xml` / worksheet-list readback) before claiming the intent landed; report the apply as completed-but-unverified until you have that evidence.
+Read the affected artifact back before claiming the intent landed; report the apply as completed-but-unverified until you have that evidence. `compose-dashboard` does this itself and emits `verified` only when workbook XML confirms both the zone tree and all requested window viewpoints.
 
 ## Source and Confidence
 

--- a/src/desktop/commands/workbook/applyFocusDispositions.test.ts
+++ b/src/desktop/commands/workbook/applyFocusDispositions.test.ts
@@ -34,6 +34,10 @@ const DISPOSITIONS: Readonly<Record<string, readonly string[]>> = {
     'loadDashboardXml:artifact',
     'loadWorkbookXml:artifact',
   ],
+  'src/tools/desktop/dashboard/composeDashboard.ts': [
+    'loadDashboardXml:artifact',
+    'loadWorkbookXml:artifact',
+  ],
   'src/tools/desktop/dashboard/dashboardAutoApply.ts': [
     'loadWorkbookXml:artifact',
     'loadDashboardXml:artifact',

--- a/src/desktop/commands/workbook/applyFocusDispositions.test.ts
+++ b/src/desktop/commands/workbook/applyFocusDispositions.test.ts
@@ -27,11 +27,11 @@ const DISPOSITIONS: Readonly<Record<string, readonly string[]>> = {
   'src/tools/desktop/coordination/batchCreateAndCacheSheets.ts': ['loadWorkbookXml:restore'],
   'src/tools/desktop/dashboard/applyDashboard.ts': ['loadDashboardXml:artifact'],
   'src/tools/desktop/dashboard/applyDashboardWithViewpoints.ts': [
-    'loadDashboardXml:artifact',
+    'loadDashboardXml:none',
     'loadWorkbookXml:artifact',
   ],
   'src/tools/desktop/dashboard/buildAndApplyDashboard.ts': [
-    'loadDashboardXml:artifact',
+    'loadDashboardXml:none',
     'loadWorkbookXml:artifact',
   ],
   'src/tools/desktop/dashboard/composeDashboard.ts': [

--- a/src/desktop/commands/workbook/applyFocusDispositions.test.ts
+++ b/src/desktop/commands/workbook/applyFocusDispositions.test.ts
@@ -35,7 +35,7 @@ const DISPOSITIONS: Readonly<Record<string, readonly string[]>> = {
     'loadWorkbookXml:artifact',
   ],
   'src/tools/desktop/dashboard/composeDashboard.ts': [
-    'loadDashboardXml:artifact',
+    'loadDashboardXml:none',
     'loadWorkbookXml:artifact',
   ],
   'src/tools/desktop/dashboard/dashboardAutoApply.ts': [

--- a/src/desktop/commands/workbook/injectViewpoints.test.ts
+++ b/src/desktop/commands/workbook/injectViewpoints.test.ts
@@ -33,7 +33,7 @@ describe('injectViewpoints', () => {
     const dashboardWindow = document.getElementsByTagName('window').item(0);
 
     expect(new XMLSerializer().serializeToString(dashboardWindow!)).toBe(
-      '<window class="dashboard" name="Sales &amp; Profit"><active id="-1"/><viewpoints><viewpoint name="Sales"/><viewpoint name="Profit"/></viewpoints></window>',
+      '<window class="dashboard" name="Sales &amp; Profit"><viewpoints><viewpoint name="Sales"/><viewpoint name="Profit"/></viewpoints><active id="-1"/></window>',
     );
     expect(dashboardWindow?.getElementsByTagName('zoom')).toHaveLength(0);
   });

--- a/src/desktop/commands/workbook/injectViewpoints.test.ts
+++ b/src/desktop/commands/workbook/injectViewpoints.test.ts
@@ -1,0 +1,40 @@
+import { DOMParser, XMLSerializer } from '@xmldom/xmldom';
+
+import { injectViewpoints } from './injectViewpoints.js';
+
+describe('injectViewpoints', () => {
+  it('creates the live-proven dashboard window when it is absent', () => {
+    const result = injectViewpoints(
+      '<workbook><windows><window class="worksheet" name="Points by Team"/></windows></workbook>',
+      'World Cup Probe Dashboard',
+      ['Points by Team', 'Goals by Country', 'Matches by Stage', 'Attendance by Venue'],
+    );
+    const document = new DOMParser().parseFromString(result, 'text/xml');
+    const windows = document.getElementsByTagName('windows').item(0);
+    const dashboardWindow = Array.from(document.getElementsByTagName('window')).find(
+      (window) => window.getAttribute('class') === 'dashboard',
+    );
+
+    expect(dashboardWindow?.parentNode).toBe(windows);
+    expect(new XMLSerializer().serializeToString(dashboardWindow!)).toBe(
+      '<window class="dashboard" name="World Cup Probe Dashboard"><viewpoints><viewpoint name="Points by Team"/><viewpoint name="Goals by Country"/><viewpoint name="Matches by Stage"/><viewpoint name="Attendance by Venue"/></viewpoints><active id="-1"/></window>',
+    );
+    expect(dashboardWindow?.getElementsByTagName('simple-id')).toHaveLength(0);
+    expect(dashboardWindow?.getElementsByTagName('zoom')).toHaveLength(0);
+  });
+
+  it('matches normalized XML names and replaces existing viewpoints with bare leaves', () => {
+    const result = injectViewpoints(
+      '<workbook><windows><window class="dashboard" name="Sales &amp; Profit"><viewpoints><viewpoint name="Old"><zoom type="entire-view"/></viewpoint></viewpoints><active id="-1"/></window></windows></workbook>',
+      ' Sales & Profit ',
+      ['Sales', 'Profit'],
+    );
+    const document = new DOMParser().parseFromString(result, 'text/xml');
+    const dashboardWindow = document.getElementsByTagName('window').item(0);
+
+    expect(new XMLSerializer().serializeToString(dashboardWindow!)).toBe(
+      '<window class="dashboard" name="Sales &amp; Profit"><active id="-1"/><viewpoints><viewpoint name="Sales"/><viewpoint name="Profit"/></viewpoints></window>',
+    );
+    expect(dashboardWindow?.getElementsByTagName('zoom')).toHaveLength(0);
+  });
+});

--- a/src/desktop/commands/workbook/injectViewpoints.ts
+++ b/src/desktop/commands/workbook/injectViewpoints.ts
@@ -1,12 +1,11 @@
 import { DOMParser, Element as XmlElement, XMLSerializer } from '@xmldom/xmldom';
 
+import { xmlNamesEqual } from '../../xmlElement.js';
+
 /**
  * Injects viewpoint elements into the dashboard window inside workbook XML.
  * A viewpoint tells Tableau Desktop which worksheets are visible through
  * the dashboard window. Without viewpoints the window renders blank.
- *
- * Returns the modified workbook XML string, or the original if the target
- * window is not found (non-fatal — Tableau will still receive the apply).
  */
 export function injectViewpoints(
   workbookXml: string,
@@ -23,14 +22,35 @@ export function injectViewpoints(
   let dashboardWindow: XmlElement | null = null;
   for (let i = 0; i < windows.length; i++) {
     const w = windows.item(i);
-    if (w && w.getAttribute('class') === 'dashboard' && w.getAttribute('name') === dashboardName) {
+    if (
+      w &&
+      w.getAttribute('class') === 'dashboard' &&
+      xmlNamesEqual(w.getAttribute('name') ?? '', dashboardName)
+    ) {
       dashboardWindow = w;
       break;
     }
   }
 
   if (!dashboardWindow) {
-    return workbookXml;
+    let windowsElement = doc.getElementsByTagName('windows').item(0);
+    if (!windowsElement) {
+      const workbookElement = doc.documentElement;
+      if (!workbookElement) return workbookXml;
+      windowsElement = doc.createElement('windows');
+      workbookElement.appendChild(windowsElement);
+    }
+
+    dashboardWindow = doc.createElement('window');
+    dashboardWindow.setAttribute('class', 'dashboard');
+    dashboardWindow.setAttribute('name', dashboardName);
+    dashboardWindow.appendChild(buildViewpoints(doc, worksheetNames));
+    const active = doc.createElement('active');
+    active.setAttribute('id', '-1');
+    dashboardWindow.appendChild(active);
+    windowsElement.appendChild(dashboardWindow);
+
+    return new XMLSerializer().serializeToString(doc);
   }
 
   // Remove any existing <viewpoints> child
@@ -42,17 +62,20 @@ export function injectViewpoints(
     }
   }
 
-  // Build new <viewpoints> element
+  dashboardWindow.appendChild(buildViewpoints(doc, worksheetNames));
+
+  return new XMLSerializer().serializeToString(doc);
+}
+
+function buildViewpoints(
+  doc: ReturnType<DOMParser['parseFromString']>,
+  worksheetNames: string[],
+): XmlElement {
   const viewpointsEl = doc.createElement('viewpoints');
   for (const name of worksheetNames) {
     const vp = doc.createElement('viewpoint');
     vp.setAttribute('name', name);
-    const zoom = doc.createElement('zoom');
-    zoom.setAttribute('type', 'entire-view');
-    vp.appendChild(zoom);
     viewpointsEl.appendChild(vp);
   }
-  dashboardWindow.appendChild(viewpointsEl);
-
-  return new XMLSerializer().serializeToString(doc);
+  return viewpointsEl;
 }

--- a/src/desktop/commands/workbook/injectViewpoints.ts
+++ b/src/desktop/commands/workbook/injectViewpoints.ts
@@ -62,7 +62,16 @@ export function injectViewpoints(
     }
   }
 
-  dashboardWindow.appendChild(buildViewpoints(doc, worksheetNames));
+  const activeElements = dashboardWindow.getElementsByTagName('active');
+  let active: XmlElement | null = null;
+  for (let i = 0; i < activeElements.length; i++) {
+    const node = activeElements.item(i);
+    if (node && node.parentNode === dashboardWindow) {
+      active = node;
+      break;
+    }
+  }
+  dashboardWindow.insertBefore(buildViewpoints(doc, worksheetNames), active);
 
   return new XMLSerializer().serializeToString(doc);
 }

--- a/src/desktop/routeTable.test.ts
+++ b/src/desktop/routeTable.test.ts
@@ -181,13 +181,14 @@ describe('DESKTOP_ROUTE_TABLE', () => {
   it('routes dashboard composition through visible dashboard tools before command search', () => {
     const dashboard = routes.find((route) => route.id === 'dashboard');
     expect(dashboard?.action).toBe(
-      'build sheets with bind-template (author calcs/params/sets first), then compose with dashboard-auto-apply (2-6 plain charts, one call) or plan-dashboard-creation -> build-and-apply-dashboard; search-commands only for commands the census does not list.',
+      'build sheets with bind-template (author calcs/params/sets first), then compose with dashboard-auto-apply (2-6 plain charts, one call) or plan-dashboard-creation -> build-and-apply-dashboard; use compose-dashboard to compose EXISTING sheets; search-commands only for commands the census does not list.',
     );
     expect(dashboard?.toolSequence).toEqual([
       'bind-template',
       'dashboard-auto-apply',
       'plan-dashboard-creation',
       'build-and-apply-dashboard',
+      'compose-dashboard',
       'search-commands',
     ]);
   });

--- a/src/desktop/routeTable.test.ts
+++ b/src/desktop/routeTable.test.ts
@@ -180,8 +180,9 @@ describe('DESKTOP_ROUTE_TABLE', () => {
 
   it('routes dashboard composition through visible dashboard tools before command search', () => {
     const dashboard = routes.find((route) => route.id === 'dashboard');
+    expect(dashboard?.trigger).toBe('a dashboard ask');
     expect(dashboard?.action).toBe(
-      'build sheets with bind-template (author calcs/params/sets first), then compose with dashboard-auto-apply (2-6 plain charts, one call) or plan-dashboard-creation -> build-and-apply-dashboard; use compose-dashboard to compose EXISTING sheets; search-commands only for commands the census does not list.',
+      'build sheets with bind-template (author calcs/params/sets first), then compose with dashboard-auto-apply (2-6 plain charts, one call) or plan-dashboard-creation -> build-and-apply-dashboard; compose-dashboard takes 2-12 EXISTING sheets; search-commands only for commands the census does not list.',
     );
     expect(dashboard?.toolSequence).toEqual([
       'bind-template',

--- a/src/desktop/routeTable.ts
+++ b/src/desktop/routeTable.ts
@@ -96,12 +96,13 @@ export const DESKTOP_ROUTE_TABLE: readonly DesktopInstructionEntry[] = [
     id: 'dashboard',
     trigger: 'a dashboard ask with 2-6 vizzes',
     action:
-      'build sheets with bind-template (author calcs/params/sets first), then compose with dashboard-auto-apply (2-6 plain charts, one call) or plan-dashboard-creation -> build-and-apply-dashboard; search-commands only for commands the census does not list.',
+      'build sheets with bind-template (author calcs/params/sets first), then compose with dashboard-auto-apply (2-6 plain charts, one call) or plan-dashboard-creation -> build-and-apply-dashboard; use compose-dashboard to compose EXISTING sheets; search-commands only for commands the census does not list.',
     toolSequence: [
       'bind-template',
       'dashboard-auto-apply',
       'plan-dashboard-creation',
       'build-and-apply-dashboard',
+      'compose-dashboard',
       'search-commands',
     ],
     stopConditions: ['search-commands only for commands the census does not list'],

--- a/src/desktop/routeTable.ts
+++ b/src/desktop/routeTable.ts
@@ -94,9 +94,9 @@ export const DESKTOP_ROUTE_TABLE: readonly DesktopInstructionEntry[] = [
   {
     kind: 'route',
     id: 'dashboard',
-    trigger: 'a dashboard ask with 2-6 vizzes',
+    trigger: 'a dashboard ask',
     action:
-      'build sheets with bind-template (author calcs/params/sets first), then compose with dashboard-auto-apply (2-6 plain charts, one call) or plan-dashboard-creation -> build-and-apply-dashboard; use compose-dashboard to compose EXISTING sheets; search-commands only for commands the census does not list.',
+      'build sheets with bind-template (author calcs/params/sets first), then compose with dashboard-auto-apply (2-6 plain charts, one call) or plan-dashboard-creation -> build-and-apply-dashboard; compose-dashboard takes 2-12 EXISTING sheets; search-commands only for commands the census does not list.',
     toolSequence: [
       'bind-template',
       'dashboard-auto-apply',

--- a/src/desktop/validation/promise-check.test.ts
+++ b/src/desktop/validation/promise-check.test.ts
@@ -142,4 +142,10 @@ describe('promise check receipt (W-23447506)', () => {
     const text = formatDashboardPromiseCheck([]);
     expect(text).toContain('full dashboard intent NOT re-verified');
   });
+
+  it('formats dashboard applies as verified after structural readback', () => {
+    const text = formatDashboardPromiseCheck([], true);
+    expect(text).toContain('HOST VERIFICATION — verified');
+    expect(text).toContain('dashboard zone tree matched structural readback');
+  });
 });

--- a/src/desktop/validation/promise-check.test.ts
+++ b/src/desktop/validation/promise-check.test.ts
@@ -146,6 +146,7 @@ describe('promise check receipt (W-23447506)', () => {
   it('formats dashboard applies as verified after structural readback', () => {
     const text = formatDashboardPromiseCheck([], true);
     expect(text).toContain('HOST VERIFICATION — verified');
-    expect(text).toContain('dashboard zone tree matched structural readback');
+    expect(text).toContain('dashboard zone tree and window viewpoints matched');
+    expect(text).toContain('beyond the findings listed above');
   });
 });

--- a/src/desktop/validation/promise-check.ts
+++ b/src/desktop/validation/promise-check.ts
@@ -114,10 +114,10 @@ export function formatDashboardPromiseCheck(
     formatPreflight(validationWarnings),
     'apply completed',
     structuralReadbackMatched
-      ? 'dashboard zone tree matched structural readback'
+      ? 'dashboard zone tree and window viewpoints matched workbook-XML readback'
       : 'full dashboard intent NOT re-verified',
   ];
   return structuralReadbackMatched
-    ? `\n\nHOST VERIFICATION — verified: ${parts.join(' · ')}. No host evidence of any dashboard problem; do not report unlisted issues.`
+    ? `\n\nHOST VERIFICATION — verified: ${parts.join(' · ')}. No host evidence of any dashboard problem beyond the findings listed above — do not report unlisted issues.`
     : `\n\nHOST VERIFICATION — unverified: ${parts.join(' · ')}. Treat dashboard state as unconfirmed until read back; do not report problems without host evidence.`;
 }

--- a/src/desktop/validation/promise-check.ts
+++ b/src/desktop/validation/promise-check.ts
@@ -6,8 +6,8 @@
  *
  * Schema-decay rule: the model fills NOTHING here. Every field derives from
  * validation issues and readback verification already computed on the apply
- * path. Dashboard/whole-workbook intent is honestly labeled unverified — only
- * worksheet readback proves structural survival.
+ * path. Whole-workbook intent remains honestly unverified; worksheet and
+ * dashboard receipts report verified only after structural readback.
  *
  * Ported from agent-to-tableau-desktop.
  */
@@ -105,12 +105,19 @@ export function formatWorkbookPromiseCheck(validationWarnings: ValidationIssue[]
   return `\n\nHOST VERIFICATION — unverified: ${parts.join(' · ')}. Treat sheet-level state as unconfirmed until read back; do not report problems without host evidence.`;
 }
 
-/** Dashboard applies likewise have no structural readback — honest by construction. */
-export function formatDashboardPromiseCheck(validationWarnings: ValidationIssue[]): string {
+/** Dashboard applies remain unverified unless the caller completed structural readback. */
+export function formatDashboardPromiseCheck(
+  validationWarnings: ValidationIssue[],
+  structuralReadbackMatched = false,
+): string {
   const parts = [
     formatPreflight(validationWarnings),
     'apply completed',
-    'full dashboard intent NOT re-verified',
+    structuralReadbackMatched
+      ? 'dashboard zone tree matched structural readback'
+      : 'full dashboard intent NOT re-verified',
   ];
-  return `\n\nHOST VERIFICATION — unverified: ${parts.join(' · ')}. Treat dashboard state as unconfirmed until read back; do not report problems without host evidence.`;
+  return structuralReadbackMatched
+    ? `\n\nHOST VERIFICATION — verified: ${parts.join(' · ')}. No host evidence of any dashboard problem; do not report unlisted issues.`
+    : `\n\nHOST VERIFICATION — unverified: ${parts.join(' · ')}. Treat dashboard state as unconfirmed until read back; do not report problems without host evidence.`;
 }

--- a/src/server.desktop.test.ts
+++ b/src/server.desktop.test.ts
@@ -145,7 +145,7 @@ For a clear derived-metric ask with no named chart type (margin %, ratio/rate/pe
 
 For an unfamiliar or non-trivial authoring ask (calc-heavy, uncertain which chart fits, formatting/design) only when no plain-chart binding path applies; a named chart type always takes plain-chart first, even with calc/formatting riders; chart-route escalation may still consult, FIRST search-knowledge; use read-knowledge-resource to read the top hit once, then proceed.
 
-For a dashboard ask with 2-6 vizzes, build sheets with bind-template (author calcs/params/sets first), then compose with dashboard-auto-apply (2-6 plain charts, one call) or plan-dashboard-creation -> build-and-apply-dashboard; search-commands only for commands the census does not list.
+For a dashboard ask with 2-6 vizzes, build sheets with bind-template (author calcs/params/sets first), then compose with dashboard-auto-apply (2-6 plain charts, one call) or plan-dashboard-creation -> build-and-apply-dashboard; use compose-dashboard to compose EXISTING sheets; search-commands only for commands the census does not list.
 
 For a data-value question, on a populated worksheet, call get-summary-data; answer only from returned rows.
 
@@ -208,10 +208,12 @@ describe('desktop tools/list serialized surface', () => {
     // Dynamic authoring is the serving surface, so this is the real budget gate.
     // The full desktop surface is not what clients see by default; its looser cap
     // only catches runaway growth without forcing valuable full-profile tools to be trimmed.
-    // Honest wire measurements are 29,463 bytes dynamic and 45,956 bytes full after adding
-    // compose-dashboard to the full profile (see the grandfathered cap comment above).
-    // Keep only a few bytes of ratchet headroom while staying well below the 46k cliff.
-    expect(dynamicAuthoringTotal).toBeLessThanOrEqual(29_479);
+    // Honest wire measurements are 30,474 bytes dynamic and 45,956 bytes full after adding
+    // compose-dashboard to the serving (dynamic-authoring) profile — 1,011 bytes for the
+    // livelock-killing compose verb, still well below the 46k cliff. The pending removal of
+    // the four legacy dashboard tools from this profile will repay far more than it costs.
+    // Keep only a few bytes of ratchet headroom.
+    expect(dynamicAuthoringTotal).toBeLessThanOrEqual(30_490);
     expect(fullSurfaceTotal).toBeLessThanOrEqual(45_978);
   });
 });
@@ -444,10 +446,10 @@ describe('selectToolsForProfile (TOOL_PROFILE, W60 spike lever 1 / preamble P1)'
     expect(selected.map((t) => t.name)).toContain('execute-tableau-command');
   });
 
-  it('TOOL_PROFILE=dynamic-authoring registers exactly the 33-tool data-first singable surface — native authoring + workbook reads + atomic sheet activation + the manual path read/edit legs, no workbook round-trip/validation XML tools', () => {
+  it('TOOL_PROFILE=dynamic-authoring registers exactly the 34-tool data-first singable surface — native authoring + workbook reads + atomic sheet activation + the manual path read/edit legs, no workbook round-trip/validation XML tools', () => {
     const selected = selectToolsForProfile(allTools(), 'dynamic-authoring');
     expect(new Set(selected.map((t) => t.name))).toEqual(DYNAMIC_AUTHORING_TOOL_PROFILE);
-    expect(selected).toHaveLength(33);
+    expect(selected).toHaveLength(34);
     // The full dynamic dialect, semantically named — every author-* verb present,
     // plus the ask-for-help, command-discovery, deterministic fast-path, and the two
     // knowledge doors the system prompt's "consult the expertise library" law routes to.
@@ -524,7 +526,7 @@ describe('selectToolsForProfile (TOOL_PROFILE, W60 spike lever 1 / preamble P1)'
     // A lean surface must have generous headroom — this is a structural win, not a
     // describe-stub squeeze. If this ever approaches 46k something is very wrong.
     // Raised with the signed-off bind-template describes (2026-07-27, #643 review fold).
-    expect(total).toBeLessThanOrEqual(29_480);
+    expect(total).toBeLessThanOrEqual(30_490);
   });
 
   it('unset ("") profile returns the lean dynamic-authoring native surface — the singer sings native by default', () => {

--- a/src/server.desktop.test.ts
+++ b/src/server.desktop.test.ts
@@ -208,11 +208,11 @@ describe('desktop tools/list serialized surface', () => {
     // Dynamic authoring is the serving surface, so this is the real budget gate.
     // The full desktop surface is not what clients see by default; its looser cap
     // only catches runaway growth without forcing valuable full-profile tools to be trimmed.
-    // Honest wire measurements are 29,463 bytes dynamic and 44,951 bytes full after the
-    // signed-off bind-template describes (see the grandfathered cap comment above).
+    // Honest wire measurements are 29,463 bytes dynamic and 45,956 bytes full after adding
+    // compose-dashboard to the full profile (see the grandfathered cap comment above).
     // Keep only a few bytes of ratchet headroom while staying well below the 46k cliff.
     expect(dynamicAuthoringTotal).toBeLessThanOrEqual(29_479);
-    expect(fullSurfaceTotal).toBeLessThanOrEqual(44_967);
+    expect(fullSurfaceTotal).toBeLessThanOrEqual(45_978);
   });
 });
 

--- a/src/server.desktop.test.ts
+++ b/src/server.desktop.test.ts
@@ -145,7 +145,7 @@ For a clear derived-metric ask with no named chart type (margin %, ratio/rate/pe
 
 For an unfamiliar or non-trivial authoring ask (calc-heavy, uncertain which chart fits, formatting/design) only when no plain-chart binding path applies; a named chart type always takes plain-chart first, even with calc/formatting riders; chart-route escalation may still consult, FIRST search-knowledge; use read-knowledge-resource to read the top hit once, then proceed.
 
-For a dashboard ask with 2-6 vizzes, build sheets with bind-template (author calcs/params/sets first), then compose with dashboard-auto-apply (2-6 plain charts, one call) or plan-dashboard-creation -> build-and-apply-dashboard; use compose-dashboard to compose EXISTING sheets; search-commands only for commands the census does not list.
+For a dashboard ask, build sheets with bind-template (author calcs/params/sets first), then compose with dashboard-auto-apply (2-6 plain charts, one call) or plan-dashboard-creation -> build-and-apply-dashboard; compose-dashboard takes 2-12 EXISTING sheets; search-commands only for commands the census does not list.
 
 For a data-value question, on a populated worksheet, call get-summary-data; answer only from returned rows.
 

--- a/src/server.desktop.ts
+++ b/src/server.desktop.ts
@@ -134,6 +134,9 @@ export const DYNAMIC_AUTHORING_TOOL_PROFILE: ReadonlySet<DesktopToolName> =
     'plan-dashboard-creation',
     'batch-create-and-cache-sheets',
     'build-and-apply-dashboard',
+    // Composes a dashboard from sheets that already exist — the verb the four tools
+    // above lack (they rebuild from asks, and error or livelock on existing sheets).
+    'compose-dashboard',
     'execute-tableau-command',
     'search-commands',
     // Atomic navigation fallback: switch the workbook active window without exposing the

--- a/src/tools/desktop/dashboard/applyDashboardWithViewpoints.test.ts
+++ b/src/tools/desktop/dashboard/applyDashboardWithViewpoints.test.ts
@@ -3,6 +3,8 @@ import { existsSync, readFileSync } from 'fs';
 import { Err, Ok } from 'ts-results-es';
 import { z } from 'zod';
 
+import * as applyFocusModule from '../../../desktop/commands/workbook/applyFocus.js';
+import * as applyMutexModule from '../../../desktop/commands/workbook/applyMutex.js';
 import * as getWorkbookXmlModule from '../../../desktop/commands/workbook/getWorkbookXml.js';
 import * as injectViewpointsModule from '../../../desktop/commands/workbook/injectViewpoints.js';
 import * as loadDashboardXmlModule from '../../../desktop/commands/workbook/loadDashboardXml.js';
@@ -15,6 +17,8 @@ import { TableauDesktopToolContext } from '../toolContext.js';
 import { getMockRequestHandlerExtra } from '../toolContext.mock.js';
 import { getApplyDashboardWithViewpointsTool } from './applyDashboardWithViewpoints.js';
 
+vi.mock('../../../desktop/commands/workbook/applyFocus.js');
+vi.mock('../../../desktop/commands/workbook/applyMutex.js');
 vi.mock('../../../desktop/commands/workbook/getWorkbookXml.js');
 vi.mock('../../../desktop/commands/workbook/loadWorkbookXml.js');
 vi.mock('../../../desktop/commands/workbook/loadDashboardXml.js');
@@ -35,6 +39,7 @@ describe('applyDashboardWithViewpointsTool', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(applyMutexModule.withApplyLock).mockImplementation(async (fn) => await fn());
     vi.mocked(existsSync).mockReturnValue(true);
     vi.mocked(readFileSync).mockReturnValue(mockDashboardXml);
     vi.spyOn(getWorkbookXmlModule, 'getWorkbookXml').mockResolvedValue(Ok(mockWorkbookXml));
@@ -47,6 +52,25 @@ describe('applyDashboardWithViewpointsTool', () => {
     vi.spyOn(loadDashboardXmlModule, 'loadDashboardXml').mockResolvedValue(
       Ok({ validationWarnings: [] }),
     );
+  });
+
+  it('defers focus until the viewpoint workbook apply', async () => {
+    await getToolResult({
+      dashboardFile: '/path/to/dashboard.xml',
+      worksheetNames: ['Sheet 1', 'Sheet 2'],
+    });
+
+    expect(loadDashboardXmlModule.loadDashboardXml).toHaveBeenCalledWith(
+      expect.objectContaining({
+        focus: { navigate: 'none', reason: 'intermediate-leg' },
+      }),
+    );
+    expect(loadWorkbookXmlModule.loadWorkbookXml).toHaveBeenCalledWith(
+      expect.objectContaining({
+        focus: { navigate: 'artifact', sheetName: 'Sales Dashboard' },
+      }),
+    );
+    expect(applyFocusModule.dispatchApplyFocus).not.toHaveBeenCalled();
   });
 
   it('should create a tool instance with correct properties', () => {
@@ -155,6 +179,13 @@ describe('applyDashboardWithViewpointsTool', () => {
       viewpointState: 'success-already-present',
     });
     expect(loadWorkbookXmlModule.loadWorkbookXml).not.toHaveBeenCalled();
+    expect(applyMutexModule.withApplyLock).toHaveBeenCalledOnce();
+    expect(applyFocusModule.dispatchApplyFocus).toHaveBeenCalledWith(
+      expect.objectContaining({
+        focus: { navigate: 'artifact', sheetName: 'Sales Dashboard' },
+        postedXml: mockWorkbookXmlWithAllViewpoints,
+      }),
+    );
   });
 
   it('should return error when dashboard file does not exist', async () => {

--- a/src/tools/desktop/dashboard/applyDashboardWithViewpoints.ts
+++ b/src/tools/desktop/dashboard/applyDashboardWithViewpoints.ts
@@ -3,6 +3,8 @@ import { existsSync, readFileSync } from 'fs';
 import { Ok } from 'ts-results-es';
 import { z } from 'zod';
 
+import { dispatchApplyFocus } from '../../../desktop/commands/workbook/applyFocus.js';
+import { withApplyLock } from '../../../desktop/commands/workbook/applyMutex.js';
 import { getWorkbookXml } from '../../../desktop/commands/workbook/getWorkbookXml.js';
 import { injectViewpoints } from '../../../desktop/commands/workbook/injectViewpoints.js';
 import { loadDashboardXml } from '../../../desktop/commands/workbook/loadDashboardXml.js';
@@ -85,12 +87,12 @@ export const getApplyDashboardWithViewpointsTool = (
 
           // Apply the dashboard first. A new dashboard has no dashboard window in the
           // pre-apply workbook, so injecting viewpoints before this step is a silent no-op.
-          // Both writes in this call produce the same dashboard, and the viewpoint apply
-          // below returns early when the viewpoints are already present, so each one names it.
+          // The later viewpoint apply names the dashboard once its window exists. If that
+          // apply is skipped, the already-present branch below explicitly names it instead.
           const dashboardApplyResult = await loadDashboardXml({
             dashboardName,
             xml: dashboardXml,
-            focus: { navigate: 'artifact', sheetName: dashboardName },
+            focus: { navigate: 'none', reason: 'intermediate-leg' },
             executor,
             signal: extra.signal,
           });
@@ -160,6 +162,14 @@ export const getApplyDashboardWithViewpointsTool = (
           }
 
           if (viewpointAccounting.state === 'success-already-present') {
+            await withApplyLock(() =>
+              dispatchApplyFocus({
+                focus: { navigate: 'artifact', sheetName: dashboardName },
+                postedXml: workbookResult.value,
+                executor,
+                signal: extra.signal,
+              }),
+            );
             return new Ok({
               message: `Dashboard "${dashboardName}" already had ${viewpointAccounting.landed.length} requested viewpoint(s).`,
               dashboardName,

--- a/src/tools/desktop/dashboard/buildAndApplyDashboard.test.ts
+++ b/src/tools/desktop/dashboard/buildAndApplyDashboard.test.ts
@@ -3,6 +3,8 @@ import { existsSync } from 'fs';
 import { Err, Ok } from 'ts-results-es';
 import { z } from 'zod';
 
+import * as applyFocusModule from '../../../desktop/commands/workbook/applyFocus.js';
+import * as applyMutexModule from '../../../desktop/commands/workbook/applyMutex.js';
 import * as getWorkbookXmlModule from '../../../desktop/commands/workbook/getWorkbookXml.js';
 import * as injectViewpointsModule from '../../../desktop/commands/workbook/injectViewpoints.js';
 import * as loadDashboardXmlModule from '../../../desktop/commands/workbook/loadDashboardXml.js';
@@ -15,6 +17,8 @@ import { TableauDesktopToolContext } from '../toolContext.js';
 import { getMockRequestHandlerExtra } from '../toolContext.mock.js';
 import { getBuildAndApplyDashboardTool } from './buildAndApplyDashboard.js';
 
+vi.mock('../../../desktop/commands/workbook/applyFocus.js');
+vi.mock('../../../desktop/commands/workbook/applyMutex.js');
 vi.mock('../../../desktop/commands/workbook/getWorkbookXml.js');
 vi.mock('../../../desktop/commands/workbook/loadWorkbookXml.js');
 vi.mock('../../../desktop/commands/workbook/loadDashboardXml.js');
@@ -46,6 +50,7 @@ describe('buildAndApplyDashboardTool', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(applyMutexModule.withApplyLock).mockImplementation(async (fn) => await fn());
     vi.mocked(existsSync).mockReturnValue(true);
     vi.spyOn(getWorkbookXmlModule, 'getWorkbookXml').mockResolvedValue(Ok(mockWorkbookXml));
     vi.spyOn(injectViewpointsModule, 'injectViewpoints').mockReturnValue(
@@ -87,7 +92,7 @@ describe('buildAndApplyDashboardTool', () => {
     expect(resultObj.viewpointCount).toBe(4);
   });
 
-  it('names the dashboard as the artifact on every write it makes', async () => {
+  it('defers focus until the viewpoint workbook apply', async () => {
     const mockLoad = vi
       .spyOn(loadDashboardXmlModule, 'loadDashboardXml')
       .mockResolvedValue(Ok({ validationWarnings: [] }));
@@ -101,16 +106,15 @@ describe('buildAndApplyDashboardTool', () => {
       expect.objectContaining({
         dashboardName: 'Sales Dashboard',
         xml: expect.stringContaining('<zone'),
-        focus: { navigate: 'artifact', sheetName: 'Sales Dashboard' },
+        focus: { navigate: 'none', reason: 'intermediate-leg' },
       }),
     );
-    // The viewpoint apply is skipped when the viewpoints are already present, so it names
-    // the same dashboard rather than relying on the write above having been the last one.
     expect(mockWorkbookLoad).toHaveBeenCalledWith(
       expect.objectContaining({
         focus: { navigate: 'artifact', sheetName: 'Sales Dashboard' },
       }),
     );
+    expect(applyFocusModule.dispatchApplyFocus).not.toHaveBeenCalled();
   });
 
   it('should include a title text zone when title is provided', async () => {
@@ -193,6 +197,13 @@ describe('buildAndApplyDashboardTool', () => {
       viewpointState: 'success-already-present',
     });
     expect(loadWorkbookXmlModule.loadWorkbookXml).not.toHaveBeenCalled();
+    expect(applyMutexModule.withApplyLock).toHaveBeenCalledOnce();
+    expect(applyFocusModule.dispatchApplyFocus).toHaveBeenCalledWith(
+      expect.objectContaining({
+        focus: { navigate: 'artifact', sheetName: 'Sales Dashboard' },
+        postedXml: mockWorkbookXmlWithAllViewpoints,
+      }),
+    );
   });
 
   it('should return error when workbook file does not exist', async () => {

--- a/src/tools/desktop/dashboard/buildAndApplyDashboard.ts
+++ b/src/tools/desktop/dashboard/buildAndApplyDashboard.ts
@@ -3,6 +3,8 @@ import { existsSync } from 'fs';
 import { Ok } from 'ts-results-es';
 import { z } from 'zod';
 
+import { dispatchApplyFocus } from '../../../desktop/commands/workbook/applyFocus.js';
+import { withApplyLock } from '../../../desktop/commands/workbook/applyMutex.js';
 import { checkSidecar } from '../../../desktop/commands/workbook/cacheFingerprint.js';
 import { getWorkbookXml } from '../../../desktop/commands/workbook/getWorkbookXml.js';
 import { injectViewpoints } from '../../../desktop/commands/workbook/injectViewpoints.js';
@@ -110,12 +112,12 @@ export const getBuildAndApplyDashboardTool = (
 
           // Apply the dashboard first. A newly created dashboard has no window in the
           // pre-apply workbook, so viewpoint injection must use a fresh post-apply read.
-          // Both writes in this call produce the same dashboard, and the viewpoint apply
-          // below is skipped when the viewpoints are already present, so each one names it.
+          // The later viewpoint apply names the dashboard once its window exists. If that
+          // apply is skipped, the already-present branch below explicitly names it instead.
           const dashboardApplyResult = await loadDashboardXml({
             dashboardName,
             xml: dashboardXml,
-            focus: { navigate: 'artifact', sheetName: dashboardName },
+            focus: { navigate: 'none', reason: 'intermediate-leg' },
             executor,
             signal: extra.signal,
           });
@@ -182,6 +184,17 @@ export const getBuildAndApplyDashboardTool = (
                 'were present in the post-injection workbook XML. Do not recreate the dashboard; retry ' +
                 'viewpoint injection for the failed worksheets.',
             }).toErr();
+          }
+
+          if (viewpointAccounting.state === 'success-already-present') {
+            await withApplyLock(() =>
+              dispatchApplyFocus({
+                focus: { navigate: 'artifact', sheetName: dashboardName },
+                postedXml: workbookResult.value,
+                executor,
+                signal: extra.signal,
+              }),
+            );
           }
 
           if (viewpointAccounting.state !== 'success-already-present') {

--- a/src/tools/desktop/dashboard/composeDashboard.test.ts
+++ b/src/tools/desktop/dashboard/composeDashboard.test.ts
@@ -1,0 +1,109 @@
+import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { Ok } from 'ts-results-es';
+
+import * as listDashboardsModule from '../../../desktop/commands/workbook/listDashboards.js';
+import * as listWorksheetsModule from '../../../desktop/commands/workbook/listWorksheets.js';
+import * as loadDashboardXmlModule from '../../../desktop/commands/workbook/loadDashboardXml.js';
+import { DesktopMcpServer } from '../../../server.desktop.js';
+import invariant from '../../../utils/invariant.js';
+import { Provider } from '../../../utils/provider.js';
+import { TableauDesktopToolContext } from '../toolContext.js';
+import { getMockRequestHandlerExtra } from '../toolContext.mock.js';
+import { getComposeDashboardTool } from './composeDashboard.js';
+
+vi.mock('../../../desktop/commands/workbook/listDashboards.js');
+vi.mock('../../../desktop/commands/workbook/listWorksheets.js');
+vi.mock('../../../desktop/commands/workbook/loadDashboardXml.js');
+
+describe('composeDashboardTool', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(listWorksheetsModule.listWorksheets).mockResolvedValue(
+      Ok({ count: 3, worksheets: ['Sales', 'Profit', 'Orders'] }),
+    );
+    vi.mocked(listDashboardsModule.listDashboards).mockResolvedValue(
+      Ok({ count: 1, dashboards: ['Executive Overview'] }),
+    );
+    vi.mocked(loadDashboardXmlModule.loadDashboardXml).mockResolvedValue(
+      Ok({ validationWarnings: [] }),
+    );
+  });
+
+  it('composes two existing sheets in the default auto-grid layout', async () => {
+    const result = await getToolResult({ worksheets: ['Sales', 'Profit'] });
+
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+    expect(JSON.parse(result.content[0].text)).toMatchObject({
+      dashboardName: 'New Dashboard',
+      zones: [
+        { worksheet: 'Sales', position: { x: 0, y: 0, width: 50000, height: 100000 } },
+        { worksheet: 'Profit', position: { x: 50000, y: 0, width: 50000, height: 100000 } },
+      ],
+      verification: expect.stringContaining('HOST VERIFICATION — unverified'),
+    });
+    expect(loadDashboardXmlModule.loadDashboardXml).toHaveBeenCalledWith(
+      expect.objectContaining({
+        dashboardName: 'New Dashboard',
+        xml: expect.stringContaining('name="Sales"'),
+        focus: { navigate: 'artifact', sheetName: 'New Dashboard' },
+      }),
+    );
+  });
+
+  it('returns a terminal error naming missing and available worksheets', async () => {
+    const result = await getToolResult({ worksheets: ['Sales', 'Missing Sheet'] });
+
+    expect(result.isError).toBe(true);
+    invariant(result.content[0].type === 'text');
+    expect(result.content[0].text).toContain('Missing worksheets: "Missing Sheet"');
+    expect(result.content[0].text).toContain('Available worksheets: "Sales", "Profit", "Orders"');
+    expect(result.content[0].text).toContain('Next call: compose-dashboard');
+    expect(loadDashboardXmlModule.loadDashboardXml).not.toHaveBeenCalled();
+  });
+
+  it('returns a terminal error when the dashboard name already exists', async () => {
+    const result = await getToolResult({ dashboardName: 'Executive Overview' });
+
+    expect(result.isError).toBe(true);
+    invariant(result.content[0].type === 'text');
+    expect(result.content[0].text).toContain('Dashboard "Executive Overview" already exists');
+    expect(result.content[0].text).toContain('Next call: compose-dashboard');
+    expect(result.content[0].text).toContain('new dashboardName');
+    expect(loadDashboardXmlModule.loadDashboardXml).not.toHaveBeenCalled();
+  });
+
+  it('uses gridColumns to position worksheet zones', async () => {
+    const result = await getToolResult({
+      worksheets: ['Sales', 'Profit', 'Orders'],
+      layout: { layoutType: 'auto-grid', gridColumns: 2 },
+    });
+
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+    expect(JSON.parse(result.content[0].text).zones).toEqual([
+      { worksheet: 'Sales', position: { x: 0, y: 0, width: 50000, height: 50000 } },
+      { worksheet: 'Profit', position: { x: 50000, y: 0, width: 50000, height: 50000 } },
+      { worksheet: 'Orders', position: { x: 0, y: 50000, width: 50000, height: 50000 } },
+    ]);
+  });
+});
+
+async function getToolResult({
+  session = '12345',
+  dashboardName = 'New Dashboard',
+  worksheets = ['Sales', 'Profit'],
+  layout,
+  mockExecutor = vi.fn().mockResolvedValue({}),
+}: {
+  session?: string;
+  dashboardName?: string;
+  worksheets?: string[];
+  layout?: { layoutType: 'auto-grid' | 'rows' | 'columns'; gridColumns?: number };
+  mockExecutor?: TableauDesktopToolContext['getExecutor'];
+} = {}): Promise<CallToolResult> {
+  const tool = getComposeDashboardTool(new DesktopMcpServer());
+  const callback = await Provider.from(tool.callback);
+  const extra = { ...getMockRequestHandlerExtra(), getExecutor: mockExecutor };
+  return await callback({ session, dashboardName, worksheets, layout }, extra);
+}

--- a/src/tools/desktop/dashboard/composeDashboard.test.ts
+++ b/src/tools/desktop/dashboard/composeDashboard.test.ts
@@ -2,6 +2,7 @@ import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { Err, Ok } from 'ts-results-es';
 import { z } from 'zod';
 
+import * as applyFocusModule from '../../../desktop/commands/workbook/applyFocus.js';
 import * as getWorkbookXmlModule from '../../../desktop/commands/workbook/getWorkbookXml.js';
 import * as listDashboardsModule from '../../../desktop/commands/workbook/listDashboards.js';
 import * as listWorksheetsModule from '../../../desktop/commands/workbook/listWorksheets.js';
@@ -14,6 +15,7 @@ import { TableauDesktopToolContext } from '../toolContext.js';
 import { getMockRequestHandlerExtra } from '../toolContext.mock.js';
 import { getComposeDashboardTool } from './composeDashboard.js';
 
+vi.mock('../../../desktop/commands/workbook/applyFocus.js');
 vi.mock('../../../desktop/commands/workbook/getWorkbookXml.js');
 vi.mock('../../../desktop/commands/workbook/listDashboards.js');
 vi.mock('../../../desktop/commands/workbook/listWorksheets.js');
@@ -76,13 +78,39 @@ describe('composeDashboardTool', () => {
       expect.objectContaining({
         dashboardName: 'New Dashboard',
         xml: expect.stringContaining('name="Sales"'),
-        focus: { navigate: 'artifact', sheetName: 'New Dashboard' },
+        focus: { navigate: 'none', reason: 'intermediate-leg' },
       }),
     );
     expect(loadWorkbookXmlModule.loadWorkbookXml).toHaveBeenCalledWith(
       expect.objectContaining({
         xml: expect.stringContaining('<viewpoint name="Sales"/>'),
         focus: { navigate: 'artifact', sheetName: 'New Dashboard' },
+      }),
+    );
+    expect(applyFocusModule.dispatchApplyFocus).not.toHaveBeenCalled();
+  });
+
+  it('activates the dashboard when its viewpoints are already present', async () => {
+    const alreadyPresentXml = `<workbook>
+      <dashboards><dashboard name="New Dashboard"><zones>
+        <zone name="Sales" x="0" y="0" w="50000" h="100000"/>
+        <zone name="Profit" x="50000" y="0" w="50000" h="100000"/>
+      </zones></dashboard></dashboards>
+      <windows><window class="dashboard" name="New Dashboard">
+        <viewpoints><viewpoint name="Sales"/><viewpoint name="Profit"/></viewpoints>
+      </window></windows>
+    </workbook>`;
+    vi.mocked(getWorkbookXmlModule.getWorkbookXml).mockResolvedValue(Ok(alreadyPresentXml));
+
+    const result = await getToolResult();
+
+    expect(result.isError).toBe(false);
+    expect(loadWorkbookXmlModule.loadWorkbookXml).not.toHaveBeenCalled();
+    expect(applyFocusModule.dispatchApplyFocus).toHaveBeenCalledOnce();
+    expect(applyFocusModule.dispatchApplyFocus).toHaveBeenCalledWith(
+      expect.objectContaining({
+        focus: { navigate: 'artifact', sheetName: 'New Dashboard' },
+        postedXml: alreadyPresentXml,
       }),
     );
   });

--- a/src/tools/desktop/dashboard/composeDashboard.test.ts
+++ b/src/tools/desktop/dashboard/composeDashboard.test.ts
@@ -3,6 +3,7 @@ import { Err, Ok } from 'ts-results-es';
 import { z } from 'zod';
 
 import * as applyFocusModule from '../../../desktop/commands/workbook/applyFocus.js';
+import * as applyMutexModule from '../../../desktop/commands/workbook/applyMutex.js';
 import * as getWorkbookXmlModule from '../../../desktop/commands/workbook/getWorkbookXml.js';
 import * as listDashboardsModule from '../../../desktop/commands/workbook/listDashboards.js';
 import * as listWorksheetsModule from '../../../desktop/commands/workbook/listWorksheets.js';
@@ -16,6 +17,7 @@ import { getMockRequestHandlerExtra } from '../toolContext.mock.js';
 import { getComposeDashboardTool } from './composeDashboard.js';
 
 vi.mock('../../../desktop/commands/workbook/applyFocus.js');
+vi.mock('../../../desktop/commands/workbook/applyMutex.js');
 vi.mock('../../../desktop/commands/workbook/getWorkbookXml.js');
 vi.mock('../../../desktop/commands/workbook/listDashboards.js');
 vi.mock('../../../desktop/commands/workbook/listWorksheets.js');
@@ -27,6 +29,7 @@ describe('composeDashboardTool', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(applyMutexModule.withApplyLock).mockImplementation(async (fn) => await fn());
     vi.mocked(listWorksheetsModule.listWorksheets).mockResolvedValue(
       Ok({ count: 3, worksheets: ['Sales', 'Profit', 'Orders'] }),
     );
@@ -105,7 +108,18 @@ describe('composeDashboardTool', () => {
     const result = await getToolResult();
 
     expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+    expect(JSON.parse(result.content[0].text)).toMatchObject({
+      dashboardName: 'New Dashboard',
+      zones: [
+        { worksheet: 'Sales', position: { x: 0, y: 0, width: 50000, height: 100000 } },
+        { worksheet: 'Profit', position: { x: 50000, y: 0, width: 50000, height: 100000 } },
+      ],
+      verification: expect.stringContaining('HOST VERIFICATION — verified'),
+    });
+    expect(JSON.parse(result.content[0].text)).not.toHaveProperty('attemptedZones');
     expect(loadWorkbookXmlModule.loadWorkbookXml).not.toHaveBeenCalled();
+    expect(applyMutexModule.withApplyLock).toHaveBeenCalledOnce();
     expect(applyFocusModule.dispatchApplyFocus).toHaveBeenCalledOnce();
     expect(applyFocusModule.dispatchApplyFocus).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/src/tools/desktop/dashboard/composeDashboard.test.ts
+++ b/src/tools/desktop/dashboard/composeDashboard.test.ts
@@ -278,6 +278,45 @@ describe('composeDashboardTool', () => {
     });
   });
 
+  it('ignores duplicate named zones in device layouts during readback', async () => {
+    vi.mocked(getWorkbookXmlModule.getWorkbookXml)
+      .mockResolvedValueOnce(Ok(emptyWorkbookXml))
+      .mockResolvedValueOnce(
+        Ok(`<workbook>
+          <dashboards>
+            <dashboard name="New Dashboard">
+              <zones>
+                <zone name="Sales" x="0" y="0" w="50000" h="100000"/>
+                <zone name="Profit" x="50000" y="0" w="50000" h="100000"/>
+              </zones>
+              <devicelayouts>
+                <devicelayout name="Phone">
+                  <zones>
+                    <zone name="Sales" x="0" y="0" w="100000" h="50000"/>
+                    <zone name="Profit" x="0" y="50000" w="100000" h="50000"/>
+                  </zones>
+                </devicelayout>
+              </devicelayouts>
+            </dashboard>
+          </dashboards>
+          <windows><window class="dashboard" name="New Dashboard">
+            <viewpoints><viewpoint name="Profit"/><viewpoint name="Sales"/></viewpoints>
+            <active id="-1"/>
+          </window></windows>
+        </workbook>`),
+      );
+
+    const result = await getToolResult();
+
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+    expect(JSON.parse(result.content[0].text)).toMatchObject({
+      dashboardName: 'New Dashboard',
+      zones: expect.any(Array),
+      verification: expect.stringContaining('HOST VERIFICATION — verified'),
+    });
+  });
+
   it('does not verify readback without the dashboard window and requested viewpoints', async () => {
     vi.mocked(getWorkbookXmlModule.getWorkbookXml)
       .mockResolvedValueOnce(Ok(emptyWorkbookXml))

--- a/src/tools/desktop/dashboard/composeDashboard.test.ts
+++ b/src/tools/desktop/dashboard/composeDashboard.test.ts
@@ -2,7 +2,6 @@ import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { Err, Ok } from 'ts-results-es';
 import { z } from 'zod';
 
-import * as getDashboardXmlModule from '../../../desktop/commands/workbook/getDashboardXml.js';
 import * as getWorkbookXmlModule from '../../../desktop/commands/workbook/getWorkbookXml.js';
 import * as listDashboardsModule from '../../../desktop/commands/workbook/listDashboards.js';
 import * as listWorksheetsModule from '../../../desktop/commands/workbook/listWorksheets.js';
@@ -15,7 +14,6 @@ import { TableauDesktopToolContext } from '../toolContext.js';
 import { getMockRequestHandlerExtra } from '../toolContext.mock.js';
 import { getComposeDashboardTool } from './composeDashboard.js';
 
-vi.mock('../../../desktop/commands/workbook/getDashboardXml.js');
 vi.mock('../../../desktop/commands/workbook/getWorkbookXml.js');
 vi.mock('../../../desktop/commands/workbook/listDashboards.js');
 vi.mock('../../../desktop/commands/workbook/listWorksheets.js');
@@ -23,6 +21,8 @@ vi.mock('../../../desktop/commands/workbook/loadDashboardXml.js');
 vi.mock('../../../desktop/commands/workbook/loadWorkbookXml.js');
 
 describe('composeDashboardTool', () => {
+  const emptyWorkbookXml = '<workbook><windows/></workbook>';
+
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(listWorksheetsModule.listWorksheets).mockResolvedValue(
@@ -34,19 +34,28 @@ describe('composeDashboardTool', () => {
     vi.mocked(loadDashboardXmlModule.loadDashboardXml).mockResolvedValue(
       Ok({ validationWarnings: [] }),
     );
-    vi.mocked(getWorkbookXmlModule.getWorkbookXml).mockResolvedValue(
-      Ok(
-        '<workbook><windows><window class="dashboard" name="New Dashboard"/></windows></workbook>',
-      ),
-    );
     vi.mocked(loadWorkbookXmlModule.loadWorkbookXml).mockResolvedValue(
       Ok({ validationWarnings: [] }),
     );
-    vi.mocked(getDashboardXmlModule.getDashboardFragment).mockImplementation(async () => {
-      const appliedXml = vi
+    vi.mocked(getWorkbookXmlModule.getWorkbookXml).mockImplementation(async () => {
+      const appliedWorkbookXml = vi
+        .mocked(loadWorkbookXmlModule.loadWorkbookXml)
+        .mock.calls.at(-1)?.[0].xml;
+      if (!appliedWorkbookXml) return Ok(emptyWorkbookXml);
+
+      const dashboardXml = vi
         .mocked(loadDashboardXmlModule.loadDashboardXml)
         .mock.calls.at(-1)?.[0].xml;
-      return Ok(appliedXml ?? '<dashboard/>');
+      const dashboardName =
+        /<window\b[^>]*\bclass="dashboard"[^>]*\bname="([^"]+)"/.exec(appliedWorkbookXml)?.[1] ??
+        'New Dashboard';
+      const viewpointNames = [...appliedWorkbookXml.matchAll(/<viewpoint name="([^"]+)"\/>/g)]
+        .map((match) => match[1])
+        .sort();
+      const viewpoints = viewpointNames.map((name) => `<viewpoint name="${name}"/>`).join('');
+      return Ok(
+        `<workbook><dashboards>${dashboardXml ?? '<dashboard/>'}</dashboards><windows><window class="dashboard" name="${dashboardName}"><viewpoints>${viewpoints}</viewpoints><active id="-1"/></window></windows></workbook>`,
+      );
     });
   });
 
@@ -72,7 +81,7 @@ describe('composeDashboardTool', () => {
     );
     expect(loadWorkbookXmlModule.loadWorkbookXml).toHaveBeenCalledWith(
       expect.objectContaining({
-        xml: expect.stringContaining('<viewpoint name="Sales">'),
+        xml: expect.stringContaining('<viewpoint name="Sales"/>'),
         focus: { navigate: 'artifact', sheetName: 'New Dashboard' },
       }),
     );
@@ -193,33 +202,11 @@ describe('composeDashboardTool', () => {
     });
   });
 
-  it('returns a terminal error when the viewpoint workbook apply fails', async () => {
+  it('returns attempted zones when the viewpoint workbook apply fails', async () => {
     vi.mocked(loadWorkbookXmlModule.loadWorkbookXml).mockResolvedValue(
       Err({
         type: 'load-workbook-xml-error',
         error: { type: 'load-rejected', message: 'Rejected viewpoints' },
-      }),
-    );
-
-    const result = await getToolResult();
-
-    expect(result.isError).toBe(true);
-    invariant(result.content[0].type === 'text');
-    expect(result.content[0].text).toContain(
-      'Dashboard "New Dashboard" exists but is NOT confirmed visible',
-    );
-    expect(result.content[0].text).toContain('Next call:');
-    expect(getDashboardXmlModule.getDashboardFragment).not.toHaveBeenCalled();
-  });
-
-  it('reports attempted zones when dashboard readback is unavailable', async () => {
-    vi.mocked(getDashboardXmlModule.getDashboardFragment).mockResolvedValue(
-      Err({
-        type: 'execute-command-error',
-        error: {
-          type: 'command-failed',
-          error: { code: 'READ_FAILED', message: 'Read failed', recoverable: true },
-        },
       }),
     );
 
@@ -230,9 +217,113 @@ describe('composeDashboardTool', () => {
     expect(JSON.parse(result.content[0].text)).toMatchObject({
       dashboardName: 'New Dashboard',
       attemptedZones: expect.any(Array),
+      verification: expect.stringMatching(
+        /Dashboard "New Dashboard" exists[\s\S]*NOT confirmed[\s\S]*activate-sheet/,
+      ),
+    });
+    expect(result.content[0].text).toContain('do not recreate');
+    expect(getWorkbookXmlModule.getWorkbookXml).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports attempted zones when dashboard readback is unavailable', async () => {
+    vi.mocked(getWorkbookXmlModule.getWorkbookXml)
+      .mockResolvedValueOnce(Ok(emptyWorkbookXml))
+      .mockResolvedValueOnce(
+        Err({
+          type: 'command-failed',
+          error: { code: 'READ_FAILED', message: 'Read failed', recoverable: true },
+        }),
+      );
+
+    const result = await getToolResult();
+
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+    expect(JSON.parse(result.content[0].text)).toMatchObject({
+      dashboardName: 'New Dashboard',
+      attemptedZones: expect.any(Array),
       verification: expect.stringContaining('NOT confirmed'),
     });
+    expect(result.content[0].text).toContain('activate-sheet');
     expect(JSON.parse(result.content[0].text)).not.toHaveProperty('zones');
+  });
+
+  it('verifies workbook readback with reordered zones and alphabetized viewpoints', async () => {
+    vi.mocked(getWorkbookXmlModule.getWorkbookXml)
+      .mockResolvedValueOnce(Ok(emptyWorkbookXml))
+      .mockResolvedValueOnce(
+        Ok(`<workbook>
+          <dashboards>
+            <dashboard name="New Dashboard"><zones>
+              <zone name="Profit" x="50000" y="0" w="50000" h="100000"/>
+              <zone name="Sales" x="0" y="0" w="50000" h="100000"/>
+              <zone x="0" y="0" w="100000" h="100000"/>
+            </zones></dashboard>
+          </dashboards>
+          <windows><window class="dashboard" name="New Dashboard">
+            <viewpoints><viewpoint name="Profit"/><viewpoint name="Sales"/></viewpoints>
+            <active id="-1"/>
+          </window></windows>
+        </workbook>`),
+      );
+
+    const result = await getToolResult();
+
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+    expect(JSON.parse(result.content[0].text)).toMatchObject({
+      dashboardName: 'New Dashboard',
+      zones: expect.any(Array),
+      verification: expect.stringContaining('HOST VERIFICATION — verified'),
+    });
+  });
+
+  it('does not verify readback without the dashboard window and requested viewpoints', async () => {
+    vi.mocked(getWorkbookXmlModule.getWorkbookXml)
+      .mockResolvedValueOnce(Ok(emptyWorkbookXml))
+      .mockResolvedValueOnce(
+        Ok(`<workbook>
+          <dashboards><dashboard name="New Dashboard"><zones>
+            <zone name="Sales" x="0" y="0" w="50000" h="100000"/>
+            <zone name="Profit" x="50000" y="0" w="50000" h="100000"/>
+          </zones></dashboard></dashboards>
+          <windows/>
+        </workbook>`),
+      );
+
+    const result = await getToolResult();
+
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+    expect(JSON.parse(result.content[0].text)).toMatchObject({
+      attemptedZones: expect.any(Array),
+      verification: expect.stringContaining('NOT confirmed'),
+    });
+  });
+
+  it('does not treat a missing zero-valued coordinate as a zone match', async () => {
+    vi.mocked(getWorkbookXmlModule.getWorkbookXml)
+      .mockResolvedValueOnce(Ok(emptyWorkbookXml))
+      .mockResolvedValueOnce(
+        Ok(`<workbook>
+          <dashboards><dashboard name="New Dashboard"><zones>
+            <zone name="Sales" y="0" w="50000" h="100000"/>
+            <zone name="Profit" x="50000" y="0" w="50000" h="100000"/>
+          </zones></dashboard></dashboards>
+          <windows><window class="dashboard" name="New Dashboard">
+            <viewpoints><viewpoint name="Profit"/><viewpoint name="Sales"/></viewpoints>
+          </window></windows>
+        </workbook>`),
+      );
+
+    const result = await getToolResult();
+
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+    expect(JSON.parse(result.content[0].text)).toMatchObject({
+      attemptedZones: expect.any(Array),
+      verification: expect.stringContaining('NOT confirmed'),
+    });
   });
 });
 

--- a/src/tools/desktop/dashboard/composeDashboard.test.ts
+++ b/src/tools/desktop/dashboard/composeDashboard.test.ts
@@ -1,9 +1,13 @@
 import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
-import { Ok } from 'ts-results-es';
+import { Err, Ok } from 'ts-results-es';
+import { z } from 'zod';
 
+import * as getDashboardXmlModule from '../../../desktop/commands/workbook/getDashboardXml.js';
+import * as getWorkbookXmlModule from '../../../desktop/commands/workbook/getWorkbookXml.js';
 import * as listDashboardsModule from '../../../desktop/commands/workbook/listDashboards.js';
 import * as listWorksheetsModule from '../../../desktop/commands/workbook/listWorksheets.js';
 import * as loadDashboardXmlModule from '../../../desktop/commands/workbook/loadDashboardXml.js';
+import * as loadWorkbookXmlModule from '../../../desktop/commands/workbook/loadWorkbookXml.js';
 import { DesktopMcpServer } from '../../../server.desktop.js';
 import invariant from '../../../utils/invariant.js';
 import { Provider } from '../../../utils/provider.js';
@@ -11,9 +15,12 @@ import { TableauDesktopToolContext } from '../toolContext.js';
 import { getMockRequestHandlerExtra } from '../toolContext.mock.js';
 import { getComposeDashboardTool } from './composeDashboard.js';
 
+vi.mock('../../../desktop/commands/workbook/getDashboardXml.js');
+vi.mock('../../../desktop/commands/workbook/getWorkbookXml.js');
 vi.mock('../../../desktop/commands/workbook/listDashboards.js');
 vi.mock('../../../desktop/commands/workbook/listWorksheets.js');
 vi.mock('../../../desktop/commands/workbook/loadDashboardXml.js');
+vi.mock('../../../desktop/commands/workbook/loadWorkbookXml.js');
 
 describe('composeDashboardTool', () => {
   beforeEach(() => {
@@ -27,6 +34,20 @@ describe('composeDashboardTool', () => {
     vi.mocked(loadDashboardXmlModule.loadDashboardXml).mockResolvedValue(
       Ok({ validationWarnings: [] }),
     );
+    vi.mocked(getWorkbookXmlModule.getWorkbookXml).mockResolvedValue(
+      Ok(
+        '<workbook><windows><window class="dashboard" name="New Dashboard"/></windows></workbook>',
+      ),
+    );
+    vi.mocked(loadWorkbookXmlModule.loadWorkbookXml).mockResolvedValue(
+      Ok({ validationWarnings: [] }),
+    );
+    vi.mocked(getDashboardXmlModule.getDashboardFragment).mockImplementation(async () => {
+      const appliedXml = vi
+        .mocked(loadDashboardXmlModule.loadDashboardXml)
+        .mock.calls.at(-1)?.[0].xml;
+      return Ok(appliedXml ?? '<dashboard/>');
+    });
   });
 
   it('composes two existing sheets in the default auto-grid layout', async () => {
@@ -40,12 +61,18 @@ describe('composeDashboardTool', () => {
         { worksheet: 'Sales', position: { x: 0, y: 0, width: 50000, height: 100000 } },
         { worksheet: 'Profit', position: { x: 50000, y: 0, width: 50000, height: 100000 } },
       ],
-      verification: expect.stringContaining('HOST VERIFICATION — unverified'),
+      verification: expect.stringContaining('HOST VERIFICATION — verified'),
     });
     expect(loadDashboardXmlModule.loadDashboardXml).toHaveBeenCalledWith(
       expect.objectContaining({
         dashboardName: 'New Dashboard',
         xml: expect.stringContaining('name="Sales"'),
+        focus: { navigate: 'artifact', sheetName: 'New Dashboard' },
+      }),
+    );
+    expect(loadWorkbookXmlModule.loadWorkbookXml).toHaveBeenCalledWith(
+      expect.objectContaining({
+        xml: expect.stringContaining('<viewpoint name="Sales">'),
         focus: { navigate: 'artifact', sheetName: 'New Dashboard' },
       }),
     );
@@ -76,7 +103,7 @@ describe('composeDashboardTool', () => {
   it('uses gridColumns to position worksheet zones', async () => {
     const result = await getToolResult({
       worksheets: ['Sales', 'Profit', 'Orders'],
-      layout: { layoutType: 'auto-grid', gridColumns: 2 },
+      layout: { gridColumns: 2 },
     });
 
     expect(result.isError).toBe(false);
@@ -86,6 +113,126 @@ describe('composeDashboardTool', () => {
       { worksheet: 'Profit', position: { x: 50000, y: 0, width: 50000, height: 50000 } },
       { worksheet: 'Orders', position: { x: 0, y: 50000, width: 50000, height: 50000 } },
     ]);
+  });
+
+  it('returns a terminal error when applying the dashboard fails', async () => {
+    vi.mocked(loadDashboardXmlModule.loadDashboardXml).mockResolvedValue(
+      Err({
+        type: 'execute-command-error',
+        error: {
+          type: 'command-failed',
+          error: { code: 'APPLY_FAILED', message: 'Apply failed', recoverable: false },
+        },
+      }),
+    );
+
+    const result = await getToolResult();
+
+    expect(result.isError).toBe(true);
+    invariant(result.content[0].type === 'text');
+    expect(result.content[0].text).toContain('not confirmed applied');
+    expect(result.content[0].text).toContain('Next call:');
+    expect(result.content[0].text).not.toContain('"zones"');
+  });
+
+  it('refuses duplicate live-resolved worksheet names', async () => {
+    const result = await getToolResult({ worksheets: ['Sales', ' Sales '] });
+
+    expect(result.isError).toBe(true);
+    invariant(result.content[0].type === 'text');
+    expect(result.content[0].text).toContain('Duplicate worksheet "Sales"');
+    expect(result.content[0].text).toContain('Next call: compose-dashboard');
+    expect(loadDashboardXmlModule.loadDashboardXml).not.toHaveBeenCalled();
+  });
+
+  it('positions worksheet zones in rows', async () => {
+    const result = await getToolResult({
+      worksheets: ['Sales', 'Profit', 'Orders'],
+      layout: { layoutType: 'rows' },
+    });
+
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+    expect(JSON.parse(result.content[0].text).zones).toEqual([
+      { worksheet: 'Sales', position: { x: 0, y: 0, width: 100000, height: 33333 } },
+      { worksheet: 'Profit', position: { x: 0, y: 33333, width: 100000, height: 33333 } },
+      { worksheet: 'Orders', position: { x: 0, y: 66666, width: 100000, height: 33333 } },
+    ]);
+  });
+
+  it('positions worksheet zones in columns', async () => {
+    const result = await getToolResult({
+      worksheets: ['Sales', 'Profit', 'Orders'],
+      layout: { layoutType: 'columns' },
+    });
+
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+    expect(JSON.parse(result.content[0].text).zones).toEqual([
+      { worksheet: 'Sales', position: { x: 0, y: 0, width: 33333, height: 100000 } },
+      { worksheet: 'Profit', position: { x: 33333, y: 0, width: 33333, height: 100000 } },
+      { worksheet: 'Orders', position: { x: 66666, y: 0, width: 33333, height: 100000 } },
+    ]);
+  });
+
+  it('composes the 12-sheet boundary', async () => {
+    const worksheets = Array.from({ length: 12 }, (_, index) => `Sheet ${index + 1}`);
+    vi.mocked(listWorksheetsModule.listWorksheets).mockResolvedValue(
+      Ok({ count: worksheets.length, worksheets }),
+    );
+
+    const result = await getToolResult({ worksheets });
+
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+    const zones = JSON.parse(result.content[0].text).zones;
+    expect(zones).toHaveLength(12);
+    expect(zones.at(-1)).toEqual({
+      worksheet: 'Sheet 12',
+      position: { x: 50000, y: 83330, width: 50000, height: 16666 },
+    });
+  });
+
+  it('returns a terminal error when the viewpoint workbook apply fails', async () => {
+    vi.mocked(loadWorkbookXmlModule.loadWorkbookXml).mockResolvedValue(
+      Err({
+        type: 'load-workbook-xml-error',
+        error: { type: 'load-rejected', message: 'Rejected viewpoints' },
+      }),
+    );
+
+    const result = await getToolResult();
+
+    expect(result.isError).toBe(true);
+    invariant(result.content[0].type === 'text');
+    expect(result.content[0].text).toContain(
+      'Dashboard "New Dashboard" exists but is NOT confirmed visible',
+    );
+    expect(result.content[0].text).toContain('Next call:');
+    expect(getDashboardXmlModule.getDashboardFragment).not.toHaveBeenCalled();
+  });
+
+  it('reports attempted zones when dashboard readback is unavailable', async () => {
+    vi.mocked(getDashboardXmlModule.getDashboardFragment).mockResolvedValue(
+      Err({
+        type: 'execute-command-error',
+        error: {
+          type: 'command-failed',
+          error: { code: 'READ_FAILED', message: 'Read failed', recoverable: true },
+        },
+      }),
+    );
+
+    const result = await getToolResult();
+
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+    expect(JSON.parse(result.content[0].text)).toMatchObject({
+      dashboardName: 'New Dashboard',
+      attemptedZones: expect.any(Array),
+      verification: expect.stringContaining('NOT confirmed'),
+    });
+    expect(JSON.parse(result.content[0].text)).not.toHaveProperty('zones');
   });
 });
 
@@ -99,11 +246,13 @@ async function getToolResult({
   session?: string;
   dashboardName?: string;
   worksheets?: string[];
-  layout?: { layoutType: 'auto-grid' | 'rows' | 'columns'; gridColumns?: number };
+  layout?: { layoutType?: 'auto-grid' | 'rows' | 'columns'; gridColumns?: number };
   mockExecutor?: TableauDesktopToolContext['getExecutor'];
 } = {}): Promise<CallToolResult> {
   const tool = getComposeDashboardTool(new DesktopMcpServer());
   const callback = await Provider.from(tool.callback);
+  const paramsSchema = await Provider.from(tool.paramsSchema);
   const extra = { ...getMockRequestHandlerExtra(), getExecutor: mockExecutor };
-  return await callback({ session, dashboardName, worksheets, layout }, extra);
+  const args = z.object(paramsSchema).parse({ session, dashboardName, worksheets, layout });
+  return await callback({ ...args, layout: args.layout, session: args.session }, extra);
 }

--- a/src/tools/desktop/dashboard/composeDashboard.ts
+++ b/src/tools/desktop/dashboard/composeDashboard.ts
@@ -1,0 +1,187 @@
+import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { Ok } from 'ts-results-es';
+import { z } from 'zod';
+
+import { listDashboards } from '../../../desktop/commands/workbook/listDashboards.js';
+import { listWorksheets } from '../../../desktop/commands/workbook/listWorksheets.js';
+import { loadDashboardXml } from '../../../desktop/commands/workbook/loadDashboardXml.js';
+import { resolveSession } from '../../../desktop/sessionResolution.js';
+import { formatDashboardPromiseCheck } from '../../../desktop/validation/promise-check.js';
+import { xmlNamesEqual } from '../../../desktop/xmlElement.js';
+import {
+  DashboardXmlLoadFailedError,
+  DesktopCommandExecutionError,
+  McpToolError,
+} from '../../../errors/mcpToolError.js';
+import { DesktopMcpServer } from '../../../server.desktop.js';
+import { DesktopTool } from '../tool.js';
+import { buildDashboardXml, computeZones } from './dashboardZones.js';
+
+const layoutSchema = z.object({
+  layoutType: z.enum(['auto-grid', 'rows', 'columns']).describe('Zone arrangement.'),
+  gridColumns: z.number().int().min(1).max(12).optional().describe('Auto-grid columns.'),
+});
+
+const paramsSchema = {
+  dashboardName: z.string().trim().min(1).describe('New dashboard name.'),
+  worksheets: z
+    .array(z.string().trim().min(1).describe('Existing worksheet name.'))
+    .min(2)
+    .max(12)
+    .describe('2-12 existing worksheet names.'),
+  layout: layoutSchema.optional().describe('Zone layout.'),
+  session: z.string().optional().describe('Desktop session ID.'),
+};
+
+type WorksheetZoneReceipt = {
+  worksheet: string;
+  position: { x: number; y: number; width: number; height: number };
+};
+
+type ComposeDashboardResult = {
+  dashboardName: string;
+  zones: WorksheetZoneReceipt[];
+  verification: string;
+};
+
+function terminalError(message: string, type = 'compose-dashboard-refused'): McpToolError {
+  return new McpToolError({ type, message, statusCode: 409 });
+}
+
+const title = 'Compose Dashboard';
+
+export const getComposeDashboardTool = (
+  server: DesktopMcpServer,
+): DesktopTool<typeof paramsSchema> => {
+  const tool = new DesktopTool({
+    server,
+    name: 'compose-dashboard',
+    title,
+    description: 'Compose a dashboard from 2-12 existing sheets; no overwrite.',
+    paramsSchema,
+    annotations: {
+      readOnlyHint: false,
+      openWorldHint: false,
+      destructiveHint: true,
+      idempotentHint: false,
+    },
+    callback: async (
+      { dashboardName, worksheets, layout, session },
+      extra,
+    ): Promise<CallToolResult> => {
+      return await tool.logAndExecute<ComposeDashboardResult>({
+        extra,
+        args: { dashboardName, worksheets, layout, session },
+        callback: async () => {
+          const sessionResult = resolveSession(session);
+          if (sessionResult.isErr()) {
+            return terminalError(
+              `${sessionResult.error.message} Next call: list-instances, then call compose-dashboard again with a valid session.`,
+              'compose-dashboard-session-error',
+            ).toErr();
+          }
+
+          const executor = await extra.getExecutor(sessionResult.value);
+          const worksheetResult = await listWorksheets({ executor, signal: extra.signal });
+          if (worksheetResult.isErr()) {
+            const detail = new DesktopCommandExecutionError(worksheetResult.error).message;
+            return terminalError(
+              `Could not read the live worksheet list (${detail}). Next call: list-worksheets, then call compose-dashboard again.`,
+              'compose-dashboard-worksheet-read-error',
+            ).toErr();
+          }
+
+          const availableWorksheets = worksheetResult.value.worksheets;
+          const resolvedWorksheets = worksheets.map((requestedName) =>
+            availableWorksheets.find((availableName) =>
+              xmlNamesEqual(availableName, requestedName),
+            ),
+          );
+          const missingWorksheets = worksheets.filter(
+            (_, index) => resolvedWorksheets[index] === undefined,
+          );
+          if (missingWorksheets.length > 0) {
+            const missing = missingWorksheets.map((name) => `"${name}"`).join(', ');
+            const available =
+              availableWorksheets.length > 0
+                ? availableWorksheets.map((name) => `"${name}"`).join(', ')
+                : '(none)';
+            return terminalError(
+              `Missing worksheets: ${missing}. Available worksheets: ${available}. ` +
+                'Next call: compose-dashboard again using only names from Available worksheets.',
+              'compose-dashboard-missing-worksheets',
+            ).toErr();
+          }
+          const canonicalWorksheets = resolvedWorksheets as string[];
+
+          const dashboardResult = await listDashboards({ executor, signal: extra.signal });
+          if (dashboardResult.isErr()) {
+            const detail = new DesktopCommandExecutionError(dashboardResult.error).message;
+            return terminalError(
+              `Could not read the live dashboard list (${detail}). Next call: list-dashboards, then call compose-dashboard again.`,
+              'compose-dashboard-dashboard-read-error',
+            ).toErr();
+          }
+
+          if (
+            dashboardResult.value.dashboards.some((existingName) =>
+              xmlNamesEqual(existingName, dashboardName),
+            )
+          ) {
+            return terminalError(
+              `Dashboard "${dashboardName}" already exists and was not overwritten. ` +
+                'Next call: compose-dashboard again with a new dashboardName.',
+              'compose-dashboard-duplicate-dashboard',
+            ).toErr();
+          }
+
+          const zones = computeZones(undefined, {
+            kpis: [],
+            charts: canonicalWorksheets,
+            layoutType: layout?.layoutType ?? 'auto-grid',
+            gridColumns: layout?.gridColumns,
+          });
+          const dashboardXml = buildDashboardXml(dashboardName, zones);
+          const applyResult = await loadDashboardXml({
+            dashboardName,
+            xml: dashboardXml,
+            focus: { navigate: 'artifact', sheetName: dashboardName },
+            executor,
+            signal: extra.signal,
+          });
+          if (applyResult.isErr()) {
+            const detail =
+              applyResult.error.type === 'execute-command-error'
+                ? new DesktopCommandExecutionError(applyResult.error.error).message
+                : new DashboardXmlLoadFailedError(applyResult.error.error).message;
+            return terminalError(
+              `Dashboard "${dashboardName}" was not confirmed applied (${detail}). ` +
+                'Next call: list-dashboards to check whether it exists before retrying compose-dashboard.',
+              'compose-dashboard-apply-error',
+            ).toErr();
+          }
+
+          const worksheetZones: WorksheetZoneReceipt[] = zones
+            .filter((zone) => zone.kind === 'worksheet')
+            .map((zone) => ({
+              worksheet: zone.name,
+              position: {
+                x: zone.x,
+                y: zone.y,
+                width: zone.w,
+                height: zone.h,
+              },
+            }));
+
+          return new Ok({
+            dashboardName,
+            zones: worksheetZones,
+            verification: formatDashboardPromiseCheck(applyResult.value.validationWarnings),
+          });
+        },
+      });
+    },
+  });
+
+  return tool;
+};

--- a/src/tools/desktop/dashboard/composeDashboard.ts
+++ b/src/tools/desktop/dashboard/composeDashboard.ts
@@ -3,6 +3,7 @@ import { DOMParser, Element as XmlElement, Node as XmlNode } from '@xmldom/xmldo
 import { Ok } from 'ts-results-es';
 import { z } from 'zod';
 
+import { dispatchApplyFocus } from '../../../desktop/commands/workbook/applyFocus.js';
 import { getWorkbookXml } from '../../../desktop/commands/workbook/getWorkbookXml.js';
 import { injectViewpoints } from '../../../desktop/commands/workbook/injectViewpoints.js';
 import { listDashboards } from '../../../desktop/commands/workbook/listDashboards.js';
@@ -173,7 +174,7 @@ export const getComposeDashboardTool = (
           const applyResult = await loadDashboardXml({
             dashboardName,
             xml: dashboardXml,
-            focus: { navigate: 'artifact', sheetName: dashboardName },
+            focus: { navigate: 'none', reason: 'intermediate-leg' },
             executor,
             signal: extra.signal,
           });
@@ -233,7 +234,14 @@ export const getComposeDashboardTool = (
             });
           }
 
-          if (viewpointAccounting.state !== 'success-already-present') {
+          if (viewpointAccounting.state === 'success-already-present') {
+            await dispatchApplyFocus({
+              focus: { navigate: 'artifact', sheetName: dashboardName },
+              postedXml: workbookResult.value,
+              executor,
+              signal: extra.signal,
+            });
+          } else {
             const viewpointApplyResult = await loadWorkbookXml({
               xml: updatedWorkbookXml,
               focus: { navigate: 'artifact', sheetName: dashboardName },

--- a/src/tools/desktop/dashboard/composeDashboard.ts
+++ b/src/tools/desktop/dashboard/composeDashboard.ts
@@ -1,9 +1,8 @@
 import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
-import { DOMParser } from '@xmldom/xmldom';
+import { DOMParser, Element as XmlElement, Node as XmlNode } from '@xmldom/xmldom';
 import { Ok } from 'ts-results-es';
 import { z } from 'zod';
 
-import { getDashboardFragment } from '../../../desktop/commands/workbook/getDashboardXml.js';
 import { getWorkbookXml } from '../../../desktop/commands/workbook/getWorkbookXml.js';
 import { injectViewpoints } from '../../../desktop/commands/workbook/injectViewpoints.js';
 import { listDashboards } from '../../../desktop/commands/workbook/listDashboards.js';
@@ -190,11 +189,27 @@ export const getComposeDashboardTool = (
             ).toErr();
           }
           const validationWarnings = [...applyResult.value.validationWarnings];
+          const worksheetZones: WorksheetZoneReceipt[] = zones
+            .filter((zone) => zone.kind === 'worksheet')
+            .map((zone) => ({
+              worksheet: zone.name,
+              position: {
+                x: zone.x,
+                y: zone.y,
+                width: zone.w,
+                height: zone.h,
+              },
+            }));
 
           const workbookResult = await getWorkbookXml({ executor, signal: extra.signal });
           if (workbookResult.isErr()) {
             const detail = new DesktopCommandExecutionError(workbookResult.error).message;
-            return viewpointTerminalError(dashboardName, detail);
+            return attemptedZonesResult({
+              dashboardName,
+              worksheetZones,
+              validationWarnings,
+              detail: `workbook XML was unavailable before viewpoint apply: ${detail}`,
+            });
           }
 
           const updatedWorkbookXml = injectViewpoints(
@@ -210,10 +225,12 @@ export const getComposeDashboardTool = (
           });
           if (viewpointAccounting.state === 'failed') {
             const failed = viewpointAccounting.failed.map((name) => `"${name}"`).join(', ');
-            return viewpointTerminalError(
+            return attemptedZonesResult({
               dashboardName,
-              `viewpoint injection did not land for ${failed}`,
-            );
+              worksheetZones,
+              validationWarnings,
+              detail: `viewpoint injection did not land for ${failed}`,
+            });
           }
 
           if (viewpointAccounting.state !== 'success-already-present') {
@@ -228,38 +245,40 @@ export const getComposeDashboardTool = (
                 viewpointApplyResult.error.type === 'execute-command-error'
                   ? new DesktopCommandExecutionError(viewpointApplyResult.error.error).message
                   : new WorkbookXmlLoadFailedError(viewpointApplyResult.error.error).message;
-              return viewpointTerminalError(dashboardName, detail);
+              return attemptedZonesResult({
+                dashboardName,
+                worksheetZones,
+                validationWarnings,
+                detail: `viewpoint workbook apply failed: ${detail}`,
+              });
             }
             validationWarnings.push(...viewpointApplyResult.value.validationWarnings);
           }
 
-          const worksheetZones: WorksheetZoneReceipt[] = zones
-            .filter((zone) => zone.kind === 'worksheet')
-            .map((zone) => ({
-              worksheet: zone.name,
-              position: {
-                x: zone.x,
-                y: zone.y,
-                width: zone.w,
-                height: zone.h,
-              },
-            }));
-
-          const readbackResult = await getDashboardFragment({
-            dashboardName,
-            executor,
-            signal: extra.signal,
-          });
-          if (
-            readbackResult.isErr() ||
-            !readbackConfirmsZones(readbackResult.value, worksheetZones)
-          ) {
-            return new Ok({
+          const readbackResult = await getWorkbookXml({ executor, signal: extra.signal });
+          if (readbackResult.isErr()) {
+            const detail = new DesktopCommandExecutionError(readbackResult.error).message;
+            return attemptedZonesResult({
               dashboardName,
-              attemptedZones: worksheetZones,
-              verification:
-                formatDashboardPromiseCheck(validationWarnings) +
-                ' Attempted dashboard zones are NOT confirmed because structural readback was unavailable or did not match.',
+              worksheetZones,
+              validationWarnings,
+              detail: `workbook XML readback was unavailable: ${detail}`,
+            });
+          }
+          if (
+            !readbackConfirmsDashboard(
+              readbackResult.value,
+              dashboardName,
+              worksheetZones,
+              canonicalWorksheets,
+            )
+          ) {
+            return attemptedZonesResult({
+              dashboardName,
+              worksheetZones,
+              validationWarnings,
+              detail:
+                'workbook XML readback did not confirm both the dashboard zone tree and all requested window viewpoints',
             });
           }
 
@@ -276,56 +295,143 @@ export const getComposeDashboardTool = (
   return tool;
 };
 
-function viewpointTerminalError(
-  dashboardName: string,
-  detail: string,
-): ReturnType<McpToolError['toErr']> {
-  return terminalError(
-    `Dashboard "${dashboardName}" exists but is NOT confirmed visible (${detail}). ` +
+function attemptedZonesResult({
+  dashboardName,
+  worksheetZones,
+  validationWarnings,
+  detail,
+}: {
+  dashboardName: string;
+  worksheetZones: WorksheetZoneReceipt[];
+  validationWarnings: Parameters<typeof formatDashboardPromiseCheck>[0];
+  detail: string;
+}): Ok<ComposeDashboardResult> {
+  return new Ok({
+    dashboardName,
+    attemptedZones: worksheetZones,
+    verification:
+      formatDashboardPromiseCheck(validationWarnings) +
+      ` Dashboard "${dashboardName}" exists because its dashboard apply completed; ` +
+      `the attempted zone tree and requested window viewpoints are NOT confirmed (${detail}). ` +
       'Next call: activate-sheet to bring it into view; do not recreate the dashboard.',
-    'compose-dashboard-viewpoint-error',
-  ).toErr();
+  });
 }
 
-function readbackConfirmsZones(
-  dashboardXml: string,
+function readbackConfirmsDashboard(
+  workbookXml: string,
+  dashboardName: string,
   expectedZones: WorksheetZoneReceipt[],
+  requestedViewpoints: string[],
 ): boolean {
   const document = new DOMParser({ errorHandler: () => {} }).parseFromString(
-    dashboardXml.trim(),
+    workbookXml.trim(),
     'text/xml',
   );
   if (document.getElementsByTagName('parsererror').length > 0) return false;
 
+  const dashboard = findNamedElement(document.getElementsByTagName('dashboard'), dashboardName);
+  if (!dashboard) return false;
+
   const actualZones: WorksheetZoneReceipt[] = [];
-  const zoneElements = document.getElementsByTagName('zone');
+  const zoneElements = dashboard.getElementsByTagName('zone');
   for (let index = 0; index < zoneElements.length; index++) {
     const zone = zoneElements.item(index);
     const worksheet = zone?.getAttribute('name');
     if (!zone || worksheet == null) continue;
+    const x = readCoordinate(zone, 'x');
+    const y = readCoordinate(zone, 'y');
+    const width = readCoordinate(zone, 'w');
+    const height = readCoordinate(zone, 'h');
+    if (x == null || y == null || width == null || height == null) continue;
     actualZones.push({
       worksheet,
-      position: {
-        x: Number(zone.getAttribute('x')),
-        y: Number(zone.getAttribute('y')),
-        width: Number(zone.getAttribute('w')),
-        height: Number(zone.getAttribute('h')),
-      },
+      position: { x, y, width, height },
     });
   }
 
-  return (
-    actualZones.length === expectedZones.length &&
-    actualZones.every((actual, index) => {
-      const expected = expectedZones[index];
-      if (expected === undefined) return false;
-      return (
+  if (!zonesMatchAsMultiset(actualZones, expectedZones)) return false;
+
+  const dashboardWindow = findDashboardWindow(document, dashboardName);
+  if (!dashboardWindow) return false;
+  const actualViewpoints = directViewpointNames(dashboardWindow);
+  return requestedViewpoints.every((requestedName) =>
+    actualViewpoints.some((actualName) => xmlNamesEqual(actualName, requestedName)),
+  );
+}
+
+function findNamedElement(
+  elements: ReturnType<XmlElement['getElementsByTagName']>,
+  name: string,
+): XmlElement | null {
+  for (let index = 0; index < elements.length; index++) {
+    const element = elements.item(index);
+    if (element && xmlNamesEqual(element.getAttribute('name') ?? '', name)) return element;
+  }
+  return null;
+}
+
+function readCoordinate(zone: XmlElement, attribute: string): number | null {
+  if (!zone.hasAttribute(attribute)) return null;
+  const raw = zone.getAttribute(attribute);
+  if (raw == null || raw.trim() === '') return null;
+  const value = Number(raw);
+  return Number.isFinite(value) ? value : null;
+}
+
+function zonesMatchAsMultiset(
+  actualZones: WorksheetZoneReceipt[],
+  expectedZones: WorksheetZoneReceipt[],
+): boolean {
+  if (actualZones.length !== expectedZones.length) return false;
+  const unmatched = [...actualZones];
+  for (const expected of expectedZones) {
+    const matchIndex = unmatched.findIndex(
+      (actual) =>
         xmlNamesEqual(actual.worksheet, expected.worksheet) &&
         actual.position.x === expected.position.x &&
         actual.position.y === expected.position.y &&
         actual.position.width === expected.position.width &&
-        actual.position.height === expected.position.height
-      );
-    })
-  );
+        actual.position.height === expected.position.height,
+    );
+    if (matchIndex === -1) return false;
+    unmatched.splice(matchIndex, 1);
+  }
+  return unmatched.length === 0;
+}
+
+function findDashboardWindow(
+  document: ReturnType<DOMParser['parseFromString']>,
+  dashboardName: string,
+): XmlElement | null {
+  const windows = document.getElementsByTagName('window');
+  for (let index = 0; index < windows.length; index++) {
+    const window = windows.item(index);
+    if (
+      window &&
+      window.getAttribute('class') === 'dashboard' &&
+      xmlNamesEqual(window.getAttribute('name') ?? '', dashboardName)
+    ) {
+      return window;
+    }
+  }
+  return null;
+}
+
+function directViewpointNames(dashboardWindow: XmlElement): string[] {
+  const names: string[] = [];
+  for (let index = 0; index < dashboardWindow.childNodes.length; index++) {
+    const child = dashboardWindow.childNodes.item(index);
+    if (!isElementNamed(child, 'viewpoints')) continue;
+    for (let viewpointIndex = 0; viewpointIndex < child.childNodes.length; viewpointIndex++) {
+      const viewpoint = child.childNodes.item(viewpointIndex);
+      if (!isElementNamed(viewpoint, 'viewpoint')) continue;
+      const name = viewpoint.getAttribute('name');
+      if (name) names.push(name);
+    }
+  }
+  return names;
+}
+
+function isElementNamed(node: XmlNode | null, tagName: string): node is XmlElement {
+  return node?.nodeType === 1 && (node as XmlElement).tagName === tagName;
 }

--- a/src/tools/desktop/dashboard/composeDashboard.ts
+++ b/src/tools/desktop/dashboard/composeDashboard.ts
@@ -333,9 +333,10 @@ function readbackConfirmsDashboard(
   if (!dashboard) return false;
 
   const actualZones: WorksheetZoneReceipt[] = [];
-  const zoneElements = dashboard.getElementsByTagName('zone');
-  for (let index = 0; index < zoneElements.length; index++) {
-    const zone = zoneElements.item(index);
+  const zonesElement = findDirectChildElement(dashboard, 'zones');
+  const zoneElements = zonesElement?.getElementsByTagName('zone');
+  for (let index = 0; index < (zoneElements?.length ?? 0); index++) {
+    const zone = zoneElements?.item(index);
     const worksheet = zone?.getAttribute('name');
     if (!zone || worksheet == null) continue;
     const x = readCoordinate(zone, 'x');
@@ -357,6 +358,13 @@ function readbackConfirmsDashboard(
   return requestedViewpoints.every((requestedName) =>
     actualViewpoints.some((actualName) => xmlNamesEqual(actualName, requestedName)),
   );
+}
+
+function findDirectChildElement(parent: XmlElement, name: string): XmlElement | null {
+  for (let child = parent.firstChild; child; child = child.nextSibling) {
+    if (child.nodeType === 1 && child.nodeName === name) return child as XmlElement;
+  }
+  return null;
 }
 
 function findNamedElement(

--- a/src/tools/desktop/dashboard/composeDashboard.ts
+++ b/src/tools/desktop/dashboard/composeDashboard.ts
@@ -4,6 +4,7 @@ import { Ok } from 'ts-results-es';
 import { z } from 'zod';
 
 import { dispatchApplyFocus } from '../../../desktop/commands/workbook/applyFocus.js';
+import { withApplyLock } from '../../../desktop/commands/workbook/applyMutex.js';
 import { getWorkbookXml } from '../../../desktop/commands/workbook/getWorkbookXml.js';
 import { injectViewpoints } from '../../../desktop/commands/workbook/injectViewpoints.js';
 import { listDashboards } from '../../../desktop/commands/workbook/listDashboards.js';
@@ -235,12 +236,14 @@ export const getComposeDashboardTool = (
           }
 
           if (viewpointAccounting.state === 'success-already-present') {
-            await dispatchApplyFocus({
-              focus: { navigate: 'artifact', sheetName: dashboardName },
-              postedXml: workbookResult.value,
-              executor,
-              signal: extra.signal,
-            });
+            await withApplyLock(() =>
+              dispatchApplyFocus({
+                focus: { navigate: 'artifact', sheetName: dashboardName },
+                postedXml: workbookResult.value,
+                executor,
+                signal: extra.signal,
+              }),
+            );
           } else {
             const viewpointApplyResult = await loadWorkbookXml({
               xml: updatedWorkbookXml,

--- a/src/tools/desktop/dashboard/composeDashboard.ts
+++ b/src/tools/desktop/dashboard/composeDashboard.ts
@@ -1,25 +1,36 @@
 import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { DOMParser } from '@xmldom/xmldom';
 import { Ok } from 'ts-results-es';
 import { z } from 'zod';
 
+import { getDashboardFragment } from '../../../desktop/commands/workbook/getDashboardXml.js';
+import { getWorkbookXml } from '../../../desktop/commands/workbook/getWorkbookXml.js';
+import { injectViewpoints } from '../../../desktop/commands/workbook/injectViewpoints.js';
 import { listDashboards } from '../../../desktop/commands/workbook/listDashboards.js';
 import { listWorksheets } from '../../../desktop/commands/workbook/listWorksheets.js';
 import { loadDashboardXml } from '../../../desktop/commands/workbook/loadDashboardXml.js';
+import { loadWorkbookXml } from '../../../desktop/commands/workbook/loadWorkbookXml.js';
 import { resolveSession } from '../../../desktop/sessionResolution.js';
 import { formatDashboardPromiseCheck } from '../../../desktop/validation/promise-check.js';
-import { xmlNamesEqual } from '../../../desktop/xmlElement.js';
+import { normalizeXmlName, xmlNamesEqual } from '../../../desktop/xmlElement.js';
 import {
   DashboardXmlLoadFailedError,
   DesktopCommandExecutionError,
   McpToolError,
+  WorkbookXmlLoadFailedError,
 } from '../../../errors/mcpToolError.js';
 import { DesktopMcpServer } from '../../../server.desktop.js';
 import { DesktopTool } from '../tool.js';
 import { buildDashboardXml, computeZones } from './dashboardZones.js';
+import { accountDashboardViewpoints } from './viewpointAccounting.js';
 
 const layoutSchema = z.object({
-  layoutType: z.enum(['auto-grid', 'rows', 'columns']).describe('Zone arrangement.'),
-  gridColumns: z.number().int().min(1).max(12).optional().describe('Auto-grid columns.'),
+  layoutType: z
+    .enum(['auto-grid', 'rows', 'columns'])
+    .optional()
+    .default('auto-grid')
+    .describe('Layout.'),
+  gridColumns: z.number().int().min(1).max(12).optional().describe('Grid columns.'),
 });
 
 const paramsSchema = {
@@ -38,11 +49,17 @@ type WorksheetZoneReceipt = {
   position: { x: number; y: number; width: number; height: number };
 };
 
-type ComposeDashboardResult = {
-  dashboardName: string;
-  zones: WorksheetZoneReceipt[];
-  verification: string;
-};
+type ComposeDashboardResult =
+  | {
+      dashboardName: string;
+      zones: WorksheetZoneReceipt[];
+      verification: string;
+    }
+  | {
+      dashboardName: string;
+      attemptedZones: WorksheetZoneReceipt[];
+      verification: string;
+    };
 
 function terminalError(message: string, type = 'compose-dashboard-refused'): McpToolError {
   return new McpToolError({ type, message, statusCode: 409 });
@@ -57,7 +74,7 @@ export const getComposeDashboardTool = (
     server,
     name: 'compose-dashboard',
     title,
-    description: 'Compose a dashboard from 2-12 existing sheets; no overwrite.',
+    description: 'Compose 2-12 existing sheets; no overwrite.',
     paramsSchema,
     annotations: {
       readOnlyHint: false,
@@ -113,6 +130,18 @@ export const getComposeDashboardTool = (
             ).toErr();
           }
           const canonicalWorksheets = resolvedWorksheets as string[];
+          const seenWorksheets = new Set<string>();
+          for (const worksheet of canonicalWorksheets) {
+            const canonicalName = normalizeXmlName(worksheet);
+            if (seenWorksheets.has(canonicalName)) {
+              return terminalError(
+                `Duplicate worksheet "${worksheet}" resolves to the same live worksheet more than once. ` +
+                  'Next call: compose-dashboard again with each worksheet listed once.',
+                'compose-dashboard-duplicate-worksheet',
+              ).toErr();
+            }
+            seenWorksheets.add(canonicalName);
+          }
 
           const dashboardResult = await listDashboards({ executor, signal: extra.signal });
           if (dashboardResult.isErr()) {
@@ -160,6 +189,49 @@ export const getComposeDashboardTool = (
               'compose-dashboard-apply-error',
             ).toErr();
           }
+          const validationWarnings = [...applyResult.value.validationWarnings];
+
+          const workbookResult = await getWorkbookXml({ executor, signal: extra.signal });
+          if (workbookResult.isErr()) {
+            const detail = new DesktopCommandExecutionError(workbookResult.error).message;
+            return viewpointTerminalError(dashboardName, detail);
+          }
+
+          const updatedWorkbookXml = injectViewpoints(
+            workbookResult.value,
+            dashboardName,
+            canonicalWorksheets,
+          );
+          const viewpointAccounting = accountDashboardViewpoints({
+            beforeXml: workbookResult.value,
+            afterXml: updatedWorkbookXml,
+            dashboardName,
+            requested: canonicalWorksheets,
+          });
+          if (viewpointAccounting.state === 'failed') {
+            const failed = viewpointAccounting.failed.map((name) => `"${name}"`).join(', ');
+            return viewpointTerminalError(
+              dashboardName,
+              `viewpoint injection did not land for ${failed}`,
+            );
+          }
+
+          if (viewpointAccounting.state !== 'success-already-present') {
+            const viewpointApplyResult = await loadWorkbookXml({
+              xml: updatedWorkbookXml,
+              focus: { navigate: 'artifact', sheetName: dashboardName },
+              executor,
+              signal: extra.signal,
+            });
+            if (viewpointApplyResult.isErr()) {
+              const detail =
+                viewpointApplyResult.error.type === 'execute-command-error'
+                  ? new DesktopCommandExecutionError(viewpointApplyResult.error.error).message
+                  : new WorkbookXmlLoadFailedError(viewpointApplyResult.error.error).message;
+              return viewpointTerminalError(dashboardName, detail);
+            }
+            validationWarnings.push(...viewpointApplyResult.value.validationWarnings);
+          }
 
           const worksheetZones: WorksheetZoneReceipt[] = zones
             .filter((zone) => zone.kind === 'worksheet')
@@ -173,10 +245,28 @@ export const getComposeDashboardTool = (
               },
             }));
 
+          const readbackResult = await getDashboardFragment({
+            dashboardName,
+            executor,
+            signal: extra.signal,
+          });
+          if (
+            readbackResult.isErr() ||
+            !readbackConfirmsZones(readbackResult.value, worksheetZones)
+          ) {
+            return new Ok({
+              dashboardName,
+              attemptedZones: worksheetZones,
+              verification:
+                formatDashboardPromiseCheck(validationWarnings) +
+                ' Attempted dashboard zones are NOT confirmed because structural readback was unavailable or did not match.',
+            });
+          }
+
           return new Ok({
             dashboardName,
             zones: worksheetZones,
-            verification: formatDashboardPromiseCheck(applyResult.value.validationWarnings),
+            verification: formatDashboardPromiseCheck(validationWarnings, true),
           });
         },
       });
@@ -185,3 +275,57 @@ export const getComposeDashboardTool = (
 
   return tool;
 };
+
+function viewpointTerminalError(
+  dashboardName: string,
+  detail: string,
+): ReturnType<McpToolError['toErr']> {
+  return terminalError(
+    `Dashboard "${dashboardName}" exists but is NOT confirmed visible (${detail}). ` +
+      'Next call: activate-sheet to bring it into view; do not recreate the dashboard.',
+    'compose-dashboard-viewpoint-error',
+  ).toErr();
+}
+
+function readbackConfirmsZones(
+  dashboardXml: string,
+  expectedZones: WorksheetZoneReceipt[],
+): boolean {
+  const document = new DOMParser({ errorHandler: () => {} }).parseFromString(
+    dashboardXml.trim(),
+    'text/xml',
+  );
+  if (document.getElementsByTagName('parsererror').length > 0) return false;
+
+  const actualZones: WorksheetZoneReceipt[] = [];
+  const zoneElements = document.getElementsByTagName('zone');
+  for (let index = 0; index < zoneElements.length; index++) {
+    const zone = zoneElements.item(index);
+    const worksheet = zone?.getAttribute('name');
+    if (!zone || worksheet == null) continue;
+    actualZones.push({
+      worksheet,
+      position: {
+        x: Number(zone.getAttribute('x')),
+        y: Number(zone.getAttribute('y')),
+        width: Number(zone.getAttribute('w')),
+        height: Number(zone.getAttribute('h')),
+      },
+    });
+  }
+
+  return (
+    actualZones.length === expectedZones.length &&
+    actualZones.every((actual, index) => {
+      const expected = expectedZones[index];
+      if (expected === undefined) return false;
+      return (
+        xmlNamesEqual(actual.worksheet, expected.worksheet) &&
+        actual.position.x === expected.position.x &&
+        actual.position.y === expected.position.y &&
+        actual.position.width === expected.position.width &&
+        actual.position.height === expected.position.height
+      );
+    })
+  );
+}

--- a/src/tools/desktop/dashboard/viewpointAccounting.test.ts
+++ b/src/tools/desktop/dashboard/viewpointAccounting.test.ts
@@ -1,0 +1,42 @@
+import { accountDashboardViewpoints } from './viewpointAccounting.js';
+
+describe('accountDashboardViewpoints', () => {
+  it('skips the second apply only when the dashboard window already has every viewpoint', () => {
+    const beforeXml =
+      '<workbook><windows><window class="dashboard" name="Sales &amp; Profit"><viewpoints><viewpoint name="Profit"/><viewpoint name="Sales"/></viewpoints></window></windows></workbook>';
+    const afterXml =
+      '<workbook><windows><window class="dashboard" name="Sales &amp; Profit"><viewpoints><viewpoint name="Sales"/><viewpoint name="Profit"/></viewpoints></window></windows></workbook>';
+
+    expect(
+      accountDashboardViewpoints({
+        beforeXml,
+        afterXml,
+        dashboardName: ' Sales & Profit ',
+        requested: ['Sales', 'Profit'],
+      }),
+    ).toEqual({
+      state: 'success-already-present',
+      requested: ['Sales', 'Profit'],
+      landed: ['Sales', 'Profit'],
+      failed: [],
+    });
+  });
+
+  it('does not report already present when the dashboard window is absent', () => {
+    const workbookXml = '<workbook><windows/></workbook>';
+
+    expect(
+      accountDashboardViewpoints({
+        beforeXml: workbookXml,
+        afterXml: workbookXml,
+        dashboardName: 'Sales Dashboard',
+        requested: ['Sales'],
+      }),
+    ).toEqual({
+      state: 'failed',
+      requested: ['Sales'],
+      landed: [],
+      failed: ['Sales'],
+    });
+  });
+});

--- a/src/tools/desktop/dashboard/viewpointAccounting.ts
+++ b/src/tools/desktop/dashboard/viewpointAccounting.ts
@@ -1,5 +1,7 @@
 import { DOMParser, Element as XmlElement, Node as XmlNode } from '@xmldom/xmldom';
 
+import { xmlNamesEqual } from '../../../desktop/xmlElement.js';
+
 export type ViewpointAccounting = {
   state: 'success' | 'success-already-present' | 'failed';
   requested: string[];
@@ -20,17 +22,21 @@ export function accountDashboardViewpoints({
 }): ViewpointAccounting {
   const before = dashboardViewpointNames(beforeXml, dashboardName);
   const after = dashboardViewpointNames(afterXml, dashboardName);
-  const landed = requested.filter((name) => after.has(name));
-  const failed = requested.filter((name) => !after.has(name));
+  const landed = requested.filter((name) =>
+    after.names.some((viewpointName) => xmlNamesEqual(viewpointName, name)),
+  );
+  const failed = requested.filter(
+    (name) => !after.names.some((viewpointName) => xmlNamesEqual(viewpointName, name)),
+  );
 
   if (failed.length === 0) {
+    const alreadyPresent =
+      before.windowExists &&
+      requested.every((name) =>
+        before.names.some((viewpointName) => xmlNamesEqual(viewpointName, name)),
+      );
     return {
-      state:
-        requested.length > 0 &&
-        afterXml === beforeXml &&
-        requested.every((name) => before.has(name))
-          ? 'success-already-present'
-          : 'success',
+      state: alreadyPresent ? 'success-already-present' : 'success',
       requested,
       landed,
       failed,
@@ -40,7 +46,10 @@ export function accountDashboardViewpoints({
   return { state: 'failed', requested, landed, failed };
 }
 
-function dashboardViewpointNames(workbookXml: string, dashboardName: string): Set<string> {
+function dashboardViewpointNames(
+  workbookXml: string,
+  dashboardName: string,
+): { windowExists: boolean; names: string[] } {
   const parser = new DOMParser({ errorHandler: () => {} });
   const doc = parser.parseFromString(workbookXml.trim(), 'text/xml');
   const windows = doc.getElementsByTagName('window');
@@ -49,16 +58,16 @@ function dashboardViewpointNames(workbookXml: string, dashboardName: string): Se
     if (
       window &&
       window.getAttribute('class') === 'dashboard' &&
-      window.getAttribute('name') === dashboardName
+      xmlNamesEqual(window.getAttribute('name') ?? '', dashboardName)
     ) {
-      return directViewpointNames(window);
+      return { windowExists: true, names: directViewpointNames(window) };
     }
   }
-  return new Set();
+  return { windowExists: false, names: [] };
 }
 
-function directViewpointNames(dashboardWindow: XmlElement): Set<string> {
-  const names = new Set<string>();
+function directViewpointNames(dashboardWindow: XmlElement): string[] {
+  const names: string[] = [];
   for (let i = 0; i < dashboardWindow.childNodes.length; i++) {
     const child = dashboardWindow.childNodes.item(i);
     if (!isElementNamed(child, 'viewpoints')) continue;
@@ -66,7 +75,7 @@ function directViewpointNames(dashboardWindow: XmlElement): Set<string> {
       const viewpoint = child.childNodes.item(j);
       if (isElementNamed(viewpoint, 'viewpoint')) {
         const name = viewpoint.getAttribute('name');
-        if (name) names.add(name);
+        if (name) names.push(name);
       }
     }
   }

--- a/src/tools/desktop/toolName.ts
+++ b/src/tools/desktop/toolName.ts
@@ -14,6 +14,7 @@ export const desktopToolNames = [
   'apply-dashboard',
   'apply-dashboard-with-viewpoints',
   'build-and-apply-dashboard',
+  'compose-dashboard',
   'list-available-fields',
   'list-fields',
   'add-field',

--- a/src/tools/desktop/tools.ts
+++ b/src/tools/desktop/tools.ts
@@ -14,6 +14,7 @@ import { getPlanDashboardCreationTool } from './coordination/planDashboardCreati
 import { getApplyDashboardTool } from './dashboard/applyDashboard.js';
 import { getApplyDashboardWithViewpointsTool } from './dashboard/applyDashboardWithViewpoints.js';
 import { getBuildAndApplyDashboardTool } from './dashboard/buildAndApplyDashboard.js';
+import { getComposeDashboardTool } from './dashboard/composeDashboard.js';
 import { getDashboardAutoApplyTool } from './dashboard/dashboardAutoApply.js';
 import { getGetDashboardGuideTool } from './dashboard/getDashboardGuide.js';
 import { getGetDashboardXmlTool } from './dashboard/getDashboardXml.js';
@@ -80,6 +81,7 @@ export const desktopToolFactories = [
   getApplyDashboardTool,
   getApplyDashboardWithViewpointsTool,
   getBuildAndApplyDashboardTool,
+  getComposeDashboardTool,
   getListAvailableFieldsTool,
   getListFieldsTool,
   getAddFieldTool,


### PR DESCRIPTION
**Decision.** Two rules we now keep, both enforced in code: (1) compose-dashboard claims success only from workbook-XML readback — the dashboard's own zone tree plus a window viewpoint per member worksheet, never from the apply call's return; (2) no dashboard tool navigates to a dashboard window that does not exist yet. The primary dashboard apply is an intermediate leg (`navigate:'none'`); focus lands with the write that creates the window, and the already-present short-circuits activate explicitly under the apply lock. The checked-in focus-disposition table pins both rules per call site.

**Why.** The old primary-apply goto fired against a windowless dashboard, failed live, popped blocking modal 47BF7751 (wedging the next call), and the failure was swallowed so receipts never showed it. Root-caused on a live probe 2026-07-28.

**Scope.** compose-dashboard (window creation, direct-zones readback, viewpoint-before-active order, focus), plus the same focus fix ported to apply-dashboard-with-viewpoints and build-and-apply-dashboard. Deliberately left out (banked with specs): applyDashboard.ts has the same shape with no later write to carry focus — needs a different fix; error-path guidance naming activate-sheet waits for window-aware activation, because today that guidance can steer an agent into the same modal.

**What future work must preserve.** A dashboard write that has not yet created its window must never carry artifact focus; the disposition table makes a silent change to that a readable diff.

**Evidence.** Suite 6335 pass + tsc + lint run firsthand; two Opus reviews (both SHIP — window existence on the already-present branch proven from viewpointAccounting, all state×window paths walked); live e1+m6 smokes on this exact bundle: PASS 96 / PASS 96, no modals. Caveat stated plainly: the smoke songs build no dashboard, so the modal kill's live proof is the banked windowless-goto probe; it ships here on unit tests + review.

**Approving this means** dashboard applies land verified and cannot wedge the session by navigating to a window that is not there yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)