### PR TITLE
@W-23653166: fix broken admonition syntax on admin-tool doc pages

### DIFF
--- a/docs/docs/configuration/mcp-config/env-vars.md
+++ b/docs/docs/configuration/mcp-config/env-vars.md
@@ -386,7 +386,7 @@ The feature gate provider to use for feature flag management.
   - `server` - File-based feature gate using `features.json` (default, for on-premise Tableau Server)
   - `custom` - Load a custom feature gate provider from a user-specified module
 
-:::tip Custom Provider
+:::tip[Custom Provider]
 
 To use a custom feature gate provider, set `FEATURE_GATE_PROVIDER=custom` and provide the module path via `FEATURE_GATE_PROVIDER_CONFIG`:
 

--- a/docs/docs/tools/admin-insights/query-admin-insights.md
+++ b/docs/docs/tools/admin-insights/query-admin-insights.md
@@ -18,10 +18,11 @@ report through a single entry point. Dispatches on `kind` to one of four backend
   ([`STALE_CONTENT_MAX_ROWS`](../../configuration/mcp-config/env-vars.md#stale_content_max_rows),
   default `100`) — see [Row cap](#row-cap-stale-content).
 
-The tool is admin-only — it is registered only when `ADMIN_TOOLS_ENABLED=true`, and at request
-time it verifies the caller's site role and rejects anything below
-`SiteAdministratorCreator` / `SiteAdministratorExplorer` / `ServerAdministrator`. Admin Insights
-datasource LUIDs are resolved automatically; callers do not pass `datasourceLuid`.
+:::warning[Admin Only]
+This tool is restricted to Tableau site administrators and requires the `ADMIN_TOOLS_ENABLED` environment variable to be enabled.
+:::
+
+Admin Insights datasource LUIDs are resolved automatically; callers do not pass `datasourceLuid`.
 
 
 ## APIs called

--- a/docs/docs/tools/content/delete-content.md
+++ b/docs/docs/tools/content/delete-content.md
@@ -11,9 +11,9 @@ Permanently deletes a workbook, published data source, or extract refresh task. 
 - `datasource` — deletes a published data source (recoverable via recycle bin; warns on downstream dependents)
 - `extract-refresh-task` — deletes an extract refresh task schedule (permanent, not recoverable)
 
-The tool is **admin-only** — it is registered only when `ADMIN_TOOLS_ENABLED=true`, and at
-request time it verifies the caller's site role and rejects anything below
-`SiteAdministratorCreator` / `SiteAdministratorExplorer` / `ServerAdministrator`.
+:::warning[Admin Only]
+This tool is restricted to Tableau site administrators and requires the `ADMIN_TOOLS_ENABLED` environment variable to be enabled.
+:::
 
 
 ## Two-phase safety
@@ -36,7 +36,7 @@ The tool is **two-phase** to keep the destructive action safe:
      preview.
    - Performs the deletion.
 
-:::warning Human confirmation required
+:::warning[Human confirmation required]
 Between the preview and the confirm, the calling agent is instructed to surface the resource
 identity to the user and obtain explicit approval. This is a prompt-level expectation; the
 tag/nonce gate proves a preview ran but cannot observe whether a human actually approved.

--- a/docs/docs/tools/jobs/list-jobs.md
+++ b/docs/docs/tools/jobs/list-jobs.md
@@ -6,7 +6,7 @@ sidebar_position: 1
 
 Retrieves a list of background jobs for the Tableau site. Each job represents a background task such as an extract refresh, subscription delivery, flow run, or other asynchronous operations.
 
-:::warning Admin Only
+:::warning[Admin Only]
 This tool is restricted to Tableau site administrators and requires the `ADMIN_TOOLS_ENABLED` environmnet variable to be enabled.
 :::
 

--- a/docs/docs/tools/tasks/list-extract-refresh-tasks.md
+++ b/docs/docs/tools/tasks/list-extract-refresh-tasks.md
@@ -6,7 +6,7 @@ sidebar_position: 1
 
 Retrieves a list of extract refresh tasks for the Tableau site. Each task describes a scheduled refresh for a data source or workbook extract and includes schedule information (e.g. frequency, next run time, schedule name on Server).
 
-:::warning Admin Only
+:::warning[Admin Only]
 This tool is restricted to Tableau site administrators and requires the `ADMIN_TOOLS_ENABLED` environment variable to be enabled.
 :::
 

--- a/docs/docs/tools/tasks/list-extract-refresh-tasks.md
+++ b/docs/docs/tools/tasks/list-extract-refresh-tasks.md
@@ -45,7 +45,7 @@ See also: [Environment Variables](../../configuration/mcp-config/env-vars.md)
 
 This tool takes no arguments.
 
-:::note API Limitation
+:::note[API Limitation]
 The Tableau REST API does not support filtering or pagination parameters for extract refresh tasks. All tasks are returned in a single request. For sites with many extract refresh tasks, consider using client-side filtering based on the returned data.
 :::
 

--- a/docs/docs/tools/tasks/update-cloud-extract-refresh-task.md
+++ b/docs/docs/tools/tasks/update-cloud-extract-refresh-task.md
@@ -6,7 +6,7 @@ sidebar_position: 3
 
 Updates the schedule of an extract refresh task on Tableau Cloud. Use this to change how often a refresh runs (e.g. downgrade Daily → Weekly), shift its time window, or modify the day/hour it executes — without recreating the task.
 
-:::warning Admin Only
+:::warning[Admin Only]
 This tool is restricted to Tableau site administrators and requires the `ADMIN_TOOLS_ENABLED` environment variable to be enabled.
 :::
 

--- a/docs/docs/tools/tasks/update-cloud-extract-refresh-task.md
+++ b/docs/docs/tools/tasks/update-cloud-extract-refresh-task.md
@@ -10,7 +10,7 @@ Updates the schedule of an extract refresh task on Tableau Cloud. Use this to ch
 This tool is restricted to Tableau site administrators and requires the `ADMIN_TOOLS_ENABLED` environment variable to be enabled.
 :::
 
-:::info Tableau Cloud Only
+:::info[Tableau Cloud Only]
 This tool calls the **Cloud variant** of the update endpoint and is not appropriate for Tableau Server. The Server variant has a different payload shape and is tracked separately.
 :::
 

--- a/docs/docs/tools/users/update-user.md
+++ b/docs/docs/tools/users/update-user.md
@@ -6,7 +6,7 @@ sidebar_position: 2
 
 Updates the site role of a user on the Tableau site. Primary use case: downgrade inactive users to "Unlicensed" to reclaim licenses.
 
-:::warning Admin Only
+:::warning[Admin Only]
 This tool is restricted to Tableau site administrators and requires the `ADMIN_TOOLS_ENABLED` environment variable to be enabled.
 :::
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "4.0.5",
+  "version": "4.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "4.0.5",
+      "version": "4.0.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1095.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "4.0.5",
+  "version": "4.0.6",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"


### PR DESCRIPTION
## Summary

Five admin-tool doc pages used \`:::warning Admin Only\` (space-separated, broken syntax), which Docusaurus does not recognise as a titled admonition — the yellow **ADMIN ONLY** warning box rendered as plain paragraph text with no visual highlight or bold heading. Additional titled admonitions across the docs had the same issue.

**Changes:**
- \`docs/tools/users/update-user.md\` — fix \`:::warning[Admin Only]\`
- \`docs/tools/tasks/list-extract-refresh-tasks.md\` — fix \`:::warning[Admin Only]\` + \`:::note[API Limitation]\`
- \`docs/tools/tasks/update-cloud-extract-refresh-task.md\` — fix \`:::warning[Admin Only]\` + \`:::info[Tableau Cloud Only]\`
- \`docs/tools/jobs/list-jobs.md\` — fix \`:::warning[Admin Only]\`
- \`docs/tools/content/delete-content.md\` — add \`:::warning[Admin Only]\` box (was inline prose) + fix \`:::warning[Human confirmation required]\`
- \`docs/tools/admin-insights/query-admin-insights.md\` — add \`:::warning[Admin Only]\` box (was inline prose)
- \`docs/configuration/mcp-config/env-vars.md\` — fix \`:::tip[Custom Provider]\`

Zero broken titled admonitions remain across \`docs/docs/\`. Reference (working): \`docs/tools/users/list-users.md\`.

## Verification

- \`npm run build\` (Docusaurus production build) exits 0 with zero MDX/admonition errors
- Compiled HTML for all fixed pages shows \`theme-admonition\` with correct title rendering

Patch bump 4.0.5 → 4.0.6 (docs bug fix). GUS: W-23653166

🤖 Generated with [Claude Code](https://claude.com/claude-code)