### PR TITLE
feat(desktop): execute-authoring-plan reports an intent digest of each step's effects

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "2.62.0",
+  "version": "2.63.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/src/desktop/validation/readback-verify.ts
+++ b/src/desktop/validation/readback-verify.ts
@@ -72,18 +72,6 @@ export interface WorksheetSignature {
   declaredInstances: Set<string>;
 }
 
-export interface FilterSignatureExpectation {
-  column: string;
-  members: string[];
-  mode: 'include' | 'exclude';
-  function?: string;
-}
-
-export interface FilterSignatureMatch {
-  matched: boolean;
-  observed: FilterSignature[];
-}
-
 function isRecord(value: unknown): value is XmlRecord {
   return !!value && typeof value === 'object' && !Array.isArray(value);
 }
@@ -250,25 +238,6 @@ export function readWorksheetSignature(xml: string): WorksheetSignature | null {
   } catch {
     return null;
   }
-}
-
-export function matchWorksheetFilterSignature(
-  xml: string,
-  expected: FilterSignatureExpectation,
-): FilterSignatureMatch | null {
-  const worksheet = readWorksheetSignature(xml);
-  if (!worksheet) return null;
-  const observed = worksheet.filters.filter((candidate) => candidate.column === expected.column);
-  const members = [...expected.members].sort();
-  return {
-    matched: observed.some(
-      (candidate) =>
-        sameMembers(candidate.members, members) &&
-        candidate.mode === expected.mode &&
-        (expected.function === undefined || candidate.groupFunction === expected.function),
-    ),
-    observed,
-  };
 }
 
 function encodingIntended(sig: EncodingSignature): string {

--- a/src/tools/desktop/commands/executeAuthoringPlan.intentDigest.test.ts
+++ b/src/tools/desktop/commands/executeAuthoringPlan.intentDigest.test.ts
@@ -1,0 +1,397 @@
+import {
+  compileIntentPlan,
+  createIntentDigest,
+  IntentDigestCompileError,
+  postconditionSchema,
+} from './executeAuthoringPlan.intentDigest.js';
+
+const legacyFilter = {
+  kind: 'filter-signature' as const,
+  worksheet: 'Sales',
+  column: '[Sample].[none:Region:nk]',
+  members: ['East', 'West'],
+  mode: 'include' as const,
+};
+
+const allPostconditions = [
+  { kind: 'worksheet-exists', name: 'Sales' },
+  { kind: 'dashboard-exists', name: 'Overview' },
+  { kind: 'datasource-exists', name: 'Sample' },
+  {
+    kind: 'calculation-signature',
+    datasource: 'Sample',
+    name: 'Profit Ratio',
+    formula: 'SUM([Profit]) / SUM([Sales])',
+    datatype: 'real',
+    role: 'measure',
+  },
+  { kind: 'datasource-binding', worksheet: 'Sales', datasource: 'Sample' },
+  {
+    kind: 'field-binding',
+    worksheet: 'Sales',
+    placement: 'rows',
+    field: '[Sample].[sum:Sales:qk]',
+  },
+  legacyFilter,
+  { kind: 'mark-type', worksheet: 'Sales', mark: 'Bar' },
+  {
+    kind: 'encoding',
+    worksheet: 'Sales',
+    channel: 'color',
+    field: '[Sample].[none:Region:nk]',
+  },
+  { kind: 'dashboard-contains', dashboard: 'Overview', worksheet: 'Sales' },
+  {
+    kind: 'dashboard-zone',
+    dashboard: 'Overview',
+    worksheet: 'Sales',
+    zoneType: 'worksheet',
+    multiplicity: 1,
+  },
+  {
+    kind: 'summary-signature',
+    worksheet: 'Sales',
+    columns: ['Region', 'SUM(Sales)'],
+    rows: [
+      ['East', 10, true, null],
+      ['West', 20, false, null],
+    ],
+  },
+];
+
+describe('executeAuthoringPlan intent digest', () => {
+  it('accepts all twelve singular postcondition variants', () => {
+    for (const postcondition of allPostconditions) {
+      expect(postconditionSchema.safeParse(postcondition).success, postcondition.kind).toBe(true);
+    }
+  });
+
+  it('rejects non-scalar summary row values', () => {
+    const parsed = postconditionSchema.safeParse({
+      kind: 'summary-signature',
+      worksheet: 'Sales',
+      columns: ['Region'],
+      rows: [[{ region: 'East' }]],
+    });
+
+    expect(parsed.success).toBe(false);
+  });
+
+  it('normalizes an omitted legacy filter function to canonical null', () => {
+    const plan = compileIntentPlan([
+      {
+        step: 1,
+        command: 'tabdoc:save',
+        dispatchArgs: {},
+        expect: legacyFilter,
+      },
+    ]);
+
+    expect(plan.digest.assertions[0].expect).toEqual({
+      ...legacyFilter,
+      function: null,
+    });
+  });
+
+  it('canonicalizes object keys without reordering semantic arrays', () => {
+    const left = {
+      schemaVersion: 1 as const,
+      assertions: [
+        {
+          id: 'a',
+          introducedByStep: 1,
+          checkpoint: 'final' as const,
+          expect: { kind: 'worksheet-exists' as const, name: 'Sales' },
+        },
+        {
+          id: 'b',
+          introducedByStep: 2,
+          checkpoint: 'final' as const,
+          expect: { kind: 'dashboard-exists' as const, name: 'Overview' },
+        },
+      ],
+    };
+    const right = {
+      assertions: left.assertions.map((assertion) => ({
+        expect: assertion.expect,
+        checkpoint: assertion.checkpoint,
+        introducedByStep: assertion.introducedByStep,
+        id: assertion.id,
+      })),
+      schemaVersion: 1 as const,
+    };
+
+    expect(createIntentDigest(left)).toEqual(createIntentDigest(right));
+    expect(
+      createIntentDigest({ ...left, assertions: [...left.assertions].reverse() }).sha256,
+    ).not.toBe(createIntentDigest(left).sha256);
+  });
+
+  it('hashes explicit null as deterministic lowercase SHA-256', () => {
+    const payload = {
+      schemaVersion: 1 as const,
+      assertions: [
+        {
+          id: 'filter',
+          introducedByStep: 1,
+          checkpoint: 'final' as const,
+          expect: {
+            kind: 'filter-signature' as const,
+            worksheet: 'Sales',
+            column: 'Region',
+            members: ['East'],
+            mode: 'include' as const,
+            function: null,
+          },
+        },
+      ],
+    };
+    const digest = createIntentDigest(payload);
+
+    expect(digest.canonicalBytes).toContain('"function":null');
+    expect(digest.sha256).toMatch(/^[a-f0-9]{64}$/);
+    expect(createIntentDigest(payload).sha256).toBe(digest.sha256);
+    expect(
+      createIntentDigest({
+        ...payload,
+        assertions: [
+          {
+            ...payload.assertions[0],
+            expect: { ...payload.assertions[0].expect, worksheet: 'Profit' },
+          },
+        ],
+      }).sha256,
+    ).not.toBe(digest.sha256);
+  });
+
+  it('compiles exact effects, dependencies, derived assertions, and checkpoints', () => {
+    const plan = compileIntentPlan([
+      {
+        step: 1,
+        command: 'tabdoc:new-worksheet',
+        dispatchArgs: { NewSheet: 'Sales' },
+      },
+      {
+        step: 2,
+        command: 'tabdoc:generate-viz-from-notional-spec',
+        dispatchArgs: {
+          NotionalSpecJson: JSON.stringify({
+            version: '0.2.0',
+            chart: 'bar',
+            fields: [
+              {
+                fieldIdentifier: '[Sample].[none:Region:nk]',
+                encoding: 'color',
+              },
+            ],
+          }),
+          ClearSheet: true,
+        },
+      },
+      { step: 3, command: 'tabdoc:save', dispatchArgs: {} },
+    ]);
+
+    expect(plan.effectsByStep[1]).toMatchObject({
+      mutationClass: 'load-bearing',
+      provides: [{ kind: 'worksheet', identity: 'Sales' }],
+      requires: [],
+      derivedAssertions: [{ kind: 'worksheet-exists', name: 'Sales' }],
+    });
+    expect(plan.effectsByStep[2]).toMatchObject({
+      mutationClass: 'load-bearing',
+      requires: [{ kind: 'worksheet', identity: 'Sales' }],
+    });
+    expect(plan.effectsByStep[3]).toEqual({
+      mutationClass: 'non-asserting-checkpoint',
+      provides: [],
+      requires: [],
+      derivedAssertions: [],
+    });
+    expect(plan.dependencyEdges).toEqual([
+      {
+        fromStep: 1,
+        toStep: 2,
+        symbol: { kind: 'worksheet', identity: 'Sales' },
+      },
+    ]);
+    expect(plan.digest.assertions.map(({ expect }) => expect)).toEqual([
+      { kind: 'worksheet-exists', name: 'Sales' },
+      { kind: 'mark-type', worksheet: 'Sales', mark: 'Bar' },
+      {
+        kind: 'encoding',
+        worksheet: 'Sales',
+        channel: 'color',
+        field: '[Sample].[none:Region:nk]',
+      },
+    ]);
+    expect(plan.digest.assertions[0].checkpoint).toBe('immediate');
+    expect(plan.immediateAssertionIdsByProducingStep[1]).toEqual([plan.digest.assertions[0].id]);
+  });
+
+  it('includes explicit expectations with deterministic IDs', () => {
+    const steps = [
+      {
+        step: 1,
+        command: 'tabdoc:save',
+        dispatchArgs: {},
+        expect: { kind: 'worksheet-exists' as const, name: 'Sales' },
+      },
+    ];
+
+    const first = compileIntentPlan(steps);
+    const second = compileIntentPlan(steps);
+
+    expect(first.digest.assertions).toEqual(second.digest.assertions);
+    expect(first.digest.assertions[0]).toMatchObject({
+      introducedByStep: 1,
+      checkpoint: 'final',
+      expect: steps[0].expect,
+    });
+  });
+
+  it('allows two worksheets to bind the same field identifier', () => {
+    const notionalSpec = JSON.stringify({
+      version: '0.2.0',
+      fields: [{ fieldIdentifier: '[Sample].[none:Region:nk]', encoding: 'color' }],
+    });
+
+    const plan = compileIntentPlan([
+      {
+        step: 1,
+        command: 'tabdoc:new-worksheet',
+        dispatchArgs: { NewSheet: 'Sales' },
+      },
+      {
+        step: 2,
+        command: 'tabdoc:generate-viz-from-notional-spec',
+        dispatchArgs: { NotionalSpecJson: notionalSpec },
+      },
+      {
+        step: 3,
+        command: 'tabdoc:new-worksheet',
+        dispatchArgs: { NewSheet: 'Profit' },
+      },
+      {
+        step: 4,
+        command: 'tabdoc:generate-viz-from-notional-spec',
+        dispatchArgs: { NotionalSpecJson: notionalSpec },
+      },
+    ]);
+
+    expect(plan.effectsByStep[2].provides).toEqual([]);
+    expect(plan.effectsByStep[4].provides).toEqual([]);
+    expect(plan.dependencyEdges).toEqual([
+      {
+        fromStep: 1,
+        toStep: 2,
+        symbol: { kind: 'worksheet', identity: 'Sales' },
+      },
+      {
+        fromStep: 3,
+        toStep: 4,
+        symbol: { kind: 'worksheet', identity: 'Profit' },
+      },
+    ]);
+  });
+
+  it.each([
+    {
+      name: 'unsupported mutation',
+      steps: [{ step: 1, command: 'tabdoc:delete-sheet', dispatchArgs: { Sheet: 'Sales' } }],
+      message: 'unclassified command',
+    },
+    {
+      name: 'unresolved active worksheet',
+      steps: [
+        {
+          step: 1,
+          command: 'tabdoc:generate-viz-from-notional-spec',
+          dispatchArgs: { NotionalSpecJson: '{"version":"0.2.0","fields":[]}' },
+        },
+      ],
+      message: 'unresolved reference',
+    },
+    {
+      name: 'implicit unobservable active worksheet',
+      steps: [
+        { step: 1, command: 'tabdoc:new-worksheet', dispatchArgs: {} },
+        {
+          step: 2,
+          command: 'tabdoc:generate-viz-from-notional-spec',
+          dispatchArgs: { NotionalSpecJson: '{"version":"0.2.0","fields":[]}' },
+        },
+      ],
+      message: 'observable worksheet identity',
+    },
+    {
+      name: 'duplicate producer',
+      steps: [
+        {
+          step: 1,
+          command: 'tabdoc:new-worksheet',
+          dispatchArgs: { NewSheet: 'Sales' },
+        },
+        {
+          step: 2,
+          command: 'tabdoc:new-worksheet',
+          dispatchArgs: { NewSheet: 'Sales' },
+        },
+      ],
+      message: 'duplicate producer',
+    },
+    {
+      name: 'forward reference',
+      steps: [
+        {
+          step: 1,
+          command: 'tabdoc:generate-viz-from-notional-spec',
+          dispatchArgs: { NotionalSpecJson: '{"version":"0.2.0","fields":[]}' },
+        },
+        {
+          step: 2,
+          command: 'tabdoc:new-worksheet',
+          dispatchArgs: { NewSheet: 'Sales' },
+        },
+      ],
+      message: 'forward reference',
+    },
+    {
+      name: 'unobservable field derivation',
+      steps: [
+        {
+          step: 1,
+          command: 'tabdoc:save',
+          dispatchArgs: {},
+          expect: {
+            kind: 'field-binding' as const,
+            worksheet: 'Sales',
+            placement: 'rows',
+            field: '[Sample].[sum:Sales:qk]',
+            derivation: 'Sum',
+          },
+        },
+      ],
+      message: 'worksheet readback cannot observe field derivation',
+    },
+    {
+      name: 'datasource creation assertion',
+      steps: [
+        {
+          step: 1,
+          command: 'tabdoc:save',
+          dispatchArgs: {},
+          expect: { kind: 'datasource-exists' as const, name: 'Sample' },
+        },
+      ],
+      message: 'no admitted command can create a datasource',
+    },
+  ])('fails closed for $name', ({ steps, message }) => {
+    const prepared = steps as Array<{
+      step: number;
+      command: string;
+      dispatchArgs: Record<string, unknown>;
+    }>;
+    expect(() => compileIntentPlan(prepared)).toThrowError(IntentDigestCompileError);
+    expect(() => compileIntentPlan(prepared)).toThrow(message);
+  });
+});

--- a/src/tools/desktop/commands/executeAuthoringPlan.intentDigest.ts
+++ b/src/tools/desktop/commands/executeAuthoringPlan.intentDigest.ts
@@ -1,0 +1,492 @@
+import { createHash } from 'node:crypto';
+
+import { z } from 'zod';
+
+const summaryScalarSchema = z.union([z.string(), z.number(), z.boolean(), z.null()]);
+
+export const postconditionSchema = z.discriminatedUnion('kind', [
+  z.object({ kind: z.literal('worksheet-exists'), name: z.string() }),
+  z.object({ kind: z.literal('dashboard-exists'), name: z.string() }),
+  z.object({ kind: z.literal('datasource-exists'), name: z.string() }),
+  z.object({
+    kind: z.literal('calculation-signature'),
+    datasource: z.string(),
+    name: z.string(),
+    formula: z.string(),
+    datatype: z.string(),
+    role: z.string(),
+  }),
+  z.object({
+    kind: z.literal('datasource-binding'),
+    worksheet: z.string(),
+    datasource: z.string(),
+  }),
+  z
+    .object({
+      kind: z.literal('field-binding'),
+      worksheet: z.string(),
+      placement: z.string(),
+      field: z.string(),
+    })
+    .passthrough(),
+  z.object({
+    kind: z.literal('filter-signature'),
+    worksheet: z.string(),
+    column: z.string(),
+    members: z.array(z.string()),
+    mode: z.enum(['include', 'exclude']),
+    function: z.string().optional(),
+  }),
+  z.object({ kind: z.literal('mark-type'), worksheet: z.string(), mark: z.string() }),
+  z.object({
+    kind: z.literal('encoding'),
+    worksheet: z.string(),
+    channel: z.string(),
+    field: z.string(),
+  }),
+  z.object({
+    kind: z.literal('dashboard-contains'),
+    dashboard: z.string(),
+    worksheet: z.string(),
+  }),
+  z.object({
+    kind: z.literal('dashboard-zone'),
+    dashboard: z.string(),
+    worksheet: z.string(),
+    zoneType: z.string(),
+    multiplicity: z.number().int().nonnegative(),
+  }),
+  z.object({
+    kind: z.literal('summary-signature'),
+    worksheet: z.string(),
+    columns: z.array(z.string()),
+    rows: z.array(z.array(summaryScalarSchema)),
+  }),
+]);
+
+export type PlanPostcondition = z.infer<typeof postconditionSchema>;
+
+type FilterSignaturePostcondition = Extract<PlanPostcondition, { kind: 'filter-signature' }>;
+type DatasourceExistsPostcondition = Extract<PlanPostcondition, { kind: 'datasource-exists' }>;
+
+export type IntentAssertion =
+  | Exclude<PlanPostcondition, FilterSignaturePostcondition | DatasourceExistsPostcondition>
+  | (Omit<FilterSignaturePostcondition, 'function'> & { function: string | null });
+
+export type IntentAssertionRecord = {
+  id: string;
+  introducedByStep: number;
+  checkpoint: 'immediate' | 'final';
+  expect: IntentAssertion;
+};
+
+export type IntentDigestPayload = {
+  schemaVersion: 1;
+  assertions: IntentAssertionRecord[];
+};
+
+export type IntentDigest = IntentDigestPayload & {
+  sha256: string;
+};
+
+export type EffectSymbol = {
+  kind: 'worksheet' | 'dashboard';
+  identity: string;
+};
+
+export type CompiledStepEffects = {
+  provides: EffectSymbol[];
+  requires: EffectSymbol[];
+  derivedAssertions: IntentAssertion[];
+  mutationClass: 'load-bearing' | 'non-asserting-checkpoint';
+};
+
+export type PreparedIntentStep = {
+  step: number;
+  command: string;
+  dispatchArgs: Record<string, unknown>;
+  expect?: PlanPostcondition;
+};
+
+export type DependencyEdge = {
+  fromStep: number;
+  toStep: number;
+  symbol: EffectSymbol;
+};
+
+export type CompiledPlan<TStep extends PreparedIntentStep = PreparedIntentStep> = {
+  steps: TStep[];
+  effectsByStep: Record<number, CompiledStepEffects>;
+  dependencyEdges: DependencyEdge[];
+  digest: IntentDigest;
+  immediateAssertionIdsByProducingStep: Record<number, string[]>;
+};
+
+export type AssertionReadback = {
+  id: string;
+  introducedByStep: number;
+  checkpoint: 'immediate' | 'final';
+  status: 'passed' | 'mismatch' | 'unobservable';
+  expected: IntentAssertion;
+  observed: unknown;
+  delta: {
+    kind: 'none' | 'mismatch' | 'unobservable';
+    expected: unknown;
+    observed: unknown;
+  };
+};
+
+export class IntentDigestCompileError extends Error {
+  readonly step: number;
+  readonly command: string;
+
+  constructor(step: number, command: string, message: string) {
+    super(message);
+    this.name = 'IntentDigestCompileError';
+    this.step = step;
+    this.command = command;
+  }
+}
+
+type DigestBuild = IntentDigest & { canonicalBytes: string };
+
+type CompilerState = {
+  activeWorksheet?: { identity: string; observable: boolean; producerStep: number };
+};
+
+type EffectCompiler = (step: PreparedIntentStep, state: CompilerState) => CompiledStepEffects;
+
+const effectRegistry = new Map<string, EffectCompiler>([
+  ['tabdoc:new-worksheet', compileNewWorksheet],
+  ['tabdoc:new-dashboard', compileNewDashboard],
+  ['tabdoc:generate-viz-from-notional-spec', compileNotionalSpec],
+  ['tabdoc:save', emptyEffects],
+]);
+
+export function compileIntentPlan<TStep extends PreparedIntentStep>(
+  steps: TStep[],
+): CompiledPlan<TStep> {
+  const effectsByStep: Record<number, CompiledStepEffects> = {};
+  const dependencyEdges: DependencyEdge[] = [];
+  const providers = new Map<string, number>();
+  const state: CompilerState = {};
+  const futureWorksheetProducer = steps.find(
+    ({ command, dispatchArgs }) =>
+      command === 'tabdoc:new-worksheet' && nonEmptyString(dispatchArgs.NewSheet) !== undefined,
+  );
+
+  for (const step of steps) {
+    const compiler = effectRegistry.get(step.command);
+    if (!compiler) {
+      throw new IntentDigestCompileError(
+        step.step,
+        step.command,
+        `Intent digest has no effect rule for unclassified command "${step.command}".`,
+      );
+    }
+
+    if (step.expect?.kind === 'field-binding' && step.expect.derivation !== undefined) {
+      throw new IntentDigestCompileError(
+        step.step,
+        step.command,
+        'Intent digest refused the assertion because worksheet readback cannot observe field derivation.',
+      );
+    }
+
+    if (step.expect?.kind === 'datasource-exists') {
+      throw new IntentDigestCompileError(
+        step.step,
+        step.command,
+        'Intent digest refused the assertion because no admitted command can create a datasource.',
+      );
+    }
+
+    if (
+      step.command === 'tabdoc:generate-viz-from-notional-spec' &&
+      state.activeWorksheet === undefined
+    ) {
+      const reason =
+        futureWorksheetProducer && futureWorksheetProducer.step > step.step
+          ? 'forward reference'
+          : 'unresolved reference';
+      throw new IntentDigestCompileError(
+        step.step,
+        step.command,
+        `Intent digest ${reason}: no earlier worksheet producer exists.`,
+      );
+    }
+
+    const effects = compiler(step, state);
+    effectsByStep[step.step] = effects;
+
+    for (const symbol of effects.requires) {
+      const producer = providers.get(symbolKey(symbol));
+      if (producer === undefined) {
+        throw new IntentDigestCompileError(
+          step.step,
+          step.command,
+          `Intent digest unresolved reference ${JSON.stringify(symbol)}.`,
+        );
+      }
+      dependencyEdges.push({ fromStep: producer, toStep: step.step, symbol });
+    }
+
+    for (const symbol of effects.provides) {
+      const key = symbolKey(symbol);
+      const previous = providers.get(key);
+      if (previous !== undefined) {
+        throw new IntentDigestCompileError(
+          step.step,
+          step.command,
+          `Intent digest duplicate producer for ${JSON.stringify(symbol)} at steps ${previous} and ${step.step}.`,
+        );
+      }
+      providers.set(key, step.step);
+    }
+  }
+
+  const immediateProducerSteps = new Set(dependencyEdges.map(({ fromStep }) => fromStep));
+  const seenAssertions = new Set<string>();
+  const assertions: IntentAssertionRecord[] = [];
+  for (const step of steps) {
+    const effects = effectsByStep[step.step];
+    const candidates = [
+      ...effects.derivedAssertions,
+      ...(step.expect === undefined ? [] : [normalizePostcondition(step.expect)]),
+    ];
+    for (const expect of candidates) {
+      const assertionKey = canonicalize(expect);
+      if (seenAssertions.has(assertionKey)) continue;
+      seenAssertions.add(assertionKey);
+      const checkpoint =
+        immediateProducerSteps.has(step.step) &&
+        assertionProvesProvidedSymbol(expect, effects.provides)
+          ? 'immediate'
+          : 'final';
+      assertions.push({
+        id: assertionId(step.step, expect),
+        introducedByStep: step.step,
+        checkpoint,
+        expect,
+      });
+    }
+  }
+
+  const payload: IntentDigestPayload = { schemaVersion: 1, assertions };
+  const builtDigest = createIntentDigest(payload);
+  const digest: IntentDigest = {
+    schemaVersion: builtDigest.schemaVersion,
+    assertions: builtDigest.assertions,
+    sha256: builtDigest.sha256,
+  };
+  const immediateAssertionIdsByProducingStep: Record<number, string[]> = {};
+  for (const assertion of assertions) {
+    if (assertion.checkpoint !== 'immediate') continue;
+    (immediateAssertionIdsByProducingStep[assertion.introducedByStep] ??= []).push(assertion.id);
+  }
+
+  return {
+    steps,
+    effectsByStep,
+    dependencyEdges,
+    digest,
+    immediateAssertionIdsByProducingStep,
+  };
+}
+
+export function normalizePostcondition(expect: PlanPostcondition): IntentAssertion {
+  const parsed = postconditionSchema.parse(expect);
+  if (parsed.kind === 'datasource-exists') {
+    throw new Error('Datasource existence must be refused before digest normalization.');
+  }
+  return parsed.kind === 'filter-signature'
+    ? { ...parsed, function: parsed.function ?? null }
+    : parsed;
+}
+
+export function createIntentDigest(payload: IntentDigestPayload): DigestBuild {
+  const canonicalBytes = canonicalize(payload);
+  return {
+    ...payload,
+    sha256: createHash('sha256').update(canonicalBytes).digest('hex'),
+    canonicalBytes,
+  };
+}
+
+export function canonicalize(value: unknown): string {
+  return JSON.stringify(canonicalValue(value));
+}
+
+function canonicalValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(canonicalValue);
+  }
+  if (value === null || typeof value !== 'object') return value;
+
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, nested]) => [key, canonicalValue(nested)]),
+  );
+}
+
+function compileNewWorksheet(step: PreparedIntentStep, state: CompilerState): CompiledStepEffects {
+  const name = nonEmptyString(step.dispatchArgs.NewSheet);
+  state.activeWorksheet = {
+    identity: name ?? `$active:${step.step}`,
+    observable: name !== undefined,
+    producerStep: step.step,
+  };
+  return {
+    mutationClass: 'load-bearing',
+    provides: [{ kind: 'worksheet', identity: state.activeWorksheet.identity }],
+    requires: [],
+    derivedAssertions: name ? [{ kind: 'worksheet-exists', name }] : [],
+  };
+}
+
+function compileNewDashboard(step: PreparedIntentStep, state: CompilerState): CompiledStepEffects {
+  const name =
+    nonEmptyString(step.dispatchArgs.NewSheet) ?? nonEmptyString(step.dispatchArgs.NewDashboard);
+  state.activeWorksheet = undefined;
+  return {
+    mutationClass: 'load-bearing',
+    provides: name ? [{ kind: 'dashboard', identity: name }] : [],
+    requires: [],
+    derivedAssertions: name ? [{ kind: 'dashboard-exists', name }] : [],
+  };
+}
+
+function compileNotionalSpec(step: PreparedIntentStep, state: CompilerState): CompiledStepEffects {
+  const active = state.activeWorksheet;
+  if (!active) {
+    throw new IntentDigestCompileError(
+      step.step,
+      step.command,
+      'Intent digest unresolved reference: no active worksheet producer.',
+    );
+  }
+  if (!active.observable) {
+    throw new IntentDigestCompileError(
+      step.step,
+      step.command,
+      'Intent digest requires an observable worksheet identity; set NewSheet on the producer.',
+    );
+  }
+
+  const spec = parseNotionalSpec(step);
+  const derivedAssertions: IntentAssertion[] = [];
+  const chart = nonEmptyString(spec.chart);
+  const mark = chart === undefined ? undefined : markForChart(chart);
+  if (mark) {
+    derivedAssertions.push({
+      kind: 'mark-type',
+      worksheet: active.identity,
+      mark,
+    });
+  }
+
+  if (Array.isArray(spec.fields)) {
+    for (const value of spec.fields) {
+      if (!isRecord(value)) continue;
+      const field = nonEmptyString(value.fieldIdentifier);
+      const channel = nonEmptyString(value.encoding);
+      if (!field) continue;
+      if (channel) {
+        derivedAssertions.push({
+          kind: 'encoding',
+          worksheet: active.identity,
+          channel,
+          field,
+        });
+      }
+    }
+  }
+
+  return {
+    mutationClass: 'load-bearing',
+    provides: [],
+    requires: [{ kind: 'worksheet', identity: active.identity }],
+    derivedAssertions,
+  };
+}
+
+function parseNotionalSpec(step: PreparedIntentStep): Record<string, unknown> {
+  const raw = step.dispatchArgs.NotionalSpecJson;
+  if (typeof raw !== 'string') {
+    throw new IntentDigestCompileError(
+      step.step,
+      step.command,
+      'Intent digest cannot classify a notional spec without NotionalSpecJson.',
+    );
+  }
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (isRecord(parsed)) return parsed;
+  } catch {
+    // The command guard normally catches this; keep the digest boundary fail-closed too.
+  }
+  throw new IntentDigestCompileError(
+    step.step,
+    step.command,
+    'Intent digest cannot classify invalid NotionalSpecJson.',
+  );
+}
+
+function markForChart(chart: string): string | undefined {
+  const marks: Record<string, string> = {
+    area: 'Area',
+    bar: 'Bar',
+    circle: 'Circle',
+    line: 'Line',
+    pie: 'Pie',
+    text: 'Text',
+  };
+  return marks[chart];
+}
+
+function emptyEffects(): CompiledStepEffects {
+  return {
+    mutationClass: 'non-asserting-checkpoint',
+    provides: [],
+    requires: [],
+    derivedAssertions: [],
+  };
+}
+
+function assertionProvesProvidedSymbol(
+  assertion: IntentAssertion,
+  provides: EffectSymbol[],
+): boolean {
+  if (assertion.kind === 'worksheet-exists') {
+    return provides.some(
+      ({ kind, identity }) => kind === 'worksheet' && identity === assertion.name,
+    );
+  }
+  if (assertion.kind === 'dashboard-exists') {
+    return provides.some(
+      ({ kind, identity }) => kind === 'dashboard' && identity === assertion.name,
+    );
+  }
+  return false;
+}
+
+function assertionId(step: number, assertion: IntentAssertion): string {
+  const suffix = createHash('sha256')
+    .update(canonicalize({ introducedByStep: step, expect: assertion }))
+    .digest('hex')
+    .slice(0, 16);
+  return `assertion-${step}-${suffix}`;
+}
+
+function symbolKey(symbol: EffectSymbol): string {
+  return `${symbol.kind}:${symbol.identity}`;
+}
+
+function nonEmptyString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/src/tools/desktop/commands/executeAuthoringPlan.test.ts
+++ b/src/tools/desktop/commands/executeAuthoringPlan.test.ts
@@ -5,6 +5,7 @@ import { DesktopMcpServer } from '../../../server.desktop.js';
 import invariant from '../../../utils/invariant.js';
 import { Provider } from '../../../utils/provider.js';
 import { getMockRequestHandlerExtra } from '../toolContext.mock.js';
+import type { PlanPostcondition } from './executeAuthoringPlan.intentDigest.js';
 import { getExecuteAuthoringPlanTool } from './executeAuthoringPlan.js';
 
 const SESSION = 'session-1';
@@ -15,7 +16,7 @@ const COMPLETED = {
   result: null,
 };
 const STEPS = [
-  { command: 'tabdoc:new-worksheet' },
+  { command: 'tabdoc:new-worksheet', args: { NewSheet: 'Sales by Region' } },
   {
     command: 'tabdoc:generate-viz-from-notional-spec',
     args: {
@@ -36,13 +37,41 @@ const WORKSHEET_XML = `<worksheet name="Sales by Region"><table><panes><pane>
   </filter>
 </pane></panes></table></worksheet>`;
 const DASHBOARD_XML =
-  '<dashboard name="Executive Overview"><zones><zone name="Sales by Region"/></zones></dashboard>';
+  '<dashboard name="Executive Overview"><zones><zone name="Sales by Region" type="worksheet"/></zones></dashboard>';
 const WORKBOOK_XML = `<workbook><datasources>
   <datasource name="sample" caption="Sample - Superstore">
     <column name="[Region]" datatype="string" role="dimension" type="nominal"/>
     <column name="[Sales]" datatype="real" role="measure" type="quantitative"/>
+    <column name="[Profit Ratio]" caption="Profit Ratio" datatype="real" role="measure" type="quantitative">
+      <calculation formula="SUM([Profit]) / SUM([Sales])"/>
+    </column>
   </datasource>
 </datasources></workbook>`;
+const BASELINE_INVENTORY = {
+  title: 'Book',
+  unsavedChanges: false,
+  worksheets: [],
+  dashboards: [],
+};
+const CURRENT_INVENTORY = {
+  title: 'Book',
+  unsavedChanges: true,
+  worksheets: [
+    {
+      id: 'worksheet-1',
+      name: 'Sales by Region',
+      hidden: false,
+      datasources: ['Sample - Superstore'],
+    },
+  ],
+  dashboards: [
+    {
+      id: 'dashboard-1',
+      name: 'Executive Overview',
+      hidden: false,
+    },
+  ],
+};
 
 describe('executeAuthoringPlanTool', () => {
   it('presents plan submission as the capability and field preflight', async () => {
@@ -86,10 +115,9 @@ describe('executeAuthoringPlanTool', () => {
       { step: 2, command: 'tabdoc:generate-viz-from-notional-spec', status: 'completed' },
       { step: 3, command: 'tabdoc:save', status: 'completed' },
     ]);
-    expect(payload.message).toContain('Readback observed worksheet "Sales by Region"');
-    expect(payload.message).toContain('dashboard "Executive Overview"');
+    expect(payload.message).toBe('Plan done: final intent diff is empty.');
     expect(payload.message).not.toContain('success');
-    expect(payload.readback).toEqual({
+    expect(payload.readback).toMatchObject({
       verified: {
         requested: ['Sales by Region', 'Executive Overview'],
         observed: [
@@ -279,7 +307,7 @@ describe('executeAuthoringPlanTool', () => {
       {
         session: SESSION,
         steps: [
-          { command: 'tabdoc:save' },
+          { command: 'tabdoc:new-worksheet', args: { NewSheet: 'Sales by Region' } },
           {
             command: 'tabdoc:generate-viz-from-notional-spec',
             args: {
@@ -332,11 +360,134 @@ describe('executeAuthoringPlanTool', () => {
       steps: [{ command: 'tabdoc:save', args: {}, expect: expectReceipt }],
       capabilities_used: [],
       would_verify: [
-        { kind: 'postcondition', step: 1, expect: expectReceipt },
+        {
+          kind: 'intent-assertion',
+          id: expect.stringMatching(/^assertion-1-/),
+          step: 1,
+          checkpoint: 'final',
+          expect: expectReceipt,
+        },
         { kind: 'name-exists', target: 'Sales by Region' },
         { kind: 'summary-data', worksheet: 'Sales by Region', max_rows: 200 },
       ],
     });
+    expect(extra.getExecutor).not.toHaveBeenCalled();
+    expectEveryExecutorMethodUntouched(executor);
+  });
+
+  it('compiles a complete derived digest and dependency DAG before execution', async () => {
+    const executor = makeExecutor();
+    const extra = makeExtra(executor);
+
+    const result = await getResult(
+      {
+        session: SESSION,
+        mode: 'compile',
+        steps: STEPS,
+      },
+      extra,
+    );
+
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+    const payload = JSON.parse(result.content[0].text);
+    expect(payload.intent_digest).toMatchObject({
+      schemaVersion: 1,
+      sha256: expect.stringMatching(/^[a-f0-9]{64}$/),
+      assertions: [
+        {
+          id: expect.stringMatching(/^assertion-1-/),
+          introducedByStep: 1,
+          checkpoint: 'immediate',
+          expect: { kind: 'worksheet-exists', name: 'Sales by Region' },
+        },
+        {
+          id: expect.stringMatching(/^assertion-2-/),
+          introducedByStep: 2,
+          checkpoint: 'final',
+          expect: { kind: 'mark-type', worksheet: 'Sales by Region', mark: 'Bar' },
+        },
+      ],
+    });
+    expect(payload.dependency_edges).toEqual([
+      {
+        fromStep: 1,
+        toStep: 2,
+        symbol: { kind: 'worksheet', identity: 'Sales by Region' },
+      },
+    ]);
+    expect(payload.would_verify).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: 'intent-assertion',
+          checkpoint: 'immediate',
+          expect: { kind: 'worksheet-exists', name: 'Sales by Region' },
+        }),
+        expect.objectContaining({
+          kind: 'intent-assertion',
+          checkpoint: 'final',
+          expect: { kind: 'mark-type', worksheet: 'Sales by Region', mark: 'Bar' },
+        }),
+      ]),
+    );
+    expect(extra.getExecutor).toHaveBeenCalledTimes(1);
+    expect(executor.getWorkbookDocument).toHaveBeenCalledTimes(1);
+    expect(executor.executeCommand).not.toHaveBeenCalled();
+    expect(executor.getWorkbook).not.toHaveBeenCalled();
+    expect(executor.getWorksheetDocument).not.toHaveBeenCalled();
+    expect(executor.getDashboardDocument).not.toHaveBeenCalled();
+    expect(executor.getWorksheetSummaryData).not.toHaveBeenCalled();
+  });
+
+  it('refuses an unclassified mutation before resolving a session or dispatching', async () => {
+    const executor = makeExecutor();
+    const extra = makeExtra(executor);
+
+    const result = await getResult(
+      {
+        session: SESSION,
+        steps: [{ command: 'tabdoc:delete-sheet', args: { Sheet: 'Sales by Region' } }],
+      },
+      extra,
+    );
+
+    expect(result.isError).toBe(true);
+    invariant(result.content[0].type === 'text');
+    const payload = JSON.parse(result.content[0].text);
+    expect(payload.message).toContain('unclassified command "tabdoc:delete-sheet"');
+    expect(payload.message).toContain('No step ran');
+    expect(extra.getExecutor).not.toHaveBeenCalled();
+    expectEveryExecutorMethodUntouched(executor);
+  });
+
+  it('refuses an unobservable field derivation before resolving a session or dispatching', async () => {
+    const executor = makeExecutor();
+    const extra = makeExtra(executor);
+
+    const result = await getResult(
+      {
+        session: SESSION,
+        steps: [
+          {
+            command: 'tabdoc:save',
+            expect: {
+              kind: 'field-binding',
+              worksheet: 'Sales by Region',
+              placement: 'rows',
+              field: '[Sample].[sum:Sales:qk]',
+              derivation: 'Sum',
+            },
+          },
+        ],
+      },
+      extra,
+    );
+
+    expect(result.isError).toBe(true);
+    invariant(result.content[0].type === 'text');
+    const payload = JSON.parse(result.content[0].text);
+    expect(payload.message).toContain('worksheet readback cannot observe field derivation');
+    expect(payload.message).toContain('No step ran');
     expect(extra.getExecutor).not.toHaveBeenCalled();
     expectEveryExecutorMethodUntouched(executor);
   });
@@ -405,6 +556,81 @@ describe('executeAuthoringPlanTool', () => {
     expect(payload.message).not.toContain('success');
   });
 
+  it('stops before a downstream consumer when its producer checkpoint mismatches', async () => {
+    const executor = makeExecutor();
+    executor.getWorkbook.mockResolvedValue(
+      new Ok({ title: 'Book', unsavedChanges: true, worksheets: [], dashboards: [] }),
+    );
+    const extra = makeExtra(executor);
+
+    const result = await getResult(
+      {
+        session: SESSION,
+        steps: STEPS.slice(0, 2),
+      },
+      extra,
+    );
+
+    expect(result.isError).toBe(true);
+    expect(executor.executeCommand).toHaveBeenCalledTimes(1);
+    expect(executor.getWorkbook).toHaveBeenCalledTimes(2);
+    invariant(result.content[0].type === 'text');
+    const payload = JSON.parse(result.content[0].text);
+    expect(payload.message).toContain('Checkpoint mismatch');
+    expect(payload.message).toContain('tabdoc:new-worksheet');
+    expect(payload.message).toContain('assertion-1-');
+    expect(payload.message).toContain('No later step ran');
+    expect(payload.message).not.toContain('Plan done');
+    expect(payload.intent_digest_sha256).toMatch(/^[a-f0-9]{64}$/);
+    expect(payload.readback.final_diff).toHaveLength(1);
+    expect(payload.readback.final_diff[0]).toMatchObject({
+      introducedByStep: 1,
+      status: 'mismatch',
+      expected: { kind: 'worksheet-exists', name: 'Sales by Region' },
+      delta: { kind: 'mismatch' },
+    });
+  });
+
+  it('does not credit the plan for a worksheet that existed before step one', async () => {
+    const executor = makeExecutor();
+    executor.getWorkbook.mockResolvedValue(new Ok(CURRENT_INVENTORY));
+
+    const result = await getResult(
+      {
+        session: SESSION,
+        steps: [{ command: 'tabdoc:new-worksheet', args: { NewSheet: 'Sales by Region' } }],
+      },
+      makeExtra(executor),
+    );
+
+    expectPostconditionFailure(result, 1, 'worksheet-exists', 'mismatch');
+    expect(executor.executeCommand).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not open an immediate readback for a final-only assertion', async () => {
+    const executor = makeExecutor();
+
+    const result = await getResult(
+      {
+        session: SESSION,
+        steps: [
+          {
+            command: 'tabdoc:save',
+            expect: { kind: 'mark-type', worksheet: 'Sales by Region', mark: 'Bar' },
+          },
+        ],
+      },
+      makeExtra(executor),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(executor.executeCommand).toHaveBeenCalledTimes(1);
+    expect(executor.getWorkbook).toHaveBeenCalledTimes(1);
+    expect(executor.executeCommand.mock.invocationCallOrder[0]).toBeLessThan(
+      executor.getWorkbook.mock.invocationCallOrder[0],
+    );
+  });
+
   it('attributes a dropped worksheet postcondition to its declaring step', async () => {
     const executor = makeExecutor();
     executor.getWorkbook.mockResolvedValue(
@@ -415,7 +641,7 @@ describe('executeAuthoringPlanTool', () => {
       {
         session: SESSION,
         steps: [
-          STEPS[0],
+          { command: 'tabdoc:save' },
           {
             ...STEPS[2],
             expect: { kind: 'worksheet-exists', name: 'Dropped Sheet' },
@@ -457,6 +683,37 @@ describe('executeAuthoringPlanTool', () => {
     );
 
     expectPostconditionFailure(result, 1, 'filter-signature', 'mismatch');
+  });
+
+  it('accepts an observed filter function when the assertion omits it', async () => {
+    const executor = makeExecutor();
+
+    const result = await getResult(
+      {
+        session: SESSION,
+        steps: [
+          {
+            command: 'tabdoc:save',
+            expect: {
+              kind: 'filter-signature',
+              worksheet: 'Sales by Region',
+              column: FIELD,
+              members: ['West', 'East'],
+              mode: 'include',
+            },
+          },
+        ],
+      },
+      makeExtra(executor),
+    );
+
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+    const payload = JSON.parse(result.content[0].text);
+    expect(payload.readback.assertions[0]).toMatchObject({
+      status: 'passed',
+      expected: { kind: 'filter-signature', function: null },
+    });
   });
 
   it('fails closed when filter members mutate', async () => {
@@ -566,6 +823,101 @@ describe('executeAuthoringPlanTool', () => {
     expectPostconditionFailure(result, 2, 'dashboard-contains', 'mismatch');
   });
 
+  it('refuses datasource existence during compilation without executor calls', async () => {
+    const executor = makeExecutor();
+    const extra = makeExtra(executor);
+
+    const result = await getResult(
+      {
+        session: SESSION,
+        mode: 'compile',
+        steps: [
+          {
+            command: 'tabdoc:save',
+            expect: { kind: 'datasource-exists', name: 'Sample - Superstore' },
+          },
+        ],
+      },
+      extra,
+    );
+
+    expect(result.isError).toBe(true);
+    invariant(result.content[0].type === 'text');
+    const payload = JSON.parse(result.content[0].text);
+    expect(payload.message).toContain('no admitted command can create a datasource');
+    expect(payload.message).toContain('No step ran');
+    expect(extra.getExecutor).not.toHaveBeenCalled();
+    expectEveryExecutorMethodUntouched(executor);
+  });
+
+  it.each<{ name: string; assertion: PlanPostcondition }>([
+    {
+      name: 'calculation-signature',
+      assertion: {
+        kind: 'calculation-signature',
+        datasource: 'Sample - Superstore',
+        name: 'Profit Ratio',
+        formula: 'SUM([Profit]) / SUM([Sales])',
+        datatype: 'real',
+        role: 'measure',
+      },
+    },
+    {
+      name: 'datasource-binding',
+      assertion: {
+        kind: 'datasource-binding',
+        worksheet: 'Sales by Region',
+        datasource: 'Sample - Superstore',
+      },
+    },
+    {
+      name: 'field-binding',
+      assertion: {
+        kind: 'field-binding',
+        worksheet: 'Sales by Region',
+        placement: 'color',
+        field: FIELD,
+      },
+    },
+    {
+      name: 'dashboard-zone',
+      assertion: {
+        kind: 'dashboard-zone',
+        dashboard: 'Executive Overview',
+        worksheet: 'Sales by Region',
+        zoneType: 'worksheet',
+        multiplicity: 1,
+      },
+    },
+    {
+      name: 'summary-signature',
+      assertion: {
+        kind: 'summary-signature',
+        worksheet: 'Sales by Region',
+        columns: ['Region', 'SUM(Sales)'],
+        rows: [['West', 100]],
+      },
+    },
+  ])('evaluates $name assertions against host evidence', async ({ assertion }) => {
+    const result = await getResult(
+      {
+        session: SESSION,
+        steps: [{ command: 'tabdoc:save', expect: assertion }],
+      },
+      makeExtra(makeExecutor()),
+    );
+
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+    const payload = JSON.parse(result.content[0].text);
+    expect(payload.readback.assertions).toEqual([
+      expect.objectContaining({
+        status: 'passed',
+        expected: assertion,
+      }),
+    ]);
+  });
+
   it('reports done only after every declared postcondition passes', async () => {
     const executor = makeExecutor();
     const result = await getResult(
@@ -627,9 +979,45 @@ describe('executeAuthoringPlanTool', () => {
     ).toBe(true);
     expect(payload.readback.verified.missing).toEqual([]);
     expect(payload.readback.summary_data.rows).toHaveLength(1);
-    expect(executor.getWorkbook).toHaveBeenCalledTimes(1);
+    expect(executor.getWorkbook).toHaveBeenCalledTimes(3);
     expect(executor.getWorksheetDocument).toHaveBeenCalledTimes(1);
     expect(executor.getDashboardDocument).toHaveBeenCalledTimes(1);
+  });
+
+  it('runs the existing final readback for derived assertions and returns an empty diff', async () => {
+    const executor = makeExecutor();
+
+    const result = await getResult(
+      {
+        session: SESSION,
+        steps: STEPS.slice(0, 2),
+      },
+      makeExtra(executor),
+    );
+
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+    const payload = JSON.parse(result.content[0].text);
+    expect(payload.message).toBe('Plan done: final intent diff is empty.');
+    expect(payload.readback.final_diff).toEqual([]);
+    expect(payload.readback.assertions).toEqual([
+      expect.objectContaining({
+        introducedByStep: 1,
+        checkpoint: 'immediate',
+        status: 'passed',
+        expected: { kind: 'worksheet-exists', name: 'Sales by Region' },
+        delta: { kind: 'none', expected: null, observed: null },
+      }),
+      expect.objectContaining({
+        introducedByStep: 2,
+        checkpoint: 'final',
+        status: 'passed',
+        expected: { kind: 'mark-type', worksheet: 'Sales by Region', mark: 'Bar' },
+        delta: { kind: 'none', expected: null, observed: null },
+      }),
+    ]);
+    expect(executor.getWorkbook).toHaveBeenCalledTimes(3);
+    expect(executor.getWorksheetDocument).toHaveBeenCalledTimes(1);
   });
 
   it('attributes an unavailable readback to the first step with an expectation', async () => {
@@ -645,7 +1033,7 @@ describe('executeAuthoringPlanTool', () => {
       {
         session: SESSION,
         steps: [
-          STEPS[0],
+          { command: 'tabdoc:save' },
           {
             ...STEPS[2],
             expect: { kind: 'mark-type', worksheet: 'Sales by Region', mark: 'Bar' },
@@ -670,30 +1058,17 @@ type MockExecutor = {
 };
 
 function makeExecutor(): MockExecutor {
+  const executeCommand = vi.fn().mockResolvedValue(new Ok(COMPLETED));
   return {
-    executeCommand: vi.fn().mockResolvedValue(new Ok(COMPLETED)),
+    executeCommand,
     getWorkbookDocument: vi.fn().mockResolvedValue(new Ok({ xml: WORKBOOK_XML })),
-    getWorkbook: vi.fn().mockResolvedValue(
-      new Ok({
-        title: 'Book',
-        unsavedChanges: true,
-        worksheets: [
-          {
-            id: 'worksheet-1',
-            name: 'Sales by Region',
-            hidden: false,
-            datasources: ['Sample - Superstore'],
-          },
-        ],
-        dashboards: [
-          {
-            id: 'dashboard-1',
-            name: 'Executive Overview',
-            hidden: false,
-          },
-        ],
-      }),
-    ),
+    getWorkbook: vi
+      .fn()
+      .mockImplementation(() =>
+        Promise.resolve(
+          new Ok(executeCommand.mock.calls.length === 0 ? BASELINE_INVENTORY : CURRENT_INVENTORY),
+        ),
+      ),
     getWorksheetDocument: vi.fn().mockResolvedValue(new Ok({ xml: WORKSHEET_XML })),
     getDashboardDocument: vi.fn().mockResolvedValue(new Ok({ xml: DASHBOARD_XML })),
     listWorksheets: vi.fn().mockResolvedValue(
@@ -730,19 +1105,7 @@ async function getResult(
     steps: Array<{
       command: string;
       args?: Record<string, unknown>;
-      expect?:
-        | { kind: 'worksheet-exists'; name: string }
-        | {
-            kind: 'filter-signature';
-            worksheet: string;
-            column: string;
-            members: string[];
-            mode: 'include' | 'exclude';
-            function?: string;
-          }
-        | { kind: 'mark-type'; worksheet: string; mark: string }
-        | { kind: 'encoding'; worksheet: string; channel: string; field: string }
-        | { kind: 'dashboard-contains'; dashboard: string; worksheet: string };
+      expect?: PlanPostcondition;
     }>;
     verify?: string[];
     summary_worksheet?: string | string[];

--- a/src/tools/desktop/commands/executeAuthoringPlan.ts
+++ b/src/tools/desktop/commands/executeAuthoringPlan.ts
@@ -14,10 +14,7 @@ import {
 import { resolveField } from '../../../desktop/metadata/field-resolver.js';
 import { normalizeArray, parseXML } from '../../../desktop/metadata/parser.js';
 import { resolveSession } from '../../../desktop/sessionResolution.js';
-import {
-  matchWorksheetFilterSignature,
-  readWorksheetSignature,
-} from '../../../desktop/validation/readback-verify.js';
+import { readWorksheetSignature } from '../../../desktop/validation/readback-verify.js';
 import {
   DesktopCommandExecutionError,
   IncompleteOperationError,
@@ -38,40 +35,46 @@ import {
 } from '../structuredContent.js';
 import { DesktopTool } from '../tool.js';
 import { checkAuthoringCapabilityCensus } from './authoringCapabilityCensus.js';
+import {
+  type AssertionReadback,
+  type CompiledPlan,
+  compileIntentPlan,
+  type IntentAssertion,
+  type IntentAssertionRecord,
+  IntentDigestCompileError,
+  type PlanPostcondition,
+  postconditionSchema,
+} from './executeAuthoringPlan.intentDigest.js';
 
 const DEFAULT_MAX_ROWS = 200;
 
-const postconditionSchema = z.discriminatedUnion('kind', [
-  z.object({ kind: z.literal('worksheet-exists'), name: z.string() }),
-  z.object({
-    kind: z.literal('filter-signature'),
-    worksheet: z.string(),
-    column: z.string(),
-    members: z.array(z.string()),
-    mode: z.enum(['include', 'exclude']),
-    function: z.string().optional(),
-  }),
-  z.object({ kind: z.literal('mark-type'), worksheet: z.string(), mark: z.string() }),
-  z.object({
-    kind: z.literal('encoding'),
-    worksheet: z.string(),
-    channel: z.string(),
-    field: z.string(),
-  }),
-  z.object({
-    kind: z.literal('dashboard-contains'),
-    dashboard: z.string(),
-    worksheet: z.string(),
-  }),
-]);
+const postconditionInputSchema = z
+  .object({
+    kind: z.enum([
+      'worksheet-exists',
+      'dashboard-exists',
+      'datasource-exists',
+      'calculation-signature',
+      'datasource-binding',
+      'field-binding',
+      'filter-signature',
+      'mark-type',
+      'encoding',
+      'dashboard-contains',
+      'dashboard-zone',
+      'summary-signature',
+    ]),
+  })
+  .passthrough()
+  .describe(
+    'Optional step assertion fields: worksheet-exists, dashboard-exists {name; each asserts the sheet was created by this plan (baseline-diffed)}; datasource-exists {name}; calculation-signature {datasource,name,formula,datatype,role}; datasource-binding {worksheet,datasource}; field-binding {worksheet,placement,field}; filter-signature {worksheet,column,members:string[],mode:include|exclude,function?}; mark-type {worksheet,mark}; encoding {worksheet,channel,field}; dashboard-contains {dashboard,worksheet}; dashboard-zone {dashboard,worksheet,zoneType,multiplicity}; summary-signature {worksheet,columns:string[],rows:scalar[][]}. Summary scalars: string, number, boolean, or null. Missing filter function is accepted for compatibility and normalized to null. Assertions use strict mechanical equality at readback; unavailable evidence is unobservable.',
+  );
 
 const stepSchema = z.object({
   command: z.string().describe('Command ID.'),
   args: z.record(z.unknown()).optional(),
-  expect: postconditionSchema.optional(),
+  expect: postconditionInputSchema.optional(),
 });
-
-type PlanPostcondition = z.infer<typeof postconditionSchema>;
 
 const paramsSchema = {
   session: z.string().optional().describe('Session ID.'),
@@ -107,7 +110,9 @@ type NamedReadback = {
 
 type PlanReadback = {
   verified?: NamedReadback;
-  postconditions?: PostconditionReadback[];
+  assertions?: AssertionReadback[];
+  final_diff?: AssertionReadback[];
+  postconditions?: LegacyPostconditionReadback[];
   summary_data?: {
     worksheet: { id: string; name: string };
     max_rows: number;
@@ -116,7 +121,7 @@ type PlanReadback = {
   };
 };
 
-type PostconditionReadback = {
+type LegacyPostconditionReadback = {
   step: number;
   kind: PlanPostcondition['kind'];
   status: 'passed' | 'mismatch' | 'unobservable';
@@ -124,9 +129,14 @@ type PostconditionReadback = {
   observed: string;
 };
 
+type IntentBaseline = {
+  inventory: WorkbookInventory;
+};
+
 type ExecutePlanResultBody = {
   message: string;
   steps: PlanStepResult[];
+  intent_digest_sha256?: string;
   readback?: PlanReadback;
 };
 
@@ -139,11 +149,19 @@ type CompilePlanResultBody = {
     expect?: PlanPostcondition;
   }>;
   capabilities_used: string[];
+  intent_digest: CompiledPlan<PreparedStep>['digest'];
+  dependency_edges: CompiledPlan<PreparedStep>['dependencyEdges'];
   would_verify: PlannedVerification[];
 };
 
 type PlannedVerification =
-  | { kind: 'postcondition'; step: number; expect: PlanPostcondition }
+  | {
+      kind: 'intent-assertion';
+      id: string;
+      step: number;
+      checkpoint: IntentAssertionRecord['checkpoint'];
+      expect: IntentAssertion;
+    }
   | { kind: 'name-exists'; target: string }
   | { kind: 'summary-data'; worksheet: string; max_rows: number };
 
@@ -179,6 +197,15 @@ export const getExecuteAuthoringPlanTool = (
           if (preparedResult.isErr()) {
             return preparedResult;
           }
+          let compiledPlan: CompiledPlan<PreparedStep>;
+          try {
+            compiledPlan = compileIntentPlan(preparedResult.value.steps);
+          } catch (error) {
+            if (error instanceof IntentDigestCompileError) {
+              return refusedPlan(error.step, error.command, error.message);
+            }
+            throw error;
+          }
           const normalizedSummaryWorksheet = normalizeSummaryWorksheet(summary_worksheet);
           const fieldReferences = collectPlannedFieldReferences(preparedResult.value.steps);
           if (mode === 'compile') {
@@ -208,8 +235,10 @@ export const getExecuteAuthoringPlanTool = (
                     ...(expect ? { expect } : {}),
                   })),
                   capabilities_used: preparedResult.value.capabilitiesUsed,
+                  intent_digest: compiledPlan.digest,
+                  dependency_edges: compiledPlan.dependencyEdges,
                   would_verify: plannedVerifications(
-                    preparedResult.value.steps,
+                    compiledPlan.digest.assertions,
                     verify,
                     normalizedSummaryWorksheet,
                   ),
@@ -233,6 +262,20 @@ export const getExecuteAuthoringPlanTool = (
           if (fieldPreflight.isErr()) {
             return fieldPreflight;
           }
+          const baselineResult = await captureIntentBaseline(
+            compiledPlan.digest.assertions,
+            executor,
+            extra.signal,
+          );
+          if (baselineResult.isErr()) {
+            const firstStep = preparedResult.value.steps[0];
+            return refusedPlan(
+              firstStep.step,
+              firstStep.command,
+              `Could not capture the pre-plan baseline: ${baselineResult.error.getErrorText()}`,
+            );
+          }
+          const intentBaseline = baselineResult.value;
           const stepResults: PlanStepResult[] = [];
 
           for (const step of preparedResult.value.steps) {
@@ -272,12 +315,64 @@ export const getExecuteAuthoringPlanTool = (
                 'Read workbook state before deciding how to continue',
               );
             }
+
+            const checkpointIds =
+              compiledPlan.immediateAssertionIdsByProducingStep[step.step] ?? [];
+            if (checkpointIds.length > 0) {
+              const checkpointAssertions = compiledPlan.digest.assertions.filter(({ id }) =>
+                checkpointIds.includes(id),
+              );
+              const checkpointResult = await runExternalApiReadTool({
+                session: resolvedSession,
+                extra,
+                callback: async (_executor, _signal, read) =>
+                  await performReadback(
+                    undefined,
+                    undefined,
+                    checkpointAssertions,
+                    read,
+                    intentBaseline,
+                  ),
+              });
+              if (checkpointResult.isErr()) {
+                return incompletePlan(
+                  `Checkpoint readback failed after step ${step.step} (${step.command}) for digest ${compiledPlan.digest.sha256}: ${checkpointResult.error.getErrorText()} Executed prefix: ${formatExecutedSteps(
+                    stepResults,
+                  )}. Skipped suffix: ${formatSkippedSteps(
+                    preparedResult.value.steps,
+                    step.step,
+                  )}. No later step ran.`,
+                  stepResults,
+                  'Repair the readback probe before deciding whether to continue',
+                  undefined,
+                  compiledPlan.digest.sha256,
+                );
+              }
+              const checkpointReadback = checkpointResult.value;
+              const firstCheckpointFailure = checkpointReadback.final_diff?.[0];
+              if (firstCheckpointFailure) {
+                return incompletePlan(
+                  formatAssertionFailure({
+                    phase: 'Checkpoint',
+                    failure: firstCheckpointFailure,
+                    digestSha256: compiledPlan.digest.sha256,
+                    command: step.command,
+                    executed: stepResults,
+                    skipped: preparedResult.value.steps.filter(
+                      ({ step: candidate }) => candidate > step.step,
+                    ),
+                  }),
+                  stepResults,
+                  'Repair or extend the readback probe; do not repeat the write',
+                  checkpointReadback,
+                  compiledPlan.digest.sha256,
+                );
+              }
+            }
           }
 
-          const expectations = preparedResult.value.steps.flatMap(({ step, expect }) =>
-            expect ? [{ step, expect }] : [],
-          );
-          if (!hasReadbackRequest(verify, normalizedSummaryWorksheet, expectations)) {
+          const assertions = compiledPlan.digest.assertions;
+          if (!hasReadbackRequest(verify, normalizedSummaryWorksheet, assertions)) {
             return new Ok(
               withNextAction(
                 {
@@ -294,31 +389,44 @@ export const getExecuteAuthoringPlanTool = (
             session: resolvedSession,
             extra,
             callback: async (_executor, _signal, read) =>
-              await performReadback(verify, normalizedSummaryWorksheet, expectations, read),
+              await performReadback(
+                verify,
+                normalizedSummaryWorksheet,
+                assertions,
+                read,
+                intentBaseline,
+              ),
           });
           if (readbackResult.isErr()) {
             return incompletePlan(
               `All ${stepResults.length} steps reported completed, but readback failed: ${readbackResult.error.getErrorText()} The outcome is unverified.`,
               stepResults,
               'Correct the readback request before claiming completion',
+              undefined,
+              compiledPlan.digest.sha256,
             );
           }
 
           const readbackValue = readbackResult.value;
-          const firstFailure = readbackValue.postconditions?.find(
-            ({ status }) => status !== 'passed',
-          );
+          const firstFailure = readbackValue.final_diff?.[0];
           if (firstFailure) {
             const unavailable = firstFailure.status === 'unobservable';
             return incompletePlan(
               `Postcondition ${unavailable ? 'could not be observed' : 'mismatch'} at step ${
-                firstFailure.step
-              } (${firstFailure.kind}). Expected ${firstFailure.expected}; ${
-                unavailable ? 'observed unavailable' : `observed ${firstFailure.observed}`
-              }.`,
+                firstFailure.introducedByStep
+              } (${firstFailure.expected.kind}), assertion ${firstFailure.id}, digest ${
+                compiledPlan.digest.sha256
+              }. Expected ${JSON.stringify(firstFailure.expected)}; ${
+                unavailable
+                  ? 'observed unavailable'
+                  : `observed ${JSON.stringify(firstFailure.observed)}`
+              }; delta ${JSON.stringify(firstFailure.delta)}.`,
               stepResults,
-              'Correct failed postcondition before claiming completion',
+              unavailable
+                ? 'Repair the readback probe before another write'
+                : 'Correct failed postcondition before claiming completion',
               readbackValue,
+              compiledPlan.digest.sha256,
             );
           }
           if (readbackValue.verified && readbackValue.verified.missing.length > 0) {
@@ -327,6 +435,7 @@ export const getExecuteAuthoringPlanTool = (
               stepResults,
               'Correct missing verify targets before claiming completion',
               readbackValue,
+              compiledPlan.digest.sha256,
             );
           }
           if (normalizedSummaryWorksheet !== undefined && !readbackValue.summary_data) {
@@ -335,6 +444,7 @@ export const getExecuteAuthoringPlanTool = (
               stepResults,
               'Correct summary readback before claiming completion',
               readbackValue,
+              compiledPlan.digest.sha256,
             );
           }
           if (readbackValue.summary_data?.rows.length === 0) {
@@ -343,16 +453,21 @@ export const getExecuteAuthoringPlanTool = (
               stepResults,
               'Correct summary readback before claiming completion',
               readbackValue,
+              compiledPlan.digest.sha256,
             );
           }
           return new Ok(
             withNextAction(
               {
                 message:
-                  expectations.length > 0
-                    ? `Plan done: all ${expectations.length} declared postcondition(s) passed.`
+                  assertions.length > 0
+                    ? assertions.length ===
+                      preparedResult.value.steps.filter(({ expect }) => expect !== undefined).length
+                      ? `Plan done: all ${assertions.length} declared postcondition(s) passed.`
+                      : 'Plan done: final intent diff is empty.'
                     : describeReadback(readbackValue),
                 steps: stepResults,
+                intent_digest_sha256: compiledPlan.digest.sha256,
                 readback: readbackValue,
               },
               prefillNextAction('Review observed readback before claiming completion'),
@@ -371,7 +486,7 @@ function prepareSteps(
   steps: Array<{
     command: string;
     args?: Record<string, unknown>;
-    expect?: PlanPostcondition;
+    expect?: unknown;
   }>,
   summaryWorksheet: string | string[] | undefined,
 ): Result<{ steps: PreparedStep[]; capabilitiesUsed: string[] }, McpToolError> {
@@ -587,10 +702,16 @@ function incompletePlan(
   steps: PlanStepResult[],
   nextAction: string,
   readback?: PlanReadback,
+  intentDigestSha256?: string,
 ): Result<PlanResult, McpToolError> {
   return new IncompleteOperationError<PlanResultBody>(
     withNextAction(
-      { message, steps, ...(readback ? { readback } : {}) },
+      {
+        message,
+        steps,
+        ...(intentDigestSha256 ? { intent_digest_sha256: intentDigestSha256 } : {}),
+        ...(readback ? { readback } : {}),
+      },
       prefillNextAction(nextAction),
     ),
   ).toErr();
@@ -602,12 +723,48 @@ function formatExecutedSteps(steps: PlanStepResult[]): string {
     : 'none';
 }
 
+function formatSkippedSteps(steps: PreparedStep[], completedStep: number): string {
+  const skipped = steps.filter(({ step }) => step > completedStep);
+  return skipped.length > 0
+    ? skipped.map(({ step, command }) => `${step} (${command})`).join(', ')
+    : 'none';
+}
+
+function formatAssertionFailure({
+  phase,
+  failure,
+  digestSha256,
+  command,
+  executed,
+  skipped,
+}: {
+  phase: 'Checkpoint' | 'Final';
+  failure: AssertionReadback;
+  digestSha256: string;
+  command: string;
+  executed: PlanStepResult[];
+  skipped: PreparedStep[];
+}): string {
+  const status = failure.status === 'unobservable' ? 'unobservable' : 'mismatch';
+  return `${phase} ${status} after step ${failure.introducedByStep} (${command}), assertion ${
+    failure.id
+  }, digest ${digestSha256}. Expected ${JSON.stringify(
+    failure.expected,
+  )}; observed ${JSON.stringify(failure.observed)}; delta ${JSON.stringify(
+    failure.delta,
+  )}. Executed prefix: ${formatExecutedSteps(executed)}. Skipped suffix: ${
+    skipped.length > 0
+      ? skipped.map(({ step, command: skippedCommand }) => `${step} (${skippedCommand})`).join(', ')
+      : 'none'
+  }. No later step ran.`;
+}
+
 function hasReadbackRequest(
   verify: string[] | undefined,
   summaryWorksheet: string | undefined,
-  expectations: Array<{ step: number; expect: PlanPostcondition }>,
+  assertions: IntentAssertionRecord[],
 ): boolean {
-  return (verify?.length ?? 0) > 0 || summaryWorksheet !== undefined || expectations.length > 0;
+  return (verify?.length ?? 0) > 0 || summaryWorksheet !== undefined || assertions.length > 0;
 }
 
 function normalizeSummaryWorksheet(
@@ -617,14 +774,18 @@ function normalizeSummaryWorksheet(
 }
 
 function plannedVerifications(
-  steps: PreparedStep[],
+  assertions: IntentAssertionRecord[],
   verify: string[] | undefined,
   summaryWorksheet: string | undefined,
 ): PlannedVerification[] {
   return [
-    ...steps.flatMap(({ step, expect }) =>
-      expect ? [{ kind: 'postcondition' as const, step, expect }] : [],
-    ),
+    ...assertions.map(({ id, introducedByStep, checkpoint, expect }) => ({
+      kind: 'intent-assertion' as const,
+      id,
+      step: introducedByStep,
+      checkpoint,
+      expect,
+    })),
     ...(verify ?? []).map((target) => ({ kind: 'name-exists' as const, target })),
     ...(summaryWorksheet
       ? [{ kind: 'summary-data' as const, worksheet: summaryWorksheet, max_rows: DEFAULT_MAX_ROWS }]
@@ -632,53 +793,84 @@ function plannedVerifications(
   ];
 }
 
+async function captureIntentBaseline(
+  assertions: IntentAssertionRecord[],
+  executor: ExternalApiToolExecutor,
+  signal: AbortSignal,
+): Promise<Result<IntentBaseline | undefined, McpToolError>> {
+  const existenceAssertions = assertions.filter(({ expect }) =>
+    ['worksheet-exists', 'dashboard-exists'].includes(expect.kind),
+  );
+  if (existenceAssertions.length === 0) return new Ok(undefined);
+
+  const inventoryResult = await executor.getWorkbook(signal);
+  if (inventoryResult.isErr()) {
+    return new DesktopCommandExecutionError(inventoryResult.error).toErr();
+  }
+
+  return new Ok({ inventory: inventoryResult.value });
+}
+
 async function performReadback(
   verify: string[] | undefined,
   summaryWorksheet: string | undefined,
-  expectations: Array<{ step: number; expect: PlanPostcondition }>,
+  assertions: IntentAssertionRecord[],
   read: ExternalApiRead,
+  baseline: IntentBaseline | undefined,
 ): Promise<Result<PlanReadback, McpToolError>> {
   const output: PlanReadback = {};
-  if ((verify?.length ?? 0) > 0 || expectations.length > 0) {
+  const summaryCache = new Map<string, Promise<Result<WorksheetSummaryData, McpToolError>>>();
+  const readSummary = (worksheet: string): Promise<Result<WorksheetSummaryData, McpToolError>> => {
+    const cached = summaryCache.get(worksheet);
+    if (cached) return cached;
+    const requested = (async (): Promise<Result<WorksheetSummaryData, McpToolError>> => {
+      const result = await fetchWorksheetSummaryData({
+        read,
+        worksheet,
+        maxRows: DEFAULT_MAX_ROWS,
+      });
+      return result.isErr() ? result.error.error.toErr() : result;
+    })();
+    summaryCache.set(worksheet, requested);
+    return requested;
+  };
+
+  if ((verify?.length ?? 0) > 0 || assertions.length > 0) {
     const inventoryResult = await read(
       'workbook inventory',
       async (executor, signal) => await executor.getWorkbook(signal),
     );
     if (inventoryResult.isErr()) {
-      if (expectations.length === 0) return inventoryResult;
+      if (assertions.length === 0) return inventoryResult;
       const observed = inventoryResult.error.getErrorText();
-      output.postconditions = expectations.map(({ step, expect }) => ({
-        step,
-        kind: expect.kind,
-        status: 'unobservable',
-        expected: JSON.stringify(expect),
-        observed,
-      }));
+      output.assertions = assertions.map((assertion) =>
+        assertionOutcome(assertion, 'unobservable', observed),
+      );
     } else {
       if ((verify?.length ?? 0) > 0) {
         output.verified = matchNamedItems(verify ?? [], inventoryResult.value);
       }
-      if (expectations.length > 0) {
-        output.postconditions = await evaluatePostconditions(
-          expectations,
+      if (assertions.length > 0) {
+        output.assertions = await evaluateAssertions(
+          assertions,
           inventoryResult.value,
           read,
+          readSummary,
+          baseline,
         );
       }
+    }
+    if (output.assertions) {
+      output.final_diff = output.assertions.filter(({ status }) => status !== 'passed');
+      output.postconditions = legacyPostconditions(output.assertions);
     }
   }
 
   if (summaryWorksheet) {
     const maxRows = DEFAULT_MAX_ROWS;
-    const summaryResult = await fetchWorksheetSummaryData({
-      read,
-      worksheet: summaryWorksheet,
-      maxRows,
-    });
+    const summaryResult = await readSummary(summaryWorksheet);
     if (summaryResult.isErr()) {
-      return summaryResult.error.type === 'worksheet'
-        ? summaryResult.error.error.toErr()
-        : summaryResult.error.error.toErr();
+      return summaryResult;
     }
     output.summary_data = shapeSummaryReadback(summaryResult.value, maxRows);
   }
@@ -712,14 +904,17 @@ function matchNamedItems(requested: string[], inventory: WorkbookInventory): Nam
   };
 }
 
-async function evaluatePostconditions(
-  expectations: Array<{ step: number; expect: PlanPostcondition }>,
+async function evaluateAssertions(
+  assertions: IntentAssertionRecord[],
   inventory: WorkbookInventory,
   read: ExternalApiRead,
-): Promise<PostconditionReadback[]> {
+  readSummary: (worksheet: string) => Promise<Result<WorksheetSummaryData, McpToolError>>,
+  baseline: IntentBaseline | undefined,
+): Promise<AssertionReadback[]> {
   const worksheetDocuments = new Map<string, Promise<Result<WorkbookDocument, McpToolError>>>();
   const dashboardDocuments = new Map<string, Promise<Result<WorkbookDocument, McpToolError>>>();
-  const outcomes: PostconditionReadback[] = [];
+  let workbookDocument: Promise<Result<WorkbookDocument, McpToolError>> | undefined;
+  const outcomes: AssertionReadback[] = [];
 
   const worksheetDocument = (
     worksheet: WorksheetItem,
@@ -745,88 +940,259 @@ async function evaluatePostconditions(
     dashboardDocuments.set(dashboard.id, requested);
     return requested;
   };
+  const getWorkbookDocument = (): Promise<Result<WorkbookDocument, McpToolError>> => {
+    workbookDocument ??= read(
+      'workbook document',
+      async (executor, signal) => await executor.getWorkbookDocument(signal),
+    );
+    return workbookDocument;
+  };
 
-  for (const { step, expect } of expectations) {
-    const expected = JSON.stringify(expect);
+  for (const assertion of assertions) {
+    const { expect } = assertion;
     if (expect.kind === 'worksheet-exists') {
-      const matched = findWorksheet(inventory, expect.name);
-      outcomes.push({
-        step,
-        kind: expect.kind,
-        status: matched ? 'passed' : 'mismatch',
-        expected,
-        observed: JSON.stringify((inventory.worksheets ?? []).map(({ name }) => name)),
-      });
+      if (!baseline) {
+        outcomes.push(
+          assertionOutcome(assertion, 'unobservable', 'pre-plan workbook baseline is unavailable'),
+        );
+        continue;
+      }
+      const observed = (inventory.worksheets ?? []).map(({ id, name }) => ({ id, name }));
+      const before = (baseline.inventory.worksheets ?? []).map(({ id, name }) => ({ id, name }));
+      const matched = observed.filter(({ id, name }) => id === expect.name || name === expect.name);
+      const existedBefore = before.some(
+        ({ id, name }) => id === expect.name || name === expect.name,
+      );
+      outcomes.push(
+        assertionOutcome(
+          assertion,
+          matched.length === 1 && !existedBefore ? 'passed' : 'mismatch',
+          { before, after: observed },
+        ),
+      );
+      continue;
+    }
+
+    if (expect.kind === 'dashboard-exists') {
+      if (!baseline) {
+        outcomes.push(
+          assertionOutcome(assertion, 'unobservable', 'pre-plan workbook baseline is unavailable'),
+        );
+        continue;
+      }
+      const observed = (inventory.dashboards ?? []).map(({ id, name }) => ({ id, name }));
+      const before = (baseline.inventory.dashboards ?? []).map(({ id, name }) => ({ id, name }));
+      const matched = observed.filter(({ id, name }) => id === expect.name || name === expect.name);
+      const existedBefore = before.some(
+        ({ id, name }) => id === expect.name || name === expect.name,
+      );
+      outcomes.push(
+        assertionOutcome(
+          assertion,
+          matched.length === 1 && !existedBefore ? 'passed' : 'mismatch',
+          { before, after: observed },
+        ),
+      );
+      continue;
+    }
+
+    if (expect.kind === 'calculation-signature') {
+      const document = await getWorkbookDocument();
+      if (document.isErr()) {
+        outcomes.push(assertionOutcome(assertion, 'unobservable', document.error.getErrorText()));
+        continue;
+      }
+      const observed = readCalculationSignatures(document.value.xml).filter(
+        ({ datasource, name }) => datasource === expect.datasource && name === expect.name,
+      );
+      const matched = observed.some(
+        ({ formula, datatype, role }) =>
+          formula === expect.formula && datatype === expect.datatype && role === expect.role,
+      );
+      outcomes.push(assertionOutcome(assertion, matched ? 'passed' : 'mismatch', observed));
+      continue;
+    }
+
+    if (expect.kind === 'summary-signature') {
+      const summary = await readSummary(expect.worksheet);
+      if (summary.isErr()) {
+        outcomes.push(assertionOutcome(assertion, 'unobservable', summary.error.getErrorText()));
+        continue;
+      }
+      const columns = summary.value.columns.map(summaryColumnName);
+      if (columns.some((column) => column === null)) {
+        outcomes.push(
+          assertionOutcome(assertion, 'unobservable', 'summary column names are unavailable'),
+        );
+        continue;
+      }
+      const observed = { columns, rows: summary.value.rows };
+      const matched =
+        JSON.stringify(columns) === JSON.stringify(expect.columns) &&
+        JSON.stringify(summary.value.rows) === JSON.stringify(expect.rows);
+      outcomes.push(assertionOutcome(assertion, matched ? 'passed' : 'mismatch', observed));
       continue;
     }
 
     if (expect.kind === 'dashboard-contains') {
       const dashboard = findDashboard(inventory, expect.dashboard);
       if (!dashboard) {
-        outcomes.push(unobservable(step, expect, `dashboard "${expect.dashboard}" not observed`));
+        outcomes.push(
+          assertionOutcome(
+            assertion,
+            'unobservable',
+            `dashboard "${expect.dashboard}" not observed`,
+          ),
+        );
         continue;
       }
       const document = await dashboardDocument(dashboard);
       if (document.isErr()) {
-        outcomes.push(unobservable(step, expect, document.error.getErrorText()));
+        outcomes.push(assertionOutcome(assertion, 'unobservable', document.error.getErrorText()));
         continue;
       }
       const zoneNames = readDashboardZoneNames(document.value.xml);
       if (!zoneNames) {
-        outcomes.push(unobservable(step, expect, 'dashboard document could not be parsed'));
+        outcomes.push(
+          assertionOutcome(assertion, 'unobservable', 'dashboard document could not be parsed'),
+        );
         continue;
       }
-      outcomes.push({
-        step,
-        kind: expect.kind,
-        status: zoneNames.includes(expect.worksheet) ? 'passed' : 'mismatch',
-        expected,
-        observed: JSON.stringify(zoneNames),
-      });
+      outcomes.push(
+        assertionOutcome(
+          assertion,
+          zoneNames.includes(expect.worksheet) ? 'passed' : 'mismatch',
+          zoneNames,
+        ),
+      );
+      continue;
+    }
+
+    if (expect.kind === 'dashboard-zone') {
+      const dashboard = findDashboard(inventory, expect.dashboard);
+      if (!dashboard) {
+        outcomes.push(
+          assertionOutcome(
+            assertion,
+            'unobservable',
+            `dashboard "${expect.dashboard}" not observed`,
+          ),
+        );
+        continue;
+      }
+      const document = await dashboardDocument(dashboard);
+      if (document.isErr()) {
+        outcomes.push(assertionOutcome(assertion, 'unobservable', document.error.getErrorText()));
+        continue;
+      }
+      const zones = readDashboardZones(document.value.xml);
+      if (!zones) {
+        outcomes.push(
+          assertionOutcome(assertion, 'unobservable', 'dashboard document could not be parsed'),
+        );
+        continue;
+      }
+      const observed = zones.filter(({ worksheet }) => worksheet === expect.worksheet);
+      if (observed.some(({ zoneType }) => zoneType === null)) {
+        outcomes.push(
+          assertionOutcome(assertion, 'unobservable', 'dashboard zone type is unavailable'),
+        );
+        continue;
+      }
+      outcomes.push(
+        assertionOutcome(
+          assertion,
+          observed.length === expect.multiplicity &&
+            observed.every(({ zoneType }) => zoneType === expect.zoneType)
+            ? 'passed'
+            : 'mismatch',
+          observed,
+        ),
+      );
       continue;
     }
 
     const worksheet = findWorksheet(inventory, expect.worksheet);
     if (!worksheet) {
-      outcomes.push(unobservable(step, expect, `worksheet "${expect.worksheet}" not observed`));
+      outcomes.push(
+        assertionOutcome(assertion, 'unobservable', `worksheet "${expect.worksheet}" not observed`),
+      );
       continue;
     }
+
+    if (expect.kind === 'datasource-binding') {
+      const observed = worksheet.datasources ?? [];
+      outcomes.push(
+        assertionOutcome(
+          assertion,
+          observed.filter((datasource) => datasource === expect.datasource).length === 1
+            ? 'passed'
+            : 'mismatch',
+          observed,
+        ),
+      );
+      continue;
+    }
+
     const document = await worksheetDocument(worksheet);
     if (document.isErr()) {
-      outcomes.push(unobservable(step, expect, document.error.getErrorText()));
+      outcomes.push(assertionOutcome(assertion, 'unobservable', document.error.getErrorText()));
       continue;
     }
 
     if (expect.kind === 'filter-signature') {
-      const match = matchWorksheetFilterSignature(document.value.xml, expect);
-      if (!match) {
-        outcomes.push(unobservable(step, expect, 'worksheet document could not be parsed'));
+      const signature = readWorksheetSignature(document.value.xml);
+      if (!signature) {
+        outcomes.push(
+          assertionOutcome(assertion, 'unobservable', 'worksheet document could not be parsed'),
+        );
         continue;
       }
-      outcomes.push({
-        step,
-        kind: expect.kind,
-        status: match.matched ? 'passed' : 'mismatch',
-        expected,
-        observed: JSON.stringify(match.observed),
-      });
+      const observed = signature.filters.filter(({ column }) => column === expect.column);
+      const members = [...expect.members].sort();
+      const matched = observed.some(
+        (candidate) =>
+          JSON.stringify(candidate.members) === JSON.stringify(members) &&
+          candidate.mode === expect.mode &&
+          (expect.function === null || candidate.groupFunction === expect.function),
+      );
+      outcomes.push(assertionOutcome(assertion, matched ? 'passed' : 'mismatch', observed));
       continue;
     }
 
     const signature = readWorksheetSignature(document.value.xml);
     if (!signature) {
-      outcomes.push(unobservable(step, expect, 'worksheet document could not be parsed'));
+      outcomes.push(
+        assertionOutcome(assertion, 'unobservable', 'worksheet document could not be parsed'),
+      );
       continue;
     }
     if (expect.kind === 'mark-type') {
       const observed = signature.marks.map(({ klass }) => klass);
-      outcomes.push({
-        step,
-        kind: expect.kind,
-        status: observed.includes(expect.mark) ? 'passed' : 'mismatch',
-        expected,
-        observed: JSON.stringify(observed),
-      });
+      outcomes.push(
+        assertionOutcome(
+          assertion,
+          observed.includes(expect.mark) ? 'passed' : 'mismatch',
+          observed,
+        ),
+      );
+      continue;
+    }
+
+    if (expect.kind === 'field-binding') {
+      const observed =
+        expect.placement === 'rows' || expect.placement === 'cols'
+          ? signature.shelves[expect.placement]
+          : signature.encodings
+              .filter(({ tag }) => tag === expect.placement)
+              .map(({ column }) => column);
+      outcomes.push(
+        assertionOutcome(
+          assertion,
+          observed.includes(expect.field) ? 'passed' : 'mismatch',
+          observed,
+        ),
+      );
       continue;
     }
 
@@ -834,34 +1200,47 @@ async function evaluatePostconditions(
       channel: tag,
       field: column,
     }));
-    outcomes.push({
-      step,
-      kind: expect.kind,
-      status: observed.some(
-        ({ channel, field }) => channel === expect.channel && field === expect.field,
-      )
-        ? 'passed'
-        : 'mismatch',
-      expected,
-      observed: JSON.stringify(observed),
-    });
+    outcomes.push(
+      assertionOutcome(
+        assertion,
+        observed.some(({ channel, field }) => channel === expect.channel && field === expect.field)
+          ? 'passed'
+          : 'mismatch',
+        observed,
+      ),
+    );
   }
 
   return outcomes;
 }
 
-function unobservable(
-  step: number,
-  expect: PlanPostcondition,
-  observed: string,
-): PostconditionReadback {
+function assertionOutcome(
+  assertion: IntentAssertionRecord,
+  status: AssertionReadback['status'],
+  observed: unknown,
+): AssertionReadback {
   return {
-    step,
-    kind: expect.kind,
-    status: 'unobservable',
-    expected: JSON.stringify(expect),
+    id: assertion.id,
+    introducedByStep: assertion.introducedByStep,
+    checkpoint: assertion.checkpoint,
+    status,
+    expected: assertion.expect,
     observed,
+    delta:
+      status === 'passed'
+        ? { kind: 'none', expected: null, observed: null }
+        : { kind: status, expected: assertion.expect, observed },
   };
+}
+
+function legacyPostconditions(assertions: AssertionReadback[]): LegacyPostconditionReadback[] {
+  return assertions.map(({ introducedByStep, expected, status, observed }) => ({
+    step: introducedByStep,
+    kind: expected.kind,
+    status,
+    expected: JSON.stringify(expected),
+    observed: typeof observed === 'string' ? observed : JSON.stringify(observed),
+  }));
 }
 
 function findWorksheet(inventory: WorkbookInventory, target: string): WorksheetItem | undefined {
@@ -872,18 +1251,99 @@ function findDashboard(inventory: WorkbookInventory, target: string): DashboardI
   return (inventory.dashboards ?? []).find(({ id, name }) => id === target || name === target);
 }
 
-function readDashboardZoneNames(xml: string): string[] | null {
+type CalculationSignature = {
+  datasource: string;
+  name: string;
+  formula: string;
+  datatype: string;
+  role: string;
+};
+
+function readCalculationSignatures(xml: string): CalculationSignature[] {
   try {
-    const names: string[] = [];
-    walkXml(parseXML(xml), (tag, node) => {
-      if (tag === 'zone' && typeof node['@_name'] === 'string') {
-        names.push(node['@_name']);
+    const signatures: CalculationSignature[] = [];
+    collectCalculationSignatures(parseXML(xml), undefined, signatures);
+    return signatures;
+  } catch {
+    return [];
+  }
+}
+
+function collectCalculationSignatures(
+  node: unknown,
+  datasource: string | undefined,
+  output: CalculationSignature[],
+): void {
+  if (!node || typeof node !== 'object' || Array.isArray(node)) return;
+  for (const [tag, value] of Object.entries(node)) {
+    if (tag.startsWith('@_') || tag === '#text') continue;
+    for (const child of normalizeArray(value)) {
+      if (!child || typeof child !== 'object' || Array.isArray(child)) continue;
+      const record = child as Record<string, unknown>;
+      const nestedDatasource =
+        tag === 'datasource'
+          ? typeof record['@_caption'] === 'string'
+            ? record['@_caption']
+            : typeof record['@_name'] === 'string'
+              ? record['@_name']
+              : datasource
+          : datasource;
+      if (tag === 'column' && nestedDatasource) {
+        const calculation = normalizeArray(record.calculation).find(
+          (candidate): candidate is Record<string, unknown> =>
+            typeof candidate === 'object' && candidate !== null && !Array.isArray(candidate),
+        );
+        const name =
+          typeof record['@_caption'] === 'string'
+            ? record['@_caption']
+            : typeof record['@_name'] === 'string'
+              ? record['@_name']
+              : undefined;
+        const formula =
+          calculation && typeof calculation['@_formula'] === 'string'
+            ? calculation['@_formula']
+            : undefined;
+        if (name && formula) {
+          output.push({
+            datasource: nestedDatasource,
+            name,
+            formula,
+            datatype: typeof record['@_datatype'] === 'string' ? record['@_datatype'] : '',
+            role: typeof record['@_role'] === 'string' ? record['@_role'] : '',
+          });
+        }
       }
+      collectCalculationSignatures(record, nestedDatasource, output);
+    }
+  }
+}
+
+type DashboardZoneObservation = {
+  worksheet: string;
+  zoneType: string | null;
+};
+
+function readDashboardZones(xml: string): DashboardZoneObservation[] | null {
+  try {
+    const zones: DashboardZoneObservation[] = [];
+    walkXml(parseXML(xml), (tag, node) => {
+      if (tag !== 'zone' || typeof node['@_name'] !== 'string') return;
+      const zoneType =
+        typeof node['@_type'] === 'string'
+          ? node['@_type']
+          : typeof node['@_zone-type'] === 'string'
+            ? node['@_zone-type']
+            : null;
+      zones.push({ worksheet: node['@_name'], zoneType });
     });
-    return names;
+    return zones;
   } catch {
     return null;
   }
+}
+
+function readDashboardZoneNames(xml: string): string[] | null {
+  return readDashboardZones(xml)?.map(({ worksheet }) => worksheet) ?? null;
 }
 
 function walkXml(node: unknown, visit: (tag: string, node: Record<string, unknown>) => void): void {
@@ -908,6 +1368,12 @@ function shapeSummaryReadback(
     columns: summary.columns,
     rows: summary.rows,
   };
+}
+
+function summaryColumnName(column: unknown): string | null {
+  if (typeof column === 'string') return column;
+  if (!isRecord(column)) return null;
+  return typeof column.name === 'string' ? column.name : null;
 }
 
 function describeReadback(readback: PlanReadback): string {


### PR DESCRIPTION
Adds an intent digest to execute-authoring-plan: after a plan runs, the result carries a per-step record of what the plan actually did, derived from a command-effect registry. The rule this sets, and the one to keep: the digest never claims an effect the code cannot observe — unclassified commands are refused before any write, unobservable host evidence is reported as unobservable, and assertions that can never be observed (datasource-exists, field-binding derivation) are refused at compile time. worksheet-exists and dashboard-exists now assert the sheet was created by this plan, diffed against a pre-plan baseline — not merely that a sheet by that name exists.

Review trail: two Opus 5 review rounds (first: FIX-FIRST with 6 findings, all fixed and re-verified at the code sites; second: delta-review confirmed the six and added the datasource-exists unpassability, fixed by compile refusal). Validation, run firsthand three times across the rounds — full suite 6462 passing / 331 skipped across 379 files, tsc clean, lint clean. Version 2.62.0 → 2.63.0 (MINOR, new tool capability).

Known nit accepted: mutationClass currently has only test consumers; it stays because the digest schema is the product surface the next packet (refusal-text rewrites) builds on.

Approving this means: the plan tool's receipts stay honest by construction, and future effect kinds must come with an observable check or a refusal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)