### PR TITLE
@W-23600028: bound list-users `limit` to post-filter matches

### DIFF
--- a/docs/docs/tools/users/list-users.md
+++ b/docs/docs/tools/users/list-users.md
@@ -47,8 +47,8 @@ See also: [Environment Variables](../../configuration/mcp-config/env-vars.md)
 | Argument | Type | Required | Description |
 |----------|------|----------|-------------|
 | `filter` | string | No | Client-side filter string with format `field:operator:value`. Multiple filters are comma-separated (AND logic). |
-| `pageSize` | number | No | Number of results per page (client-side pagination after filtering) |
-| `limit` | number | No | Maximum total results to return (client-side limit after filtering) |
+| `pageSize` | number | No | Number of users to fetch from the API per page (default 100, max 1000) |
+| `limit` | number | No | Maximum number of **matching** users to return. `limit` bounds results **after** `filter` is applied — the tool keeps paging until it has `limit` filter-matches (or the site is exhausted), so `limit:5` with an inactivity filter returns the first 5 matching users, never 5 pre-filter rows that all get filtered away. |
 
 :::note[API Limitation]
 The Tableau REST API does not support server-side filtering or pagination for users. All users are fetched and filtering is performed client-side by this tool.
@@ -95,7 +95,9 @@ Common values for `siteRole`:
 
 ## Response structure
 
-Each user includes:
+Returns a JSON object `{ users: [...], mcp: { resultInfo: {...} } }`.
+
+Each user in `users` includes:
 
 - `id` – user ID (LUID)
 - `name` – username (login name)
@@ -104,6 +106,18 @@ Each user includes:
 - `fullName` – user's full display name
 - `lastLogin` – timestamp of last login (ISO 8601 format)
 
+`mcp.resultInfo` is present on every non-empty result and reports the completeness of the (filtered) list (a filter matching zero users returns a plain message instead of this object):
+
+- `returnedCount` – number of users in `users`.
+- `truncated` – `false` means `users` is the **complete** set matching the filter; `true` means more matching users exist server-side than were returned.
+- `truncationReason` (present only when `truncated` is `true`):
+  - `"requested-limit"` – the `limit` you passed cut the result short. Call again with a higher `limit` (or omit it) to get more.
+  - `"admin-cap"` – a site-administrator per-call cap (`MAX_RESULT_LIMIT[S]`) cut the result short. `limit` cannot raise it, so either narrow the `filter` so the matching set fits, or ask an administrator to raise the cap.
+
+:::note[`limit` bounds matches, not fetched rows]
+Because filtering is client-side, `limit` bounds the number of users that **match the filter**, not the number of raw rows fetched from the API. The tool keeps paging until it has collected `limit` matching users (or the site is exhausted). A limit-truncated filtered list is reported via `mcp.resultInfo.truncated: true` rather than silently appearing complete.
+:::
+
 :::note[Output fields]
 This tool returns a lean, fixed field set: `id`, `name`, `fullName`, `siteRole`, `email`, and `lastLogin`. Tableau's REST API may return additional attributes (such as `authSetting`, `locale`, `language`), but the tool strips them from its output; only the six fields above appear.
 :::
@@ -111,32 +125,41 @@ This tool returns a lean, fixed field set: `id`, `name`, `fullName`, `siteRole`,
 ## Example result
 
 ```json
-[
-  {
-    "id": "user-abc123",
-    "name": "jsmith",
-    "siteRole": "Creator",
-    "email": "john.smith@example.com",
-    "fullName": "John Smith",
-    "lastLogin": "2026-05-20T10:30:00Z"
-  },
-  {
-    "id": "user-def456",
-    "name": "asmith",
-    "siteRole": "Viewer",
-    "email": "alice.smith@example.com",
-    "fullName": "Alice Smith",
-    "lastLogin": "2026-05-15T08:00:00Z"
-  },
-  {
-    "id": "user-ghi789",
-    "name": "bjones",
-    "siteRole": "Unlicensed",
-    "email": "bob.jones@example.com",
-    "fullName": "Bob Jones",
-    "lastLogin": "2024-12-01T12:00:00Z"
+{
+  "users": [
+    {
+      "id": "user-abc123",
+      "name": "jsmith",
+      "siteRole": "Creator",
+      "email": "john.smith@example.com",
+      "fullName": "John Smith",
+      "lastLogin": "2026-05-20T10:30:00Z"
+    },
+    {
+      "id": "user-def456",
+      "name": "asmith",
+      "siteRole": "Viewer",
+      "email": "alice.smith@example.com",
+      "fullName": "Alice Smith",
+      "lastLogin": "2026-05-15T08:00:00Z"
+    },
+    {
+      "id": "user-ghi789",
+      "name": "bjones",
+      "siteRole": "Unlicensed",
+      "email": "bob.jones@example.com",
+      "fullName": "Bob Jones",
+      "lastLogin": "2024-12-01T12:00:00Z"
+    }
+  ],
+  "mcp": {
+    "resultInfo": {
+      "returnedCount": 3,
+      "truncated": true,
+      "truncationReason": "requested-limit"
+    }
   }
-]
+}
 ```
 
 ## Empty result

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "3.6.1",
+  "version": "3.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "3.6.1",
+      "version": "3.6.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.7.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "3.6.1",
+  "version": "3.6.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/src/tools/web/users/listUsers.test.ts
+++ b/src/tools/web/users/listUsers.test.ts
@@ -2,6 +2,7 @@ import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { Err, Ok } from 'ts-results-es';
 
 import { WebMcpServer } from '../../../server.web.js';
+import { stubDefaultEnvVars } from '../../../testShared.js';
 import invariant from '../../../utils/invariant.js';
 import { Provider } from '../../../utils/provider.js';
 import { getMockRequestHandlerExtra } from '../toolContext.mock.js';
@@ -324,6 +325,252 @@ describe('listUsersTool', () => {
     const parsed = JSON.parse(`${result.content[0].text}`);
     expect(parsed.users).toHaveLength(5);
     expect(parsed.totalAvailable).toBe(27034);
+  });
+
+  // === W-23600028: limit must bound POST-filter matches, not the raw fetch ===
+
+  it('EXACT bug repro: limit + selective filter returns matching users (not 0) when early rows fail the filter', async () => {
+    // Single page of 5 users. The FIRST 3 are recent (fail lastLogin:lt), the
+    // LAST 2 are inactive (match). Under the old behavior `limit:2` bounded the
+    // FETCH → only the first 2 (recent) rows were fetched, both filtered out,
+    // result was empty (the exact W-23600028 defect). Now the filter runs inside
+    // the pagination loop, so `limit:2` returns the first 2 MATCHING users.
+    const users = [
+      { ...mockUser, id: 'recent-1', lastLogin: '2026-06-01T00:00:00Z' },
+      { ...mockUser, id: 'recent-2', lastLogin: '2026-06-02T00:00:00Z' },
+      { ...mockUser, id: 'recent-3', lastLogin: '2026-06-03T00:00:00Z' },
+      { ...mockUser, id: 'inactive-1', lastLogin: '2020-01-01T00:00:00Z' },
+      { ...mockUser, id: 'inactive-2', lastLogin: '2020-02-01T00:00:00Z' },
+    ];
+    mocks.mockListUsers.mockResolvedValue({
+      users,
+      pagination: { pageNumber: 1, pageSize: 1000, totalAvailable: 5 },
+    });
+    const result = await getToolResult({ limit: 2, filter: 'lastLogin:lt:2025-01-01T00:00:00Z' });
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+    const parsed = JSON.parse(`${result.content[0].text}`);
+    // Returns the MATCHING users, not the first raw `limit` rows and not empty.
+    expect(parsed.users).toHaveLength(2);
+    expect(parsed.users.map((u: any) => u.id)).toEqual(['inactive-1', 'inactive-2']);
+    // Only 2 users matched the filter total and both are returned; nothing more
+    // matches beyond the limit → NOT truncated.
+    expect(parsed.mcp.resultInfo.returnedCount).toBe(2);
+    expect(parsed.mcp.resultInfo.truncated).toBe(false);
+    expect(parsed.mcp.resultInfo.truncationReason).toBeUndefined();
+  });
+
+  it('emits a requested-limit truncation warning when more filter-matches exist beyond the limit', async () => {
+    // 4 inactive users match the filter but limit:2 cuts it to 2 → truncated,
+    // and the caller-supplied limit was the binding constraint (no admin cap).
+    const users = [
+      { ...mockUser, id: 'recent-1', lastLogin: '2026-06-01T00:00:00Z' },
+      { ...mockUser, id: 'inactive-1', lastLogin: '2020-01-01T00:00:00Z' },
+      { ...mockUser, id: 'inactive-2', lastLogin: '2020-02-01T00:00:00Z' },
+      { ...mockUser, id: 'inactive-3', lastLogin: '2020-03-01T00:00:00Z' },
+      { ...mockUser, id: 'inactive-4', lastLogin: '2020-04-01T00:00:00Z' },
+    ];
+    mocks.mockListUsers.mockResolvedValue({
+      users,
+      pagination: { pageNumber: 1, pageSize: 1000, totalAvailable: 5 },
+    });
+    const result = await getToolResult({ limit: 2, filter: 'lastLogin:lt:2025-01-01T00:00:00Z' });
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+    const parsed = JSON.parse(`${result.content[0].text}`);
+    expect(parsed.users.map((u: any) => u.id)).toEqual(['inactive-1', 'inactive-2']);
+    expect(parsed.mcp.resultInfo.returnedCount).toBe(2);
+    expect(parsed.mcp.resultInfo.truncated).toBe(true);
+    expect(parsed.mcp.resultInfo.truncationReason).toBe('requested-limit');
+  });
+
+  it('limit >= total matches → truncated:false and no truncationReason', async () => {
+    const users = [
+      { ...mockUser, id: 'inactive-1', lastLogin: '2020-01-01T00:00:00Z' },
+      { ...mockUser, id: 'inactive-2', lastLogin: '2020-02-01T00:00:00Z' },
+      { ...mockUser, id: 'recent-1', lastLogin: '2026-06-01T00:00:00Z' },
+    ];
+    mocks.mockListUsers.mockResolvedValue({
+      users,
+      pagination: { pageNumber: 1, pageSize: 1000, totalAvailable: 3 },
+    });
+    const result = await getToolResult({ limit: 10, filter: 'lastLogin:lt:2025-01-01T00:00:00Z' });
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+    const parsed = JSON.parse(`${result.content[0].text}`);
+    // Both inactive users returned; recent one filtered out.
+    expect(parsed.users.map((u: any) => u.id)).toEqual(['inactive-1', 'inactive-2']);
+    expect(parsed.mcp.resultInfo.returnedCount).toBe(2);
+    expect(parsed.mcp.resultInfo.truncated).toBe(false);
+    expect(parsed.mcp.resultInfo).not.toHaveProperty('truncationReason');
+  });
+
+  it('limit with a filter matching zero users → empty result path', async () => {
+    // Every fetched user is recent, so lastLogin:lt matches none → the tool must
+    // take the empty-result branch (not an error, not a spurious truncation).
+    const users = [
+      { ...mockUser, id: 'recent-1', lastLogin: '2026-06-01T00:00:00Z' },
+      { ...mockUser, id: 'recent-2', lastLogin: '2026-06-02T00:00:00Z' },
+    ];
+    mocks.mockListUsers.mockResolvedValue({
+      users,
+      pagination: { pageNumber: 1, pageSize: 1000, totalAvailable: 2 },
+    });
+    const result = await getToolResult({ limit: 5, filter: 'lastLogin:lt:2025-01-01T00:00:00Z' });
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+    expect(result.content[0].text).toBe(
+      'No users were found. Either none exist or you do not have permission to view them.',
+    );
+  });
+
+  it('honors never-logged-in semantics: undefined lastLogin MATCHES lt and counts toward limit', async () => {
+    // Never-logged-in users (no lastLogin) are the most inactive and MUST match
+    // lastLogin:lt. Mix them with recent users; a small limit should still
+    // surface the never-logged-in candidates, not the recent rows.
+    const neverA = { id: 'never-a', name: 'na', siteRole: 'Creator', email: 'na@x.com' };
+    const neverB = { id: 'never-b', name: 'nb', siteRole: 'Creator', email: 'nb@x.com' };
+    const users = [
+      { ...mockUser, id: 'recent-1', lastLogin: '2026-06-01T00:00:00Z' },
+      neverA,
+      { ...mockUser, id: 'recent-2', lastLogin: '2026-06-02T00:00:00Z' },
+      neverB,
+    ];
+    mocks.mockListUsers.mockResolvedValue({
+      users,
+      pagination: { pageNumber: 1, pageSize: 1000, totalAvailable: 4 },
+    });
+    const result = await getToolResult({ limit: 2, filter: 'lastLogin:lt:2025-01-01T00:00:00Z' });
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+    const parsed = JSON.parse(`${result.content[0].text}`);
+    expect(parsed.users.map((u: any) => u.id)).toEqual(['never-a', 'never-b']);
+    // lastLogin omitted (never emitted as null) for never-logged-in users.
+    expect(parsed.users[0]).not.toHaveProperty('lastLogin');
+  });
+
+  it('excludes never-logged-in users from lastLogin:gt filters', async () => {
+    const neverA = { id: 'never-a', name: 'na', siteRole: 'Creator', email: 'na@x.com' };
+    const users = [neverA, { ...mockUser, id: 'recent-1', lastLogin: '2026-06-01T00:00:00Z' }];
+    mocks.mockListUsers.mockResolvedValue({
+      users,
+      pagination: { pageNumber: 1, pageSize: 1000, totalAvailable: 2 },
+    });
+    const result = await getToolResult({ filter: 'lastLogin:gt:2020-01-01T00:00:00Z' });
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+    const parsed = JSON.parse(`${result.content[0].text}`);
+    expect(parsed.users.map((u: any) => u.id)).toEqual(['recent-1']);
+  });
+
+  it('reports admin-cap truncationReason when MAX_RESULT_LIMITS caps below the matching set', async () => {
+    // Stub the per-tool admin cap at 1. Two users match the filter but the cap
+    // trims to 1, and the caller passed no smaller limit → admin-cap. Restore
+    // the suite-level env stubs in `finally` so other tests keep SERVER/etc.
+    vi.stubEnv('MAX_RESULT_LIMITS', 'list-users:1');
+    try {
+      const users = [
+        { ...mockUser, id: 'inactive-1', lastLogin: '2020-01-01T00:00:00Z' },
+        { ...mockUser, id: 'inactive-2', lastLogin: '2020-02-01T00:00:00Z' },
+      ];
+      mocks.mockListUsers.mockResolvedValue({
+        users,
+        pagination: { pageNumber: 1, pageSize: 1000, totalAvailable: 2 },
+      });
+      const result = await getToolResult({ filter: 'lastLogin:lt:2025-01-01T00:00:00Z' });
+      expect(result.isError).toBe(false);
+      invariant(result.content[0].type === 'text');
+      const parsed = JSON.parse(`${result.content[0].text}`);
+      expect(parsed.users).toHaveLength(1);
+      expect(parsed.mcp.resultInfo.returnedCount).toBe(1);
+      expect(parsed.mcp.resultInfo.truncated).toBe(true);
+      expect(parsed.mcp.resultInfo.truncationReason).toBe('admin-cap');
+    } finally {
+      vi.unstubAllEnvs();
+      stubDefaultEnvVars();
+    }
+  });
+
+  it('reports requested-limit (not admin-cap) when the caller limit is smaller than the admin cap', async () => {
+    // Admin cap 100, caller limit 1 → the caller's own limit was binding.
+    vi.stubEnv('MAX_RESULT_LIMITS', 'list-users:100');
+    try {
+      const users = [
+        { ...mockUser, id: 'inactive-1', lastLogin: '2020-01-01T00:00:00Z' },
+        { ...mockUser, id: 'inactive-2', lastLogin: '2020-02-01T00:00:00Z' },
+      ];
+      mocks.mockListUsers.mockResolvedValue({
+        users,
+        pagination: { pageNumber: 1, pageSize: 1000, totalAvailable: 2 },
+      });
+      const result = await getToolResult({
+        limit: 1,
+        filter: 'lastLogin:lt:2025-01-01T00:00:00Z',
+      });
+      expect(result.isError).toBe(false);
+      invariant(result.content[0].type === 'text');
+      const parsed = JSON.parse(`${result.content[0].text}`);
+      expect(parsed.users).toHaveLength(1);
+      expect(parsed.mcp.resultInfo.truncated).toBe(true);
+      expect(parsed.mcp.resultInfo.truncationReason).toBe('requested-limit');
+    } finally {
+      vi.unstubAllEnvs();
+      stubDefaultEnvVars();
+    }
+  });
+
+  it('always emits mcp.resultInfo with returnedCount and truncated:false on an unfiltered complete list', async () => {
+    const users = [
+      { ...mockUser, id: 'u1' },
+      { ...mockUser, id: 'u2' },
+    ];
+    mocks.mockListUsers.mockResolvedValue({
+      users,
+      pagination: { pageNumber: 1, pageSize: 1000, totalAvailable: 2 },
+    });
+    const result = await getToolResult({});
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+    const parsed = JSON.parse(`${result.content[0].text}`);
+    expect(parsed.mcp.resultInfo).toEqual({ returnedCount: 2, truncated: false });
+  });
+
+  it('pages across multiple fetches to accumulate limit matches when matches are sparse', async () => {
+    // Page 1: 100 recent users (all fail the filter). Page 2: 3 inactive users
+    // (match). With limit:2 the loop MUST fetch page 2 to find matches — proving
+    // limit bounds post-filter matches across page boundaries, not the fetch.
+    const page1 = Array.from({ length: 100 }, (_, i) => ({
+      ...mockUser,
+      id: `recent-${i}`,
+      lastLogin: '2026-06-01T00:00:00Z',
+    }));
+    const page2 = [
+      { ...mockUser, id: 'inactive-1', lastLogin: '2020-01-01T00:00:00Z' },
+      { ...mockUser, id: 'inactive-2', lastLogin: '2020-02-01T00:00:00Z' },
+      { ...mockUser, id: 'inactive-3', lastLogin: '2020-03-01T00:00:00Z' },
+    ];
+    mocks.mockListUsers
+      .mockResolvedValueOnce({
+        users: page1,
+        pagination: { pageNumber: 1, pageSize: 100, totalAvailable: 103 },
+      })
+      .mockResolvedValueOnce({
+        users: page2,
+        pagination: { pageNumber: 2, pageSize: 100, totalAvailable: 103 },
+      });
+    const result = await getToolResult({
+      pageSize: 100,
+      limit: 2,
+      filter: 'lastLogin:lt:2025-01-01T00:00:00Z',
+    });
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+    const parsed = JSON.parse(`${result.content[0].text}`);
+    expect(parsed.users.map((u: any) => u.id)).toEqual(['inactive-1', 'inactive-2']);
+    // A 3rd match existed beyond the limit → truncated (requested-limit).
+    expect(parsed.mcp.resultInfo.truncated).toBe(true);
+    expect(parsed.mcp.resultInfo.truncationReason).toBe('requested-limit');
+    expect(mocks.mockListUsers).toHaveBeenCalledTimes(2);
   });
 
   it('should paginate through all pages when users exceed one page', async () => {

--- a/src/tools/web/users/listUsers.ts
+++ b/src/tools/web/users/listUsers.ts
@@ -6,10 +6,11 @@ import { getConfig } from '../../../config.js';
 import { useRestApi } from '../../../restApiInstance.js';
 import { User } from '../../../sdks/tableau/types/user.js';
 import { WebMcpServer } from '../../../server.web.js';
-import { paginate } from '../../../utils/paginate.js';
+import { paginateWithMetadata } from '../../../utils/paginate.js';
 import { assertAdmin } from '../adminGate.js';
+import { buildTruncationInfo, ListFlowsTruncationReason } from '../flows/listFlows/listFlows.js';
 import { ConstrainedResult, WebTool } from '../tool.js';
-import { applyUserFilters } from './usersFilterUtils.js';
+import { buildUserFilterPredicate } from './usersFilterUtils.js';
 
 const paramsSchema = {
   filter: z.string().optional(),
@@ -36,7 +37,7 @@ export const getListUsersTool = (server: WebMcpServer): WebTool<typeof paramsSch
   **Parameters:**
   - \`filter\` (optional) – Filter string with format \`field:operator:value\`. Multiple filters are comma-separated (AND logic). Same field can appear multiple times for range queries (e.g. \`lastLogin:gt:X,lastLogin:lt:Y\`).
   - \`pageSize\` (optional) – Number of users to fetch from the API per page (default 100, max 1000). Controls server-side pagination.
-  - \`limit\` (optional) – Maximum total results to return after filtering.
+  - \`limit\` (optional) – Maximum number of MATCHING users to return. \`limit\` bounds results AFTER \`filter\` is applied: the tool keeps paging until it has \`limit\` filter-matches (or the site is exhausted), so \`limit:5\` with an inactivity filter returns the first 5 matching users, never 5 pre-filter rows that all get filtered away.
 
   **Filterable Fields:**
 
@@ -57,13 +58,18 @@ export const getListUsersTool = (server: WebMcpServer): WebTool<typeof paramsSch
   - IN operator: \`siteRole:in:Creator|Explorer\`
   - Inactive users: \`lastLogin:lt:2024-12-01T00:00:00Z\`
 
-  **Response:** Each user includes:
+  **Response:** A JSON object \`{ users: [...], mcp: { resultInfo: {...} } }\`. Each user in \`users\` includes:
   - \`id\` – user ID
   - \`name\` – username
   - \`siteRole\` – ServerAdministrator, SiteAdministratorCreator, Creator, Explorer, Viewer, Unlicensed, etc.
   - \`email\` – user email address
   - \`fullName\` – user's full display name
   - \`lastLogin\` – timestamp of last login (ISO 8601)
+
+  \`mcp.resultInfo\` is present on every non-empty result and reports completeness of the (filtered) list (a filter matching zero users returns a plain message instead):
+  - \`returnedCount\` – number of users in \`users\`.
+  - \`truncated\` – \`false\` means \`users\` is the COMPLETE set matching the filter; \`true\` means more matching users exist server-side than were returned.
+  - \`truncationReason\` (only when \`truncated\`): \`"requested-limit"\` (your \`limit\` cut it short — call again with a higher \`limit\`) or \`"admin-cap"\` (a site per-call cap cut it short — narrow the \`filter\` or ask an admin to raise the cap).
   `,
     paramsSchema,
     annotations: {
@@ -76,13 +82,19 @@ export const getListUsersTool = (server: WebMcpServer): WebTool<typeof paramsSch
     callback: async (args, extra): Promise<CallToolResult> => {
       const configWithOverrides = await extra.getConfigWithOverrides();
 
-      return await listUsersTool.logAndExecute({
+      return await listUsersTool.logAndExecute<ListUsersToolResult>({
         extra,
         args,
         callback: async () => {
           let siteTotalAvailable: number | undefined;
 
-          const users = await useRestApi({
+          // Build the filter predicate INSIDE the executed callback so an invalid
+          // filter surfaces as a clean `isError` result rather than an uncaught
+          // throw. `buildUserFilterPredicate` is the single source of truth shared
+          // with `applyUserFilters`.
+          const filterPredicate = buildUserFilterPredicate(args.filter);
+
+          const { users, truncated, truncationReason } = await useRestApi({
             ...extra,
             jwtScopes: listUsersTool.requiredApiScopes,
             callback: async (restApi) => {
@@ -93,14 +105,21 @@ export const getListUsersTool = (server: WebMcpServer): WebTool<typeof paramsSch
               }
 
               const maxResultLimit = configWithOverrides.getMaxResultLimit(listUsersTool.name);
+              const effectiveLimit = maxResultLimit
+                ? Math.min(maxResultLimit, args.limit ?? Number.MAX_SAFE_INTEGER)
+                : args.limit;
 
-              return paginate({
+              const { items, truncatedByLimit } = await paginateWithMetadata<User>({
                 pageConfig: {
                   pageSize: args.pageSize,
-                  limit: maxResultLimit
-                    ? Math.min(maxResultLimit, args.limit ?? Number.MAX_SAFE_INTEGER)
-                    : args.limit,
+                  limit: effectiveLimit,
                 },
+                // Push the filter INTO the pagination loop so `limit` bounds
+                // POST-filter matches, not the raw fetch (the W-23600028 bug: a
+                // small `limit` + an inactivity filter returned 0 because the
+                // first `limit` fetched rows were active users filtered out after
+                // truncation).
+                filterFn: filterPredicate,
                 getDataFn: async (pageConfig) => {
                   const result = await restApi.usersMethods.listUsers({
                     siteId: restApi.siteId,
@@ -130,28 +149,43 @@ export const getListUsersTool = (server: WebMcpServer): WebTool<typeof paramsSch
                   return { pagination, data: result.users };
                 },
               });
+
+              // Project to exactly the fields this tool advertises. The `fields`
+              // query param is only an "include at least" hint on this endpoint —
+              // Tableau still returns authSetting/locale/language/externalAuthUserId,
+              // and userSchema declares them as known optional keys so Zod does NOT
+              // strip them. This projection is what actually enforces the lean
+              // output. Filtering already happened inside the pagination loop
+              // (order: fetch → filter (limit-bounded) → project → serialize).
+              const projectedUsers = items.map(projectLeanUser);
+
+              // Reuse list-flows' truncation classifier so the "requested-limit"
+              // vs "admin-cap" reasoning stays a single source of truth.
+              const { truncated, truncationReason } = buildTruncationInfo({
+                truncatedByLimit,
+                maxResultLimit,
+                llmLimit: args.limit,
+                effectiveLimit,
+              });
+
+              return { users: projectedUsers, truncated, truncationReason };
             },
           });
 
-          // Apply client-side filtering (may reference any of the fetched fields).
-          const filteredUsers = applyUserFilters(users, args.filter);
-
-          // Project to exactly the fields this tool advertises. The `fields` query
-          // param is only an "include at least" hint on this endpoint — Tableau
-          // still returns authSetting/locale/language/externalAuthUserId, and
-          // userSchema declares them as known optional keys so Zod does NOT strip
-          // them. This projection is what actually enforces the lean output. Runs
-          // AFTER filtering (order: fetch → filter → project → serialize).
-          const projectedUsers = filteredUsers.map(projectLeanUser);
-
           const toolResult: ListUsersToolResult = {
-            users: projectedUsers,
+            users,
             totalAvailable: siteTotalAvailable,
+            mcp: {
+              resultInfo: {
+                returnedCount: users.length,
+                truncated,
+                ...(truncationReason && { truncationReason }),
+              },
+            },
           };
           return new Ok(toolResult);
         },
-        constrainSuccessResult: (toolResult) =>
-          constrainUsers({ users: toolResult.users, totalAvailable: toolResult.totalAvailable }),
+        constrainSuccessResult: (toolResult) => constrainUsers(toolResult),
       });
     },
   });
@@ -180,18 +214,35 @@ function projectLeanUser(user: User): LeanUser {
   return lean;
 }
 
+/**
+ * Completeness status attached to every successful list-users response. Mirrors
+ * list-flows' `ListFlowsResultInfo` (adapted for users): `truncated:false` means
+ * `users` is the COMPLETE set matching the filter; `truncated:true` means more
+ * matching users exist server-side than were returned (a limit-truncated
+ * FILTERED list is reported as "more matches exist", not silently complete).
+ */
+export type ListUsersResultInfo = {
+  returnedCount: number;
+  truncated: boolean;
+  truncationReason?: ListFlowsTruncationReason;
+};
+
 interface ListUsersToolResult {
   users: Array<LeanUser>;
+  // Raw server-side site total (pre-filter). Kept top-level as before; because a
+  // filter runs client-side this can exceed the matching count, so it is NOT the
+  // "matches available" signal — `mcp.resultInfo.truncated` is.
   totalAvailable?: number;
+  mcp?: {
+    resultInfo: ListUsersResultInfo;
+  };
 }
 
 export function constrainUsers({
   users,
   totalAvailable,
-}: {
-  users: Array<LeanUser>;
-  totalAvailable?: number;
-}): ConstrainedResult<ListUsersToolResult> {
+  mcp,
+}: ListUsersToolResult): ConstrainedResult<ListUsersToolResult> {
   if (users.length === 0) {
     return {
       type: 'empty',
@@ -199,5 +250,5 @@ export function constrainUsers({
     };
   }
 
-  return { type: 'success', result: { users, totalAvailable } };
+  return { type: 'success', result: { users, totalAvailable, ...(mcp && { mcp }) } };
 }

--- a/src/tools/web/users/usersFilterUtils.test.ts
+++ b/src/tools/web/users/usersFilterUtils.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import { User } from '../../../sdks/tableau/types/user.js';
 import {
   applyUserFilters,
+  buildUserFilterPredicate,
   exportedForTesting,
   parseAndValidateUsersFilterString,
 } from './usersFilterUtils.js';
@@ -314,6 +315,72 @@ describe('usersFilterUtils', () => {
       );
       expect(result).toHaveLength(1);
       expect(result[0].id).toBe('user-456');
+    });
+  });
+
+  // buildUserFilterPredicate is the single source of truth (the pagination-loop
+  // filterFn uses it directly); applyUserFilters is now a thin wrapper over it.
+  // These guards prove the wrapper did NOT change behavior — the predicate and
+  // the wrapper must agree on every user across a representative filter matrix.
+  describe('buildUserFilterPredicate ⇄ applyUserFilters equivalence', () => {
+    const neverLoggedIn: User = {
+      id: 'user-never',
+      name: 'nlogin',
+      siteRole: 'Creator',
+      email: 'never.login@example.com',
+    };
+    const users: User[] = [
+      mockUser,
+      {
+        id: 'user-456',
+        name: 'asmith',
+        siteRole: 'Viewer',
+        email: 'alice.smith@example.com',
+        fullName: 'Alice Smith',
+        lastLogin: '2026-05-15T08:00:00Z',
+      },
+      {
+        id: 'user-789',
+        name: 'bjones',
+        siteRole: 'Unlicensed',
+        email: 'bob.jones@example.com',
+        fullName: 'Bob Jones',
+        lastLogin: '2024-12-01T12:00:00Z',
+      },
+      neverLoggedIn,
+    ];
+
+    const filterStrings = [
+      undefined,
+      '',
+      'siteRole:eq:Creator',
+      'siteRole:in:Creator|Viewer',
+      'email:eq:alice.smith@example.com',
+      'lastLogin:lt:2025-01-01T00:00:00Z',
+      'lastLogin:gt:2025-01-01T00:00:00Z',
+      'lastLogin:gt:2025-01-01T00:00:00Z,lastLogin:lt:2026-05-20T00:00:00Z',
+      'siteRole:eq:Unlicensed,lastLogin:lt:2025-01-01T00:00:00Z',
+      'fullName:eq:Alice Smith',
+    ];
+
+    it.each(filterStrings)(
+      'predicate applied per-user matches applyUserFilters for filter %s',
+      (filter) => {
+        const predicate = buildUserFilterPredicate(filter);
+        const viaPredicate = users.filter(predicate);
+        const viaWrapper = applyUserFilters(users, filter);
+        expect(viaPredicate).toEqual(viaWrapper);
+      },
+    );
+
+    it('predicate accepts every user when the filter string is falsy', () => {
+      expect(users.every(buildUserFilterPredicate(undefined))).toBe(true);
+      expect(users.every(buildUserFilterPredicate(''))).toBe(true);
+    });
+
+    it('predicate throws on an invalid field (same validation as the wrapper)', () => {
+      expect(() => buildUserFilterPredicate('authSetting:eq:SAML')).toThrow(/authSetting/);
+      expect(() => buildUserFilterPredicate('id:gt:123')).toThrow(/not allowed/);
     });
   });
 });

--- a/src/tools/web/users/usersFilterUtils.ts
+++ b/src/tools/web/users/usersFilterUtils.ts
@@ -46,13 +46,26 @@ export function parseAndValidateUsersFilterString(filterString: string): string 
 }
 
 /**
- * Apply client-side filtering to users based on filter expressions.
- * Supports field:operator:value syntax (e.g., "siteRole:eq:Creator")
- * Supports multiple conditions on the same field (e.g., "lastLogin:gt:X,lastLogin:lt:Y" for date ranges)
+ * Build a reusable per-user predicate from a filter string. This is the single
+ * source of truth for the client-side filter logic: both {@link applyUserFilters}
+ * (used to filter an already-fetched array) and the pagination-loop `filterFn`
+ * in listUsers.ts build on it, so `limit` can bound POST-filter matches without
+ * duplicating the parse/match logic.
+ *
+ * Parses/validates the filter string ONCE (throwing on invalid field/operator),
+ * then returns a predicate that evaluates every parsed expression against a
+ * single user with AND logic. When `filterString` is falsy the predicate accepts
+ * every user (matching the "no filter → all users" behavior).
+ *
+ * Supports field:operator:value syntax (e.g., "siteRole:eq:Creator") and
+ * multiple conditions on the same field (e.g., "lastLogin:gt:X,lastLogin:lt:Y"
+ * for date ranges).
  */
-export function applyUserFilters(users: User[], filterString: string | undefined): User[] {
+export function buildUserFilterPredicate(
+  filterString: string | undefined,
+): (user: User) => boolean {
   if (!filterString) {
-    return users;
+    return () => true;
   }
 
   // Parse filter expressions directly to preserve duplicate fields (e.g., date ranges)
@@ -79,12 +92,21 @@ export function applyUserFilters(users: User[], filterString: string | undefined
     };
   });
 
-  return users.filter((user) => {
-    return filters.every(({ field, operator, value }) => {
+  return (user: User): boolean =>
+    filters.every(({ field, operator, value }) => {
       const fieldValue = getFieldValue(user, field);
       return matchesFilter(fieldValue, operator, value, field);
     });
-  });
+}
+
+/**
+ * Apply client-side filtering to users based on filter expressions. Thin wrapper
+ * over {@link buildUserFilterPredicate} kept for callers that filter an
+ * already-materialized array.
+ */
+export function applyUserFilters(users: User[], filterString: string | undefined): User[] {
+  const predicate = buildUserFilterPredicate(filterString);
+  return users.filter(predicate);
 }
 
 function getFieldValue(user: User, field: FilterField): string | number | undefined {

--- a/src/utils/paginate.test.ts
+++ b/src/utils/paginate.test.ts
@@ -439,6 +439,231 @@ describe('paginateWithMetadata', () => {
   });
 });
 
+// ----------------------------------------------------------------------------
+// paginateWithMetadata — opt-in filterFn (W-23600028)
+// ----------------------------------------------------------------------------
+// The bug: `limit` was applied to the FETCH before the client-side filter ran,
+// so a small `limit` + a selective filter returned 0 matches even though many
+// matched server-side. The fix: when a `filterFn` is supplied, `limit` bounds
+// POST-filter matches. The loop pages by `pageSize` (NOT the raw limit), counts
+// only PASSING rows toward `limit`, collects one past the limit ("limit+1") to
+// set `truncatedByLimit` honestly, then slices to `limit`.
+describe('paginateWithMetadata (filterFn — limit bounds post-filter matches)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('fetches additional pages until it has `limit` PASSING rows when early rows are rejected', async () => {
+    // filterFn keeps only even ids. limit 2, pageSize 2 across 3 pages (total 6).
+    // Page 1 [1,2] → 1 match; must fetch page 2 [3,4] → 2 matches; and page 3
+    // [5,6] to discover a 3rd match exists (limit+1) → truncatedByLimit=true.
+    const getDataFn = vi
+      .fn()
+      .mockResolvedValueOnce({
+        pagination: { pageNumber: 1, pageSize: 2, totalAvailable: 6 },
+        data: [{ id: 1 }, { id: 2 }],
+      })
+      .mockResolvedValueOnce({
+        pagination: { pageNumber: 2, pageSize: 2, totalAvailable: 6 },
+        data: [{ id: 3 }, { id: 4 }],
+      })
+      .mockResolvedValueOnce({
+        pagination: { pageNumber: 3, pageSize: 2, totalAvailable: 6 },
+        data: [{ id: 5 }, { id: 6 }],
+      });
+
+    const result = await paginateWithMetadata<{ id: number }>({
+      pageConfig: { pageSize: 2, pageNumber: 1, limit: 2 },
+      getDataFn,
+      filterFn: (item) => item.id % 2 === 0,
+    });
+
+    // Up to `limit` PASSING rows are returned — never the raw first `limit` rows.
+    expect(result.items).toEqual([{ id: 2 }, { id: 4 }]);
+    // A further match ({id:6}) existed server-side beyond the limit → truncated.
+    expect(result.truncatedByLimit).toBe(true);
+    // totalAvailable is the server's RAW pre-filter count.
+    expect(result.totalAvailable).toBe(6);
+    expect(getDataFn).toHaveBeenCalledTimes(3);
+  });
+
+  it('reports truncatedByLimit=false when all filtered matches are fully returned', async () => {
+    // filterFn keeps only even ids; only 2 exist (2,4) in a 4-row set. limit 5.
+    const getDataFn = vi
+      .fn()
+      .mockResolvedValueOnce({
+        pagination: { pageNumber: 1, pageSize: 2, totalAvailable: 4 },
+        data: [{ id: 1 }, { id: 2 }],
+      })
+      .mockResolvedValueOnce({
+        pagination: { pageNumber: 2, pageSize: 2, totalAvailable: 4 },
+        data: [{ id: 3 }, { id: 4 }],
+      });
+
+    const result = await paginateWithMetadata<{ id: number }>({
+      pageConfig: { pageSize: 2, pageNumber: 1, limit: 5 },
+      getDataFn,
+      filterFn: (item) => item.id % 2 === 0,
+    });
+
+    expect(result.items).toEqual([{ id: 2 }, { id: 4 }]);
+    expect(result.truncatedByLimit).toBe(false);
+    expect(result.totalAvailable).toBe(4);
+    expect(getDataFn).toHaveBeenCalledTimes(2);
+  });
+
+  it('EXACT bug repro: first `limit` fetched rows fail the filter but later rows pass → returns passing rows, not 0', async () => {
+    // Single page: ids 1..5, all fetched. filter keeps id > 2. Under the OLD
+    // behavior `limit:2` bounded the FETCH, so only [1,2] were fetched, both
+    // failed the filter, and the result was empty. Now the filter runs inside
+    // the loop so `limit:2` returns the first 2 PASSING rows.
+    const getDataFn = vi.fn().mockResolvedValue({
+      pagination: { pageNumber: 1, pageSize: 10, totalAvailable: 5 },
+      data: [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }, { id: 5 }],
+    });
+
+    const result = await paginateWithMetadata<{ id: number }>({
+      pageConfig: { pageSize: 10, pageNumber: 1, limit: 2 },
+      getDataFn,
+      filterFn: (item) => item.id > 2,
+    });
+
+    expect(result.items).toEqual([{ id: 3 }, { id: 4 }]);
+    expect(result.items).not.toHaveLength(0);
+    expect(result.truncatedByLimit).toBe(true); // {id:5} matches beyond the limit
+  });
+
+  it('returns all passing rows (truncatedByLimit=false) when no limit is set with a filter', async () => {
+    const getDataFn = vi.fn().mockResolvedValue({
+      pagination: { pageNumber: 1, pageSize: 10, totalAvailable: 5 },
+      data: [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }, { id: 5 }],
+    });
+
+    const result = await paginateWithMetadata<{ id: number }>({
+      pageConfig: { pageSize: 10, pageNumber: 1 },
+      getDataFn,
+      filterFn: (item) => item.id > 2,
+    });
+
+    expect(result.items).toEqual([{ id: 3 }, { id: 4 }, { id: 5 }]);
+    expect(result.truncatedByLimit).toBe(false);
+  });
+
+  it('edge: filterFn that rejects everything exhausts all pages cleanly (no infinite loop, 0 matches)', async () => {
+    const getDataFn = vi
+      .fn()
+      .mockResolvedValueOnce({
+        pagination: { pageNumber: 1, pageSize: 2, totalAvailable: 5 },
+        data: [{ id: 1 }, { id: 2 }],
+      })
+      .mockResolvedValueOnce({
+        pagination: { pageNumber: 2, pageSize: 2, totalAvailable: 5 },
+        data: [{ id: 3 }, { id: 4 }],
+      })
+      .mockResolvedValueOnce({
+        pagination: { pageNumber: 3, pageSize: 2, totalAvailable: 5 },
+        data: [{ id: 5 }],
+      });
+
+    const result = await paginateWithMetadata<{ id: number }>({
+      pageConfig: { pageSize: 2, pageNumber: 1 },
+      getDataFn,
+      filterFn: () => false,
+    });
+
+    expect(result.items).toEqual([]);
+    expect(result.truncatedByLimit).toBe(false);
+    expect(result.totalAvailable).toBe(5);
+    // All pages exhausted exactly once — the loop terminated when the raw fetch
+    // count reached totalAvailable, not by matches.
+    expect(getDataFn).toHaveBeenCalledTimes(3);
+  });
+
+  it('does NOT thread the raw `limit` into getDataFn on the filtered path (limit bounds post-filter, not the fetch)', async () => {
+    // Regression guard for the fix: the filtered path must page by pageSize only.
+    // If `limit` leaked into the fetch we would reintroduce the original bug.
+    const getDataFn = vi
+      .fn()
+      .mockResolvedValueOnce({
+        pagination: { pageNumber: 1, pageSize: 2, totalAvailable: 4 },
+        data: [{ id: 1 }, { id: 2 }],
+      })
+      .mockResolvedValueOnce({
+        pagination: { pageNumber: 2, pageSize: 2, totalAvailable: 4 },
+        data: [{ id: 3 }, { id: 4 }],
+      });
+
+    await paginateWithMetadata<{ id: number }>({
+      pageConfig: { pageSize: 2, pageNumber: 1, limit: 3 },
+      getDataFn,
+      filterFn: () => true,
+    });
+
+    for (const call of getDataFn.mock.calls) {
+      expect(call[0]).not.toHaveProperty('limit');
+    }
+    expect(getDataFn).toHaveBeenNthCalledWith(1, { pageSize: 2, pageNumber: 1 });
+    expect(getDataFn).toHaveBeenNthCalledWith(2, { pageSize: 2, pageNumber: 2 });
+  });
+});
+
+// ----------------------------------------------------------------------------
+// Regression guard: NO-filterFn path must remain byte-for-byte unchanged.
+// ----------------------------------------------------------------------------
+// The fix added an opt-in filtered branch; the original no-filter branch (used
+// by list-flows, list-flow-runs, list-projects, …) must behave exactly as
+// before. Here `limit` bounds the RAW fetch and the returned slice — the OPPOSITE
+// of the filtered path — which is the invariant those callers depend on.
+describe('paginateWithMetadata (no filterFn — legacy behavior unchanged)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('limit bounds the raw fetch/slice (not post-filter) and threads `limit` into subsequent getDataFn calls', async () => {
+    const getDataFn = vi
+      .fn()
+      .mockResolvedValueOnce({
+        pagination: { pageNumber: 1, pageSize: 2, totalAvailable: 5 },
+        data: [{ id: 1 }, { id: 2 }],
+      })
+      .mockResolvedValueOnce({
+        pagination: { pageNumber: 2, pageSize: 2, totalAvailable: 5 },
+        data: [{ id: 3 }, { id: 4 }],
+      });
+
+    const result = await paginateWithMetadata<{ id: number }>({
+      pageConfig: { pageSize: 2, pageNumber: 1, limit: 3 },
+      getDataFn,
+    });
+
+    // Raw first 3 rows — no filtering.
+    expect(result.items).toEqual([{ id: 1 }, { id: 2 }, { id: 3 }]);
+    // totalAvailable(5) > items(3) → truncated.
+    expect(result.truncatedByLimit).toBe(true);
+    expect(result.totalAvailable).toBe(5);
+    // Legacy path DOES thread `limit` into the paging calls.
+    expect(getDataFn).toHaveBeenNthCalledWith(2, { pageSize: 2, pageNumber: 2, limit: 3 });
+  });
+
+  it('single-page limit bounds the raw fetch (would-be-filtered rows are still returned raw)', async () => {
+    // Same 5-row single page as the filtered "bug repro" above, but WITHOUT a
+    // filterFn: the no-filter path returns the raw first `limit` rows [1,2].
+    const getDataFn = vi.fn().mockResolvedValue({
+      pagination: { pageNumber: 1, pageSize: 10, totalAvailable: 5 },
+      data: [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }, { id: 5 }],
+    });
+
+    const result = await paginateWithMetadata<{ id: number }>({
+      pageConfig: { pageSize: 10, pageNumber: 1, limit: 2 },
+      getDataFn,
+    });
+
+    expect(result.items).toEqual([{ id: 1 }, { id: 2 }]);
+    expect(result.truncatedByLimit).toBe(true);
+    expect(getDataFn).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe('paginate (delegates to paginateWithMetadata)', () => {
   // Regression guard: paginate is now a thin wrapper over paginateWithMetadata.
   // Make sure it still behaves identically to its prior contract — items only.

--- a/src/utils/paginate.ts
+++ b/src/utils/paginate.ts
@@ -17,6 +17,20 @@ type PageConfig = z.infer<typeof pageConfigSchema>;
 type PaginateArgs<T> = {
   pageConfig: PageConfig;
   getDataFn: (pagination: PageConfig) => Promise<{ pagination: Pagination; data: Array<T> }>;
+  /**
+   * OPT-IN client-side predicate. When provided, {@link paginateWithMetadata}
+   * fetches pages by `pageSize` (the raw `limit` is deliberately NOT threaded
+   * into the fetch), applies this predicate to every fetched row, and counts
+   * ONLY passing rows toward `limit`. `limit` therefore bounds POST-filter
+   * matches, and `truncatedByLimit` reflects POST-filter truncation.
+   *
+   * When omitted, the pagination behavior is byte-for-byte identical to the
+   * original implementation (raw `limit` bounds the fetch and the returned
+   * slice). This invariant is load-bearing: existing callers (`list-flows`,
+   * `list-flow-runs`, `list-projects`, …) rely on the no-filter path and must
+   * not change. See the explicit no-filter branch in {@link paginateWithMetadata}.
+   */
+  filterFn?: (item: T) => boolean;
 };
 
 const MAX_PAGE_SIZE = 1000;
@@ -31,10 +45,16 @@ const MAX_PAGE_SIZE = 1000;
  *   query (across all pages, ignoring `limit`). For multi-page paginations
  *   this is the value Tableau returned on the last page actually fetched;
  *   Tableau returns the same value on every page response, so for the loops
- *   we run it's stable.
- * - `truncatedByLimit` — `true` iff `items.length < totalAvailable`. When
- *   `true`, the caller can confidently surface a "more results available,
- *   but a limit cut you off" signal (e.g. an MCP warning).
+ *   we run it's stable. NOTE: when a `filterFn` is supplied this is the
+ *   server's RAW, PRE-filter count — it is NOT a count of matching rows and
+ *   cannot be (the server does no filtering). With a filter, callers should
+ *   rely on `truncatedByLimit` (not `totalAvailable`) as the "more matches
+ *   exist server-side" signal.
+ * - `truncatedByLimit` — `true` iff more rows exist server-side beyond the
+ *   returned (limited) set. Without a filter this is `items.length <
+ *   totalAvailable`. With a filter it means more MATCHING rows exist beyond the
+ *   `limit` returned. When `true`, the caller can confidently surface a "more
+ *   results available, but a limit cut you off" signal (e.g. an MCP warning).
  */
 export type PaginateResult<T> = {
   items: Array<T>;
@@ -56,9 +76,62 @@ export type PaginateResult<T> = {
 export async function paginateWithMetadata<T>({
   pageConfig,
   getDataFn,
+  filterFn,
 }: PaginateArgs<T>): Promise<PaginateResult<T>> {
   const { pageSize, limit } = pageConfigSchema.parse(pageConfig);
   const effectivePageSize = pageSize ? Math.min(pageSize, MAX_PAGE_SIZE) : pageSize;
+
+  // --- Filtered path (opt-in) ---------------------------------------------
+  // When a predicate is supplied, `limit` must bound POST-filter matches, not
+  // the fetch. So we page by `pageSize` (deliberately NOT threading raw `limit`
+  // into getDataFn) and count only rows that PASS toward `limit`. To set
+  // `truncatedByLimit` HONESTLY we collect until we have `limit + 1` matches —
+  // one past the limit proves more matches exist server-side — or the server's
+  // pages are exhausted. `totalAvailable` here is the server's RAW pre-filter
+  // count (the server does no filtering); with a filter the truncation SIGNAL,
+  // not `totalAvailable`, is what tells the model "more matches exist".
+  if (filterFn) {
+    const first = await getDataFn({
+      pageSize: effectivePageSize,
+      pageNumber: pageConfig.pageNumber,
+    });
+    let { totalAvailable, pageNumber } = first.pagination;
+    let rawFetched = first.data.length;
+    const matches = first.data.filter(filterFn);
+
+    while (totalAvailable > rawFetched && (!limit || matches.length <= limit)) {
+      const { pagination: nextPagination, data: nextData } = await getDataFn({
+        pageSize: effectivePageSize,
+        pageNumber: pageNumber + 1,
+      });
+
+      if (nextData.length === 0) {
+        throw new Error(
+          `No more data available. Last fetched page number: ${pageNumber}, Total available: ${totalAvailable}, Total fetched: ${rawFetched}`,
+        );
+      }
+
+      ({ totalAvailable, pageNumber } = nextPagination);
+      rawFetched += nextData.length;
+      for (const item of nextData) {
+        if (filterFn(item)) {
+          matches.push(item);
+        }
+      }
+    }
+
+    const truncatedByLimit = limit !== undefined && matches.length > limit;
+    if (truncatedByLimit) {
+      matches.length = limit;
+    }
+
+    return { items: matches, totalAvailable, truncatedByLimit };
+  }
+
+  // --- No-filter path -------------------------------------------------------
+  // INVARIANT: behavior below MUST stay byte-for-byte identical to the original
+  // implementation. Other callers (list-flows, list-flow-runs, list-projects,
+  // …) depend on it; do NOT alter this branch when touching the filtered path.
   const { pagination, data } = await getDataFn({ ...pageConfig, pageSize: effectivePageSize });
   const items = [...data];
 

--- a/tests/e2e/users/listUsers.test.ts
+++ b/tests/e2e/users/listUsers.test.ts
@@ -24,6 +24,15 @@ import { McpClient } from '../mcpClient.js';
 const listUsersResultSchema = z.object({
   users: z.array(userSchema),
   totalAvailable: z.number().optional(),
+  mcp: z
+    .object({
+      resultInfo: z.object({
+        returnedCount: z.number(),
+        truncated: z.boolean(),
+        truncationReason: z.enum(['requested-limit', 'admin-cap']).optional(),
+      }),
+    })
+    .optional(),
 });
 
 describe('list-users', () => {
@@ -110,11 +119,13 @@ describe('list-users', () => {
     // `gt` excludes never-logged-in users (undefined lastLogin), so any row returned here MUST
     // have a real lastLogin — this is a stronger proof that lastLogin is populated end-to-end.
     // The site's admin PAT owner has logged in well after 2020 and appears in the first page, so
-    // this is guaranteed non-empty. Bound to one page — client-side filtering otherwise fetches
-    // all ~27k users first (the filter is applied after pagination) and blows the timeout.
+    // this is guaranteed non-empty. Keep `limit` small: post-W-23600028 the filter is applied
+    // DURING pagination and `limit` bounds POST-filter matches, so a large limit against a site
+    // with sparse `lastLogin` matches (seeded sites are almost all never-logged-in users) would
+    // page the entire population to prove it can't reach the limit and blow the timeout.
     const result = await client.callTool('list-users', {
       schema: listUsersResultSchema,
-      toolArgs: { pageSize: 1000, limit: 1000, filter: 'lastLogin:gt:2020-01-01T00:00:00Z' },
+      toolArgs: { pageSize: 1000, limit: 5, filter: 'lastLogin:gt:2020-01-01T00:00:00Z' },
     });
 
     expect(result.users.length).toBeGreaterThan(0);
@@ -125,6 +136,49 @@ describe('list-users', () => {
         new Date('2020-01-01T00:00:00Z').getTime(),
       );
     }
+  });
+
+  it('W-23600028: a small limit + an inactivity filter returns `limit` matching users, not 0', async () => {
+    if (!toolsAvailable) {
+      return;
+    }
+
+    // THE BUG: `limit` was applied to the FETCH before the client-side filter
+    // ran. On the live site (~18,008 users) the first `limit` fetched rows are
+    // typically active admins/service accounts that FAIL an inactivity filter,
+    // so `limit:5` + `lastLogin:lt:<recent cutoff>` returned 0 users even though
+    // thousands matched. After the fix `limit` bounds POST-filter matches: the
+    // tool pages until it has 5 filter-matches, so this returns exactly 5 users.
+    //
+    // Use a large pageSize so the 5 matches are found in as few sequential REST
+    // calls as possible. The cutoff is recent (2026-07-01) so the vast majority
+    // of the 18,008 users — anyone who has not logged in since then, plus every
+    // never-logged-in user — match; 5 matches are found on the very first page.
+    const result = await client.callTool('list-users', {
+      schema: listUsersResultSchema,
+      toolArgs: { pageSize: 1000, limit: 5, filter: 'lastLogin:lt:2026-07-01T00:00:00Z' },
+    });
+
+    // The regression assertion: NON-empty, and exactly `limit` matching users.
+    expect(result.users.length).toBe(5);
+
+    // Every returned user actually satisfies the filter: either an inactive
+    // lastLogin strictly before the cutoff, or a never-logged-in user (no
+    // lastLogin — the most-inactive class, which MUST match `lt`).
+    const cutoff = new Date('2026-07-01T00:00:00Z').getTime();
+    for (const user of result.users) {
+      if (user.lastLogin === undefined) {
+        continue; // never-logged-in: correctly included by lt
+      }
+      expect(new Date(user.lastLogin).getTime()).toBeLessThan(cutoff);
+    }
+
+    // resultInfo must report the limit-truncation honestly: far more than 5
+    // users match on an 18,008-user site, so truncated:true with
+    // truncationReason 'requested-limit' (the caller's own limit was binding).
+    expect(result.mcp?.resultInfo.returnedCount).toBe(5);
+    expect(result.mcp?.resultInfo.truncated).toBe(true);
+    expect(result.mcp?.resultInfo.truncationReason).toBe('requested-limit');
   });
 
   it('should reject a filter on a now-removed field (authSetting) with an enum error, not silent-empty', async () => {


### PR DESCRIPTION
`list-users` applied `limit` to the FETCH in `paginateWithMetadata`, which ran BEFORE the client-side `applyUserFilters`. On large sites the first `limit` fetched rows were often active admins/service accounts that fail an inactivity filter, so e.g. `limit:5` + `lastLogin:lt:<recent-cutoff>` returned 0 users while thousands matched — silently under-returning.

Fix: add an opt-in `filterFn` predicate to `paginateWithMetadata` so the loop pages until it has collected `limit + 1` matching rows (or the site is exhausted), then truncates. `limit` now bounds POST-filter matches. The no-filter path is unchanged (predicate omitted -> prior behavior, byte-for-byte).

- Extract `buildUserFilterPredicate`; `applyUserFilters` becomes a thin wrapper.
- Truncation is reported via `mcp.resultInfo.truncated`/`truncationReason` reflecting post-filter truncation (reuses the list-flows truncation helper).
- Docs + tool description corrected: `limit` bounds filtered matches; a zero-match filter returns a plain message (no `resultInfo`).
- Unit + e2e coverage for the repro, never-logged-in semantics, and a guard that `limit` no longer leaks into the fetch.

Patch bump 3.6.1 -> 3.6.2.

**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of
the pull request._

# Pull Request Template

<!-- Thank you for your contribution! Please fill out the following template to help us review your pull
request! -->

## Description

<!-- Please include a summary of the change. -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## How Has This Been Tested?

<!-- Please describe the tests that you performed to verify your changes. -->

## Related Issues

<!-- List any related issues, pull requests, or discussions. -->

## Checklist

- [x] I have updated the version in the package.json file by using `npm run version`. For example,
      use `npm run version:patch` for a patch version bump.
- [x] I have made any necessary changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have documented any breaking changes in the PR description. For example, renaming a config
      environment variable or changing its default value.

## Contributor Agreement

By submitting this pull request, I confirm that:

- [x] I have read the [CONTRIBUTING guidelines](../../CONTRIBUTING.md) for this project and followed
      its Contribution Checklist.
