### PR TITLE
feat(desktop): plan submission is the capability and field check

### DIFF
--- a/src/server.desktop.test.ts
+++ b/src/server.desktop.test.ts
@@ -296,7 +296,7 @@ describe('desktop tools/list per-tool byte accounting', () => {
     ['plan-dashboard-creation', 1383], // ratcheted down in the author-set/action/format-labels funding trim (CODA, empty describe stubs); do not grow
     ['build-and-apply-dashboard', 1430], // ratcheted down in the CODA funding trim; do not grow
     ['validate-proposal', 1510], // ratcheted down with compact shared proposal descriptions; 46k stays green
-    ['execute-authoring-plan', 2445], // capability admission plus compile/execute mode
+    ['execute-authoring-plan', 2441], // capability admission plus compile/execute mode
     // The template parameter is a z.enum over the real template vocabulary, so its cost
     // is the vocabulary itself, not prose. Agents invented 13 template ids against 47
     // real ones and burned 188s discovering it; the enum makes that unrepresentable.

--- a/src/tools/desktop/commands/authoringCapabilityCensus.test.ts
+++ b/src/tools/desktop/commands/authoringCapabilityCensus.test.ts
@@ -58,4 +58,15 @@ describe('checkAuthoringCapabilityCensus', () => {
     expect(result.missing).toBeUndefined();
     expect(result.capabilitiesUsed).toEqual([]);
   });
+
+  it('defaults to denial when a command is absent from the command census', () => {
+    const result = checkAuthoringCapabilityCensus({
+      steps: [{ command: 'tabdoc:add-binned-axis' }],
+    });
+
+    expect(result.missing).toMatchObject({
+      name: 'tabdoc:add-binned-axis',
+      reason: expect.stringContaining('absent from the bundled Tableau command census'),
+    });
+  });
 });

--- a/src/tools/desktop/commands/authoringCapabilityCensus.ts
+++ b/src/tools/desktop/commands/authoringCapabilityCensus.ts
@@ -1,3 +1,5 @@
+import { knownCommands } from '../../../desktop/commandRegistry.js';
+
 type CensusPlan = {
   steps: ReadonlyArray<{ command: string; args?: Record<string, unknown> }>;
   summaryWorksheet?: string | readonly string[];
@@ -94,7 +96,17 @@ export function checkAuthoringCapabilityCensus(plan: CensusPlan): CensusResult {
   const capabilitiesUsed = CENSUS.filter(
     (entry) => typeof entry.detect === 'function' && entry.detect(plan),
   ).map(({ name }) => name);
-  const missing = CENSUS.find(({ name }) => capabilitiesUsed.includes(name));
+  const missingCapability = CENSUS.find(({ name }) => capabilitiesUsed.includes(name));
+  const commandCensus = knownCommands();
+  const uncensusedCommand = plan.steps.find(({ command }) => !commandCensus?.has(command))?.command;
+  const missing =
+    missingCapability ??
+    (uncensusedCommand
+      ? {
+          name: uncensusedCommand,
+          reason: 'the command is absent from the bundled Tableau command census',
+        }
+      : undefined);
 
   return {
     capabilitiesUsed,

--- a/src/tools/desktop/commands/executeAuthoringPlan.test.ts
+++ b/src/tools/desktop/commands/executeAuthoringPlan.test.ts
@@ -37,8 +37,27 @@ const WORKSHEET_XML = `<worksheet name="Sales by Region"><table><panes><pane>
 </pane></panes></table></worksheet>`;
 const DASHBOARD_XML =
   '<dashboard name="Executive Overview"><zones><zone name="Sales by Region"/></zones></dashboard>';
+const WORKBOOK_XML = `<workbook><datasources>
+  <datasource name="sample" caption="Sample - Superstore">
+    <column name="[Region]" datatype="string" role="dimension" type="nominal"/>
+    <column name="[Sales]" datatype="real" role="measure" type="quantitative"/>
+  </datasource>
+</datasources></workbook>`;
 
 describe('executeAuthoringPlanTool', () => {
+  it('presents plan submission as the capability and field preflight', async () => {
+    const tool = getExecuteAuthoringPlanTool(new DesktopMcpServer());
+    const description = await Provider.from(tool.description);
+
+    expect(description).toMatch(
+      /^Submitting the plan is the capability and field check: preflight validates every step and field reference before any run/,
+    );
+    expect(description).toContain('No step ran');
+    expect(description).toContain('Do not pre-verify fields with resolve-field');
+    expect(description).toContain('scan search-commands');
+    expect(description).toContain('submit the plan and read the refusal');
+  });
+
   it('executes three completed steps in order and returns requested readback', async () => {
     const executor = makeExecutor();
     const extra = makeExtra(executor);
@@ -233,6 +252,56 @@ describe('executeAuthoringPlanTool', () => {
     expectCapabilityRefusal(result, name);
     expect(extra.getExecutor).not.toHaveBeenCalled();
     expectEveryExecutorMethodUntouched(executor);
+  });
+
+  it('refuses a command absent from the census before any plan step runs', async () => {
+    const executor = makeExecutor();
+    const extra = makeExtra(executor);
+
+    const result = await getResult(
+      {
+        session: SESSION,
+        steps: [{ command: 'tabdoc:save' }, { command: 'tabdoc:add-binned-axis' }],
+      },
+      extra,
+    );
+
+    expectCapabilityRefusal(result, 'tabdoc:add-binned-axis');
+    expect(extra.getExecutor).not.toHaveBeenCalled();
+    expectEveryExecutorMethodUntouched(executor);
+  });
+
+  it('refuses unresolved notional-spec fields before any plan step runs', async () => {
+    const executor = makeExecutor();
+    const extra = makeExtra(executor);
+
+    const result = await getResult(
+      {
+        session: SESSION,
+        steps: [
+          { command: 'tabdoc:save' },
+          {
+            command: 'tabdoc:generate-viz-from-notional-spec',
+            args: {
+              NotionalSpecJson: JSON.stringify({
+                version: '0.2.0',
+                fields: [{ caption: 'Missing Revenue' }],
+              }),
+            },
+          },
+        ],
+      },
+      extra,
+    );
+
+    expect(result.isError).toBe(true);
+    invariant(result.content[0].type === 'text');
+    const payload = JSON.parse(result.content[0].text);
+    expect(payload.steps).toEqual([]);
+    expect(payload.message).toContain('Unresolved field reference(s): "Missing Revenue"');
+    expect(payload.message).toContain('No step ran');
+    expect(executor.getWorkbookDocument).toHaveBeenCalledTimes(1);
+    expect(executor.executeCommand).not.toHaveBeenCalled();
   });
 
   it('compiles a fully admitted plan without dispatch or readback', async () => {
@@ -593,6 +662,7 @@ describe('executeAuthoringPlanTool', () => {
 type MockExecutor = {
   executeCommand: ReturnType<typeof vi.fn>;
   getWorkbook: ReturnType<typeof vi.fn>;
+  getWorkbookDocument: ReturnType<typeof vi.fn>;
   getWorksheetDocument: ReturnType<typeof vi.fn>;
   getDashboardDocument: ReturnType<typeof vi.fn>;
   listWorksheets: ReturnType<typeof vi.fn>;
@@ -602,6 +672,7 @@ type MockExecutor = {
 function makeExecutor(): MockExecutor {
   return {
     executeCommand: vi.fn().mockResolvedValue(new Ok(COMPLETED)),
+    getWorkbookDocument: vi.fn().mockResolvedValue(new Ok({ xml: WORKBOOK_XML })),
     getWorkbook: vi.fn().mockResolvedValue(
       new Ok({
         title: 'Book',

--- a/src/tools/desktop/commands/executeAuthoringPlan.ts
+++ b/src/tools/desktop/commands/executeAuthoringPlan.ts
@@ -5,11 +5,13 @@ import { z } from 'zod';
 import { knownLiveFailureFixFor } from '../../../desktop/commandPolicy.js';
 import { guardCommand } from '../../../desktop/commands/externalApiCommandGuard.js';
 import type { WorkbookDocument } from '../../../desktop/externalApi/externalApiClient.js';
+import type { ExternalApiToolExecutor } from '../../../desktop/externalApi/externalApiToolExecutor.js';
 import {
   DashboardItem,
   WorkbookInventory,
   WorksheetItem,
 } from '../../../desktop/externalApi/types.js';
+import { resolveField } from '../../../desktop/metadata/field-resolver.js';
 import { normalizeArray, parseXML } from '../../../desktop/metadata/parser.js';
 import { resolveSession } from '../../../desktop/sessionResolution.js';
 import {
@@ -64,7 +66,7 @@ const postconditionSchema = z.discriminatedUnion('kind', [
 ]);
 
 const stepSchema = z.object({
-  command: z.string().describe("'namespace:command' ID."),
+  command: z.string().describe('Command ID.'),
   args: z.record(z.unknown()).optional(),
   expect: postconditionSchema.optional(),
 });
@@ -72,20 +74,14 @@ const stepSchema = z.object({
 type PlanPostcondition = z.infer<typeof postconditionSchema>;
 
 const paramsSchema = {
-  session: z.string().optional().describe('Session ID if not pinned.'),
-  mode: z
-    .enum(['compile', 'execute'])
-    .default('execute')
-    .describe('Compile validates only; execute dispatches.'),
-  steps: z.array(stepSchema).min(1).max(24).describe('1-24 ordered steps.'),
-  verify: z
-    .array(z.string())
-    .optional()
-    .describe('Sheet/dashboard names to verify after the plan.'),
+  session: z.string().optional().describe('Session ID.'),
+  mode: z.enum(['compile', 'execute']).default('execute').describe('Validate or execute.'),
+  steps: z.array(stepSchema).min(1).max(24).describe('1-24 steps.'),
+  verify: z.array(z.string()).optional().describe('Post-plan targets.'),
   summary_worksheet: z
     .union([z.string(), z.array(z.string()).min(2)])
     .optional()
-    .describe('Worksheet to read; multiple names are refused.'),
+    .describe('Summary worksheet.'),
 };
 
 type PreparedStep = {
@@ -163,7 +159,7 @@ export const getExecuteAuthoringPlanTool = (
     name: 'execute-authoring-plan',
     title,
     description:
-      'Runs an ordered plan of guarded Tableau commands in one call; stops at first failure; optional readback and typed per-step postconditions after the last step.',
+      'Submitting the plan is the capability and field check: preflight validates every step and field reference before any run and refuses safely with "No step ran." Do not pre-verify fields with resolve-field or scan search-commands; submit the plan and read the refusal.',
     paramsSchema,
     annotations: {
       readOnlyHint: false,
@@ -184,7 +180,23 @@ export const getExecuteAuthoringPlanTool = (
             return preparedResult;
           }
           const normalizedSummaryWorksheet = normalizeSummaryWorksheet(summary_worksheet);
+          const fieldReferences = collectPlannedFieldReferences(preparedResult.value.steps);
           if (mode === 'compile') {
+            if (fieldReferences.length > 0) {
+              const sessionResult = resolveSession(session);
+              if (sessionResult.isErr()) {
+                return sessionResult.error.toErr();
+              }
+              const executor = await extra.getExecutor(sessionResult.value);
+              const fieldPreflight = await preflightFieldReferences(
+                fieldReferences,
+                executor,
+                extra.signal,
+              );
+              if (fieldPreflight.isErr()) {
+                return fieldPreflight;
+              }
+            }
             return new Ok(
               withNextAction(
                 {
@@ -213,6 +225,14 @@ export const getExecuteAuthoringPlanTool = (
           }
           const resolvedSession = sessionResult.value;
           const executor = await extra.getExecutor(resolvedSession);
+          const fieldPreflight = await preflightFieldReferences(
+            fieldReferences,
+            executor,
+            extra.signal,
+          );
+          if (fieldPreflight.isErr()) {
+            return fieldPreflight;
+          }
           const stepResults: PlanStepResult[] = [];
 
           for (const step of preparedResult.value.steps) {
@@ -421,6 +441,117 @@ function prepareSteps(
     });
   }
   return new Ok({ steps: prepared, capabilitiesUsed: census.capabilitiesUsed });
+}
+
+type PlannedFieldReference = {
+  step: number;
+  command: string;
+  field: string;
+};
+
+function collectPlannedFieldReferences(steps: PreparedStep[]): PlannedFieldReference[] {
+  const references = new Map<string, PlannedFieldReference>();
+
+  for (const step of steps) {
+    if (step.command !== 'tabdoc:generate-viz-from-notional-spec') continue;
+    const rawSpec = step.dispatchArgs.NotionalSpecJson;
+    if (typeof rawSpec !== 'string') continue;
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(rawSpec);
+    } catch {
+      continue;
+    }
+    if (!isRecord(parsed)) continue;
+
+    const add = (value: unknown): void => {
+      if (typeof value !== 'string' || value.trim().length === 0) return;
+      const field = value.trim();
+      if (!references.has(field)) {
+        references.set(field, { step: step.step, command: step.command, field });
+      }
+    };
+
+    if (Array.isArray(parsed.fields)) {
+      for (const field of parsed.fields) {
+        if (!isRecord(field)) continue;
+        add(typeof field.fieldIdentifier === 'string' ? field.fieldIdentifier : field.caption);
+      }
+    }
+    if (isRecord(parsed.sort)) {
+      add(parsed.sort.field);
+      add(parsed.sort.by);
+    }
+    for (const key of [
+      'rangeFilters',
+      'dateRangeFilters',
+      'relativeDateFilters',
+      'categoricalFilters',
+    ]) {
+      const filters = parsed[key];
+      if (!Array.isArray(filters)) continue;
+      for (const filter of filters) {
+        if (isRecord(filter)) add(filter.field);
+      }
+    }
+  }
+
+  return [...references.values()];
+}
+
+async function preflightFieldReferences(
+  references: PlannedFieldReference[],
+  executor: ExternalApiToolExecutor,
+  signal: AbortSignal,
+): Promise<Result<void, McpToolError>> {
+  if (references.length === 0) {
+    return new Ok(undefined);
+  }
+
+  const documentResult = await executor.getWorkbookDocument(signal);
+  const first = references[0];
+  if (documentResult.isErr()) {
+    const error = new DesktopCommandExecutionError(documentResult.error);
+    return refusedPlan(
+      first.step,
+      first.command,
+      `Could not validate field references: ${error.getErrorText()}`,
+    );
+  }
+
+  let unresolved: PlannedFieldReference[];
+  try {
+    unresolved = references.filter(({ field }) => {
+      const resolution = resolveField(documentResult.value.xml, field);
+      return resolution.kind !== 'exact' && resolution.kind !== 'rewritten';
+    });
+  } catch (error) {
+    return refusedPlan(
+      first.step,
+      first.command,
+      `Could not validate field references from the workbook document: ${
+        error instanceof Error ? error.message : String(error)
+      }.`,
+    );
+  }
+
+  if (unresolved.length > 0) {
+    const refused = unresolved[0];
+    return refusedPlan(
+      refused.step,
+      refused.command,
+      `Unresolved field reference(s): ${unresolved
+        .map(({ field }) => JSON.stringify(field))
+        .join(', ')}.`,
+    );
+  }
+
+  return new Ok(undefined);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
 function refusedPlan(


### PR DESCRIPTION
Rule this sets: execute-authoring-plan admission is default-deny — a step command absent from the bundled command census refuses the whole plan before anything runs, and field references in notional-spec steps are resolved during preflight with the unresolved names in the refusal. The tool description now tells the agent to submit first instead of pre-verifying with resolve-field; live round 6 measured that pre-verification ritual at ~80 seconds per run.

Stacks on claude/authoring-plan-spike. Validated firsthand: full suite 6433 pass / 0 fail (378 files), lint clean, desktop bundle builds. Matt merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)