### PR TITLE
feat(desktop): report only observed command outcomes and carry Desktop's real error text

### DIFF
--- a/src/desktop/desktopLogError.test.ts
+++ b/src/desktop/desktopLogError.test.ts
@@ -1,0 +1,213 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+import { readDesktopCommandError, snapshotDesktopLogs } from './desktopLogError.js';
+
+const PID = 63475;
+const STARTED_AT = new Date('2026-07-28T16:33:30.000');
+
+function record(value: Record<string, unknown>): string {
+  return `${JSON.stringify(value)}\n`;
+}
+
+describe('desktopLogError', () => {
+  let logDir: string;
+  let logPath: string;
+
+  beforeEach(() => {
+    logDir = fs.mkdtempSync(path.join(process.cwd(), '.desktop-log-error-test-'));
+    logPath = path.join(logDir, 'log_2.txt');
+    fs.writeFileSync(
+      logPath,
+      record({ ts: '2026-07-28T16:33:29.000', pid: PID, k: 'msg', v: 'before' }),
+    );
+  });
+
+  afterEach(() => {
+    fs.rmSync(logDir, { recursive: true, force: true });
+  });
+
+  it('extracts the Desktop parameter message and detailed-dialog error code', () => {
+    const cursor = snapshotDesktopLogs({ pid: PID, candidateDirs: [logDir] });
+    fs.appendFileSync(
+      logPath,
+      [
+        record({
+          ts: '2026-07-28T16:33:30.929',
+          pid: PID,
+          k: 'begin-commands-controller.invoke-command',
+          a: { id: 'command-id' },
+          v: { name: 'tabdoc:edit-calc', args: 'tabdoc:edit-calc field-name="A"' },
+        }),
+        record({
+          ts: '2026-07-28T16:33:30.929',
+          pid: PID,
+          k: 'msg',
+          v: "Error in parameters for command 'edit-calc'\nmissing: fn\n",
+        }),
+        record({
+          ts: '2026-07-28T16:33:30.930',
+          pid: PID,
+          k: 'begin-commands-controller.invoke-command',
+          a: { sponsor: 'command-id' },
+          v: {
+            name: 'tabdoc:show-detailed-error-dialog',
+            args: 'tabdoc:show-detailed-error-dialog error-short-message="Error in parameters for command \'edit-calc\'missing: fn" error-help-link="https://help.tableau.com/?errorcode=47bf7751"',
+          },
+        }),
+      ].join(''),
+    );
+
+    const result = readDesktopCommandError({
+      cursor,
+      pid: PID,
+      namespace: 'tabdoc',
+      command: 'edit-calc',
+      startedAt: STARTED_AT,
+    });
+
+    expect(result.logDetail).toBe('found');
+    expect(result.detail).toMatchObject({
+      message: "Error in parameters for command 'edit-calc'\nmissing: fn",
+      code: '47BF7751',
+      source: 'tableau-desktop-log',
+      logPath,
+      timestamp: '2026-07-28T16:33:30.929',
+    });
+  });
+
+  it('ignores matching records from another pid and before command start', () => {
+    const cursor = snapshotDesktopLogs({ pid: PID, candidateDirs: [logDir] });
+    fs.appendFileSync(
+      logPath,
+      [
+        record({
+          ts: '2026-07-28T16:33:30.929',
+          pid: PID + 1,
+          k: 'msg',
+          v: "Error in parameters for command 'edit-calc'\nwrong pid",
+        }),
+        record({
+          ts: '2026-07-28T16:33:20.000',
+          pid: PID,
+          k: 'msg',
+          v: "Error in parameters for command 'edit-calc'\nstale",
+        }),
+      ].join(''),
+    );
+
+    expect(
+      readDesktopCommandError({
+        cursor,
+        pid: PID,
+        namespace: 'tabdoc',
+        command: 'edit-calc',
+        startedAt: STARTED_AT,
+      }),
+    ).toEqual({ detail: null, logDetail: 'not-found' });
+  });
+
+  it('extracts the detailed-error-msg carrier', () => {
+    const cursor = snapshotDesktopLogs({ pid: PID, candidateDirs: [logDir] });
+    fs.appendFileSync(
+      logPath,
+      record({
+        ts: '2026-07-28T16:33:30.929',
+        pid: PID,
+        k: 'detailed-error-msg',
+        v: {
+          shortMessage: "Command 'edit-calc' rejected the formula",
+          supportUrl: 'https://help.tableau.com/?errorcode=abc123',
+        },
+      }),
+    );
+
+    const result = readDesktopCommandError({
+      cursor,
+      pid: PID,
+      namespace: 'tabdoc',
+      command: 'edit-calc',
+      startedAt: STARTED_AT,
+    });
+
+    expect(result.detail).toMatchObject({
+      message: "Command 'edit-calc' rejected the formula",
+      code: 'ABC123',
+    });
+  });
+
+  it('extracts the correlated command-end carrier', () => {
+    const cursor = snapshotDesktopLogs({ pid: PID, candidateDirs: [logDir] });
+    fs.appendFileSync(
+      logPath,
+      [
+        record({
+          ts: '2026-07-28T16:33:30.929',
+          pid: PID,
+          k: 'begin-commands-controller.invoke-command',
+          a: { id: 'command-id' },
+          v: { name: 'tabdoc:edit-calc' },
+        }),
+        record({
+          ts: '2026-07-28T16:33:30.930',
+          pid: PID,
+          k: 'end-commands-controller.invoke-command',
+          a: { id: 'command-id', rv: { msg: 'Calculation failed', 'e-code': '47bf7751' } },
+        }),
+      ].join(''),
+    );
+
+    const result = readDesktopCommandError({
+      cursor,
+      pid: PID,
+      namespace: 'tabdoc',
+      command: 'edit-calc',
+      startedAt: STARTED_AT,
+    });
+
+    expect(result.detail).toMatchObject({ message: 'Calculation failed', code: '47BF7751' });
+  });
+
+  it('follows a same-inode rotation and ignores a malformed final line', () => {
+    const cursor = snapshotDesktopLogs({ pid: PID, candidateDirs: [logDir] });
+    const rotatedPath = path.join(logDir, 'log_2_bk.txt');
+    fs.renameSync(logPath, rotatedPath);
+    fs.appendFileSync(
+      rotatedPath,
+      record({
+        ts: '2026-07-28T16:33:30.929',
+        pid: PID,
+        k: 'msg',
+        v: "Error in parameters for command 'edit-calc'\nmissing: fn",
+      }) + '{"partial":',
+    );
+
+    const result = readDesktopCommandError({
+      cursor,
+      pid: PID,
+      namespace: 'tabdoc',
+      command: 'edit-calc',
+      startedAt: STARTED_AT,
+    });
+
+    expect(result.logDetail).toBe('found');
+    expect(result.detail?.logPath).toBe(rotatedPath);
+  });
+
+  it('degrades to unavailable without readable log files', () => {
+    const cursor = snapshotDesktopLogs({
+      pid: PID,
+      candidateDirs: [path.join(logDir, 'missing')],
+    });
+
+    expect(
+      readDesktopCommandError({
+        cursor,
+        pid: PID,
+        namespace: 'tabdoc',
+        command: 'edit-calc',
+        startedAt: STARTED_AT,
+      }),
+    ).toEqual({ detail: null, logDetail: 'unavailable' });
+  });
+});

--- a/src/desktop/desktopLogError.test.ts
+++ b/src/desktop/desktopLogError.test.ts
@@ -27,7 +27,7 @@ describe('desktopLogError', () => {
     fs.rmSync(logDir, { recursive: true, force: true });
   });
 
-  it('extracts the Desktop parameter message and detailed-dialog error code', () => {
+  it('extracts the Desktop parameter message and detailed-dialog error code', async () => {
     const cursor = snapshotDesktopLogs({ pid: PID, candidateDirs: [logDir] });
     fs.appendFileSync(
       logPath,
@@ -58,7 +58,7 @@ describe('desktopLogError', () => {
       ].join(''),
     );
 
-    const result = readDesktopCommandError({
+    const result = await readDesktopCommandError({
       cursor,
       pid: PID,
       namespace: 'tabdoc',
@@ -76,7 +76,7 @@ describe('desktopLogError', () => {
     });
   });
 
-  it('ignores matching records from another pid and before command start', () => {
+  it('ignores matching records from another pid and before command start', async () => {
     const cursor = snapshotDesktopLogs({ pid: PID, candidateDirs: [logDir] });
     fs.appendFileSync(
       logPath,
@@ -97,7 +97,7 @@ describe('desktopLogError', () => {
     );
 
     expect(
-      readDesktopCommandError({
+      await readDesktopCommandError({
         cursor,
         pid: PID,
         namespace: 'tabdoc',
@@ -107,7 +107,7 @@ describe('desktopLogError', () => {
     ).toEqual({ detail: null, logDetail: 'not-found' });
   });
 
-  it('extracts the detailed-error-msg carrier', () => {
+  it('extracts the detailed-error-msg carrier', async () => {
     const cursor = snapshotDesktopLogs({ pid: PID, candidateDirs: [logDir] });
     fs.appendFileSync(
       logPath,
@@ -122,7 +122,7 @@ describe('desktopLogError', () => {
       }),
     );
 
-    const result = readDesktopCommandError({
+    const result = await readDesktopCommandError({
       cursor,
       pid: PID,
       namespace: 'tabdoc',
@@ -136,7 +136,7 @@ describe('desktopLogError', () => {
     });
   });
 
-  it('extracts the correlated command-end carrier', () => {
+  it('extracts the correlated command-end carrier', async () => {
     const cursor = snapshotDesktopLogs({ pid: PID, candidateDirs: [logDir] });
     fs.appendFileSync(
       logPath,
@@ -157,7 +157,7 @@ describe('desktopLogError', () => {
       ].join(''),
     );
 
-    const result = readDesktopCommandError({
+    const result = await readDesktopCommandError({
       cursor,
       pid: PID,
       namespace: 'tabdoc',
@@ -168,7 +168,7 @@ describe('desktopLogError', () => {
     expect(result.detail).toMatchObject({ message: 'Calculation failed', code: '47BF7751' });
   });
 
-  it('follows a same-inode rotation and ignores a malformed final line', () => {
+  it('follows a same-inode rotation and ignores a malformed final line', async () => {
     const cursor = snapshotDesktopLogs({ pid: PID, candidateDirs: [logDir] });
     const rotatedPath = path.join(logDir, 'log_2_bk.txt');
     fs.renameSync(logPath, rotatedPath);
@@ -182,7 +182,7 @@ describe('desktopLogError', () => {
       }) + '{"partial":',
     );
 
-    const result = readDesktopCommandError({
+    const result = await readDesktopCommandError({
       cursor,
       pid: PID,
       namespace: 'tabdoc',
@@ -194,14 +194,46 @@ describe('desktopLogError', () => {
     expect(result.detail?.logPath).toBe(rotatedPath);
   });
 
-  it('degrades to unavailable without readable log files', () => {
+  it('retries once when the matching record is flushed after the first read', async () => {
+    const cursor = snapshotDesktopLogs({ pid: PID, candidateDirs: [logDir] });
+    const recordFlushed = new Promise<void>((resolve) => {
+      setTimeout(() => {
+        fs.appendFileSync(
+          logPath,
+          record({
+            ts: '2026-07-28T16:33:30.929',
+            pid: PID,
+            k: 'msg',
+            v: "Error in parameters for command 'edit-calc'\nflushed late",
+          }),
+        );
+        resolve();
+      }, 0);
+    });
+
+    const pendingResult = readDesktopCommandError({
+      cursor,
+      pid: PID,
+      namespace: 'tabdoc',
+      command: 'edit-calc',
+      startedAt: STARTED_AT,
+      logFlushDelayMs: 1,
+    });
+    await recordFlushed;
+    const result = await pendingResult;
+
+    expect(result.logDetail).toBe('found');
+    expect(result.detail?.message).toContain('flushed late');
+  });
+
+  it('degrades to unavailable without readable log files', async () => {
     const cursor = snapshotDesktopLogs({
       pid: PID,
       candidateDirs: [path.join(logDir, 'missing')],
     });
 
     expect(
-      readDesktopCommandError({
+      await readDesktopCommandError({
         cursor,
         pid: PID,
         namespace: 'tabdoc',

--- a/src/desktop/desktopLogError.ts
+++ b/src/desktop/desktopLogError.ts
@@ -5,6 +5,8 @@ const MAX_BYTES_PER_FILE = 256 * 1024;
 const MAX_BYTES_TOTAL = 1024 * 1024;
 const CLOCK_TOLERANCE_MS = 1_000;
 const MAX_MESSAGE_LENGTH = 4_096;
+const DEFAULT_LOG_FLUSH_DELAY_MS = 150;
+const MAX_LOG_FLUSH_DELAY_MS = 250;
 
 type LogFileCursor = {
   path: string;
@@ -47,6 +49,14 @@ type ParsedRecord = {
   logPath: string;
   timestamp: string;
   timestampMs: number;
+};
+
+type ReadDesktopCommandErrorArgs = {
+  cursor: DesktopLogCursor;
+  pid: number;
+  namespace: string;
+  command: string;
+  startedAt: Date;
 };
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -217,19 +227,13 @@ function quotedArgument(args: string, argumentName: string): string | undefined 
   return args.match(new RegExp(`(?:^|\\s)${escapedName}="([^"]*)"`))?.[1];
 }
 
-export function readDesktopCommandError({
+function readDesktopCommandErrorOnce({
   cursor,
   pid,
   namespace,
   command,
   startedAt,
-}: {
-  cursor: DesktopLogCursor;
-  pid: number;
-  namespace: string;
-  command: string;
-  startedAt: Date;
-}): DesktopCommandErrorRead {
+}: ReadDesktopCommandErrorArgs): DesktopCommandErrorRead {
   try {
     if (!cursor.available || cursor.pid !== pid) {
       return { detail: null, logDetail: 'unavailable' };
@@ -339,4 +343,20 @@ export function readDesktopCommandError({
   } catch {
     return { detail: null, logDetail: 'unavailable' };
   }
+}
+
+export async function readDesktopCommandError({
+  logFlushDelayMs = DEFAULT_LOG_FLUSH_DELAY_MS,
+  ...args
+}: ReadDesktopCommandErrorArgs & {
+  logFlushDelayMs?: number;
+}): Promise<DesktopCommandErrorRead> {
+  const firstRead = readDesktopCommandErrorOnce(args);
+  if (firstRead.logDetail !== 'not-found') return firstRead;
+
+  const boundedDelay = Number.isFinite(logFlushDelayMs)
+    ? Math.min(MAX_LOG_FLUSH_DELAY_MS, Math.max(0, logFlushDelayMs))
+    : DEFAULT_LOG_FLUSH_DELAY_MS;
+  await new Promise((resolve) => setTimeout(resolve, boundedDelay));
+  return readDesktopCommandErrorOnce(args);
 }

--- a/src/desktop/desktopLogError.ts
+++ b/src/desktop/desktopLogError.ts
@@ -1,0 +1,342 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+const MAX_BYTES_PER_FILE = 256 * 1024;
+const MAX_BYTES_TOTAL = 1024 * 1024;
+const CLOCK_TOLERANCE_MS = 1_000;
+const MAX_MESSAGE_LENGTH = 4_096;
+
+type LogFileCursor = {
+  path: string;
+  dev: number;
+  ino: number;
+  size: number;
+  mtimeMs: number;
+};
+
+export type DesktopLogCursor = {
+  pid: number;
+  candidateDirs: string[];
+  files: LogFileCursor[];
+  available: boolean;
+};
+
+export type DesktopCommandError = {
+  message: string;
+  code?: string;
+  source: 'tableau-desktop-log';
+  logPath: string;
+  timestamp: string;
+};
+
+export type DesktopCommandErrorRead = {
+  detail: DesktopCommandError | null;
+  logDetail: 'found' | 'not-found' | 'unavailable';
+};
+
+type DesktopLogRecord = {
+  ts?: unknown;
+  pid?: unknown;
+  k?: unknown;
+  v?: unknown;
+  a?: unknown;
+};
+
+type ParsedRecord = {
+  record: DesktopLogRecord;
+  logPath: string;
+  timestamp: string;
+  timestampMs: number;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function listLogFiles(candidateDirs: string[]): {
+  files: LogFileCursor[];
+  readableDirectory: boolean;
+} {
+  const files: LogFileCursor[] = [];
+  let readableDirectory = false;
+
+  for (const candidateDir of candidateDirs) {
+    let names: string[];
+    try {
+      names = fs.readdirSync(candidateDir);
+      readableDirectory = true;
+    } catch {
+      continue;
+    }
+
+    for (const name of names) {
+      if (!/^log.*\.txt$/i.test(name)) continue;
+      const logPath = path.join(candidateDir, name);
+      try {
+        const stat = fs.lstatSync(logPath);
+        if (!stat.isFile()) continue;
+        files.push({
+          path: logPath,
+          dev: stat.dev,
+          ino: stat.ino,
+          size: stat.size,
+          mtimeMs: stat.mtimeMs,
+        });
+      } catch {
+        // Rotation can remove a file between directory listing and stat.
+      }
+    }
+  }
+
+  return { files, readableDirectory };
+}
+
+export function snapshotDesktopLogs({
+  pid,
+  candidateDirs,
+}: {
+  pid: number;
+  candidateDirs: string[];
+}): DesktopLogCursor {
+  try {
+    const { files, readableDirectory } = listLogFiles(candidateDirs);
+    return {
+      pid,
+      candidateDirs: [...candidateDirs],
+      files,
+      available: readableDirectory && files.length > 0,
+    };
+  } catch {
+    return { pid, candidateDirs: [...candidateDirs], files: [], available: false };
+  }
+}
+
+function readChangedLines(cursor: DesktopLogCursor): {
+  lines: Array<{ line: string; logPath: string }>;
+  accessible: boolean;
+  readAny: boolean;
+} {
+  const { files: currentFiles, readableDirectory } = listLogFiles(cursor.candidateDirs);
+  if (!readableDirectory || currentFiles.length === 0) {
+    return { lines: [], accessible: false, readAny: false };
+  }
+
+  const priorByPath = new Map(cursor.files.map((file) => [file.path, file]));
+  const priorByIdentity = new Map(cursor.files.map((file) => [`${file.dev}:${file.ino}`, file]));
+  const lines: Array<{ line: string; logPath: string }> = [];
+  let bytesRemaining = MAX_BYTES_TOTAL;
+  let readAny = false;
+
+  for (const current of currentFiles.sort((left, right) => left.mtimeMs - right.mtimeMs)) {
+    if (bytesRemaining <= 0) break;
+    const atPath = priorByPath.get(current.path);
+    const byIdentity = priorByIdentity.get(`${current.dev}:${current.ino}`);
+    const prior = atPath?.dev === current.dev && atPath.ino === current.ino ? atPath : byIdentity;
+
+    if (prior && prior.size === current.size && prior.mtimeMs === current.mtimeMs) continue;
+
+    let start = 0;
+    if (prior && current.size >= prior.size) {
+      start = prior.size;
+    } else if (prior || current.size > MAX_BYTES_PER_FILE) {
+      start = Math.max(0, current.size - MAX_BYTES_PER_FILE);
+    }
+
+    const availableBytes = Math.max(0, current.size - start);
+    const length = Math.min(availableBytes, MAX_BYTES_PER_FILE, bytesRemaining);
+    if (length === 0) continue;
+    if (availableBytes > length) start = current.size - length;
+
+    let fileDescriptor: number | undefined;
+    try {
+      fileDescriptor = fs.openSync(current.path, 'r');
+      const buffer = Buffer.alloc(length);
+      const bytesRead = fs.readSync(fileDescriptor, buffer, 0, length, start);
+      const text = buffer.subarray(0, bytesRead).toString('utf8');
+      readAny = true;
+      bytesRemaining -= bytesRead;
+      for (const line of text.split('\n')) {
+        if (line.trim()) lines.push({ line, logPath: current.path });
+      }
+    } catch {
+      // Diagnostics are best-effort; unreadable files are ignored.
+    } finally {
+      if (fileDescriptor !== undefined) {
+        try {
+          fs.closeSync(fileDescriptor);
+        } catch {
+          // A close failure must not affect command handling.
+        }
+      }
+    }
+  }
+
+  return { lines, accessible: true, readAny };
+}
+
+function parseTimestamp(value: unknown): { timestamp: string; timestampMs: number } | null {
+  if (typeof value !== 'string') return null;
+  const timestampMs = Date.parse(value);
+  return Number.isFinite(timestampMs) ? { timestamp: value, timestampMs } : null;
+}
+
+function commandName(record: DesktopLogRecord): string | null {
+  if (!isRecord(record.v)) return null;
+  if (typeof record.v.name === 'string') return record.v.name;
+  if (typeof record.v.args === 'string') return record.v.args.split(/\s/, 1)[0] || null;
+  return null;
+}
+
+function invocationId(record: DesktopLogRecord): string | null {
+  return isRecord(record.a) && typeof record.a.id === 'string' ? record.a.id : null;
+}
+
+function sponsorId(record: DesktopLogRecord): string | null {
+  return isRecord(record.a) && typeof record.a.sponsor === 'string' ? record.a.sponsor : null;
+}
+
+function boundedMessage(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const message = value.trim().slice(0, MAX_MESSAGE_LENGTH);
+  return message || null;
+}
+
+function normalizeCode(value: unknown): string | undefined {
+  if (typeof value !== 'string' && typeof value !== 'number') return undefined;
+  const code = String(value).trim().slice(0, 64);
+  return code ? code.toUpperCase() : undefined;
+}
+
+function errorCodeFromUrl(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  return normalizeCode(value.match(/[?&]errorcode=([^&#"\s]+)/i)?.[1]);
+}
+
+function quotedArgument(args: string, argumentName: string): string | undefined {
+  const escapedName = argumentName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return args.match(new RegExp(`(?:^|\\s)${escapedName}="([^"]*)"`))?.[1];
+}
+
+export function readDesktopCommandError({
+  cursor,
+  pid,
+  namespace,
+  command,
+  startedAt,
+}: {
+  cursor: DesktopLogCursor;
+  pid: number;
+  namespace: string;
+  command: string;
+  startedAt: Date;
+}): DesktopCommandErrorRead {
+  try {
+    if (!cursor.available || cursor.pid !== pid) {
+      return { detail: null, logDetail: 'unavailable' };
+    }
+
+    const changed = readChangedLines(cursor);
+    if (!changed.accessible) return { detail: null, logDetail: 'unavailable' };
+    if (!changed.readAny) return { detail: null, logDetail: 'not-found' };
+
+    const earliestTimestamp = startedAt.getTime() - CLOCK_TOLERANCE_MS;
+    const parsed: ParsedRecord[] = [];
+    for (const candidate of changed.lines) {
+      try {
+        const record = JSON.parse(candidate.line) as DesktopLogRecord;
+        if (record.pid !== pid) continue;
+        const timestamp = parseTimestamp(record.ts);
+        if (!timestamp || timestamp.timestampMs < earliestTimestamp) continue;
+        parsed.push({ record, logPath: candidate.logPath, ...timestamp });
+      } catch {
+        // Ignore malformed and partially flushed JSONL records.
+      }
+    }
+
+    const targetCommand = `${namespace}:${command}`;
+    const commandInvocationIds = new Set<string>();
+    for (const candidate of parsed) {
+      if (
+        candidate.record.k === 'begin-commands-controller.invoke-command' &&
+        commandName(candidate.record) === targetCommand
+      ) {
+        const id = invocationId(candidate.record);
+        if (id) commandInvocationIds.add(id);
+      }
+    }
+
+    let message: string | null = null;
+    let code: string | undefined;
+    let carrier: ParsedRecord | null = null;
+
+    for (const candidate of parsed) {
+      const { record } = candidate;
+      if (
+        record.k === 'msg' &&
+        typeof record.v === 'string' &&
+        record.v.includes(`Error in parameters for command '${command}'`)
+      ) {
+        const nextMessage = boundedMessage(record.v);
+        if (nextMessage) {
+          message = nextMessage;
+          carrier = candidate;
+        }
+        continue;
+      }
+
+      if (record.k === 'detailed-error-msg' && isRecord(record.v)) {
+        const nextMessage = boundedMessage(record.v.shortMessage);
+        if (nextMessage?.includes(command)) {
+          message ??= nextMessage;
+          carrier ??= candidate;
+          code ??= errorCodeFromUrl(record.v.supportUrl ?? record.v.helpLink);
+        }
+        continue;
+      }
+
+      if (record.k === 'end-commands-controller.invoke-command' && isRecord(record.a)) {
+        const belongsToCommand =
+          commandName(record) === targetCommand ||
+          commandInvocationIds.has(invocationId(record) ?? '') ||
+          commandInvocationIds.has(sponsorId(record) ?? '');
+        const returnValue = isRecord(record.a.rv) ? record.a.rv : null;
+        const nextMessage = boundedMessage(returnValue?.msg);
+        if (belongsToCommand && nextMessage) {
+          message ??= nextMessage;
+          carrier ??= candidate;
+          code ??= normalizeCode(returnValue?.['e-code']);
+        }
+        continue;
+      }
+
+      if (
+        record.k === 'begin-commands-controller.invoke-command' &&
+        commandName(record) === 'tabdoc:show-detailed-error-dialog' &&
+        commandInvocationIds.has(sponsorId(record) ?? '') &&
+        isRecord(record.v) &&
+        typeof record.v.args === 'string'
+      ) {
+        const nextMessage = boundedMessage(quotedArgument(record.v.args, 'error-short-message'));
+        if (nextMessage) {
+          message ??= nextMessage;
+          carrier ??= candidate;
+        }
+        code ??= errorCodeFromUrl(quotedArgument(record.v.args, 'error-help-link'));
+      }
+    }
+
+    if (!message || !carrier) return { detail: null, logDetail: 'not-found' };
+    return {
+      detail: {
+        message,
+        ...(code ? { code } : {}),
+        source: 'tableau-desktop-log',
+        logPath: carrier.logPath,
+        timestamp: carrier.timestamp,
+      },
+      logDetail: 'found',
+    };
+  } catch {
+    return { detail: null, logDetail: 'unavailable' };
+  }
+}

--- a/src/desktop/externalApi/externalApiToolExecutor.test.ts
+++ b/src/desktop/externalApi/externalApiToolExecutor.test.ts
@@ -1,3 +1,6 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
 import * as logger from '../../logging/logger.js';
 import { ExternalApiToolExecutor } from './externalApiToolExecutor.js';
 import { MockExternalApiServer, startMockExternalApiServer } from './mockExternalApiServer.js';
@@ -154,6 +157,116 @@ describe('ExternalApiToolExecutor', () => {
       expect(error.type).toBe('command-failed');
       if (error.type === 'command-failed') {
         expect(error.error?.code).toBe('operation-failed');
+      }
+    });
+
+    it('preserves a running operation instead of reporting it completed', async () => {
+      server.setOverride('POST /v0/app:invokeCommand', {
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          id: 'op-running-1',
+          kind: 'command.invoke',
+          state: 'RUNNING',
+          createdAt: '2026-07-28T16:33:30.000Z',
+        }),
+      });
+      const executor = new ExternalApiToolExecutor({ discover: () => [instanceFor(server)] });
+      await executor.start();
+
+      const result = await executor.executeCommand({
+        namespace: 'tabdoc',
+        command: 'undo',
+        signal,
+      });
+
+      expect(result.isOk()).toBe(true);
+      expect(result.unwrap()).toMatchObject({
+        command_id: 'op-running-1',
+        status: 'running',
+        submitted_at: '2026-07-28T16:33:30.000Z',
+      });
+      expect(result.unwrap().completed_at).toBeUndefined();
+    });
+
+    it('enriches a failed operation with bounded Desktop-log detail', async () => {
+      const logDir = fs.mkdtempSync(path.join(process.cwd(), '.executor-log-error-test-'));
+      const logPath = path.join(logDir, 'log_2.txt');
+      fs.writeFileSync(logPath, '');
+      server.setOverride('POST /v0/app:invokeCommand', {
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          id: 'op-fail-log-1',
+          kind: 'command.invoke',
+          state: 'FAILED',
+          error: { code: 'operation-failed', message: 'Command execution failed' },
+        }),
+      });
+      const fetchFn: typeof fetch = async (input, init) => {
+        const response = await fetch(input, init);
+        const timestamp = new Date().toISOString();
+        fs.appendFileSync(
+          logPath,
+          [
+            JSON.stringify({
+              ts: timestamp,
+              pid: 999,
+              k: 'begin-commands-controller.invoke-command',
+              a: { id: 'command-id' },
+              v: { name: 'tabdoc:edit-calc', args: 'tabdoc:edit-calc field-name="A"' },
+            }),
+            JSON.stringify({
+              ts: timestamp,
+              pid: 999,
+              k: 'msg',
+              v: "Error in parameters for command 'edit-calc'\nmissing: fn\n",
+            }),
+            JSON.stringify({
+              ts: timestamp,
+              pid: 999,
+              k: 'begin-commands-controller.invoke-command',
+              a: { sponsor: 'command-id' },
+              v: {
+                name: 'tabdoc:show-detailed-error-dialog',
+                args: 'tabdoc:show-detailed-error-dialog error-short-message="bad calc" error-help-link="https://help.tableau.com/?errorcode=47bf7751"',
+              },
+            }),
+          ].join('\n') + '\n',
+        );
+        return response;
+      };
+
+      try {
+        const executor = new ExternalApiToolExecutor({
+          discover: () => [instanceFor(server)],
+          clientOptions: { fetchFn },
+          desktopLogDirs: [logDir],
+        });
+        await executor.start();
+
+        const result = await executor.executeCommand({
+          namespace: 'tabdoc',
+          command: 'edit-calc',
+          signal,
+        });
+
+        const error = result.unwrapErr();
+        expect(error.type).toBe('command-failed');
+        if (error.type === 'command-failed') {
+          expect(error.error).toMatchObject({
+            code: 'operation-failed',
+            message: "Error in parameters for command 'edit-calc'\nmissing: fn",
+            recoverable: false,
+            'tableau-error-code': '47BF7751',
+            log_detail: {
+              source: 'tableau-desktop-log',
+              file: 'log_2.txt',
+            },
+          });
+        }
+      } finally {
+        fs.rmSync(logDir, { recursive: true, force: true });
       }
     });
 

--- a/src/desktop/externalApi/externalApiToolExecutor.test.ts
+++ b/src/desktop/externalApi/externalApiToolExecutor.test.ts
@@ -256,10 +256,11 @@ describe('ExternalApiToolExecutor', () => {
         if (error.type === 'command-failed') {
           expect(error.error).toMatchObject({
             code: 'operation-failed',
-            message: "Error in parameters for command 'edit-calc'\nmissing: fn",
+            message: 'Command execution failed',
             recoverable: false,
             'tableau-error-code': '47BF7751',
             log_detail: {
+              message: "Error in parameters for command 'edit-calc'\nmissing: fn",
               source: 'tableau-desktop-log',
               file: 'log_2.txt',
             },

--- a/src/desktop/externalApi/externalApiToolExecutor.test.ts
+++ b/src/desktop/externalApi/externalApiToolExecutor.test.ts
@@ -599,6 +599,56 @@ describe('ExternalApiToolExecutor', () => {
       expect(discover).toHaveBeenCalledTimes(1);
     });
 
+    it('appends matching Desktop-log detail to the original timeout message', async () => {
+      const logDir = fs.mkdtempSync(path.join(process.cwd(), '.executor-timeout-log-test-'));
+      const logPath = path.join(logDir, 'log_2.txt');
+      fs.writeFileSync(logPath, '');
+      const fetchFn = ((_url: string, init?: RequestInit): Promise<Response> =>
+        new Promise((_resolve, reject) => {
+          init?.signal?.addEventListener(
+            'abort',
+            () => {
+              fs.appendFileSync(
+                logPath,
+                `${JSON.stringify({
+                  ts: new Date().toISOString(),
+                  pid: 999,
+                  k: 'msg',
+                  v: "Error in parameters for command 'undo': blocking dialog",
+                })}\n`,
+              );
+              reject(init.signal?.reason);
+            },
+            { once: true },
+          );
+        })) as unknown as typeof fetch;
+
+      try {
+        const executor = new ExternalApiToolExecutor({
+          discover: () => [instanceFor(server)],
+          clientOptions: { fetchFn, timeoutMs: 60 },
+          desktopLogDirs: [logDir],
+        });
+        await executor.start();
+
+        const result = await executor.executeCommand({
+          namespace: 'tabdoc',
+          command: 'undo',
+          signal,
+        });
+
+        const error = result.unwrapErr();
+        expect(error.type).toBe('command-timed-out');
+        if (error.type === 'command-timed-out') {
+          expect(error.error).toContain('The operation was aborted due to timeout');
+          expect(error.error).toContain('blocking dialog');
+          expect(error.error).toContain('Desktop log (log_2.txt');
+        }
+      } finally {
+        fs.rmSync(logDir, { recursive: true, force: true });
+      }
+    });
+
     it('respects caller aborts and maps them to command-timed-out', async () => {
       const discover = vi.fn(() => [instanceFor(server)]);
       const executor = new ExternalApiToolExecutor({

--- a/src/desktop/externalApi/externalApiToolExecutor.ts
+++ b/src/desktop/externalApi/externalApiToolExecutor.ts
@@ -604,9 +604,9 @@ function enrichCommandErrorFromDesktopLog(
     type: 'command-failed',
     error: {
       ...error.error,
-      message: detail.message,
       ...(detail.code ? { 'tableau-error-code': detail.code } : {}),
       log_detail: {
+        message: detail.message,
         source: detail.source,
         file: path.basename(detail.logPath),
         timestamp: detail.timestamp,

--- a/src/desktop/externalApi/externalApiToolExecutor.ts
+++ b/src/desktop/externalApi/externalApiToolExecutor.ts
@@ -181,7 +181,7 @@ export class ExternalApiToolExecutor extends ToolExecutor {
     });
 
     if (outcomeResult.isErr()) {
-      const mapped = enrichCommandErrorFromDesktopLog(
+      const mapped = await enrichCommandErrorFromDesktopLog(
         mapClientError(outcomeResult.error, this.deps.pid),
         diagnostic,
         namespace,
@@ -198,7 +198,7 @@ export class ExternalApiToolExecutor extends ToolExecutor {
 
     const statusResult = buildCommandStatus(outcomeResult.value, { namespace, command });
     if (statusResult.isErr()) {
-      const enrichedError = enrichCommandErrorFromDesktopLog(
+      const enrichedError = await enrichCommandErrorFromDesktopLog(
         statusResult.error,
         diagnostic,
         namespace,
@@ -582,15 +582,21 @@ function defaultDesktopLogDirs(): string[] {
   ];
 }
 
-function enrichCommandErrorFromDesktopLog(
+async function enrichCommandErrorFromDesktopLog(
   error: ExecuteCommandError,
   diagnostic: CommandDiagnostic | undefined,
   namespace: string,
   command: string,
-): ExecuteCommandError {
-  if (!diagnostic || error.type !== 'command-failed' || !error.error) return error;
+): Promise<ExecuteCommandError> {
+  if (
+    !diagnostic ||
+    (error.type !== 'command-failed' && error.type !== 'command-timed-out') ||
+    !error.error
+  ) {
+    return error;
+  }
 
-  const logRead = readDesktopCommandError({
+  const logRead = await readDesktopCommandError({
     cursor: diagnostic.cursor,
     pid: diagnostic.pid,
     namespace,
@@ -600,6 +606,16 @@ function enrichCommandErrorFromDesktopLog(
   if (!logRead.detail) return error;
 
   const detail = logRead.detail;
+  if (error.type === 'command-timed-out') {
+    const code = detail.code ? ` (code=${detail.code})` : '';
+    return {
+      type: 'command-timed-out',
+      error:
+        `${error.error}\nDesktop log (${path.basename(detail.logPath)} ${detail.timestamp}): ` +
+        `${detail.message}${code}`,
+    };
+  }
+
   return {
     type: 'command-failed',
     error: {

--- a/src/desktop/externalApi/externalApiToolExecutor.ts
+++ b/src/desktop/externalApi/externalApiToolExecutor.ts
@@ -1,9 +1,16 @@
+import * as os from 'os';
+import * as path from 'path';
 import { Err, Ok, Result } from 'ts-results-es';
 import { z } from 'zod';
 
 import { log } from '../../logging/logger.js';
 import { GetCommandStatusResponse, GetEventsResponse } from '../../sdks/desktop/agentApi/types.js';
 import { desktopCallTimeoutMessage, isDesktopCallTimeout } from '../callDeadline.js';
+import {
+  type DesktopLogCursor,
+  readDesktopCommandError,
+  snapshotDesktopLogs,
+} from '../desktopLogError.js';
 import {
   ExecuteCommandArgs,
   ExecuteCommandError,
@@ -54,6 +61,8 @@ export type ExternalApiToolExecutorDeps = {
   pid?: number;
   /** Options forwarded to each {@link ExternalApiClient}. */
   clientOptions?: ExternalApiClientOptions;
+  /** Candidate Tableau Desktop log directories. Defaults to standard repositories. */
+  desktopLogDirs?: string[];
   /** Client factory — injectable for tests. Defaults to a real client. */
   createClient?: (
     instance: ExternalApiInstance,
@@ -73,6 +82,12 @@ type RawOutcome = {
   completedAt: string | undefined;
   operationId: string | undefined;
   apiVersion: string | undefined;
+};
+
+type CommandDiagnostic = {
+  cursor: DesktopLogCursor;
+  pid: number;
+  startedAt: Date;
 };
 
 /**
@@ -150,13 +165,28 @@ export class ExternalApiToolExecutor extends ToolExecutor {
     >
   > {
     const resolvedArgs = args ?? {};
+    let diagnostic: CommandDiagnostic | undefined;
 
-    const outcomeResult = await this.withRescan((client) =>
-      this.callEndpoint(client, { namespace, command, args: resolvedArgs, signal }),
-    );
+    const outcomeResult = await this.withRescan((client) => {
+      const startedAt = new Date();
+      diagnostic = {
+        cursor: snapshotDesktopLogs({
+          pid: client.pid,
+          candidateDirs: this.deps.desktopLogDirs ?? defaultDesktopLogDirs(),
+        }),
+        pid: client.pid,
+        startedAt,
+      };
+      return this.callEndpoint(client, { namespace, command, args: resolvedArgs, signal });
+    });
 
     if (outcomeResult.isErr()) {
-      const mapped = mapClientError(outcomeResult.error, this.deps.pid);
+      const mapped = enrichCommandErrorFromDesktopLog(
+        mapClientError(outcomeResult.error, this.deps.pid),
+        diagnostic,
+        namespace,
+        command,
+      );
       log({
         message: `Failed to execute command ${namespace}:${command} via External Client API`,
         level: 'error',
@@ -168,13 +198,19 @@ export class ExternalApiToolExecutor extends ToolExecutor {
 
     const statusResult = buildCommandStatus(outcomeResult.value, { namespace, command });
     if (statusResult.isErr()) {
+      const enrichedError = enrichCommandErrorFromDesktopLog(
+        statusResult.error,
+        diagnostic,
+        namespace,
+        command,
+      );
       log({
         message: `Command ${namespace}:${command} failed`,
         level: 'error',
         logger: LOGGER,
-        data: statusResult.error,
+        data: enrichedError,
       });
-      return statusResult;
+      return Err(enrichedError);
     }
 
     const commandResult = statusResult.value;
@@ -511,20 +547,72 @@ function buildCommandStatus(
     });
   }
 
+  if (state !== 'succeeded' && state !== 'queued' && state !== 'running') {
+    return Err({
+      type: 'invalid-response',
+      error: new Error(
+        `External Client API returned nonterminal or unknown operation state ${JSON.stringify(outcome.state)} for ${namespace}:${command}.`,
+      ),
+    });
+  }
+
   const now = new Date().toISOString();
   const resultPayload =
     outcome.result !== undefined || supportsOperationResult(outcome.apiVersion)
       ? { result: outcome.result }
       : {};
+  const status: GetCommandStatusResponse['status'] =
+    state === 'succeeded' ? 'completed' : state === 'queued' ? 'queued' : 'running';
   return Ok({
     command_id: outcome.operationId ?? `ext_${namespace}:${command}_${Date.now()}`,
-    status: 'completed',
+    status,
     submitted_at: outcome.createdAt ?? now,
-    started_at: outcome.createdAt ?? now,
-    completed_at: outcome.completedAt ?? now,
+    ...(state !== 'queued' ? { started_at: outcome.createdAt ?? now } : {}),
+    ...(state === 'succeeded' ? { completed_at: outcome.completedAt ?? now } : {}),
     ...resultPayload,
     ...(outcome.warnings ? { warnings: outcome.warnings } : {}),
   });
+}
+
+function defaultDesktopLogDirs(): string[] {
+  const documents = path.join(os.homedir(), 'Documents');
+  return [
+    path.join(documents, 'My Tableau Repository', 'Logs'),
+    path.join(documents, 'My Tableau Repository (Beta)', 'Logs'),
+  ];
+}
+
+function enrichCommandErrorFromDesktopLog(
+  error: ExecuteCommandError,
+  diagnostic: CommandDiagnostic | undefined,
+  namespace: string,
+  command: string,
+): ExecuteCommandError {
+  if (!diagnostic || error.type !== 'command-failed' || !error.error) return error;
+
+  const logRead = readDesktopCommandError({
+    cursor: diagnostic.cursor,
+    pid: diagnostic.pid,
+    namespace,
+    command,
+    startedAt: diagnostic.startedAt,
+  });
+  if (!logRead.detail) return error;
+
+  const detail = logRead.detail;
+  return {
+    type: 'command-failed',
+    error: {
+      ...error.error,
+      message: detail.message,
+      ...(detail.code ? { 'tableau-error-code': detail.code } : {}),
+      log_detail: {
+        source: detail.source,
+        file: path.basename(detail.logPath),
+        timestamp: detail.timestamp,
+      },
+    },
+  };
 }
 
 function getTableauErrorCode(error: OperationError | undefined): string | undefined {

--- a/src/tools/desktop/commands/executeTableauCommand.test.ts
+++ b/src/tools/desktop/commands/executeTableauCommand.test.ts
@@ -157,7 +157,9 @@ describe('executeTableauCommandTool', () => {
     const commandResult = { some_key: 'some_value' };
     const executeCommand = vi
       .fn()
-      .mockResolvedValue(new Ok({ command_id: 'c1', result: commandResult }));
+      .mockResolvedValue(
+        new Ok({ command_id: 'c1', status: 'completed', submitted_at: '', result: commandResult }),
+      );
     const extra = makeExtra(executeCommand);
 
     const result = await getResult({ session: SESSION, command: 'tabdoc:save' }, extra);
@@ -191,6 +193,8 @@ describe('executeTableauCommandTool', () => {
     const executeCommand = vi.fn().mockResolvedValue(
       new Ok({
         command_id: 'c1',
+        status: 'completed',
+        submitted_at: '',
         result: { ok: true },
         warnings: [
           {
@@ -226,7 +230,11 @@ describe('executeTableauCommandTool', () => {
   });
 
   it('is silent about missing output when a command succeeds without result data', async () => {
-    const executeCommand = vi.fn().mockResolvedValue(new Ok({ command_id: 'c1', result: null }));
+    const executeCommand = vi
+      .fn()
+      .mockResolvedValue(
+        new Ok({ command_id: 'c1', status: 'completed', submitted_at: '', result: null }),
+      );
     const extra = makeExtra(executeCommand);
 
     const result = await getResult({ session: SESSION, command: 'tabdoc:save' }, extra);
@@ -237,6 +245,25 @@ describe('executeTableauCommandTool', () => {
     expect(payload.message).toBe('Command executed successfully.');
     expect(payload.result).toBeUndefined();
     expect(payload.message).not.toContain('no result data');
+  });
+
+  it('does not claim success when Desktop reports a non-completed status', async () => {
+    const executeCommand = vi
+      .fn()
+      .mockResolvedValue(
+        new Ok({ command_id: 'c1', status: 'running', submitted_at: '', result: null }),
+      );
+    const extra = makeExtra(executeCommand);
+
+    const result = await getResult({ session: SESSION, command: 'tabdoc:save' }, extra);
+
+    expect(result.isError).toBeFalsy();
+    invariant(result.content[0].type === 'text');
+    const payload = JSON.parse(result.content[0].text);
+    expect(payload.message).toBe(
+      "Command accepted; Desktop reports status 'running'. Completion was not observed.",
+    );
+    expect(payload.message).not.toContain('success');
   });
 
   it('surfaces command failure message and tableau-error-code extension', async () => {
@@ -495,9 +522,14 @@ describe('executeTableauCommandTool', () => {
     });
 
     it('does not inspect the workbook after generate-viz-from-notional-spec succeeds', async () => {
-      const executeCommand = vi
-        .fn()
-        .mockResolvedValue(new Ok({ command_id: 'generate-1', result: null }));
+      const executeCommand = vi.fn().mockResolvedValue(
+        new Ok({
+          command_id: 'generate-1',
+          status: 'completed',
+          submitted_at: '',
+          result: null,
+        }),
+      );
       const extra = makeExtra(executeCommand);
 
       const result = await getResult(

--- a/src/tools/desktop/commands/executeTableauCommand.ts
+++ b/src/tools/desktop/commands/executeTableauCommand.ts
@@ -7,6 +7,7 @@ import { guardCommand } from '../../../desktop/commands/externalApiCommandGuard.
 import { resolveSession } from '../../../desktop/sessionResolution.js';
 import type { ExecuteCommandWarning } from '../../../desktop/toolExecutor/toolExecutor.js';
 import { ArgsValidationError, DesktopCommandExecutionError } from '../../../errors/mcpToolError.js';
+import type { GetCommandStatusResponse } from '../../../sdks/desktop/agentApi/types.js';
 import { DesktopMcpServer } from '../../../server.desktop.js';
 import { DesktopTool } from '../tool.js';
 
@@ -82,6 +83,7 @@ export const getExecuteTableauCommandTool = (
           }
 
           const payload = shapeCommandResult({
+            status: result.value.status,
             result: result.value.result,
             envelopeWarnings: result.value.warnings ?? [],
             guardWarnings: commandGuardWarnings,
@@ -107,10 +109,12 @@ type ExecuteTableauCommandSuccess = {
 };
 
 function shapeCommandResult({
+  status,
   result,
   envelopeWarnings,
   guardWarnings,
 }: {
+  status: GetCommandStatusResponse['status'];
   result: Record<string, unknown> | null | undefined;
   envelopeWarnings: ExecuteCommandWarning[];
   guardWarnings: string[];
@@ -118,10 +122,16 @@ function shapeCommandResult({
   const outputSerializationFailed = envelopeWarnings.some(
     (warning) => warning.code === 'output-serialization-failed',
   );
+  const completionMessage =
+    status === 'completed'
+      ? 'Command executed successfully.'
+      : `Command accepted; Desktop reports status '${status}'. Completion was not observed.`;
   const payload: ExecuteTableauCommandSuccess = {
     message: outputSerializationFailed
-      ? 'Command executed, but the requested result cannot be returned because Desktop reported output serialization failed; the command executed; state may have changed; do NOT retry - re-read state instead.'
-      : 'Command executed successfully.',
+      ? status === 'completed'
+        ? 'Command executed, but the requested result cannot be returned because Desktop reported output serialization failed; the command executed; state may have changed; do NOT retry - re-read state instead.'
+        : `${completionMessage} The requested result cannot be returned because Desktop reported output serialization failed; state may have changed; do NOT retry - re-read state instead.`
+      : completionMessage,
   };
 
   if (result !== undefined && result !== null) {
@@ -132,7 +142,7 @@ function shapeCommandResult({
       const previewBytes = Buffer.byteLength(preview, 'utf-8');
       payload.result = `${preview}\n...`;
       payload.message =
-        `Command executed successfully. result truncated: ${previewBytes} of ${totalBytes} bytes - ` +
+        `${completionMessage} result truncated: ${previewBytes} of ${totalBytes} bytes - ` +
         're-run with a narrower command if you need the rest.';
     } else {
       payload.result = result;

--- a/src/tools/desktop/dashboard/composeDashboard.test.ts
+++ b/src/tools/desktop/dashboard/composeDashboard.test.ts
@@ -258,12 +258,13 @@ describe('composeDashboardTool', () => {
     invariant(result.content[0].type === 'text');
     expect(JSON.parse(result.content[0].text)).toMatchObject({
       dashboardName: 'New Dashboard',
+      dashboardState: 'unknown',
       attemptedZones: expect.any(Array),
       verification: expect.stringMatching(
-        /Dashboard "New Dashboard" exists[\s\S]*NOT confirmed[\s\S]*activate-sheet/,
+        /existence is UNKNOWN[\s\S]*NOT confirmed[\s\S]*list-dashboards/,
       ),
     });
-    expect(result.content[0].text).toContain('do not recreate');
+    expect(result.content[0].text).not.toContain('do not recreate');
     expect(getWorkbookXmlModule.getWorkbookXml).toHaveBeenCalledTimes(1);
   });
 
@@ -283,10 +284,11 @@ describe('composeDashboardTool', () => {
     invariant(result.content[0].type === 'text');
     expect(JSON.parse(result.content[0].text)).toMatchObject({
       dashboardName: 'New Dashboard',
+      dashboardState: 'unknown',
       attemptedZones: expect.any(Array),
       verification: expect.stringContaining('NOT confirmed'),
     });
-    expect(result.content[0].text).toContain('activate-sheet');
+    expect(result.content[0].text).toContain('list-dashboards');
     expect(JSON.parse(result.content[0].text)).not.toHaveProperty('zones');
   });
 

--- a/src/tools/desktop/dashboard/composeDashboard.ts
+++ b/src/tools/desktop/dashboard/composeDashboard.ts
@@ -58,6 +58,7 @@ type ComposeDashboardResult =
     }
   | {
       dashboardName: string;
+      dashboardState: 'unknown';
       attemptedZones: WorksheetZoneReceipt[];
       verification: string;
     };
@@ -319,12 +320,16 @@ function attemptedZonesResult({
 }): Ok<ComposeDashboardResult> {
   return new Ok({
     dashboardName,
+    dashboardState: 'unknown',
     attemptedZones: worksheetZones,
     verification:
-      formatDashboardPromiseCheck(validationWarnings) +
-      ` Dashboard "${dashboardName}" exists because its dashboard apply completed; ` +
+      formatDashboardPromiseCheck(validationWarnings).replace(
+        'apply completed',
+        'apply request returned without an error',
+      ) +
+      ` Dashboard "${dashboardName}" existence is UNKNOWN because post-apply readback did not confirm it; ` +
       `the attempted zone tree and requested window viewpoints are NOT confirmed (${detail}). ` +
-      'Next call: activate-sheet to bring it into view; do not recreate the dashboard.',
+      'Next call: list-dashboards to check whether it exists before deciding whether to retry.',
   });
 }
 

--- a/src/tools/desktop/dashboard/dashboardAutoApply.test.ts
+++ b/src/tools/desktop/dashboard/dashboardAutoApply.test.ts
@@ -299,6 +299,11 @@ describe('dashboardAutoApplyTool happy path', () => {
     expect(body.applied).toBe('unverified');
     expect(body.guidance).toContain('accepted');
     expect(body.guidance).toContain('unverified');
+    expect(body.guidance).toContain('Read the workbook to verify');
+    expect(result.structuredContent).toEqual({
+      ...body,
+      nextAction: { label: 'Read the workbook to verify', kind: 'prefill' },
+    });
     expect(body.dashboard).toBe('Sales Dashboard');
     expect(body.sheets).toEqual([
       { title: 'Sales by Region', template_name: 'bar-basic' },
@@ -639,7 +644,38 @@ describe('dashboardAutoApplyTool all-or-nothing gate matrix', () => {
     expect(String(body.apply_error)).toContain('preflight validation failed');
     expect(String(body.guidance)).toContain('Nothing was applied');
     expect(String(body.guidance)).toContain('fall back to the per-viz');
+    expect(result.structuredContent).toEqual({
+      ...body,
+      nextAction: { label: 'Fall back to per-viz auto-apply', kind: 'prefill' },
+    });
     expect(applyWorkbookDocument).not.toHaveBeenCalled();
+  });
+
+  it('invalid XML keeps the pre-dispatch fallback action', async () => {
+    const { getExecutor } = setupMocks();
+    const loadSpy = vi.spyOn(loadWorkbookXmlModule, 'loadWorkbookXml').mockResolvedValue(
+      Err({
+        type: 'load-workbook-xml-error',
+        error: { type: 'invalid-xml' },
+      }),
+    );
+
+    try {
+      const result = await getToolResult({
+        session: '1',
+        asks: [{ ask: 'bar chart of Sales by Region' }, { ask: 'line chart of Profit by Month' }],
+        getExecutor,
+      });
+
+      invariant(result.content[0].type === 'text');
+      const body = JSON.parse(result.content[0].text);
+      expect(result.structuredContent).toEqual({
+        ...body,
+        nextAction: { label: 'Fall back to per-viz auto-apply', kind: 'prefill' },
+      });
+    } finally {
+      loadSpy.mockRestore();
+    }
   });
 
   it('failed workbook apply is an error with every ask outcome preserved', async () => {
@@ -667,6 +703,10 @@ describe('dashboardAutoApplyTool all-or-nothing gate matrix', () => {
     expect(String(body.guidance)).toContain('Read the workbook before falling back');
     expect(String(body.guidance)).toContain('fall back to the per-viz');
     expect(String(body.guidance)).not.toContain('Nothing was applied');
+    expect(result.structuredContent).toEqual({
+      ...body,
+      nextAction: { label: 'Read the workbook before falling back', kind: 'prefill' },
+    });
   });
 
   it('load rejection reports the live outcome as unverified before fallback', async () => {
@@ -693,6 +733,10 @@ describe('dashboardAutoApplyTool all-or-nothing gate matrix', () => {
       expect(String(body.guidance)).toContain('Read the workbook before falling back');
       expect(String(body.guidance)).toContain('fall back to the per-viz');
       expect(String(body.guidance)).not.toContain('Nothing was applied');
+      expect(result.structuredContent).toEqual({
+        ...body,
+        nextAction: { label: 'Read the workbook before falling back', kind: 'prefill' },
+      });
     } finally {
       loadSpy.mockRestore();
     }

--- a/src/tools/desktop/dashboard/dashboardAutoApply.test.ts
+++ b/src/tools/desktop/dashboard/dashboardAutoApply.test.ts
@@ -295,7 +295,9 @@ describe('dashboardAutoApplyTool happy path', () => {
     expect(result.isError).toBe(false);
     invariant(result.content[0].type === 'text');
     const body = JSON.parse(result.content[0].text);
-    expect(body.applied).toBe(true);
+    expect(body.applied).toBe('unverified');
+    expect(body.guidance).toContain('accepted');
+    expect(body.guidance).toContain('unverified');
     expect(body.dashboard).toBe('Sales Dashboard');
     expect(body.sheets).toEqual([
       { title: 'Sales by Region', template_name: 'bar-basic' },
@@ -456,7 +458,7 @@ describe('dashboardAutoApplyTool happy path', () => {
 
     invariant(result.content[0].type === 'text');
     const body = JSON.parse(result.content[0].text);
-    expect(body.applied).toBe(true);
+    expect(body.applied).toBe('unverified');
     expect(body.replaced).toEqual({ dashboard: 'Sales Dashboard', sheets: [] });
   });
 });
@@ -595,7 +597,7 @@ describe('dashboardAutoApplyTool all-or-nothing gate matrix', () => {
     expect(result.isError).toBe(false);
     invariant(result.content[0].type === 'text');
     const body = JSON.parse(result.content[0].text);
-    expect(body.applied).toBe(true);
+    expect(body.applied).toBe('unverified');
     expect(applyWorkbookDocument).toHaveBeenCalled();
   });
 
@@ -678,7 +680,7 @@ describe('dashboardAutoApplyTool all-or-nothing gate matrix', () => {
     expect(result.isError).toBe(true);
     invariant(result.content[0].type === 'text');
     const body = JSON.parse(result.content[0].text);
-    expect(body.applied).toBe('partial');
+    expect(body.applied).toBe('unverified');
     expect(body.dashboard).toBe('Sales Dashboard');
     expect(body.sheets).toEqual([
       { title: 'Sales by Region', template_name: 'bar-basic' },
@@ -725,7 +727,7 @@ describe('dashboardAutoApplyTool all-or-nothing gate matrix', () => {
     expect(result.isError).toBe(true);
     invariant(result.content[0].type === 'text');
     const body = JSON.parse(result.content[0].text);
-    expect(body.applied).toBe('partial');
+    expect(body.applied).toBe('unverified');
     expect(body.zones).toEqual({
       state: 'unknown',
       attempted: [
@@ -821,7 +823,7 @@ describe('dashboardAutoApplyTool all-or-nothing gate matrix', () => {
 
     invariant(result.content[0].type === 'text');
     const body = JSON.parse(result.content[0].text);
-    expect(body.applied).toBe(true);
+    expect(body.applied).toBe('unverified');
     expect(applyWorkbookDocument).toHaveBeenCalledTimes(1);
   });
 
@@ -841,7 +843,7 @@ describe('dashboardAutoApplyTool all-or-nothing gate matrix', () => {
 
     invariant(result.content[0].type === 'text');
     const body = JSON.parse(result.content[0].text);
-    expect(body.applied).toBe(true);
+    expect(body.applied).toBe('unverified');
     expect(body.replaced.sheets).toEqual(['Sales by Region']);
   });
 });

--- a/src/tools/desktop/dashboard/dashboardAutoApply.test.ts
+++ b/src/tools/desktop/dashboard/dashboardAutoApply.test.ts
@@ -8,6 +8,7 @@ import type { TemplateManifest } from '../../../desktop/binder/manifest-types.js
 import * as getWorkbookXmlModule from '../../../desktop/commands/workbook/getWorkbookXml.js';
 import * as injectViewpointsModule from '../../../desktop/commands/workbook/injectViewpoints.js';
 import * as loadDashboardXmlModule from '../../../desktop/commands/workbook/loadDashboardXml.js';
+import * as loadWorkbookXmlModule from '../../../desktop/commands/workbook/loadWorkbookXml.js';
 import * as externalDiscovery from '../../../desktop/externalApi/discovery.js';
 import { bundledIntelligenceProvider } from '../../../desktop/intelligence/provider.js';
 import * as xmlToJsonModule from '../../../desktop/libraries/workbook-serialization-converter/index.js';
@@ -636,6 +637,8 @@ describe('dashboardAutoApplyTool all-or-nothing gate matrix', () => {
     const body = JSON.parse(result.content[0].text);
     expect(body.applied).toBe(false);
     expect(String(body.apply_error)).toContain('preflight validation failed');
+    expect(String(body.guidance)).toContain('Nothing was applied');
+    expect(String(body.guidance)).toContain('fall back to the per-viz');
     expect(applyWorkbookDocument).not.toHaveBeenCalled();
   });
 
@@ -659,6 +662,40 @@ describe('dashboardAutoApplyTool all-or-nothing gate matrix', () => {
       { index: 1, ask: 'line chart of Profit by Month', result: boundB },
     ]);
     expect(String(body.apply_error)).toContain('command-timed-out');
+    expect(String(body.guidance)).toContain('The document reached Desktop');
+    expect(String(body.guidance)).toContain('live outcome is unverified');
+    expect(String(body.guidance)).toContain('Read the workbook before falling back');
+    expect(String(body.guidance)).toContain('fall back to the per-viz');
+    expect(String(body.guidance)).not.toContain('Nothing was applied');
+  });
+
+  it('load rejection reports the live outcome as unverified before fallback', async () => {
+    const { getExecutor } = setupMocks();
+    const loadSpy = vi.spyOn(loadWorkbookXmlModule, 'loadWorkbookXml').mockResolvedValue(
+      Err({
+        type: 'load-workbook-xml-error',
+        error: { type: 'load-rejected', message: 'Desktop rejected the document' },
+      }),
+    );
+
+    try {
+      const result = await getToolResult({
+        session: '1',
+        asks: [{ ask: 'bar chart of Sales by Region' }, { ask: 'line chart of Profit by Month' }],
+        getExecutor,
+      });
+
+      expect(result.isError).toBe(true);
+      invariant(result.content[0].type === 'text');
+      const body = JSON.parse(result.content[0].text);
+      expect(String(body.apply_error)).toContain('Desktop rejected the document');
+      expect(String(body.guidance)).toContain('The document reached Desktop');
+      expect(String(body.guidance)).toContain('Read the workbook before falling back');
+      expect(String(body.guidance)).toContain('fall back to the per-viz');
+      expect(String(body.guidance)).not.toContain('Nothing was applied');
+    } finally {
+      loadSpy.mockRestore();
+    }
   });
 
   it('zone apply failure reports an error naming failed zones and landed artifacts', async () => {
@@ -705,6 +742,10 @@ describe('dashboardAutoApplyTool all-or-nothing gate matrix', () => {
       failed: expectedZones,
     });
     expect(String(body.apply_error)).toContain('zone load failed');
+    expect(result.structuredContent).toEqual({
+      ...body,
+      nextAction: { label: 'Read the workbook before retrying', kind: 'prefill' },
+    });
   });
 
   it('zone transport timeout reports unknown zone state with complete attempted specs', async () => {

--- a/src/tools/desktop/dashboard/dashboardAutoApply.ts
+++ b/src/tools/desktop/dashboard/dashboardAutoApply.ts
@@ -139,27 +139,35 @@ function describeApplyError(
   return `workbook load command failed: ${JSON.stringify(error.error)}`;
 }
 
-function describeApplyFailureGuidance(
+function describeApplyFailure(
   error:
     | { type: 'execute-command-error'; error: ExecuteCommandError }
     | { type: 'load-workbook-xml-error'; error: LoadWorkbookXmlError },
-): string {
+): { guidance: string; nextAction: NextAction } {
   const detail = describeApplyError(error);
   const fallback =
     "fall back to the per-viz bind-template(auto_apply:true) flow using each ask's bound args.";
 
   if (error.type === 'load-workbook-xml-error' && error.error.type === 'validation-failed') {
-    return `Server-side auto-apply did not complete (${detail}). Nothing was applied — ${fallback}`;
+    return {
+      guidance: `Server-side auto-apply did not complete (${detail}). Nothing was applied — ${fallback}`,
+      nextAction: prefillNextAction('Fall back to per-viz auto-apply'),
+    };
   }
 
   if (error.type === 'load-workbook-xml-error' && error.error.type === 'invalid-xml') {
-    return `Server-side auto-apply did not complete (${detail}). The invalid document was not sent to Desktop — ${fallback}`;
+    return {
+      guidance: `Server-side auto-apply did not complete (${detail}). The invalid document was not sent to Desktop — ${fallback}`,
+      nextAction: prefillNextAction('Fall back to per-viz auto-apply'),
+    };
   }
 
-  return (
-    `Server-side auto-apply did not complete (${detail}). The document reached Desktop, but the ` +
-    `live outcome is unverified. Read the workbook before falling back: ${fallback}`
-  );
+  return {
+    guidance:
+      `Server-side auto-apply did not complete (${detail}). The document reached Desktop, but the ` +
+      `live outcome is unverified. Read the workbook before falling back: ${fallback}`,
+    nextAction: prefillNextAction('Read the workbook before falling back'),
+  };
 }
 
 function refusal(
@@ -475,11 +483,12 @@ export const getDashboardAutoApplyTool = (
             signal: extra.signal,
           });
           if (applyResult.isErr()) {
+            const failure = describeApplyFailure(applyResult.error);
             return refusal(
               outcomes,
-              describeApplyFailureGuidance(applyResult.error),
+              failure.guidance,
               describeApplyError(applyResult.error),
-              prefillNextAction('Fall back to per-viz auto-apply'),
+              failure.nextAction,
             );
           }
           if (!zonesViaWorkbook) {
@@ -537,14 +546,23 @@ export const getDashboardAutoApplyTool = (
 
           const applyMs = Date.now() - applyStart;
 
-          return new Ok({
-            applied: 'unverified',
-            dashboard: dashboardName,
-            sheets,
-            phase_ms: { read: readMs, bind: bindMs, inject: injectMs, apply: applyMs },
-            guidance: `Desktop accepted the document request for "${dashboardName}" (${sheets.length} sheet(s)), but no readback after the apply confirmed the live workbook; outcome unverified (read ${readMs}ms, bind ${bindMs}ms, inject ${injectMs}ms, apply ${applyMs}ms).`,
-            ...(replaced.dashboard || replaced.sheets.length > 0 ? { replaced } : {}),
-          });
+          return new Ok(
+            withNextAction(
+              {
+                applied: 'unverified',
+                dashboard: dashboardName,
+                sheets,
+                phase_ms: { read: readMs, bind: bindMs, inject: injectMs, apply: applyMs },
+                guidance:
+                  `Desktop accepted the document request for "${dashboardName}" (${sheets.length} sheet(s)), ` +
+                  'but no readback after the apply confirmed the live workbook; outcome unverified. Read the ' +
+                  `workbook to verify before retrying or reporting completion (read ${readMs}ms, bind ${bindMs}ms, ` +
+                  `inject ${injectMs}ms, apply ${applyMs}ms).`,
+                ...(replaced.dashboard || replaced.sheets.length > 0 ? { replaced } : {}),
+              },
+              prefillNextAction('Read the workbook to verify'),
+            ),
+          );
         },
         getSuccessResult: (result) => jsonToolResult(result, { isError: false }),
       });

--- a/src/tools/desktop/dashboard/dashboardAutoApply.ts
+++ b/src/tools/desktop/dashboard/dashboardAutoApply.ts
@@ -94,7 +94,7 @@ type DashboardAutoApplyRefusalResult = {
 type Replaced = { dashboard?: string; sheets: string[] };
 
 type DashboardAutoApplySuccessResult = {
-  applied: true;
+  applied: 'unverified';
   dashboard: string;
   sheets: Array<{ title: string; template_name: string }>;
   phase_ms: { read: number; bind: number; inject: number; apply: number };
@@ -103,7 +103,7 @@ type DashboardAutoApplySuccessResult = {
 };
 
 type DashboardAutoApplyPartialResult = {
-  applied: 'partial';
+  applied: 'unverified';
   dashboard: string;
   sheets: Array<{ title: string; template_name: string }>;
   zones:
@@ -462,10 +462,9 @@ export const getDashboardAutoApplyTool = (
             );
           }
           if (!zonesViaWorkbook) {
-            // Fallback mode (§2 "Probe fails"): the workbook (worksheets + minimal empty
-            // dashboard) is already live; a second dispatch lays in the real zones. A
-            // failure here is a REAL partial window (Q3) — the dashboard exists with a
-            // valid empty layout, coherent and recoverable via build-and-apply-dashboard.
+            // Fallback mode (§2 "Probe fails"): the first document request returned without
+            // an error, then a second dispatch lays in the real zones. Without readback, a
+            // second-leg failure cannot prove which first-leg artifacts reached Desktop.
             const realZones = computeZones(titleText, {
               kpis: [],
               charts: resolvedTitles,
@@ -498,15 +497,15 @@ export const getDashboardAutoApplyTool = (
               return new IncompleteOperationError(
                 withNextAction(
                   {
-                    applied: 'partial',
+                    applied: 'unverified',
                     dashboard: dashboardName,
                     sheets,
                     zones: zonesState,
                     apply_error: message,
                     guidance:
-                      `The workbook (sheets + an empty "${dashboardName}" dashboard) was applied, but laying ` +
-                      `in the zones failed (${message}). Re-issue the zones via build-and-apply-dashboard — the ` +
-                      'dashboard exists with a valid empty layout, nothing is corrupted.',
+                      `Desktop accepted the workbook request for the sheets and "${dashboardName}", but no ` +
+                      `readback confirmed those artifacts before the zone request failed (${message}). ` +
+                      'The live workbook outcome is unverified. Read the workbook and dashboard list before retrying.',
                     ...(replaced.dashboard || replaced.sheets.length > 0 ? { replaced } : {}),
                   },
                   prefillNextAction('Re-issue the zones'),
@@ -518,11 +517,11 @@ export const getDashboardAutoApplyTool = (
           const applyMs = Date.now() - applyStart;
 
           return new Ok({
-            applied: true,
+            applied: 'unverified',
             dashboard: dashboardName,
             sheets,
             phase_ms: { read: readMs, bind: bindMs, inject: injectMs, apply: applyMs },
-            guidance: `Applied "${dashboardName}" (${sheets.length} sheet(s)) to the live workbook (read ${readMs}ms, bind ${bindMs}ms, inject ${injectMs}ms, apply ${applyMs}ms).`,
+            guidance: `Desktop accepted the document request for "${dashboardName}" (${sheets.length} sheet(s)), but no readback after the apply confirmed the live workbook; outcome unverified (read ${readMs}ms, bind ${bindMs}ms, inject ${injectMs}ms, apply ${applyMs}ms).`,
             ...(replaced.dashboard || replaced.sheets.length > 0 ? { replaced } : {}),
           });
         },

--- a/src/tools/desktop/dashboard/dashboardAutoApply.ts
+++ b/src/tools/desktop/dashboard/dashboardAutoApply.ts
@@ -139,6 +139,29 @@ function describeApplyError(
   return `workbook load command failed: ${JSON.stringify(error.error)}`;
 }
 
+function describeApplyFailureGuidance(
+  error:
+    | { type: 'execute-command-error'; error: ExecuteCommandError }
+    | { type: 'load-workbook-xml-error'; error: LoadWorkbookXmlError },
+): string {
+  const detail = describeApplyError(error);
+  const fallback =
+    "fall back to the per-viz bind-template(auto_apply:true) flow using each ask's bound args.";
+
+  if (error.type === 'load-workbook-xml-error' && error.error.type === 'validation-failed') {
+    return `Server-side auto-apply did not complete (${detail}). Nothing was applied — ${fallback}`;
+  }
+
+  if (error.type === 'load-workbook-xml-error' && error.error.type === 'invalid-xml') {
+    return `Server-side auto-apply did not complete (${detail}). The invalid document was not sent to Desktop — ${fallback}`;
+  }
+
+  return (
+    `Server-side auto-apply did not complete (${detail}). The document reached Desktop, but the ` +
+    `live outcome is unverified. Read the workbook before falling back: ${fallback}`
+  );
+}
+
 function refusal(
   results: AskOutcome[],
   guidance: string,
@@ -454,9 +477,7 @@ export const getDashboardAutoApplyTool = (
           if (applyResult.isErr()) {
             return refusal(
               outcomes,
-              `Server-side auto-apply did not complete (${describeApplyError(applyResult.error)}). Nothing ` +
-                'was applied — fall back to the per-viz bind-template(auto_apply:true) flow using each ' +
-                "ask's bound args.",
+              describeApplyFailureGuidance(applyResult.error),
               describeApplyError(applyResult.error),
               prefillNextAction('Fall back to per-viz auto-apply'),
             );
@@ -508,7 +529,7 @@ export const getDashboardAutoApplyTool = (
                       'The live workbook outcome is unverified. Read the workbook and dashboard list before retrying.',
                     ...(replaced.dashboard || replaced.sheets.length > 0 ? { replaced } : {}),
                   },
-                  prefillNextAction('Re-issue the zones'),
+                  prefillNextAction('Read the workbook before retrying'),
                 ),
               ).toErr();
             }

--- a/src/tools/desktop/worksheet/deleteWorksheet.test.ts
+++ b/src/tools/desktop/worksheet/deleteWorksheet.test.ts
@@ -231,6 +231,12 @@ const successSchema = z.object({
   guidance: z.string(),
 });
 
+const unverifiedSchema = z.object({
+  deleted: z.literal('unverified'),
+  worksheet: z.string(),
+  guidance: z.string(),
+});
+
 const refusalSchema = z.object({
   deleted: z.literal(false),
   reason: z.enum(['dashboard-referenced', 'last-worksheet', 'user-changed-workbook']),
@@ -263,7 +269,11 @@ describe('deleteWorksheetTool', () => {
       dashboards: [dashboardXml('Dash One', 'Alpha')],
       extraWindows: ["<window class='dashboard' name='Dash One'><viewpoints/></window>"],
     });
-    vi.spyOn(getWorkbookXmlModule, 'getWorkbookXml').mockResolvedValue(Ok(fixture));
+    const expected = removeWorksheetFromWorkbook(fixture, 'Beta');
+    invariant(expected.status === 'removed');
+    vi.spyOn(getWorkbookXmlModule, 'getWorkbookXml')
+      .mockResolvedValueOnce(Ok(fixture))
+      .mockResolvedValueOnce(Ok(expected.xml));
     const loadSpy = vi
       .spyOn(loadWorkbookXmlModule, 'loadWorkbookXml')
       .mockResolvedValue(Ok({ validationWarnings: [] }));
@@ -277,10 +287,30 @@ describe('deleteWorksheetTool', () => {
 
     // The applied XML is byte-identical to the pure core's output for the same
     // fixture — the tool adds nothing and loses nothing between core and dispatch.
-    const expected = removeWorksheetFromWorkbook(fixture, 'Beta');
-    invariant(expected.status === 'removed');
     expect(loadSpy).toHaveBeenCalledTimes(1);
     expect(loadSpy).toHaveBeenCalledWith(expect.objectContaining({ xml: expected.xml }));
+  });
+
+  it('reports deletion as unverified when post-apply readback is unavailable', async () => {
+    vi.spyOn(getWorkbookXmlModule, 'getWorkbookXml')
+      .mockResolvedValueOnce(Ok(buildWorkbook()))
+      .mockResolvedValueOnce(
+        Err({
+          type: 'command-failed',
+          error: { code: 'READ_FAILED', message: 'Read failed', recoverable: true },
+        }),
+      );
+    vi.spyOn(loadWorkbookXmlModule, 'loadWorkbookXml').mockResolvedValue(
+      Ok({ validationWarnings: [] }),
+    );
+
+    const result = await getToolResult({ worksheetName: 'Beta' });
+
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+    const parsed = unverifiedSchema.parse(JSON.parse(result.content[0].text));
+    expect(parsed.guidance).toContain('outcome is unverified');
+    expect(parsed.guidance).not.toContain('Deleted worksheet');
   });
 
   it('refuses a dashboard-referenced sheet, names the dashboards, and dispatches nothing', async () => {
@@ -319,7 +349,12 @@ describe('deleteWorksheetTool', () => {
   });
 
   it('proceeds without the events gate on transports without event support', async () => {
-    vi.spyOn(getWorkbookXmlModule, 'getWorkbookXml').mockResolvedValue(Ok(buildWorkbook()));
+    const fixture = buildWorkbook();
+    const expected = removeWorksheetFromWorkbook(fixture, 'Beta');
+    invariant(expected.status === 'removed');
+    vi.spyOn(getWorkbookXmlModule, 'getWorkbookXml')
+      .mockResolvedValueOnce(Ok(fixture))
+      .mockResolvedValueOnce(Ok(expected.xml));
     const loadSpy = vi
       .spyOn(loadWorkbookXmlModule, 'loadWorkbookXml')
       .mockResolvedValue(Ok({ validationWarnings: [] }));

--- a/src/tools/desktop/worksheet/deleteWorksheet.ts
+++ b/src/tools/desktop/worksheet/deleteWorksheet.ts
@@ -151,6 +151,7 @@ type DeleteWorksheetRefusalReason =
 
 type DeleteWorksheetToolResult =
   | { deleted: true; worksheet: string; guidance: string }
+  | { deleted: 'unverified'; worksheet: string; guidance: string }
   | {
       deleted: false;
       reason: DeleteWorksheetRefusalReason;
@@ -297,12 +298,34 @@ export const getDeleteWorksheetTool = (
             }
           }
 
+          const readbackResult = await getWorkbookXml({ executor, signal: extra.signal });
+          if (readbackResult.isErr()) {
+            return new Ok({
+              deleted: 'unverified',
+              worksheet: worksheetName,
+              guidance:
+                `Desktop accepted the document request that omitted worksheet "${worksheetName}", ` +
+                'but post-apply readback failed; the deletion outcome is unverified. ' +
+                'Call list-worksheets before retrying.',
+            });
+          }
+          const readbackRemoval = removeWorksheetFromWorkbook(readbackResult.value, worksheetName);
+          if (readbackRemoval.status !== 'not-found') {
+            return new Ok({
+              deleted: 'unverified',
+              worksheet: worksheetName,
+              guidance:
+                `Post-apply readback did not confirm that worksheet "${worksheetName}" is absent; ` +
+                'the deletion outcome is unverified. Call list-worksheets before retrying.',
+            });
+          }
+
           return new Ok({
             deleted: true,
             worksheet: worksheetName,
             guidance:
-              `Deleted worksheet "${worksheetName}" (worksheet node + window entry) from the ` +
-              'live workbook.',
+              `Deleted worksheet "${worksheetName}" (worksheet node + window entry); ` +
+              'post-apply workbook readback confirmed the worksheet is absent.',
           });
         },
       });


### PR DESCRIPTION
**Decision:** a Desktop tool never reports an outcome it did not observe. This is a rule we keep, applied here to the five worst sites from the 2026-07-28 census: the external-API executor, dashboard-auto-apply, compose-dashboard, delete-worksheet, and failed-command error text. bind-template was already honest on this base (#667) and is untouched.

**Scope:** stacks into the v12 train (`claude/v12-fixes`), not feature/desktop directly.
- Executor: operation state maps honestly (`succeeded`→completed, `queued`/`running` pass through, unknown states are errors) instead of forcing `completed`.
- On a failed command, the executor reads Desktop's own log (new `desktopLogError.ts`, ported from agent-to-tableau-desktop#294: snapshot-before-request cursor, pid+time filtered, bounded reads) and reports Desktop's real message and error code with file/timestamp provenance.
- delete-worksheet re-reads the workbook after the apply and says `deleted: true` only when the worksheet is confirmed absent — using the same document read the tool already depends on.
- dashboard-auto-apply and compose-dashboard label unverified outcomes as unverified and point the agent at reads (`list-dashboards`) that exist in the shipped dynamic profile.

**What future work must preserve:** log reading is diagnostics-only — bounded and unable to throw into or alter command handling. Status fields come from observed evidence or say so.

**Evidence:** full suite 6382 passed / 0 failed, tsc clean, lint clean — run firsthand by the orchestrator, not taken from the builder (whose environment could not run them). Not yet live-smoked: a live e1+m6 smoke runs before this merges, since receipt text is live-fragile.

**Risk:** if the /v0 route ever returns `queued`/`running` for a synchronous command, callers now see the true state instead of a false `completed`; a client that assumed instant completion would need to poll. Delete readback failure now yields `deleted: "unverified"` instead of a blind `deleted: true`.

**Approving this means:** the v12 train ships tools that state what they saw, and failed commands carry Desktop's real error text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)