### PR TITLE
feat(desktop): census refusals name the nearest working door

### DIFF
--- a/src/tools/desktop/commands/authoringCapabilityCensus.test.ts
+++ b/src/tools/desktop/commands/authoringCapabilityCensus.test.ts
@@ -1,3 +1,4 @@
+import { knownCommands } from '../../../desktop/commandRegistry.js';
 import { checkAuthoringCapabilityCensus } from './authoringCapabilityCensus.js';
 
 const SAFE_PLAN = { steps: [{ command: 'tabdoc:save' }] };
@@ -52,6 +53,35 @@ describe('checkAuthoringCapabilityCensus', () => {
     expect(result.outcomes.every(({ reason }) => !reason.includes('\n'))).toBe(true);
   });
 
+  it('names the required arguments on recovery doors', () => {
+    const reasons = new Map(
+      checkAuthoringCapabilityCensus(SAFE_PLAN).outcomes.map(({ name, reason }) => [name, reason]),
+    );
+
+    expect(reasons.get('worksheet-lifecycle')).toContain(
+      'tabdoc:new-worksheet {NewSheet, ActivateNew: true}',
+    );
+    expect(reasons.get('bin-spec')).toContain(
+      "author-calc {role: 'dimension', datatype: 'integer'}",
+    );
+    expect(reasons.get('bin-spec')).toContain('COUNTD([row-level key])');
+    expect(reasons.get('fiscal-calendar')).toContain("author-calc {datatype: 'date'}");
+    expect(reasons.get('relative-date-window')).toContain("author-calc {datatype: 'boolean'}");
+  });
+
+  it('keeps every prescribed tabdoc command in the bundled command census', () => {
+    const commands = knownCommands();
+    if (commands === null) throw new Error('Bundled Tableau command census is unavailable');
+    const prescribedCommands = new Set(
+      checkAuthoringCapabilityCensus(SAFE_PLAN).outcomes.flatMap(
+        ({ reason }) => reason.match(/\btabdoc:[a-z0-9-]+/g) ?? [],
+      ),
+    );
+
+    expect(prescribedCommands.size).toBeGreaterThan(0);
+    expect([...prescribedCommands].filter((command) => !commands.has(command))).toEqual([]);
+  });
+
   it('leaves a fully censused plan admitted', () => {
     const result = checkAuthoringCapabilityCensus(SAFE_PLAN);
 
@@ -66,7 +96,7 @@ describe('checkAuthoringCapabilityCensus', () => {
 
     expect(result.missing).toMatchObject({
       name: 'tabdoc:add-binned-axis',
-      reason: expect.stringContaining('absent from the bundled Tableau command census'),
+      reason: expect.stringContaining('search-commands'),
     });
   });
 });

--- a/src/tools/desktop/commands/authoringCapabilityCensus.ts
+++ b/src/tools/desktop/commands/authoringCapabilityCensus.ts
@@ -20,7 +20,7 @@ const CENSUS = [
   {
     name: 'bin-spec',
     reason:
-      'No command key exists for bin field, width, or origin. Use author-calc or bind-template with calcs[] to author FLOOR([measure] / width) * width as an integer dimension, add COUNTD, then build the bar.',
+      "No command key exists for bin field, width, or origin. Use author-calc {role: 'dimension', datatype: 'integer'} or bind-template with calcs[] to author FLOOR([measure] / width) * width, add COUNTD([row-level key]), then build the bar.",
     detect: (plan: CensusPlan) => argsHaveKey(plan, BIN_KEYS),
   },
   {
@@ -32,7 +32,7 @@ const CENSUS = [
   {
     name: 'worksheet-lifecycle',
     reason:
-      'Plan commands cannot create, name, or activate a worksheet in one step. Use tabdoc:new-worksheet {}, tabdoc:rename-sheet {Sheet,NewSheet}, and activate-sheet {sheetName}; placing fields on the new worksheet still has no command.',
+      'Use tabdoc:new-worksheet {NewSheet, ActivateNew: true} to create, name, and activate a worksheet in one step. If those arguments fail, use tabdoc:new-worksheet {}, tabdoc:rename-sheet {Sheet,NewSheet}, and activate-sheet {sheetName}; placing fields on the new worksheet still has no command.',
     detect: 'route-prose',
   },
   {
@@ -62,13 +62,13 @@ const CENSUS = [
   {
     name: 'fiscal-calendar',
     reason:
-      'There is no fiscal-year-start or current-period command key. Use author-calc to author a fiscal-period date-arithmetic field, then bind it.',
+      "There is no fiscal-year-start or current-period command key. Use author-calc {datatype: 'date'} to author a fiscal-period date-arithmetic field, then bind it.",
     detect: (plan: CensusPlan) => argsHaveKey(plan, FISCAL_KEYS),
   },
   {
     name: 'relative-date-window',
     reason:
-      'There is no current-plus-previous-N-quarters plan semantic. Use author-calc to author a date-window field comparing dates against {MAX([Date])}, then bind it.',
+      "There is no current-plus-previous-N-quarters plan semantic. Use author-calc {datatype: 'boolean'} to author a date-window field comparing dates against {MAX([Date])}, then bind it.",
     detect: 'route-prose',
   },
   {
@@ -111,7 +111,8 @@ export function checkAuthoringCapabilityCensus(plan: CensusPlan): CensusResult {
     (uncensusedCommand
       ? {
           name: uncensusedCommand,
-          reason: 'the command is absent from the bundled Tableau command census',
+          reason:
+            'No bundled Tableau command matches this name. Use search-commands to find the correct command name, then resubmit the plan.',
         }
       : undefined);
 

--- a/src/tools/desktop/commands/authoringCapabilityCensus.ts
+++ b/src/tools/desktop/commands/authoringCapabilityCensus.ts
@@ -20,60 +20,67 @@ const CENSUS = [
   {
     name: 'bin-spec',
     reason:
-      'the host has no command key for bin field, width, or origin; histogram auto-binning is undocumented',
+      'No command key exists for bin field, width, or origin. Use author-calc or bind-template with calcs[] to author FLOOR([measure] / width) * width as an integer dimension, add COUNTD, then build the bar.',
     detect: (plan: CensusPlan) => argsHaveKey(plan, BIN_KEYS),
   },
   {
     name: 'calc-authoring',
     reason:
-      'the host has no guarded command contract for creating a calculated field; authoring is host-file-only today',
+      'Calculated fields are unavailable in plan command args. Use author-calc or bind-template with calcs[]; put aggregation inside the formula.',
     detect: (plan: CensusPlan) => argsHaveKey(plan, CALC_KEYS),
   },
   {
     name: 'worksheet-lifecycle',
-    reason: 'the host has no create, name, or activate worksheet command',
+    reason:
+      'Plan commands cannot create, name, or activate a worksheet in one step. Use tabdoc:new-worksheet {}, tabdoc:rename-sheet {Sheet,NewSheet}, and activate-sheet {sheetName}; placing fields on the new worksheet still has no command.',
     detect: 'route-prose',
   },
   {
     name: 'dashboard-composition',
-    reason: 'the host has no dashboard create or compose command step',
+    reason:
+      'The plan grammar cannot compose a dashboard directly. Use tabdoc:new-dashboard {}, then tabdoc:add-sheet-to-dashboard {Dashboard,Worksheet,AddAsFloating:false}.',
     detect: 'route-prose',
   },
   {
     name: 'multi-summary-readback',
-    reason: 'the host accepts at most one summary worksheet per plan',
+    reason:
+      'A plan reads one summary worksheet. Submit one plan per summary worksheet, or use get-summary-data with each additional worksheet after the plan.',
     detect: (plan: CensusPlan) =>
       Array.isArray(plan.summaryWorksheet) && plan.summaryWorksheet.length > 1,
   },
   {
     name: 'summary-rows-beyond-200',
-    reason: 'the host readback is capped at 200 summary rows',
+    reason: 'Plan summary readback is capped at 200 rows. Aggregate or filter before readback.',
     detect: 'route-prose',
   },
   {
     name: 'structural-verify',
     reason:
-      'UNKNOWN: structural targets beyond the declared typed expectations have not been verified on the host surface',
+      'UNKNOWN: structural targets beyond the declared typed expectations are not live-verified. Use only the declared typed expectations.',
     detect: 'route-prose',
   },
   {
     name: 'fiscal-calendar',
-    reason: 'the host has no fiscal-year-start or current-period command key',
+    reason:
+      'There is no fiscal-year-start or current-period command key. Use author-calc to author a fiscal-period date-arithmetic field, then bind it.',
     detect: (plan: CensusPlan) => argsHaveKey(plan, FISCAL_KEYS),
   },
   {
     name: 'relative-date-window',
-    reason: 'the host has no current-plus-previous-N-quarters semantic',
+    reason:
+      'There is no current-plus-previous-N-quarters plan semantic. Use author-calc to author a date-window field comparing dates against {MAX([Date])}, then bind it.',
     detect: 'route-prose',
   },
   {
     name: 'filter-identity-readback',
-    reason: 'the host omits members, mode, and function from filter identity',
+    reason:
+      'Filter readback omits members, mode, and function, so it cannot identify the filter. Use get-summary-data values to verify the filter effect.',
     detect: 'route-prose',
   },
   {
     name: 'goto-sheet-contract',
-    reason: 'the host goto-sheet argument contract is unverified live',
+    reason:
+      'The tabdoc:goto-sheet argument contract is not live-verified. Use activate-sheet {sheetName}.',
     detect: (plan: CensusPlan) => plan.steps.some(({ command }) => command === 'tabdoc:goto-sheet'),
   },
 ] as const satisfies ReadonlyArray<{

--- a/src/tools/desktop/commands/executeAuthoringPlan.test.ts
+++ b/src/tools/desktop/commands/executeAuthoringPlan.test.ts
@@ -795,6 +795,7 @@ function expectCapabilityRefusal(result: CallToolResult, capability: string): vo
   expect(payload.steps).toEqual([]);
   expect(payload.message).toContain(`requires uncensused capability '${capability}'`);
   expect(payload.message).toContain('No step ran');
+  expect(payload.message).not.toContain('.. No step ran');
 }
 
 function expectEveryExecutorMethodUntouched(executor: MockExecutor): void {

--- a/src/tools/desktop/commands/executeAuthoringPlan.ts
+++ b/src/tools/desktop/commands/executeAuthoringPlan.ts
@@ -574,7 +574,7 @@ function refusedCapability(name: string, reason: string): Result<never, McpToolE
   return new IncompleteOperationError(
     withNextAction(
       {
-        message: `Plan refused during preflight: requires uncensused capability '${name}': ${reason}. No step ran.`,
+        message: `Plan refused during preflight: requires uncensused capability '${name}': ${reason} No step ran.`,
         steps: [],
       },
       prefillNextAction('Revise the plan to use admitted capabilities'),


### PR DESCRIPTION
Rewrites the 11 capability-census reason strings so a refused agent reads what is missing and the exact tool or command shape that works today. This sets the rule for refusal text: name the door, in plain words, in at most two sentences — and never claim more than the shape asserts. Two factual corrections included: worksheet lifecycle (create, name, activate all work via commands; field placement still has no command) and dashboard composition (new-dashboard plus add-sheet-to-dashboard). Strings only — no entry or detection changes.

Review trail: Opus 5 review, six findings applied (FIXED-LOD idiom for the date-window door, zoneId claim dropped, worksheet-lifecycle headline inverted, arg-shape consistency, redundancy cut). Validation firsthand: full suite 6433 passing, tsc clean, lint clean. One known gap the review surfaced, left for a follow-up: no test pins the reason content (only a no-newline check) — a reason-content ratchet would make these strings regression-proof.

Approving this means refusals become teaching moments; future census entries follow the same two-sentence door-naming shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)