### PR TITLE
docs(knowledge): add the eight live-proven authoring recipes to the shipped corpus

### DIFF
--- a/resources/desktop/knowledge/tactics/dashboard/structure-command-composition.md
+++ b/resources/desktop/knowledge/tactics/dashboard/structure-command-composition.md
@@ -8,8 +8,8 @@ Use Tableau structure commands to create and rename a dashboard and place alread
 - Authoring outcome improved: create, compose, validate
 - In-scope reason: Provides a proven fallback for assembling verified worksheets when the higher-level dashboard tools are not suitable.
 - Out-of-scope risk: Structure commands do not build worksheet marks, shelves, calculations, or encodings.
-- Tags: dashboard, composition, worksheets, structure-commands, rename-sheet, add-sheet, tiled-layout
-- Relevant user prompts/search terms: "build a dashboard", "compose a dashboard", "put sheets on a dashboard", "add worksheets to dashboard", "rename dashboard", "dashboard"
+- Tags: composition, worksheets, structure-commands, rename-sheet, add-sheet, tiled-layout
+- Relevant user prompts/search terms: "add-sheet-to-dashboard", "dashboard shell", "place existing sheets", "rename-sheet", "tiled-layout"
 
 ## When to Use
 

--- a/resources/desktop/knowledge/tactics/dashboard/structure-command-composition.md
+++ b/resources/desktop/knowledge/tactics/dashboard/structure-command-composition.md
@@ -1,0 +1,111 @@
+# Compose a Dashboard with Structure Commands
+
+Use Tableau structure commands to create and rename a dashboard and place already-built worksheets without hand-authoring dashboard XML.
+
+## Scope Check
+
+- Primary audience: Tableau agent
+- Authoring outcome improved: create, compose, validate
+- In-scope reason: Provides a proven fallback for assembling verified worksheets when the higher-level dashboard tools are not suitable.
+- Out-of-scope risk: Structure commands do not build worksheet marks, shelves, calculations, or encodings.
+- Tags: dashboard, composition, worksheets, structure-commands, rename-sheet, add-sheet, tiled-layout
+- Relevant user prompts/search terms: "build a dashboard", "compose a dashboard", "put sheets on a dashboard", "add worksheets to dashboard", "rename dashboard", "dashboard"
+
+## When to Use
+
+For a straightforward dashboard request, first use `dashboard-auto-apply`; use `plan-dashboard-creation` followed by `build-and-apply-dashboard` when a planned layout is needed. Use this lower-level recipe when the worksheets already exist or must be built and verified independently, and the task only needs a dashboard shell plus tiled worksheet zones.
+
+The proven structure sequence is:
+
+- `tabdoc:new-worksheet` creates a worksheet named `Sheet N`.
+- `tabdoc:rename-sheet` renames a worksheet or dashboard.
+- `tabdoc:new-dashboard` creates a dashboard named `Dashboard N`.
+- `tabdoc:add-sheet-to-dashboard` with `AddAsFloating:false` places an existing worksheet and returns a zone ID.
+
+Build worksheet content through `bind-template`, `author-calc`, `build-and-apply-worksheet`, or the worksheet XML lane. The structure commands only compose those results.
+
+## Best Practices
+
+- Build and verify every source worksheet before assembling the dashboard.
+- Use `bind-template` first for a named chart shape. If it returns a proposal, resubmit the same ask with that proposal and, when correcting an existing sheet, `target_worksheet`.
+- Author reusable calculations before binding them by caption.
+- Verify values on each source worksheet with `get-summary-data`; dashboard presence alone is not evidence that the source vizzes rendered.
+- Pass `AddAsFloating:false` explicitly when adding each sheet. That exact argument shape is observed working.
+- Use one targeted `search-commands` call if a command is unknown; do not guess command names.
+
+## Common Mistakes
+
+1. Treating `tabdoc:add-sheet-to-dashboard` as a worksheet builder. It only places an existing worksheet.
+2. Looking for a standalone command that places fields on Rows, Columns, Text, or Color. No such command is confirmed; use the worksheet authoring tools.
+3. Omitting `AddAsFloating`. The form without that argument is unconfirmed.
+4. Declaring success after dashboard assembly without checking the source worksheets.
+5. Omitting the needed date derivation in a trend proposal. An observed proposal collapsed a datetime trend to one row; adding `"derivation":"tdy"` restored the intended day-grain series.
+6. Creating a duplicate worksheet instead of correcting the existing one with `target_worksheet`.
+
+## Implementation
+
+After building and verifying the worksheets, compose them:
+
+```json
+[
+  {
+    "tool": "execute-tableau-command",
+    "input": {
+      "session": "<session>",
+      "command": "tabdoc:new-dashboard",
+      "args": {}
+    }
+  },
+  {
+    "tool": "execute-tableau-command",
+    "input": {
+      "session": "<session>",
+      "command": "tabdoc:rename-sheet",
+      "args": {
+        "Sheet": "Dashboard 1",
+        "NewSheet": "Performance Dashboard"
+      }
+    }
+  },
+  {
+    "tool": "execute-tableau-command",
+    "input": {
+      "session": "<session>",
+      "command": "tabdoc:add-sheet-to-dashboard",
+      "args": {
+        "Dashboard": "Performance Dashboard",
+        "Worksheet": "Win Rate by Team",
+        "AddAsFloating": false
+      }
+    }
+  },
+  {
+    "tool": "activate-sheet",
+    "input": {
+      "session": "<session>",
+      "sheetName": "Performance Dashboard"
+    }
+  }
+]
+```
+
+Repeat the add-sheet call for each verified worksheet.
+
+### What is confirmed working
+
+- Bare `tabdoc:new-worksheet` and `tabdoc:new-dashboard` calls create default-named objects.
+- `tabdoc:rename-sheet` renames worksheets and dashboards.
+- `tabdoc:add-sheet-to-dashboard` with `Dashboard`, `Worksheet`, and `AddAsFloating:false` places a worksheet and returns a zone ID.
+- The dashboard can combine worksheets built through different supported authoring lanes.
+
+### What does not work or remains unconfirmed
+
+- No standalone field-placement command is confirmed.
+- Adding a sheet without `AddAsFloating` is unconfirmed.
+- Dashboard assembly does not prove worksheet marks rendered; verify the source worksheets separately.
+
+## Source and Confidence
+
+- Source/evidence type: live Desktop proof, sanitized for product use
+- Customer-identifying and run-specific details removed: yes
+- Confidence: field-tested

--- a/resources/desktop/knowledge/tactics/data/calc-aggregation-in-formula.md
+++ b/resources/desktop/knowledge/tactics/data/calc-aggregation-in-formula.md
@@ -1,0 +1,100 @@
+# Put Aggregation Inside Template-Bound Calculations
+
+When a calculated measure binds cleanly but renders no marks, aggregate inside the formula instead of relying on the worksheet binding to add aggregation.
+
+## Scope Check
+
+- Primary audience: Tableau agent
+- Authoring outcome improved: calculate, create, troubleshoot, validate
+- In-scope reason: Prevents the clean-apply/zero-marks failure for conditional KPIs, deltas, ratios, and other template-bound calculated measures.
+- Out-of-scope risk: This rule applies when the requested value is an aggregate; genuinely row-level calculations should remain row-level.
+- Tags: calculated-field, aggregation, no-marks, blank-viz, kpi, conditional-aggregation, delta, ratio
+- Relevant user prompts/search terms: "calculation has no marks", "KPI is blank", "running total", "ratio", "win rate", "latest value", "prior value", "delta", "calculated measure renders blank"
+
+## When to Use
+
+Use this when `author-calc`, `build-and-apply-worksheet`, or `bind-template` accepts a calculated measure, but the resulting worksheet has no marks or no summary rows.
+
+Template-bound calculated fields use the `User` derivation. That is correct when the formula already aggregates. It is insufficient when the formula is row-level and the desired mark is an aggregate value.
+
+## Best Practices
+
+- Write aggregate measures as aggregate formulas. Use `SUM(IF <condition> THEN [Measure] END)`, not a bare `IF`.
+- For deltas, subtract one aggregate from another.
+- For ratios, divide aggregate numerators by aggregate denominators.
+- Keep `User` derivation for formulas that already aggregate.
+- Verify each KPI with `get-summary-data`. A clean preflight, apply, or structural readback does not prove a visible value.
+- Treat a proposal-level `"derivation":"sum"` override as unproven for calculated fields; an observed bind ignored it and kept the calculation as `User`.
+
+## Common Mistakes
+
+1. Assuming the template binding will aggregate a row-level calculation.
+2. Treating a clean apply receipt as proof that marks rendered.
+3. Trying to fix a calculated field by adding `"derivation":"sum"` to the proposal.
+4. Reusing a bare conditional formula after an aggregate formula succeeds.
+
+## Implementation
+
+Author aggregate conditional measures before placing them in KPI templates:
+
+```json
+[
+  {
+    "tool": "author-calc",
+    "input": {
+      "session": "<session>",
+      "caption": "Goals at Latest Snapshot",
+      "formula": "SUM(IF [Snapshot Time] = {FIXED : MAX([Snapshot Time])} THEN [Goals] END)",
+      "datatype": "integer",
+      "role": "measure"
+    }
+  },
+  {
+    "tool": "author-calc",
+    "input": {
+      "session": "<session>",
+      "caption": "Goal Delta vs Prior Snapshot",
+      "formula": "SUM(IF [Snapshot Time] = {FIXED : MAX([Snapshot Time])} THEN [Goals] END) - SUM(IF [Snapshot Time] = {FIXED : MAX(IF [Snapshot Time] < {FIXED : MAX([Snapshot Time])} THEN [Snapshot Time] END)} THEN [Goals] END)",
+      "datatype": "integer",
+      "role": "measure"
+    }
+  },
+  {
+    "tool": "build-and-apply-worksheet",
+    "input": {
+      "session": "<session>",
+      "taskSpec": {
+        "worksheetName": "KPI - Goals Latest",
+        "template": "kpi-text",
+        "fields": [
+          "Goals at Latest Snapshot"
+        ]
+      }
+    }
+  },
+  {
+    "tool": "get-summary-data",
+    "input": {
+      "session": "<session>",
+      "worksheet": "KPI - Goals Latest"
+    }
+  }
+]
+```
+
+### What is confirmed working
+
+- Aggregate conditional formulas render in template-bound KPI sheets.
+- Aggregate-minus-aggregate works for deltas.
+- Aggregate-over-aggregate works for rates and percent change.
+
+### What does not work
+
+- A row-level `IF ... THEN [Measure] END` calculation can bind cleanly and still render zero marks in an aggregate KPI.
+- A proposal binding with `"derivation":"sum"` did not force aggregation for a calculated field in the observed path.
+
+## Source and Confidence
+
+- Source/evidence type: live Desktop proof, sanitized for product use
+- Customer-identifying and run-specific details removed: yes
+- Confidence: field-tested

--- a/resources/desktop/knowledge/tactics/data/calc-based-bins.md
+++ b/resources/desktop/knowledge/tactics/data/calc-based-bins.md
@@ -13,9 +13,9 @@ When the workbook has no native bin field, derive bins from the data and use the
 
 ## When to Use
 
-Use this when the user asks for a histogram and no native bin key is available. Read an existing worksheet or source summary to establish the measure range, choose a defensible width, author a bin calculation and count measure, then build the histogram through a cached worksheet document.
+Use this when the user asks for a histogram and no native bin key is available. First try the two-call `bind-template` proposal route with the shipped distribution-histogram template.
 
-This is a fallback after `bind-template` does not provide a usable histogram path. Do not guess a bin width or fabricate field references.
+The template's bin width is baked in (`size='283'`) and does not recompute on bind. When the bound measure's observed range makes that width inappropriate, read an existing worksheet or source summary, choose a defensible width, author a bin calculation and count measure, then build the histogram through a cached worksheet document. Do not guess a bin width or fabricate field references.
 
 ## Best Practices
 
@@ -32,7 +32,7 @@ This is a fallback after `bind-template` does not provide a usable histogram pat
 1. Choosing a bin width without inspecting the data range.
 2. Declaring success because a worksheet rendered while the bin dimension is absent.
 3. Using a generic `build-and-apply-worksheet` result without checking requested field coverage. In the observed source path, the bin dimension was dropped. This product now reports dropped-field coverage, but that gate is not evidence that the generic histogram path works.
-4. Citing a `bind-template` refusal as part of this exact proof. A related earlier run observed refusals; this recipe's successful run skipped that lane.
+4. Assuming the distribution-histogram template's baked bin width is appropriate for every measure range.
 5. Passing an arbitrary temporary path to `apply-worksheet`. Use a cache path produced by this server's worksheet tools.
 
 ## Implementation
@@ -82,7 +82,7 @@ For an entity-level Goals histogram:
 ### What does not work or remains scoped
 
 - The observed generic worksheet build dropped the bin dimension; do not use its render alone as proof.
-- A related run observed repeated template refusals, but this successful recipe did not retest that behavior.
+- Use the calculation lane only when the bound measure's range makes the distribution-histogram template's baked bin width inappropriate.
 - A histogram without the bin dimension in readback is not a successful result.
 
 ## Source and Confidence

--- a/resources/desktop/knowledge/tactics/data/calc-based-bins.md
+++ b/resources/desktop/knowledge/tactics/data/calc-based-bins.md
@@ -1,0 +1,92 @@
+# Build a Histogram with Calculation-Based Bins
+
+When the workbook has no native bin field, derive bins from the data and use the sanctioned cached worksheet lane to preserve the bin dimension.
+
+## Scope Check
+
+- Primary audience: Tableau agent
+- Authoring outcome improved: calculate, create, validate
+- In-scope reason: Provides a proven fallback for a histogram whose bin dimension cannot be preserved by a generic template build.
+- Out-of-scope risk: Bin width is data-dependent; do not copy the example width without reading the actual range.
+- Tags: histogram, bins, calculated-bins, distribution, count-distinct, fixed-lod, worksheet-xml
+- Relevant user prompts/search terms: "histogram", "bins", "create bins", "distribution", "bucket values", "bin width", "count entities per bin"
+
+## When to Use
+
+Use this when the user asks for a histogram and no native bin key is available. Read an existing worksheet or source summary to establish the measure range, choose a defensible width, author a bin calculation and count measure, then build the histogram through a cached worksheet document.
+
+This is a fallback after `bind-template` does not provide a usable histogram path. Do not guess a bin width or fabricate field references.
+
+## Best Practices
+
+- Derive bin width from observed values before authoring the calculation.
+- Compute at the intended entity grain. For team totals, one proven shape is `FLOOR({FIXED [Team Name]: SUM([Goals])} / 25) * 25`.
+- Count entities with `COUNTD([Team Name])`.
+- Use `resolve-field` for the exact source references.
+- Create or rename a worksheet scaffold, fetch it with `get-worksheet-xml` in file mode, update only the cached worksheet through `write-cached-xml`, then call `apply-worksheet`.
+- Verify that both the bin dimension and count measure survive in summary data or worksheet readback.
+- Reconcile the total count to the expected source entity count.
+
+## Common Mistakes
+
+1. Choosing a bin width without inspecting the data range.
+2. Declaring success because a worksheet rendered while the bin dimension is absent.
+3. Using a generic `build-and-apply-worksheet` result without checking requested field coverage. In the observed source path, the bin dimension was dropped. This product now reports dropped-field coverage, but that gate is not evidence that the generic histogram path works.
+4. Citing a `bind-template` refusal as part of this exact proof. A related earlier run observed refusals; this recipe's successful run skipped that lane.
+5. Passing an arbitrary temporary path to `apply-worksheet`. Use a cache path produced by this server's worksheet tools.
+
+## Implementation
+
+For an entity-level Goals histogram:
+
+1. Read an existing populated sheet with `get-summary-data` and, when needed, `get-worksheet-xml` to establish the observed range.
+2. Choose a width appropriate to that range.
+3. Create the calculations:
+
+```json
+[
+  {
+    "tool": "author-calc",
+    "input": {
+      "session": "<session>",
+      "caption": "Goals Bin",
+      "formula": "FLOOR({FIXED [Team Name]: SUM([Goals])} / 25) * 25",
+      "datatype": "integer",
+      "role": "dimension"
+    }
+  },
+  {
+    "tool": "author-calc",
+    "input": {
+      "session": "<session>",
+      "caption": "Teams in Bin",
+      "formula": "COUNTD([Team Name])",
+      "datatype": "integer",
+      "role": "measure"
+    }
+  }
+]
+```
+
+4. Resolve the bin and count fields, create a worksheet scaffold, and fetch its cached XML.
+5. Write the histogram worksheet element to that same cache file with `write-cached-xml`, preserving the scaffold worksheet name and using the resolved references.
+6. Apply with `apply-worksheet`.
+7. Verify with `get-summary-data` and `get-worksheet-xml`.
+
+### What is confirmed working
+
+- A FIXED entity-level aggregate can define equal-width calculated bins.
+- `COUNTD` can provide the entity count per bin.
+- A hand-authored worksheet applied through the cached XML lane can preserve the bin and count fields.
+
+### What does not work or remains scoped
+
+- The observed generic worksheet build dropped the bin dimension; do not use its render alone as proof.
+- A related run observed repeated template refusals, but this successful recipe did not retest that behavior.
+- A histogram without the bin dimension in readback is not a successful result.
+
+## Source and Confidence
+
+- Source/evidence type: live Desktop proof, sanitized and adapted to the shipped cache boundary
+- Customer-identifying and run-specific details removed: yes
+- Confidence: field-tested for the calculation and worksheet route

--- a/resources/desktop/knowledge/tactics/data/calc-template-binding.md
+++ b/resources/desktop/knowledge/tactics/data/calc-template-binding.md
@@ -1,0 +1,114 @@
+# Bind a Template to a Derived Metric
+
+Create a derived metric in the `bind-template` calculation prelude, then bind that calculation by caption in the returned proposal.
+
+## Scope Check
+
+- Primary audience: Tableau agent
+- Authoring outcome improved: calculate, create, validate
+- In-scope reason: Gives the proven two-call template path for rates, ratios, and other derived measures that are not already workbook fields.
+- Out-of-scope risk: Summary-data row order does not prove the visual sort order.
+- Tags: calculated-field, derived-metric, template-binding, ratio, rate, percentage, win-rate
+- Relevant user prompts/search terms: "win rate", "ratio", "conversion rate", "completion rate", "derived metric chart", "calculated percentage"
+
+## When to Use
+
+Use this when the requested chart can be built through `bind-template`, but its measure does not yet exist in the workbook. This is especially useful for ratio-style metrics such as win rate, conversion rate, completion rate, or margin.
+
+When the calculation is needed only for the current chart, put it in the first call's `calcs` prelude. When it must be reused across several sheets, `author-calc` followed by binding the caption is also proven, but costs an extra call.
+
+## Best Practices
+
+- Send the user's ask verbatim with `auto_apply:true` and a complete `calcs` entry: caption, formula, datatype, and role.
+- Resubmit the same ask verbatim with the concrete proposal.
+- Bind the new field by its human-facing caption.
+- Put required visual ordering in the proposal's `sort` object.
+- Use aggregate formulas for rates and ratios, such as `SUM([Won]) / SUM([Played])`.
+- Verify the rendered values with `get-summary-data`.
+- Carry the intended `session` on every call when more than one Desktop instance may be available.
+
+## Common Mistakes
+
+1. Changing the ask between the calculation-prelude call and the proposal call.
+2. Omitting calculation metadata, which prevents reliable field authoring and binding.
+3. Authoring a one-chart calculation separately when the prelude can create it in the same flow.
+4. Declaring success after apply without verifying plausible values.
+5. Treating summary-data row order as proof of visual sort direction. Readback order is not visual-order evidence.
+6. Trying manual sort repair after a sorted proposal has applied and the values are verified. That adds risk without producing better sort evidence.
+
+## Implementation
+
+For a descending Win Rate chart:
+
+```json
+[
+  {
+    "tool": "bind-template",
+    "input": {
+      "session": "<session>",
+      "ask": "Build a bar chart of Win Rate % by team, sorted highest to lowest.",
+      "auto_apply": true,
+      "calcs": [
+        {
+          "caption": "Win Rate %",
+          "formula": "SUM([Won]) / SUM([Played])",
+          "datatype": "real",
+          "role": "measure"
+        }
+      ]
+    }
+  },
+  {
+    "tool": "bind-template",
+    "input": {
+      "session": "<session>",
+      "ask": "Build a bar chart of Win Rate % by team, sorted highest to lowest.",
+      "auto_apply": true,
+      "proposal": {
+        "template": "ranking-ordered-bar",
+        "title": "Win Rate % by Team",
+        "confidence": 0.9,
+        "bindings": [
+          {
+            "slot_id": "region",
+            "field": "Team Name"
+          },
+          {
+            "slot_id": "sales",
+            "field": "Win Rate %"
+          }
+        ],
+        "sort": {
+          "by": "Win Rate %",
+          "direction": "desc"
+        }
+      }
+    }
+  },
+  {
+    "tool": "get-summary-data",
+    "input": {
+      "session": "<session>",
+      "worksheet": "Win Rate % by Team"
+    }
+  }
+]
+```
+
+### What is confirmed working
+
+- The `calcs` prelude can author an aggregate ratio and make its caption bindable.
+- A ranking proposal can bind the dimension and derived metric and request descending sort.
+- `get-summary-data` can verify that derived values rendered.
+- `author-calc` followed by binding the caption remains a valid reuse path.
+
+### What does not work or is not valid proof
+
+- Summary-data row order does not prove visual sort direction.
+- A previously pinned or inferred session is not guaranteed to be the intended target; pass the session explicitly when needed.
+
+## Source and Confidence
+
+- Source/evidence type: live Desktop proof, sanitized for product use
+- Customer-identifying and run-specific details removed: yes
+- Confidence: field-tested

--- a/resources/desktop/knowledge/tactics/data/date-coercion-calc.md
+++ b/resources/desktop/knowledge/tactics/data/date-coercion-calc.md
@@ -1,0 +1,86 @@
+# Coerce a Datetime with a Template Calculation Prelude
+
+Create a named, date-typed calculation before template binding when the request specifically needs a derived date field from a datetime.
+
+## Scope Check
+
+- Primary audience: Tableau agent
+- Authoring outcome improved: calculate, create, validate
+- In-scope reason: Provides an observed template-prelude route for a named day-grain field derived from a timestamp.
+- Out-of-scope risk: This proof does not establish that direct binding of the source datetime fails.
+- Tags: date, datetime, timestamp, datetrunc, date-coercion, template-binding, trend, day-grain
+- Relevant user prompts/search terms: "date from timestamp", "group timestamp by day", "daily trend", "Snapshot Date", "convert datetime to date", "line chart by day"
+
+## When to Use
+
+Prefer a native date derivation when it directly expresses the requested grain; `expertise://tableau/tactics/data/tableau-date-handling` is the general rule. Use this calculation-prelude recipe when the user explicitly asks for a separately named derived date field, or when the template flow needs a date-typed field created from a datetime before binding.
+
+The observed route created `Snapshot Date` as `DATETRUNC('day', [Snapshot Time])`, with datatype `date` and role `dimension`, then bound the generated calculation field to the temporal slot with day derivation.
+
+## Best Practices
+
+- Create the requested grain before binding the viz.
+- Use `calcs` in the first `bind-template` call rather than a separate `author-calc` call when the derived date exists only for this chart.
+- Apply the proposal returned by the binder. The observed proposal bound a generated calculation field ID, not the caption.
+- Verify both data and structure: summary data should contain the derived field, and worksheet readback should show the intended day-level temporal shape.
+- Keep the evidence scoped. A rendered worksheet alone does not prove the requested grain.
+
+## Common Mistakes
+
+1. Assuming the binder chose the correct date grain because the worksheet rendered.
+2. Claiming direct raw-datetime binding fails. That alternative was not tested in the proof.
+3. Treating the observed field-ID binding as proof that caption binding cannot work.
+4. Creating a calculated date when a native derivation already meets the request and no separately named field is needed.
+
+## Implementation
+
+First call `bind-template` with the user's ask and this prelude:
+
+```json
+{
+  "session": "<session>",
+  "ask": "Build a line chart of Played by Snapshot Date, using a derived date field from Snapshot Time so the trend is grouped by day.",
+  "auto_apply": true,
+  "calcs": [
+    {
+      "caption": "Snapshot Date",
+      "formula": "DATETRUNC('day', [Snapshot Time])",
+      "datatype": "date",
+      "role": "dimension"
+    }
+  ]
+}
+```
+
+Then resubmit the same ask with the returned trend proposal. The observed proposal shape bound the generated calculation field to `order_date` with `"derivation":"tdy"` and the measure to `sales`.
+
+Finally, verify with:
+
+```json
+{
+  "tool": "get-summary-data",
+  "input": {
+    "session": "<session>",
+    "worksheet": "Played by Snapshot Date"
+  }
+}
+```
+
+Read the worksheet with `get-worksheet-xml` when summary data alone does not expose the date function or shelf shape.
+
+### What is confirmed working
+
+- A `calcs` prelude can create a date-typed `DATETRUNC('day', ...)` dimension.
+- The generated calculation field ID can bind to the trend template's temporal slot with day derivation.
+- Summary and worksheet readback can verify the derived date and day-level shape.
+
+### What remains unconfirmed
+
+- Directly binding the raw datetime for the same ask was not tested; do not present it as a proven failure.
+- The proof used a generated field ID and does not establish whether caption binding is equivalent for this route.
+
+## Source and Confidence
+
+- Source/evidence type: live Desktop proof, sanitized for product use
+- Customer-identifying and run-specific details removed: yes
+- Confidence: field-tested for the stated route

--- a/resources/desktop/knowledge/tactics/data/template-owned-table-calcs.md
+++ b/resources/desktop/knowledge/tactics/data/template-owned-table-calcs.md
@@ -30,7 +30,7 @@ Check available fields before creating a likely duplicate calculation. The prove
 
 1. Creating `Goal Difference` when the datasource already contains `goal_difference`. The observed caption collision failed.
 2. Duplicating running-total responsibility in both a calculation and the template.
-3. Calling summary rows "marks." Summary readback does not observe rendered marks.
+3. Treating summary rows as proof of the rendered structure. Summary rows prove values exist; they do not prove mark type, shelf placement, or sort order.
 4. Claiming datasource-authored `RUNNING_SUM` fails. That route was not tested.
 
 ## Implementation
@@ -91,7 +91,7 @@ After apply, use `get-summary-data` for numeric readback and `get-worksheet-xml`
 
 - A calculation prelude that duplicates an existing datasource field caption failed with a collision.
 - Creating `RUNNING_SUM` as a datasource calculation was not tested; do not claim it fails.
-- Summary-data rows do not prove the rendered mark structure.
+- Summary rows prove values exist; they do not prove mark type, shelf placement, or sort order.
 
 ## Source and Confidence
 

--- a/resources/desktop/knowledge/tactics/data/template-owned-table-calcs.md
+++ b/resources/desktop/knowledge/tactics/data/template-owned-table-calcs.md
@@ -1,0 +1,100 @@
+# Let the Template Own Its Table Calculation
+
+For a running-total waterfall, bind the step measure and category to the waterfall template instead of duplicating the template's table-calculation logic.
+
+## Scope Check
+
+- Primary audience: Tableau agent
+- Authoring outcome improved: create, calculate, validate
+- In-scope reason: Gives the proven binding route for a waterfall whose template owns the running total.
+- Out-of-scope risk: This does not prove that every template owns every requested calculation.
+- Tags: table-calculation, running-total, waterfall, template-owned, goal-difference, field-collision
+- Relevant user prompts/search terms: "running total", "waterfall", "bridge chart", "running goal difference", "cumulative steps", "Goals minus Goals Against"
+
+## When to Use
+
+Use this when the user asks for a running-total or part-to-whole waterfall and the available template already carries the accumulation behavior. Bind the per-step measure and category; let the template own the running total.
+
+Check available fields before creating a likely duplicate calculation. The proven recovery path used an existing datasource field after a calculation prelude collided with it.
+
+## Best Practices
+
+- Call `bind-template` first for a named waterfall ask.
+- Bind the per-step measure to the template's measure slot and the category to its dimension slot.
+- Check available fields before authoring a calculation with a likely existing caption or local name.
+- Existing snake_case local names can be valid bindings when returned by field discovery.
+- Verify worksheet structure and summary values separately. Summary rows are numeric evidence, not proof of rendered mark structure.
+- Do not author a second running-sum calculation unless evidence shows the template does not own the behavior.
+
+## Common Mistakes
+
+1. Creating `Goal Difference` when the datasource already contains `goal_difference`. The observed caption collision failed.
+2. Duplicating running-total responsibility in both a calculation and the template.
+3. Calling summary rows "marks." Summary readback does not observe rendered marks.
+4. Claiming datasource-authored `RUNNING_SUM` fails. That route was not tested.
+
+## Implementation
+
+Use the user's ask verbatim. If an attempted calculation prelude collides with an existing field, list fields and bind the existing local name:
+
+```json
+[
+  {
+    "tool": "bind-template",
+    "input": {
+      "session": "<session>",
+      "ask": "Build a waterfall chart showing the running goal difference by team.",
+      "auto_apply": true
+    }
+  },
+  {
+    "tool": "bind-template",
+    "input": {
+      "session": "<session>",
+      "ask": "Build a waterfall chart showing the running goal difference by team.",
+      "auto_apply": true,
+      "proposal": {
+        "template": "part-to-whole-waterfall",
+        "title": "Running Goal Difference by Team",
+        "confidence": 0.9,
+        "bindings": [
+          {
+            "slot_id": "profit",
+            "field": "goal_difference",
+            "derivation": "sum"
+          },
+          {
+            "slot_id": "sub_category",
+            "field": "team_name",
+            "derivation": "none"
+          }
+        ],
+        "sort": {
+          "by": "goal_difference",
+          "direction": "desc"
+        }
+      }
+    }
+  }
+]
+```
+
+After apply, use `get-summary-data` for numeric readback and `get-worksheet-xml` for the worksheet structure.
+
+### What is confirmed working
+
+- The part-to-whole waterfall template can own running-total behavior.
+- Existing datasource local names can bind directly into the proposal.
+- The observed proposal produced internally consistent summary rows and worksheet structure.
+
+### What does not work or remains unconfirmed
+
+- A calculation prelude that duplicates an existing datasource field caption failed with a collision.
+- Creating `RUNNING_SUM` as a datasource calculation was not tested; do not claim it fails.
+- Summary-data rows do not prove the rendered mark structure.
+
+## Source and Confidence
+
+- Source/evidence type: live Desktop proof, sanitized for product use
+- Customer-identifying and run-specific details removed: yes
+- Confidence: field-tested

--- a/resources/desktop/knowledge/tactics/viz/small-multiples-facet-col.md
+++ b/resources/desktop/knowledge/tactics/viz/small-multiples-facet-col.md
@@ -1,0 +1,107 @@
+# Build Small Multiples with the facet_col Slot
+
+Use the trend template's optional `facet_col` slot to create side-by-side line-chart panes without manually composing shelves.
+
+## Scope Check
+
+- Primary audience: Tableau agent
+- Authoring outcome improved: create, compose, validate
+- In-scope reason: Provides the proven template route for a faceted line chart.
+- Out-of-scope risk: The proof observed pane structure, not summary values or pixel-level rendering.
+- Tags: small-multiples, faceting, facet-col, side-by-side, line-chart, panes, trend
+- Relevant user prompts/search terms: "small multiples", "side by side", "faceted line chart", "one panel per group", "trellis", "compare trends by category"
+
+## When to Use
+
+Use this when one dimension should create side-by-side panes while a measure remains a time series. The trend-line template exposes an optional `facet_col` slot, so the facet can be bound without manual shelf crossing.
+
+Use `expertise://tableau/tactics/viz/viz-in-tooltip` instead when the finer-grain dimension belongs only in hover detail rather than visible panes.
+
+## Best Practices
+
+- Check template slots before reaching for manual worksheet composition.
+- Bind the temporal field to `order_date`, the measure to `sales`, and the pane dimension to `facet_col`.
+- Include the required temporal derivation for a datetime field; the observed route used `"derivation":"tdy"`.
+- Follow the two-call `bind-template` protocol: send the ask verbatim, then resubmit it with the proposal and `target_worksheet`.
+- Let the template create the worksheet and shelves. Do not use `add-field` merely to place the facet.
+- If the structure is correct but the mark remains Automatic, use the cached XML lane for the smallest possible change from Automatic to Line.
+- Verify the pane count and shelf shape with `get-worksheet-xml`. Do not borrow numeric evidence from another worksheet.
+
+## Common Mistakes
+
+1. Assuming small multiples require hand-authored shelf crossing before checking `facet_col`.
+2. Omitting the date derivation and producing a collapsed temporal series.
+3. Using `add-field` only to place the facet dimension.
+4. Claiming values were verified when the observed verification only established pane and XML structure.
+5. Rewriting the entire worksheet when only the mark class needs correction.
+
+## Implementation
+
+```json
+[
+  {
+    "tool": "bind-template",
+    "input": {
+      "session": "<session>",
+      "ask": "Build a small-multiples line chart showing Goals over Snapshot Time, faceted side-by-side by Group Name.",
+      "auto_apply": true
+    }
+  },
+  {
+    "tool": "bind-template",
+    "input": {
+      "session": "<session>",
+      "ask": "Build a small-multiples line chart showing Goals over Snapshot Time, faceted side-by-side by Group Name.",
+      "auto_apply": true,
+      "target_worksheet": "Goals over Snapshot Time by Group",
+      "proposal": {
+        "template": "trend-line-chart",
+        "title": "Goals over Snapshot Time by Group",
+        "confidence": 0.9,
+        "bindings": [
+          {
+            "slot_id": "order_date",
+            "field": "Snapshot Time",
+            "derivation": "tdy"
+          },
+          {
+            "slot_id": "sales",
+            "field": "Goals"
+          },
+          {
+            "slot_id": "facet_col",
+            "field": "Group Name"
+          }
+        ]
+      }
+    }
+  }
+]
+```
+
+The observed structural readback had a Line mark, Goals on Rows, and Group Name crossed with day-grain Snapshot Time on Columns. If readback shows Automatic when Line is required:
+
+1. Call `get-worksheet-xml` with `"mode":"file"`.
+2. Read and replace only the mark-class element.
+3. Save the replacement through `write-cached-xml`.
+4. Apply with `apply-worksheet`.
+5. Read the worksheet back again.
+
+### What is confirmed working
+
+- `facet_col` on the trend template creates visible side-by-side panes.
+- The successful proposal used day-grain Snapshot Time, Goals, and Group Name.
+- A minimal cached XML touch-up can change Automatic to Line.
+- The observed readback confirmed a 12-pane structure and the expected shelf crossing.
+
+### What does not work or remains unobserved
+
+- Manual shelf crossing is unnecessary for this proven route.
+- The proof did not record values for the final faceted worksheet; do not claim numeric verification.
+- XML structure does not prove pixel-level rendering beyond what the readback can observe.
+
+## Source and Confidence
+
+- Source/evidence type: live Desktop proof, sanitized for product use
+- Customer-identifying and run-specific details removed: yes
+- Confidence: field-tested for structure

--- a/resources/desktop/knowledge/tactics/viz/small-multiples-facet-col.md
+++ b/resources/desktop/knowledge/tactics/viz/small-multiples-facet-col.md
@@ -89,7 +89,7 @@ The observed structural readback had a Line mark, Goals on Rows, and Group Name 
 
 ### What is confirmed working
 
-- `facet_col` on the trend template creates visible side-by-side panes.
+- `facet_col` produces the expected 12-pane cols crossing in worksheet readback.
 - The successful proposal used day-grain Snapshot Time, Goals, and Group Name.
 - A minimal cached XML touch-up can change Automatic to Line.
 - The observed readback confirmed a 12-pane structure and the expected shelf crossing.

--- a/resources/desktop/knowledge/tactics/viz/viz-in-tooltip.md
+++ b/resources/desktop/knowledge/tactics/viz/viz-in-tooltip.md
@@ -1,0 +1,102 @@
+# Show Finer-Grain Members with Viz in Tooltip
+
+Keep visible marks at an aggregate grain while a separate detail worksheet supplies finer-grain hover content.
+
+## Scope Check
+
+- Primary audience: Tableau agent
+- Authoring outcome improved: create, compose, validate
+- In-scope reason: Provides the proven worksheet-XML route for embedding a detail sheet in a customized tooltip.
+- Out-of-scope risk: XML round-trip does not observe the actual hover render.
+- Tags: tooltip, viz-in-tooltip, hover, detail-sheet, aggregate-grain, attr, customized-tooltip
+- Relevant user prompts/search terms: "tooltip", "viz in tooltip", "show members on hover", "hover detail", "keep aggregate bars", "inspect contributing teams"
+
+## When to Use
+
+Use this when the visible parent viz must remain at an aggregate grain, but the user wants to inspect finer-grain members on hover. Build one aggregate parent worksheet and one finer-grain detail worksheet, then reference the detail sheet from the parent's customized tooltip.
+
+Use `expertise://tableau/tactics/viz/small-multiples-facet-col` when the dimension should be visible as panes rather than hidden in hover detail.
+
+## Best Practices
+
+- Build the aggregate parent sheet first and verify that its row count remains at the requested grain.
+- Build a separate detail sheet for the hover content.
+- Use the two-call `bind-template` protocol for each sheet.
+- In an aggregated parent view, a dimension on Tooltip must use Attribute derivation; see `expertise://tableau/tactics/viz/tooltip`.
+- Treat `%many-values%` as evidence that ATTR preserved the parent grain but collapsed several finer-grain members behind a mark.
+- Use a customized tooltip with a `<Sheet name="...">` reference when the user needs member-level hover detail.
+- State the evidence precisely: clean apply plus XML round-trip proves the tooltip reference survived; actual hover rendering remains UNOBSERVED until captured live.
+
+## Common Mistakes
+
+1. Putting the finer-grain dimension on Detail or LOD in the parent view. In the observed case, this changed the parent from aggregate rows to finer-grain rows.
+2. Using an ATTR tooltip field and expecting a list of members. It preserved aggregate grain but read back `%many-values%`.
+3. Adding the finer-grain field to the parent view when the ask is hover-only.
+4. Claiming that XML readback proves the hover rendered. It does not.
+
+## Implementation
+
+Build the parent:
+
+```json
+{
+  "tool": "bind-template",
+  "input": {
+    "session": "<session>",
+    "ask": "Build a bar chart of total Goals by Group Name, with contributing Team Name members available on hover.",
+    "auto_apply": true,
+    "proposal": {
+      "template": "ranking-ordered-bar",
+      "title": "Total Goals by Group Name",
+      "bindings": [
+        {
+          "slot_id": "region",
+          "field": "Group Name"
+        },
+        {
+          "slot_id": "sales",
+          "field": "Goals",
+          "derivation": "sum"
+        }
+      ],
+      "confidence": 0.9
+    }
+  }
+}
+```
+
+Build a separate detail sheet such as `Teams in Group (tooltip)` with Team Name and Goals. Then fetch the parent with `get-worksheet-xml` in file mode and update its cached worksheet through `write-cached-xml`. The load-bearing shape is:
+
+```xml
+<customized-tooltip>
+  <formatted-text>
+    <run>Group &lt;[datasource].[none:group_name:nk]&gt;</run>
+    <run>Total Goals: &lt;[datasource].[sum:goals:qk]&gt;</run>
+    <run>&lt;Sheet name=&quot;Teams in Group (tooltip)&quot; maxwidth=&quot;320&quot; maxheight=&quot;300&quot; filter=&quot;&lt;All Fields&gt;&quot;&gt;</run>
+  </formatted-text>
+</customized-tooltip>
+```
+
+Apply with `apply-worksheet`, read the parent back, and verify that:
+
+- the `<Sheet>` reference survived;
+- the parent summary row count remains at aggregate grain;
+- the detail sheet exists and is populated.
+
+### What is confirmed working
+
+- Customized tooltip XML containing a detail-sheet reference can apply and round-trip.
+- An ATTR tooltip field can preserve aggregate parent grain.
+- A separate detail sheet avoids adding its dimension to the parent view's level of detail.
+
+### What does not work or remains unobserved
+
+- A detail/LOD encoding changed the observed parent to finer-grain rows, so it did not satisfy the hover-only ask.
+- An ATTR tooltip field returned `%many-values%` rather than a member list.
+- The actual hover render is UNOBSERVED. Do not claim it works from XML readback alone.
+
+## Source and Confidence
+
+- Source/evidence type: live Desktop proof, sanitized for product use
+- Customer-identifying and run-specific details removed: yes
+- Confidence: field-tested for apply and round-trip; hover render unobserved


### PR DESCRIPTION
The campaign proved eight authoring recipes live and wrote them up in the eval repo — where the shipped product cannot read them. This puts them in the corpus the product actually loads, so the agent can find them at runtime.

Each module carries the tool names this repo registers (the eval repo's corpus uses the reversed spelling) and a Tags line using the words a user would type, because a module without tags lands search-dark: histogram, bins, small multiples, side by side, tooltip, running total, ratio, dashboard.

The recipes: derived-metric calcs through the bind-template calcs prelude; aggregation must live inside the calc formula (a row-level calc renders zero marks while every receipt reads clean); date-grain calcs; the waterfall template already owns RUNNING_SUM; calc-based histogram bins; small multiples via the trend-line-chart facet_col slot; hover detail via viz-in-tooltip without splitting mark grain; and dashboard composition from bare commands.

Claims stay scoped to what readback can observe — where a run could not observe something, the module says so rather than promising it. Validation run firsthand: knowledge corpus 27/27, full suite 6387 passing, tsc and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)