### PR TITLE
@W-23633781 - Make tableau-mcp-desktop serve both profiles (desktop stdio + web http)

### DIFF
--- a/src/index.desktop.ts
+++ b/src/index.desktop.ts
@@ -1,15 +1,38 @@
+#!/usr/bin/env node
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { SetLevelRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 import dotenv from 'dotenv';
 
+import pkg from '../package.json';
 import { getDesktopConfig } from './config.desktop.js';
+import { getConfig } from './config.js';
+import { initializeFeatureGate } from './features/init.js';
+import { getTableauServerInfo } from './getTableauServerInfo.js';
 import { FileLogger, setFileLogger } from './logging/fileLogger.js';
 import { log } from './logging/logger.js';
 import { isNotificationLevel, notifier, setNotificationLevel } from './logging/notification.js';
+import { RestApi } from './sdks/tableau/restApi.js';
 import { DesktopMcpServer } from './server.desktop.js';
+import { startExpressServer } from './server/express.js';
+import { resolveTransportProfile } from './transportProfile.js';
 
-async function startServer(): Promise<void> {
-  dotenv.config();
+const serverVersion = pkg.version;
+
+// The shipped tableau-mcp-desktop binary now serves BOTH profiles from one artifact,
+// selected purely by TRANSPORT — so tab-agent-south can spawn the web/insights profile
+// from the very same installed binary it launches for desktop authoring, without a
+// second bundled artifact (Chiron insights "B1"):
+//
+//   TRANSPORT=stdio (default) -> desktop authoring profile: DesktopMcpServer over
+//     stdio, driving the local Tableau Desktop via the External Client API. No
+//     Tableau Server credentials.
+//   TRANSPORT=http            -> web/insights profile: the Express server calling
+//     Tableau Server/Cloud REST (OAuth or passthrough wg_session auth), mirroring the
+//     http case of src/index.ts.
+//
+// stdio behaviour is unchanged for existing desktop consumers; http is additive.
+
+async function startDesktopProfile(): Promise<void> {
   const config = getDesktopConfig();
 
   const notificationLevel = isNotificationLevel(config.defaultNotificationLevel)
@@ -22,10 +45,6 @@ async function startServer(): Promise<void> {
         fileNamePrefix: 'desktop-mcp-',
       }),
     );
-  }
-
-  if (config.transport !== 'stdio') {
-    throw new Error('Transport must be stdio for Desktop server');
   }
 
   const server = new DesktopMcpServer();
@@ -41,6 +60,85 @@ async function startServer(): Promise<void> {
 
   setNotificationLevel(server.mcpServer, notificationLevel);
   notifier.info(server.mcpServer, `${server.name} v${server.version} running on stdio`);
+}
+
+async function startWebProfile(): Promise<void> {
+  const config = getConfig();
+
+  RestApi.host = config.server;
+
+  // Initialize feature gate provider
+  initializeFeatureGate();
+
+  // Start fetching server info immediately but don't block the port from opening.
+  // Any failure here is fatal and logged explicitly -- no silent failures. The port
+  // opens first so health checks can succeed, then we await this before declaring ready.
+  const serverInfoReady = getTableauServerInfo(config.server).catch((error) => {
+    log({
+      message: 'Fatal error initializing server info',
+      level: 'error',
+      logger: 'startup',
+      data: error,
+    });
+    process.exit(1);
+  });
+
+  const notificationLevel = isNotificationLevel(config.defaultNotificationLevel)
+    ? config.defaultNotificationLevel
+    : 'debug';
+  if (config.loggers.has('fileLogger')) {
+    setFileLogger(new FileLogger({ logDirectory: config.fileLoggerDirectory }));
+  }
+
+  const { url } = await startExpressServer({
+    basePath: 'tableau-mcp',
+    config,
+    logLevel: notificationLevel,
+  });
+
+  // Port is now open. Wait for server info before logging the ready message.
+  await serverInfoReady;
+
+  if (!config.oauth.enabled) {
+    log({
+      message:
+        '⚠️ TRANSPORT is "http" but OAuth is disabled! Your MCP server may not be protected from unauthorized access. Non-OAuth HTTP usage is intended only for testing/prototyping or deployments that are licensed and approved for user-based licensing (UBL). For general multi-user HTTP deployments, prefer OAuth. By explicitly disabling OAuth with DANGEROUSLY_DISABLE_OAUTH="true", confirm this matches your Tableau licensing/security guidance.',
+      level: 'info',
+      logger: 'startup',
+    });
+  }
+
+  log({
+    message: `tableau-mcp v${serverVersion} ${config.disableSessionManagement ? 'stateless ' : ''}streamable HTTP server available at ${url}`,
+    level: 'info',
+    logger: 'startup',
+  });
+
+  if (config.disableLogMasking) {
+    log({ message: '⚠️ Log masking is disabled!', level: 'info', logger: 'startup' });
+  }
+
+  if (config.breakGlassDisableGlobally) {
+    log({
+      message:
+        '⚠️ BREAK_GLASS_DISABLE_GLOBALLY is enabled! This means that the MCP server will be disabled globally and will return errors to all users!',
+      level: 'info',
+      logger: 'startup',
+    });
+  }
+}
+
+async function startServer(): Promise<void> {
+  dotenv.config();
+  // Profile is selected (and TRANSPORT validated) before any profile-specific config is
+  // loaded: getDesktopConfig() requires stdio, getConfig() (web) requires SERVER/auth, so
+  // we must not construct the wrong one — and an invalid transport must not fail open to
+  // the HTTP path (see resolveTransportProfile).
+  if (resolveTransportProfile(process.env.TRANSPORT) === 'desktop') {
+    await startDesktopProfile();
+  } else {
+    await startWebProfile();
+  }
 }
 
 startServer().catch((error) => {

--- a/src/transportProfile.test.ts
+++ b/src/transportProfile.test.ts
@@ -1,0 +1,21 @@
+import { resolveTransportProfile } from './transportProfile.js';
+
+describe('resolveTransportProfile', () => {
+  it('defaults to the desktop profile when TRANSPORT is unset', () => {
+    expect(resolveTransportProfile(undefined)).toBe('desktop');
+  });
+
+  it('maps stdio to the desktop authoring profile', () => {
+    expect(resolveTransportProfile('stdio')).toBe('desktop');
+  });
+
+  it('maps http to the web/insights profile', () => {
+    expect(resolveTransportProfile('http')).toBe('web');
+  });
+
+  it('throws on an invalid transport instead of failing open to the web path', () => {
+    expect(() => resolveTransportProfile('htpp')).toThrow(/Unsupported TRANSPORT/);
+    expect(() => resolveTransportProfile('sse')).toThrow(/expected "stdio"/);
+    expect(() => resolveTransportProfile('')).toThrow(/Unsupported TRANSPORT/);
+  });
+});

--- a/src/transportProfile.ts
+++ b/src/transportProfile.ts
@@ -1,0 +1,19 @@
+export type TransportProfile = 'desktop' | 'web';
+
+// The shipped tableau-mcp-desktop binary serves one profile per process, selected by
+// TRANSPORT. Validate here (rather than treating "not stdio" as web) so a typo fails
+// fast instead of failing open to the OAuth-disabled HTTP startup path: getConfig()
+// would normalize an unknown transport back to stdio while this entrypoint had already
+// started the Express server against it.
+export function resolveTransportProfile(transport: string | undefined): TransportProfile {
+  const t = transport ?? 'stdio';
+  if (t === 'stdio') {
+    return 'desktop';
+  }
+  if (t === 'http') {
+    return 'web';
+  }
+  throw new Error(
+    `Unsupported TRANSPORT "${t}" for the tableau-mcp-desktop server; expected "stdio" (desktop authoring profile) or "http" (web/insights profile).`,
+  );
+}


### PR DESCRIPTION
## Summary

The shipped **`tableau-mcp-desktop`** binary now serves **both** profiles from one artifact, selected by `TRANSPORT` — `stdio` → desktop authoring (unchanged), `http` → web/insights. This lets `tab-agent-south` spawn the web profile from the **same installed binary** it already launches for desktop authoring, so Chiron's **B1** needs **no new release artifact** and **no `upload-binaries.yml` / Southard packaging change**.

> Reworked from the earlier approach (a separate `bundled` SEA variant, per the discussion below): reusing the existing `tableau-mcp-desktop` name keeps the release workflow and Southard packaging untouched, and drops the extra variant.

## Changes
- **`src/index.desktop.ts`** — dispatch on `TRANSPORT`: `stdio` → `getDesktopConfig()` + `DesktopMcpServer` (the unchanged desktop authoring path); `http` → `getConfig()` + `startExpressServer` (mirrors `index.ts`'s http case). `stdio` behaviour is unchanged for existing desktop/npm consumers; `http` is additive.
- **`src/transportProfile.ts`** — `resolveTransportProfile(TRANSPORT)` returns `desktop`/`web` and **throws** on anything else, so a typo can't fail open to the OAuth‑disabled HTTP path. Unit‑tested in `src/transportProfile.test.ts`.

The separate `bundled` SEA variant (and its `variants.ts`/`buildSea.ts`/`build.ts`/`prepareVariantPackage.ts`/`package.json` additions) is dropped as redundant.

## Companion change (separate MR)
`tab-agent-south` drops the `_looks_desktop_only` discovery guard so the now‑web‑capable `tableau-mcp-desktop` is accepted for the web profile (the guard existed only to reject the *old* stdio‑only desktop SEA). It's a separate MR, gated on this shipping — an old desktop binary + guard‑removed backend soft‑degrades (Increment C) rather than crashes.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `transportProfile.test.ts` — dispatch unit tests (unset / stdio / http / invalid) pass (4/4)
- [x] `tsx src/scripts/build.ts --variant desktop` → builds `build/index.desktop.js` + stages the desktop‑data allowlist
- [x] eslint clean
- [x] **Both profiles from the desktop binary (local):** `stdio` → 31 desktop authoring tools; `http` → boots the web/insights server (`tableau-mcp v2.47.0 streamable HTTP server available…`); and driven through `tab-agent-south` + the real UI it returned **real Pulse insight cards** for GUS‑Work.
- [ ] released‑SEA http smoke — CI/reviewer

## Notes
- Base is **`feature/desktop`**.
- **"One binary":** the installer keeps vendoring the single `tableau-mcp-desktop` (now dual‑profile). `tableau-mcp`'s other variants (`default` web, `combined`) are unchanged and remain for their own consumers.
- **Naming:** `tableau-mcp-desktop` serving `http` is a mild misnomer, kept intentionally so the release workflow + Southard packaging need **no** change (a rename is exactly what would force those edits). Open to a follow‑up rename if preferred.
