### PR TITLE
fix(desktop): a level-of-detail calc is not an aggregate

### DIFF
--- a/src/desktop/metadata/calculation-classifier.test.ts
+++ b/src/desktop/metadata/calculation-classifier.test.ts
@@ -1,0 +1,45 @@
+import { isAggregateOrTableCalc, stripStringsAndComments } from './calculation-classifier.js';
+
+describe('isAggregateOrTableCalc', () => {
+  it.each([
+    ['a FIXED LOD aggregate', '{FIXED [A] : SUM([B])}', false],
+    ['an aggregate calculation', 'SUM([B])', true],
+    [
+      'the live failing FIXED LOD calculation',
+      'FLOOR({FIXED [Team Name] : SUM([Goals])} / 25) * 25',
+      false,
+    ],
+    ['an aggregate outside an INCLUDE LOD block', '{INCLUDE [A] : AVG([B])} + SUM([C])', true],
+    ['a table calculation', 'RUNNING_SUM(SUM([B]))', true],
+    [
+      'an unreachable-in-Tableau table calculation inside an LOD block, pinned only to document the raw table-calc path',
+      '{FIXED [A] : RUNNING_SUM(SUM([B]))}',
+      true,
+    ],
+    ['a SUM prefix inside another function name', 'SUMMARY([X])', false],
+    ['aggregates inside nested LOD blocks', '{FIXED [A] : AVG({INCLUDE [B] : SUM([C])})}', false],
+    ['VAR with a space inside a bracketed field name', '[Var (Budget)] / [Budget]', false],
+    ['TOTAL inside a bracketed field name', '[Total (USD)]', false],
+    ['RANK inside a bracketed field name', '[Rank (2024)]', false],
+    ['COUNT inside a bracketed field name', '[Count (Net)]', false],
+    ['a Tableau-escaped bracket inside a field name', '[Weird ]] Total (USD)]', false],
+    ['a table-calc name in an LOD dimension', '{FIXED [Rank (Season)] : SUM([X])}', false],
+    ['an aggregate between quoted braces', '"{" + STR(SUM([Sales])) + "}"', true],
+    ['an aggregate after a string ending in an escaped backslash', "'C:\\\\' + SUM([Sales])", true],
+    [
+      'an aggregate-looking call after an escaped quote inside a string',
+      "'It\\'s SUM([Sales])'",
+      false,
+    ],
+  ])('classifies %s', (_label, formula, expected) => {
+    expect(isAggregateOrTableCalc(formula)).toBe(expected);
+  });
+
+  it('keeps code after a string ending in an escaped backslash', () => {
+    expect(stripStringsAndComments("'C:\\\\' + SUM([Sales])")).toContain('SUM([Sales])');
+  });
+
+  it('keeps an escaped quote inside a string', () => {
+    expect(stripStringsAndComments("'It\\'s SUM([Sales])'")).not.toContain('SUM([Sales])');
+  });
+});

--- a/src/desktop/metadata/calculation-classifier.ts
+++ b/src/desktop/metadata/calculation-classifier.ts
@@ -1,0 +1,148 @@
+const AGG_FUNCS = [
+  'SUM',
+  'AVG',
+  'COUNTD',
+  'COUNT',
+  'MEDIAN',
+  'MIN',
+  'MAX',
+  'STDEVP',
+  'STDEV',
+  'VARP',
+  'VAR',
+  'ATTR',
+  'CORR',
+  'COVARP',
+  'COVAR',
+  'PERCENTILE',
+];
+
+const TABLE_CALC_FUNCS = [
+  'INDEX',
+  'SIZE',
+  'FIRST',
+  'LAST',
+  'RANK_DENSE',
+  'RANK_MODIFIED',
+  'RANK_PERCENTILE',
+  'RANK_UNIQUE',
+  'RANK',
+  'LOOKUP',
+  'TOTAL',
+  'PREVIOUS_VALUE',
+  'RUNNING_SUM',
+  'RUNNING_AVG',
+  'RUNNING_MIN',
+  'RUNNING_MAX',
+  'RUNNING_COUNT',
+  'WINDOW_SUM',
+  'WINDOW_AVG',
+  'WINDOW_MIN',
+  'WINDOW_MAX',
+  'WINDOW_COUNT',
+  'WINDOW_MEDIAN',
+  'WINDOW_STDEV',
+  'WINDOW_STDEVP',
+  'WINDOW_VARP',
+  'WINDOW_VAR',
+  'WINDOW_PERCENTILE',
+  'WINDOW_CORR',
+  'WINDOW_COVAR',
+];
+
+const AGG_RE = new RegExp(`\\b(${AGG_FUNCS.join('|')})\\s*\\(`, 'i');
+const TABLE_CALC_RE = new RegExp(`\\b(${TABLE_CALC_FUNCS.join('|')})\\s*\\(`, 'i');
+
+export function stripStringsAndComments(formula: string): string {
+  const src = String(formula ?? '');
+  let out = '';
+  let inSingle = false;
+  let inDouble = false;
+  let inLineComment = false;
+  let inBlockComment = false;
+
+  for (let i = 0; i < src.length; i += 1) {
+    const c = src[i];
+    const next = i + 1 < src.length ? src[i + 1] : '';
+
+    if (inLineComment) {
+      if (c === '\n') {
+        inLineComment = false;
+        out += c;
+      }
+      continue;
+    }
+    if (inBlockComment) {
+      if (c === '*' && next === '/') {
+        inBlockComment = false;
+        i += 1;
+      }
+      continue;
+    }
+    if (inSingle) {
+      if (c === '\\' && next) {
+        out += '  ';
+        i += 1;
+        continue;
+      }
+      if (c === "'") inSingle = false;
+      out += ' ';
+      continue;
+    }
+    if (inDouble) {
+      if (c === '\\' && next) {
+        out += '  ';
+        i += 1;
+        continue;
+      }
+      if (c === '"') inDouble = false;
+      out += ' ';
+      continue;
+    }
+
+    if (c === '/' && next === '/') {
+      inLineComment = true;
+      i += 1;
+      continue;
+    }
+    if (c === '/' && next === '*') {
+      inBlockComment = true;
+      i += 1;
+      continue;
+    }
+    if (c === "'") {
+      inSingle = true;
+      out += ' ';
+      continue;
+    }
+    if (c === '"') {
+      inDouble = true;
+      out += ' ';
+      continue;
+    }
+
+    out += c;
+  }
+
+  return out;
+}
+
+export function stripBracketedIdentifiers(formula: string): string {
+  return formula.replace(/\[(?:[^\]]|\]\])*\]/g, (identifier) => ' '.repeat(identifier.length));
+}
+
+function stripLodBlocks(formula: string): string {
+  let prev: string;
+  let out = formula;
+  do {
+    prev = out;
+    out = out.replace(/\{[^{}]*\}/g, ' ');
+  } while (out !== prev);
+  return out;
+}
+
+export function isAggregateOrTableCalc(formula: string): boolean {
+  const sanitized = stripBracketedIdentifiers(stripStringsAndComments(formula));
+  if (TABLE_CALC_RE.test(sanitized)) return true;
+  return AGG_RE.test(stripLodBlocks(sanitized));
+}

--- a/src/desktop/metadata/field-builder.test.ts
+++ b/src/desktop/metadata/field-builder.test.ts
@@ -16,6 +16,24 @@ const WORKBOOK_XML = `<?xml version="1.0" encoding="UTF-8"?>
       <column name="[Profit Ratio]" datatype="real" role="measure" type="quantitative" caption="Profit Ratio">
         <calculation class="tableau" formula="SUM([Profit])/SUM([Sales])"/>
       </column>
+      <column name="[Goals Band]" datatype="real" role="measure" type="quantitative" caption="Goals Band">
+        <calculation class="tableau" formula="FLOOR({FIXED [Team Name] : SUM([Goals])} / 25) * 25"/>
+      </column>
+      <column name="[Running Sales]" datatype="real" role="measure" type="quantitative" caption="Running Sales">
+        <calculation class="tableau" formula="RUNNING_SUM(SUM([Sales]))"/>
+      </column>
+      <column name="[Attr Category]" datatype="string" role="dimension" type="nominal" caption="Attr Category">
+        <calculation class="tableau" formula="ATTR([Category])"/>
+      </column>
+      <column name="[Sales Correlation]" datatype="real" role="measure" type="quantitative" caption="Sales Correlation">
+        <calculation class="tableau" formula="CORR([Sales], [Sales])"/>
+      </column>
+      <column name="[Sales Population Covariance]" datatype="real" role="measure" type="quantitative" caption="Sales Population Covariance">
+        <calculation class="tableau" formula="COVARP([Sales], [Sales])"/>
+      </column>
+      <column name="[Sales Sample Covariance]" datatype="real" role="measure" type="quantitative" caption="Sales Sample Covariance">
+        <calculation class="tableau" formula="COVAR([Sales], [Sales])"/>
+      </column>
     </datasource>
   </datasources>
   <worksheets>
@@ -159,6 +177,39 @@ describe('listAvailableFields', () => {
     expect(profitRatio).toBeDefined();
     expect(profitRatio?.isAggregated).toBe(true);
     expect(profitRatio?.formula).toBeDefined();
+  });
+
+  it('keeps a FIXED LOD calculation on a non-usr derivation', () => {
+    const fields = listAvailableFields(WORKBOOK_XML);
+    const goalsBand = fields.find((f) => f.columnName === '[Goals Band]');
+
+    expect(goalsBand?.isAggregated).toBe(false);
+    expect(goalsBand?.derivation).toBe(AggregationType.Sum);
+    expect(goalsBand?.columnInstanceName).toBe('[sum:Goals Band:qk]');
+  });
+
+  it('classifies a table calculation as aggregated with a usr derivation', () => {
+    const fields = listAvailableFields(WORKBOOK_XML);
+    const runningSales = fields.find((f) => f.columnName === '[Running Sales]');
+
+    expect(runningSales?.isAggregated).toBe(true);
+    expect(runningSales?.derivation).toBe(AggregationType.User);
+    expect(runningSales?.columnInstanceName).toBe('[usr:Running Sales:qk]');
+  });
+
+  it.each([
+    ['Attr Category', 'nk'],
+    ['Sales Correlation', 'qk'],
+    ['Sales Population Covariance', 'qk'],
+    ['Sales Sample Covariance', 'qk'],
+  ])('classifies %s as aggregated with a usr derivation', (fieldName, typeSuffix) => {
+    const field = listAvailableFields(WORKBOOK_XML).find(
+      (candidate) => candidate.columnName === `[${fieldName}]`,
+    );
+
+    expect(field?.isAggregated).toBe(true);
+    expect(field?.derivation).toBe(AggregationType.User);
+    expect(field?.columnInstanceName).toBe(`[usr:${fieldName}:${typeSuffix}]`);
   });
 
   it('should return an empty array when the workbook has no datasources', () => {

--- a/src/desktop/metadata/field-builder.ts
+++ b/src/desktop/metadata/field-builder.ts
@@ -2,6 +2,7 @@
  * Field builder utilities for constructing column references from user-friendly names
  */
 
+import { isAggregateOrTableCalc } from './calculation-classifier.js';
 import { normalizeArray, parseXML } from './parser.js';
 import {
   AggregationType,
@@ -409,21 +410,7 @@ export function listAvailableFields(
 
         if (column.calculation && column.calculation['@_formula']) {
           formula = column.calculation['@_formula'];
-          const aggFunctions = [
-            'SUM(',
-            'AVG(',
-            'MIN(',
-            'MAX(',
-            'COUNT(',
-            'COUNTD(',
-            'STDEV(',
-            'STDEVP(',
-            'VAR(',
-            'VARP(',
-            'MEDIAN(',
-            'PERCENTILE(',
-          ];
-          isAggregated = aggFunctions.some((fn) => formula!.toUpperCase().includes(fn));
+          isAggregated = isAggregateOrTableCalc(formula!);
         }
 
         if (column['@_hidden'] === 'true') continue;

--- a/src/desktop/metadata/fields.test.ts
+++ b/src/desktop/metadata/fields.test.ts
@@ -242,6 +242,28 @@ describe('addFieldToRows user derivations', () => {
     );
     expect(modified).not.toContain('derivation="usr"');
   });
+
+  it('does not rewrite a FIXED LOD calculation to a usr derivation', () => {
+    const worksheetXml = `<worksheet name="Sheet 1">
+      <table>
+        <view>
+          <datasources><datasource name="Sample"/></datasources>
+          <datasource-dependencies datasource="Sample">
+            <column name="[Goals Band]" datatype="real" role="measure" type="quantitative">
+              <calculation class="tableau" formula="FLOOR({FIXED [Team Name] : SUM([Goals])} / 25) * 25"/>
+            </column>
+          </datasource-dependencies>
+        </view>
+      </table>
+    </worksheet>`;
+
+    const modified = addFieldToRows(worksheetXml, '[Sample].[sum:Goals Band:qk]');
+
+    expect(modified).toContain(
+      '<column-instance name="[sum:Goals Band:qk]" column="[Goals Band]" derivation="Sum"',
+    );
+    expect(modified).not.toContain('[usr:Goals Band:qk]');
+  });
 });
 
 describe('addFieldToRows date-part derivations', () => {

--- a/src/desktop/metadata/fields.ts
+++ b/src/desktop/metadata/fields.ts
@@ -4,6 +4,7 @@
  */
 
 import { resolveDerivation } from '../derivations.js';
+import { isAggregateOrTableCalc } from './calculation-classifier.js';
 import {
   forEachRelationColumn,
   inferFieldTypeFromType,
@@ -834,21 +835,7 @@ function ensureColumnInstanceInDependencies(
   // If it's a calculated field with aggregation, we need to use usr prefix
   if (existingBaseColumn?.calculation?.['@_formula']) {
     const formula = existingBaseColumn.calculation['@_formula'];
-    const aggFunctions = [
-      'SUM(',
-      'AVG(',
-      'MIN(',
-      'MAX(',
-      'COUNT(',
-      'COUNTD(',
-      'STDEV(',
-      'STDEVP(',
-      'VAR(',
-      'VARP(',
-      'MEDIAN(',
-      'PERCENTILE(',
-    ];
-    const hasAggregation = aggFunctions.some((fn) => formula.toUpperCase().includes(fn));
+    const hasAggregation = isAggregateOrTableCalc(formula);
 
     if (hasAggregation && parsed.derivation !== 'User') {
       correctedInstanceName = `[usr:${parsed.localFieldName}:${parsed.pivot}]`;
@@ -1004,21 +991,7 @@ function ensureColumnInstanceInDependencies(
     let actualColumnInstanceName = correctedInstanceName;
     if (baseColumn?.calculation?.['@_formula']) {
       const formula = baseColumn.calculation['@_formula'];
-      const aggFunctions = [
-        'SUM(',
-        'AVG(',
-        'MIN(',
-        'MAX(',
-        'COUNT(',
-        'COUNTD(',
-        'STDEV(',
-        'STDEVP(',
-        'VAR(',
-        'VARP(',
-        'MEDIAN(',
-        'PERCENTILE(',
-      ];
-      const hasAggregation = aggFunctions.some((fn) => formula.toUpperCase().includes(fn));
+      const hasAggregation = isAggregateOrTableCalc(formula);
 
       if (hasAggregation && parsedCorrected.derivation !== 'User') {
         // This calculated field already has aggregation - use User derivation to prevent double aggregation

--- a/src/desktop/validation/rules/aggregateCalcDerivation.ts
+++ b/src/desktop/validation/rules/aggregateCalcDerivation.ts
@@ -1,77 +1,8 @@
 import * as xpath from 'xpath';
 
+import { isAggregateOrTableCalc } from '../../metadata/calculation-classifier.js';
 import type { ValidationIssue, ValidationRule } from '../types.js';
 import { parseXml } from './parseXml.js';
-
-const AGG_FUNCS = [
-  'SUM',
-  'AVG',
-  'COUNTD',
-  'COUNT',
-  'MEDIAN',
-  'MIN',
-  'MAX',
-  'STDEVP',
-  'STDEV',
-  'VARP',
-  'VAR',
-  'ATTR',
-  'CORR',
-  'COVARP',
-  'COVAR',
-  'PERCENTILE',
-];
-
-const TABLE_CALC_FUNCS = [
-  'INDEX',
-  'SIZE',
-  'FIRST',
-  'LAST',
-  'RANK_DENSE',
-  'RANK_MODIFIED',
-  'RANK_PERCENTILE',
-  'RANK_UNIQUE',
-  'RANK',
-  'LOOKUP',
-  'TOTAL',
-  'PREVIOUS_VALUE',
-  'RUNNING_SUM',
-  'RUNNING_AVG',
-  'RUNNING_MIN',
-  'RUNNING_MAX',
-  'RUNNING_COUNT',
-  'WINDOW_SUM',
-  'WINDOW_AVG',
-  'WINDOW_MIN',
-  'WINDOW_MAX',
-  'WINDOW_COUNT',
-  'WINDOW_MEDIAN',
-  'WINDOW_STDEV',
-  'WINDOW_STDEVP',
-  'WINDOW_VARP',
-  'WINDOW_VAR',
-  'WINDOW_PERCENTILE',
-  'WINDOW_CORR',
-  'WINDOW_COVAR',
-];
-
-const AGG_RE = new RegExp(`\\b(${AGG_FUNCS.join('|')})\\s*\\(`, 'i');
-const TABLE_CALC_RE = new RegExp(`\\b(${TABLE_CALC_FUNCS.join('|')})\\s*\\(`, 'i');
-
-function stripLodBlocks(formula: string): string {
-  let prev: string;
-  let out = formula;
-  do {
-    prev = out;
-    out = out.replace(/\{[^{}]*\}/g, ' ');
-  } while (out !== prev);
-  return out;
-}
-
-function isAggregateOrTableCalc(formula: string): boolean {
-  if (TABLE_CALC_RE.test(formula)) return true;
-  return AGG_RE.test(stripLodBlocks(formula));
-}
 
 function isNoneDerivation(ci: Element): boolean {
   const derivation = ci.getAttribute('derivation');

--- a/src/desktop/validation/rules/mixedAggregationCalc.test.ts
+++ b/src/desktop/validation/rules/mixedAggregationCalc.test.ts
@@ -36,6 +36,18 @@ describe('mixed-aggregation-calc rule', () => {
     expect(mixedAggregationCalcRule.validate(wb(formula))).toHaveLength(0);
   });
 
+  it('does not treat an aggregate-looking bracketed field as an aggregate call', () => {
+    const formula = 'IF [Region]="West" THEN [Total (USD)] ELSE 0 END';
+    expect(checkFormula(formula)).toBe(false);
+    expect(mixedAggregationCalcRule.validate(wb(formula))).toHaveLength(0);
+  });
+
+  it('preserves an aggregate-looking bare field in a condition', () => {
+    const formula = 'IF [Total (USD)] > 0 THEN SUM([Sales]) ELSE 0 END';
+    expect(checkFormula(formula)).toBe(true);
+    expect(mixedAggregationCalcRule.validate(wb(formula))).toHaveLength(1);
+  });
+
   it('flags IIF with a bare-field condition and aggregate branches', () => {
     const formula = "IIF([Profit Tier] = 'Everyone Else', SUM([Profit]), SUM([Profit]) / 2)";
     expect(checkFormula(formula)).toBe(true);

--- a/src/desktop/validation/rules/mixedAggregationCalc.ts
+++ b/src/desktop/validation/rules/mixedAggregationCalc.ts
@@ -1,3 +1,7 @@
+import {
+  stripBracketedIdentifiers,
+  stripStringsAndComments,
+} from '../../metadata/calculation-classifier.js';
 import type { ValidationIssue, ValidationRule } from '../types.js';
 
 const AGG_FUNC_NAMES = [
@@ -61,82 +65,25 @@ function stripLodBlocks(formula: string): string {
   return out;
 }
 
-function stripStringsAndComments(formula: string): string {
-  const src = String(formula ?? '');
-  let out = '';
-  let inSingle = false;
-  let inDouble = false;
-  let inLineComment = false;
-  let inBlockComment = false;
-
-  for (let i = 0; i < src.length; i += 1) {
-    const c = src[i];
-    const next = i + 1 < src.length ? src[i + 1] : '';
-
-    if (inLineComment) {
-      if (c === '\n') {
-        inLineComment = false;
-        out += c;
-      }
-      continue;
-    }
-    if (inBlockComment) {
-      if (c === '*' && next === '/') {
-        inBlockComment = false;
-        i += 1;
-      }
-      continue;
-    }
-    if (inSingle) {
-      if (c === "'" && src[i - 1] !== '\\') inSingle = false;
-      out += ' ';
-      continue;
-    }
-    if (inDouble) {
-      if (c === '"' && src[i - 1] !== '\\') inDouble = false;
-      out += ' ';
-      continue;
-    }
-
-    if (c === '/' && next === '/') {
-      inLineComment = true;
-      i += 1;
-      continue;
-    }
-    if (c === '/' && next === '*') {
-      inBlockComment = true;
-      i += 1;
-      continue;
-    }
-    if (c === "'") {
-      inSingle = true;
-      out += ' ';
-      continue;
-    }
-    if (c === '"') {
-      inDouble = true;
-      out += ' ';
-      continue;
-    }
-
-    out += c;
-  }
-
-  return out;
-}
-
 function stripAggregateCalls(formula: string): string {
-  let prev: string;
   let out = formula;
-  do {
-    prev = out;
-    out = out.replace(AGG_CALL_RE, ' ');
-  } while (out !== prev);
-  return out;
+  let searchable = stripBracketedIdentifiers(formula);
+
+  while (true) {
+    const matches = [...searchable.matchAll(AGG_CALL_RE)];
+    if (matches.length === 0) return out;
+
+    for (const match of matches) {
+      const start = match.index;
+      const spaces = ' '.repeat(match[0].length);
+      out = out.slice(0, start) + spaces + out.slice(start + match[0].length);
+      searchable = searchable.slice(0, start) + spaces + searchable.slice(start + match[0].length);
+    }
+  }
 }
 
 function hasAggregateInExpression(expr: string): boolean {
-  const upper = stripLodBlocks(expr).toUpperCase();
+  const upper = stripBracketedIdentifiers(stripLodBlocks(expr)).toUpperCase();
   const re = /\b([A-Z_][A-Z0-9_]*)\s*\(/g;
   let m: RegExpExecArray | null;
   while ((m = re.exec(upper))) {


### PR DESCRIPTION
One classifier explains three separate defects we have been treating as unrelated: charts that render zero marks while every receipt reads clean, a caller's derivation override silently ignored, and a bin dimension silently dropped.

field-builder decided whether a calculated field was aggregated by asking whether its formula string contained `SUM(`. A level-of-detail formula such as `FLOOR({FIXED [Team Name] : SUM([Goals])} / 25) * 25` contains it, so it was classified as aggregated, took a `usr:` derivation, and its pill was dropped. The correct logic — strip LOD blocks, match on word boundaries, test table calcs against the raw formula — already shipped a few files away in the aggregate-calc validation rule. Nobody had wired them together.

This shares one classifier across the three call sites that had their own copies. It blanks strings and comments with a character scanner, removes bracketed identifiers so a field named `[Var (Budget)]` is not read as a `VAR()` call, then strips LOD blocks before the aggregate test. Net -185 lines against +301, most of the additions being tests.

Reviewed in three Opus rounds. The first caught that the word-boundary regexes had introduced a *new* instance of the same bug via field names; the second verified the sanitizer's order of operations (strings before brackets, so a `]` inside a string cannot shred a formula); the third closed the sibling rule that still carried the original pattern, an escaped-backslash case that could swallow a real aggregate, and the `]]` escape. Tests pin the exact live-failing formula at three levels including through the real field-building path. Validation run firsthand: 6415 passing, tsc clean, lint clean.

No performance claim is attached. A live A/B on this fix measured 113s, 307s and 321s across three runs of an identical ask, so run-to-run variance swamps any effect at that sample size; a paired 10-per-arm campaign is running separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)