### PR TITLE
@W-23635879: Fix MCP Apps embed PARSE_ERROR on empty tool-result re-delivery

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "4.0.0",
+      "version": "4.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.7.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/src/web/apps/src/embed/handleToolResult.test.ts
+++ b/src/web/apps/src/embed/handleToolResult.test.ts
@@ -344,6 +344,61 @@ describe('handleToolResult', () => {
     expect(vi.mocked(setupOpenInTableauLink)).toHaveBeenCalledTimes(1);
   });
 
+  it('no-ops on an empty (dataless) delivery instead of showing PARSE_ERROR', async () => {
+    // The host can re-fire ui/notifications/tool-result on a re-render/re-mount with a
+    // protocol-legal but empty result (content: [], no structuredContent). There is nothing to
+    // embed, so this must be a silent no-op — NOT a PARSE_ERROR.
+    const emptyResult: CallToolResult = {
+      content: [],
+    };
+
+    await handleToolResult(mockApp, emptyResult);
+    await new Promise((r) => setTimeout(r, 0));
+
+    const container = document.getElementById('tableauVizContainer');
+
+    // NO error UI displayed
+    expect(container?.querySelector('.mcp-app-error')).toBeNull();
+
+    // No embedding attempted and no telemetry event recorded
+    expect(vi.mocked(embedTableauViz)).not.toHaveBeenCalled();
+    expect(vi.mocked(recordEvent)).not.toHaveBeenCalled();
+  });
+
+  it('does not overwrite an existing render when an empty re-delivery arrives', async () => {
+    // First delivery: happy path renders a viz.
+    const validResult: CallToolResult = {
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify({
+            url: 'https://prod-uswest-c.online.tableau.com/site/mysite/views/workbook/view',
+          }),
+        },
+      ],
+    };
+
+    vi.mocked(callGetEmbedTokenTool).mockResolvedValue('test-token-123');
+    vi.mocked(embedTableauViz).mockImplementation((_url, _token) => {
+      const container = document.getElementById('tableauVizContainer');
+      container?.replaceChildren(document.createElement('tableau-viz'));
+    });
+    vi.mocked(setupOpenInTableauLink).mockImplementation(() => {});
+
+    await handleToolResult(mockApp, validResult);
+    await new Promise((r) => setTimeout(r, 0));
+
+    const container = document.getElementById('tableauVizContainer');
+    expect(container?.querySelector('tableau-viz')).toBeTruthy();
+
+    // Second delivery: empty re-fire. Must leave the rendered viz intact and show no error.
+    await handleToolResult(mockApp, { content: [] });
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(container?.querySelector('tableau-viz')).toBeTruthy();
+    expect(container?.querySelector('.mcp-app-error')).toBeNull();
+  });
+
   it('reports telemetry with the tool error message when a tool error occurs', async () => {
     const errorResult: CallToolResult = {
       isError: true,

--- a/src/web/apps/src/embed/handleToolResult.ts
+++ b/src/web/apps/src/embed/handleToolResult.ts
@@ -38,6 +38,19 @@ export function extractUrlObjectFromResult(result: CallToolResult): string {
 }
 
 /**
+ * Whether a delivery carries no usable payload (empty `content`, no `structuredContent`).
+ * Empty `content` is protocol-legal (MCP defaults it to `[]`), so this is not a parse failure —
+ * just nothing to render. Content that is present but unparseable is NOT empty and still surfaces
+ * PARSE_ERROR downstream.
+ */
+function isEmptyDelivery(result: CallToolResult): boolean {
+  const hasContent = Array.isArray(result.content) && result.content.length > 0;
+  const hasStructuredContent =
+    result.structuredContent != null && Object.keys(result.structuredContent).length > 0;
+  return !hasContent && !hasStructuredContent;
+}
+
+/**
  * Handles a tool result from an embed-Tableau-viz tool (get-view / get-workbook) and embeds the viz.
  * @param app - The MCP App instance
  * @param result - The tool result containing the view URL
@@ -46,6 +59,12 @@ export async function handleToolResult(app: App, result: CallToolResult): Promis
   if (!result || result.isError) {
     const cause = result ? extractToolErrorMessage(result) : undefined;
     showError('TOOL_ERROR', cause, app);
+    return;
+  }
+
+  // Empty re-delivery: the host can re-fire tool-result with no payload on a re-render/re-mount.
+  // Nothing to embed, so no-op and keep the current render instead of overwriting it with an error.
+  if (isEmptyDelivery(result)) {
     return;
   }
 


### PR DESCRIPTION
## Description

Fix MCP Apps embed throwing PARSE_ERROR when the MCP host re-delivers an empty tool-result notification on re-render/re-mount.

## Motivation and Context

Sometimes the client receives empty tool results shortly after the original tool result renders the viz, its not coming from the server. This causes the app to render initially, and later fail with an error. Im adding this client side guard to simply return if it receives an empty tool result, which should be fine as tool errors are already handled, so this case should not let through any actual error scenarios and only guard against this specific behavior.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## How Has This Been Tested?

Unit tests: `npx vitest run` — full suite 2581 tests pass, including 2 new tests in `handleToolResult.test.ts` covering:
- Empty-delivery no-op case
- Re-delivery-preserves-render case

Independent review passed (VERDICT: PASS).

## Related Issues

W-23635879

## Checklist

- [ ] I have updated the version in the package.json file by using `npm run version`. For example, use `npm run version:patch` for a patch version bump.
- [ ] I have made any necessary changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have documented any breaking changes in the PR description. For example, renaming a config environment variable or changing its default value.

## Contributor Agreement

By submitting this pull request, I confirm that:

- [x] I have read the [CONTRIBUTING guidelines](../../CONTRIBUTING.md) for this project and followed its Contribution Checklist.