### PR TITLE
fix(desktop): the readback verifier reports what it saw

### DIFF
--- a/resources/desktop/knowledge/tactics/workflow/failure-recovery-honesty.md
+++ b/resources/desktop/knowledge/tactics/workflow/failure-recovery-honesty.md
@@ -40,7 +40,7 @@ What does **NOT** work:
 
 - **Declaring "Tableau is unreachable" or "that datasource is gone" on the first `not_found`** without a session refresh. The far more common cause is a stale cache from before the user's change.
 - **Re-reading the same stale cache repeatedly** — calling `resolve-field` again against an un-refreshed `workbookFile` and expecting a different answer. `resolve-field` reads the file as-is; nothing changes until you refresh the file.
-- **Narrating success over a failed/unverified receipt** — e.g. answering "Done — sorted descending and filtered to Top 10" when the line reads `HOST VERIFICATION — failed: … readback FAILED (nodes dropped).` The nodes were dropped; the claim is false.
+- **Narrating success over a failed/unverified receipt** — e.g. answering "Done — sorted descending and filtered to Top 10" when the line reads `HOST VERIFICATION — failed: … readback did not match the intended nodes (listed above).` The readback does not support the claim.
 - **Treating a whole-workbook or dashboard `unverified` receipt as confirmation.** `unverified` means "not re-verified," not "verified." A `compose-dashboard` receipt is verified only after workbook XML confirms its zone tree and dashboard-window viewpoints.
 - **Inventing problems that nothing measured** when the receipt is `verified` — the guard text explicitly says not to report unlisted issues.
 
@@ -69,12 +69,12 @@ Equivalent refresh via a fresh snapshot: `get-workbook-xml({ session: "inst-1" }
 apply-worksheet({ ... }) →
   "Applied worksheet 'Sales by Region'.
 
-   HOST VERIFICATION — failed: preflight clean · apply completed · readback FAILED (nodes dropped).
+   HOST VERIFICATION — failed: preflight clean · apply completed · readback did not match the intended nodes (listed above).
    Do not claim the change is confirmed; report only the evidence above."
 ```
 
 - **Wrong:** "Done — I sorted by Sales descending and filtered to Top 10." (contradicts `failed`)
-- **Right:** the receipt says nodes were dropped, so re-read and correct before reporting:
+- **Right:** the receipt says the intended nodes did not match readback, so re-read and correct before reporting:
 
 ```
 1. get-worksheet-xml({ session, worksheet: "Sales by Region", mode: "file" })   # inspect what actually survived

--- a/src/desktop/validation/promise-check.test.ts
+++ b/src/desktop/validation/promise-check.test.ts
@@ -86,7 +86,7 @@ describe('promise check receipt (W-23447506)', () => {
       readback: { ok: false, status: 'failed' },
     });
     expect(text).toContain('HOST VERIFICATION — failed');
-    expect(text).toContain('readback FAILED');
+    expect(text).toContain('readback did not match the intended nodes (listed above)');
   });
 
   it('escalates promised computed-sort loss from warning to failed', () => {

--- a/src/desktop/validation/promise-check.ts
+++ b/src/desktop/validation/promise-check.ts
@@ -71,7 +71,7 @@ export function formatWorksheetPromiseCheck(input: WorksheetReceiptInput): strin
       parts.push('readback warnings (listed above)');
       break;
     case 'failed':
-      parts.push('readback FAILED (nodes dropped)');
+      parts.push('readback did not match the intended nodes (listed above)');
       break;
     case 'skipped':
     default:

--- a/src/desktop/validation/readback-verify.test.ts
+++ b/src/desktop/validation/readback-verify.test.ts
@@ -1,10 +1,18 @@
 import { describe, expect, it } from 'vitest';
 
-import { verifyWorksheetReadback } from './readback-verify.js';
+import {
+  formatReadbackVerificationError,
+  formatReadbackVerificationWarnings,
+  verifyWorksheetReadback,
+} from './readback-verify.js';
 
 const GEO_FIELD = '[DS].[none:State:nk]';
 const PROFIT_FIELD = '[DS].[sum:Profit:qk]';
 const SALES_FIELD = '[DS].[sum:Sales:qk]';
+const GROUP_FIELD = '[DS].[none:Group Name:nk]';
+const SNAPSHOT_FIELD = 'Day-Trunc([DS].[Snapshot Time])';
+const TEAM_FIELD = '[DS].[none:Team:nk]';
+const BINARY_COPY_FIELD = '[DS].[none:Binary (copy):nk]';
 
 function worksheet(inner: string): string {
   return `<worksheet name="Blank Map"><table>${inner}</table></worksheet>`;
@@ -115,6 +123,96 @@ describe('verifyWorksheetReadback', () => {
     );
   });
 
+  it.each([
+    {
+      shelf: 'cols',
+      intended: GROUP_FIELD,
+      readback: `(${GROUP_FIELD})`,
+    },
+    {
+      shelf: 'cols',
+      intended: `${GROUP_FIELD} / ${SNAPSHOT_FIELD}`,
+      readback: `( ${SNAPSHOT_FIELD} * ${GROUP_FIELD} )`,
+    },
+    {
+      shelf: 'cols',
+      intended: `${GROUP_FIELD} / ${SNAPSHOT_FIELD} / ${TEAM_FIELD}`,
+      readback: `( ${GROUP_FIELD} * ( ${SNAPSHOT_FIELD} * ${TEAM_FIELD} ) )`,
+    },
+    {
+      shelf: 'rows',
+      intended: GROUP_FIELD,
+      readback: `(${GROUP_FIELD})`,
+    },
+    {
+      shelf: 'rows',
+      intended: `${GROUP_FIELD} / ${SNAPSHOT_FIELD}`,
+      readback: `(${GROUP_FIELD}*${SNAPSHOT_FIELD})`,
+    },
+    {
+      shelf: 'rows',
+      intended: `${GROUP_FIELD} / ${SNAPSHOT_FIELD} / ${TEAM_FIELD}`,
+      readback: `((${TEAM_FIELD} * ${GROUP_FIELD})*${SNAPSHOT_FIELD})`,
+    },
+  ])(
+    'compares the declared field set for $shelf shelf expressions',
+    ({ shelf, intended, readback }) => {
+      const intendedXml = worksheet(`<${shelf}>${intended}</${shelf}>`);
+      const readbackXml = worksheet(`<${shelf}>${readback}</${shelf}>`);
+
+      expect(verifyWorksheetReadback(intendedXml, readbackXml)).toEqual([]);
+    },
+  );
+
+  it('still flags a field genuinely absent from a combined shelf expression', () => {
+    const intended = worksheet(`<cols>(${GROUP_FIELD} * ${SNAPSHOT_FIELD})</cols>`);
+    const readback = worksheet(`<cols>${GROUP_FIELD}</cols>`);
+
+    expect(verifyWorksheetReadback(intended, readback)).toContainEqual({
+      kind: 'shelf',
+      node: 'cols',
+      column: SNAPSHOT_FIELD,
+      intended: SNAPSHOT_FIELD,
+      readback: 'changed',
+      severity: 'error',
+    });
+  });
+
+  it('displays the raw field name while matching shelves by normalized value', () => {
+    const intended = worksheet(`<cols>${BINARY_COPY_FIELD}</cols>`);
+    const readback = worksheet('<cols></cols>');
+
+    expect(verifyWorksheetReadback(intended, readback)).toContainEqual({
+      kind: 'shelf',
+      node: 'cols',
+      column: BINARY_COPY_FIELD,
+      intended: BINARY_COPY_FIELD,
+      readback: 'missing',
+      severity: 'error',
+    });
+  });
+
+  it('ignores spacing differences around plus shelf expressions', () => {
+    const intended = worksheet(`<cols>(${PROFIT_FIELD} + ${SALES_FIELD})</cols>`);
+    const readback = worksheet(`<cols>(${PROFIT_FIELD}+${SALES_FIELD})</cols>`);
+
+    expect(verifyWorksheetReadback(intended, readback)).toEqual([]);
+  });
+
+  it('does not deduplicate a repeated field in a plus shelf expression', () => {
+    const intended = worksheet(`<cols>(${SALES_FIELD} + ${SALES_FIELD})</cols>`);
+    const readback = worksheet(`<cols>${SALES_FIELD}</cols>`);
+
+    expect(verifyWorksheetReadback(intended, readback)).toContainEqual({
+      kind: 'shelf',
+      node: 'cols',
+      column: `${SALES_FIELD} + ${SALES_FIELD}`,
+      intended: `${SALES_FIELD} + ${SALES_FIELD}`,
+      readback: 'changed',
+      severity: 'error',
+    });
+  });
+
   it('does not flag an authored Automatic mark that Tableau resolved to a concrete class', () => {
     const intended = encodedWorksheet().replace(
       '<mark class="Shape"/>',
@@ -157,6 +255,42 @@ describe('verifyWorksheetReadback', () => {
   });
 });
 
+describe('readback finding messages', () => {
+  it('describes the missing readback evidence without asserting chart failure', () => {
+    const findings = [
+      {
+        kind: 'shelf',
+        node: 'cols',
+        column: SNAPSHOT_FIELD,
+        intended: SNAPSHOT_FIELD,
+        readback: 'missing',
+        severity: 'error',
+      },
+    ] as const;
+
+    expect(formatReadbackVerificationError([...findings])).toBe(
+      `Readback had no exact match for intended <cols column="${SNAPSHOT_FIELD}">. Inspect the readback XML and rendered chart before relying on the result.`,
+    );
+  });
+
+  it('describes the unmatched sort evidence in the warning', () => {
+    const findings = [
+      {
+        kind: 'sort',
+        node: 'computed-sort',
+        column: GEO_FIELD,
+        intended: '<computed-sort>',
+        readback: 'changed',
+        severity: 'warning',
+      },
+    ] as const;
+
+    expect(formatReadbackVerificationWarnings([...findings])).toBe(
+      `\n\n⚠️ Readback verification warning — readback had no exact match for intended <computed-sort column="${GEO_FIELD}">. Inspect the readback XML and rendered chart before relying on the result.`,
+    );
+  });
+});
+
 describe('verifyWorksheetReadback — column-instance co-dependency (RT finding RB-03)', () => {
   const withDeps = (deps: string): string =>
     `<worksheet name="Map"><table>
@@ -194,5 +328,28 @@ describe('verifyWorksheetReadback — column-instance co-dependency (RT finding 
 
   it('does not fire when the intended XML never declared the instance either', () => {
     expect(verifyWorksheetReadback(withDeps(''), withDeps(''))).toHaveLength(0);
+  });
+
+  it('flags a surviving shelf pill whose column-instance declaration was dropped', () => {
+    const binField = '[DS].[bin:Sales:qk]';
+    const binCI =
+      '<column-instance column="[Sales]" derivation="Bin" name="[bin:Sales:qk]" pivot="key" type="quantitative"/>';
+    const intended = withDeps(binCI).replace(
+      '<rows>[DS].[avg:Latitude:qk]</rows>',
+      `<rows>${binField}</rows>`,
+    );
+    const readback = withDeps('').replace(
+      '<rows>[DS].[avg:Latitude:qk]</rows>',
+      `<rows>${binField}</rows>`,
+    );
+
+    expect(verifyWorksheetReadback(intended, readback)).toContainEqual({
+      kind: 'encoding',
+      node: 'column-instance',
+      column: '[bin:Sales:qk]',
+      intended: '<column-instance name="[bin:Sales:qk]">',
+      readback: 'missing',
+      severity: 'error',
+    });
   });
 });

--- a/src/desktop/validation/readback-verify.ts
+++ b/src/desktop/validation/readback-verify.ts
@@ -55,11 +55,16 @@ interface SortSignature {
   field: string;
 }
 
+interface ShelfFieldSignature {
+  normalized: string;
+  raw: string;
+}
+
 interface WorksheetSignature {
   encodings: EncodingSignature[];
   shelves: {
-    rows: string[];
-    cols: string[];
+    rows: Map<string, string>;
+    cols: Map<string, string>;
   };
   marks: MarkSignature[];
   filters: FilterSignature[];
@@ -110,11 +115,82 @@ function walkElements(node: unknown, visit: (tag: string, element: XmlRecord) =>
   }
 }
 
-function shelfValues(value: unknown): string[] {
-  return normalizeArray(value)
-    .flatMap((item) => textValue(item).split('/'))
-    .map((item) => item.trim())
-    .filter(Boolean);
+function stripEnclosingParentheses(value: string): string {
+  if (!value.startsWith('(') || !value.endsWith(')')) return value;
+
+  let parentheses = 0;
+  let brackets = 0;
+  for (let index = 0; index < value.length; index += 1) {
+    const character = value[index];
+    if (character === '[') brackets += 1;
+    if (character === ']' && brackets > 0) brackets -= 1;
+    if (brackets > 0) continue;
+    if (character === '(') parentheses += 1;
+    if (character === ')') parentheses -= 1;
+    if (parentheses === 0 && index < value.length - 1) return value;
+  }
+
+  return parentheses === 0 ? value.slice(1, -1).trim() : value;
+}
+
+function normalizeShelfField(value: string): string {
+  const normalized = value
+    .trim()
+    .replace(/\s+/g, ' ')
+    .replace(/\s*\(\s*/g, '(')
+    .replace(/\s*\)\s*/g, ')');
+  let out = '';
+  let brackets = 0;
+  for (let index = 0; index < normalized.length; index += 1) {
+    const character = normalized[index];
+    if (character === '[') brackets += 1;
+    if (character === ']' && brackets > 0) brackets -= 1;
+    if (character !== '+' || brackets > 0) {
+      out += character;
+      continue;
+    }
+    out = out.trimEnd() + '+';
+    while (normalized[index + 1] === ' ') index += 1;
+  }
+  return out;
+}
+
+function declaredShelfFields(expression: string): ShelfFieldSignature[] {
+  const unwrapped = stripEnclosingParentheses(expression.trim());
+  const parts: string[] = [];
+  let start = 0;
+  let parentheses = 0;
+  let brackets = 0;
+
+  for (let index = 0; index < unwrapped.length; index += 1) {
+    const character = unwrapped[index];
+    if (character === '[') brackets += 1;
+    if (character === ']' && brackets > 0) brackets -= 1;
+    if (brackets > 0) continue;
+    if (character === '(') parentheses += 1;
+    if (character === ')') parentheses -= 1;
+    if (parentheses === 0 && (character === '*' || character === '/')) {
+      parts.push(unwrapped.slice(start, index));
+      start = index + 1;
+    }
+  }
+
+  if (parts.length === 0) {
+    const raw = unwrapped.trim();
+    const normalized = normalizeShelfField(raw);
+    return normalized ? [{ normalized, raw }] : [];
+  }
+
+  parts.push(unwrapped.slice(start));
+  return parts.flatMap(declaredShelfFields);
+}
+
+function shelfValues(value: unknown): Map<string, string> {
+  return new Map(
+    normalizeArray(value)
+      .flatMap((item) => declaredShelfFields(textValue(item)))
+      .map(({ normalized, raw }) => [normalized, raw]),
+  );
 }
 
 function collectEncodings(worksheet: XmlRecord): EncodingSignature[] {
@@ -295,14 +371,31 @@ export function verifyWorksheetReadback(
   }
 
   for (const shelf of ['rows', 'cols'] as const) {
-    for (const value of intended.shelves[shelf]) {
-      if (readback.shelves[shelf].includes(value)) continue;
+    for (const [normalized, raw] of intended.shelves[shelf]) {
+      if (readback.shelves[shelf].has(normalized)) continue;
       findings.push({
         kind: 'shelf',
         node: shelf,
-        column: value,
-        intended: value,
-        readback: readback.shelves[shelf].length > 0 ? 'changed' : 'missing',
+        column: raw,
+        intended: raw,
+        readback: readback.shelves[shelf].size > 0 ? 'changed' : 'missing',
+        severity: 'error',
+      });
+    }
+  }
+
+  for (const shelf of ['rows', 'cols'] as const) {
+    for (const [normalized, raw] of intended.shelves[shelf]) {
+      const instanceName = instanceNameFromColumnRef(raw);
+      if (!instanceName || !intended.declaredInstances.has(instanceName)) continue;
+      if (readback.declaredInstances.has(instanceName)) continue;
+      if (!readback.shelves[shelf].has(normalized)) continue; // shelf loss already reported above
+      findings.push({
+        kind: 'encoding',
+        node: 'column-instance',
+        column: instanceName,
+        intended: `<column-instance name="${instanceName}">`,
+        readback: 'missing',
         severity: 'error',
       });
     }
@@ -363,11 +456,7 @@ export function formatReadbackFinding(finding: ReadbackFinding): string {
 export function formatReadbackVerificationError(findings: ReadbackFinding[]): string {
   const errors = findings.filter((finding) => finding.severity === 'error');
   if (errors.length === 0) return '';
-  return (
-    `apply succeeded but Tableau silently dropped: ${errors.map(formatReadbackFinding).join(', ')}. ` +
-    'The rendered chart does NOT match the intent — likely an invalid/unsupported node. ' +
-    'Fix the worksheet XML to use Tableau-supported shelf, mark, filter, and encoding nodes, then re-apply.'
-  );
+  return `Readback had no exact match for intended ${errors.map(formatReadbackFinding).join(', ')}. Inspect the readback XML and rendered chart before relying on the result.`;
 }
 
 export function formatReadbackVerificationStatus(
@@ -380,5 +469,5 @@ export function formatReadbackVerificationStatus(
 export function formatReadbackVerificationWarnings(findings: ReadbackFinding[]): string {
   const warnings = findings.filter((finding) => finding.severity === 'warning');
   if (warnings.length === 0) return '';
-  return `\n\n⚠️ Readback verification warning — Tableau changed or dropped: ${warnings.map(formatReadbackFinding).join(', ')}. Re-check the rendered chart before moving on.`;
+  return `\n\n⚠️ Readback verification warning — readback had no exact match for intended ${warnings.map(formatReadbackFinding).join(', ')}. Inspect the readback XML and rendered chart before relying on the result.`;
 }

--- a/src/tools/desktop/binder/bindTemplate.test.ts
+++ b/src/tools/desktop/binder/bindTemplate.test.ts
@@ -5250,7 +5250,7 @@ describe('bindTemplateTool host verification on the bind hot path', () => {
     expect(applied.guidance).toContain('Done — no further tool calls needed');
   });
 
-  it('a dropped node is reported and the bind is no longer terminal', async () => {
+  it('a readback mismatch is reported and the bind is no longer terminal', async () => {
     const mocks = setupAutoApplyMocks({ inject: { ok: true, xml: INJECTED_RANKING_WORKBOOK_XML } });
     // Tableau accepted the document but rendered a different mark than the one we wrote.
     let read = 0;
@@ -5275,7 +5275,7 @@ describe('bindTemplateTool host verification on the bind hot path', () => {
 
     expect(applied.applied).toBe(true);
     expect(applied.guidance).toContain('HOST VERIFICATION — failed');
-    expect(applied.guidance).toContain('readback FAILED (nodes dropped)');
+    expect(applied.guidance).toContain('readback did not match the intended nodes (listed above)');
     expect(applied.guidance).not.toContain('Done — no further tool calls needed');
     expect(
       (result.structuredContent as { nextAction?: { kind: string } } | undefined)?.nextAction?.kind,


### PR DESCRIPTION
Across five live cold-ask runs this verifier raised six false failures and missed the one real one. The false alarms are not free: in one run the agent spent about a dozen calls chasing a warning about nothing.

The confirmed cause: it did not understand a combined `(A * B)` shelf expression. It looked for separate `<cols column=…>` child nodes, found none, and reported dropped nodes on an apply that was correct. Shelves are now compared as sets of fields. `+` is spacing-normalized but deliberately not split, because a bump chart legitimately carries the same measure twice and a set would dedupe that into silence.

Two smaller honesty fixes: findings displayed a normalized field name, handing the agent a name that does not exist in the workbook to go looking for — they now match on the normalized key and display the raw one. And the failure message asserted a conclusion ("readback FAILED (nodes dropped)") that the code cannot support; it now states what did not match.

It also adds the one detection honestly available: a calculation declared in the intended XML and absent from the readback is a provably inert pill. Bin *placement* is still not claimed, because a declaration cannot prove it — that restraint is deliberate and the reviewer agreed with it.

Known and left alone, with evidence rather than a guess: the sort signature reads `column`/`using`/`field` while the real XML uses `dimension-to-sort`/`measure-to-sort-by`, so a re-targeted sort compares equal. Fixing it needs live pane evidence we do not have; it is logged rather than guessed at.

Two Opus rounds. Validation run firsthand: 6400 passing, tsc clean, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)