### PR TITLE
feat(desktop): apply worksheets, dashboards, and storyboards in place via the per-sheet document route

### DIFF
--- a/src/desktop/commands/workbook/applyFocusDispositions.test.ts
+++ b/src/desktop/commands/workbook/applyFocusDispositions.test.ts
@@ -21,7 +21,12 @@ import ts from 'typescript';
 const DISPOSITIONS: Readonly<Record<string, readonly string[]>> = {
   'src/desktop/commands/workbook/loadWorkbookXml.ts': ['applyWorkbookText:forward'],
   'src/desktop/commands/workbook/loadWorksheetXml.ts': ['applyWorkbookText:forward'],
-  'src/desktop/commands/workbook/loadDashboardXml.ts': ['applyWorkbookText:forward'],
+  // loadStoryboardXml forwards its caller's verdict straight into loadDashboardXml (storyboards
+  // reuse the dashboard per-sheet path), so this file has two forward seams in source order.
+  'src/desktop/commands/workbook/loadDashboardXml.ts': [
+    'loadDashboardXml:forward',
+    'applyWorkbookText:forward',
+  ],
   'src/tools/desktop/binder/bindTemplate.ts': ['loadWorkbookXml:artifact'],
   'src/tools/desktop/coordination/buildAndApplyWorksheet.ts': ['loadWorksheetXml:artifact'],
   'src/tools/desktop/coordination/batchCreateAndCacheSheets.ts': ['loadWorkbookXml:restore'],

--- a/src/desktop/commands/workbook/cacheFingerprint.ts
+++ b/src/desktop/commands/workbook/cacheFingerprint.ts
@@ -23,7 +23,7 @@ export interface InstanceFingerprint {
   start_time: string;
 }
 
-export type CacheArtifactKind = 'worksheet' | 'workbook' | 'dashboard';
+export type CacheArtifactKind = 'worksheet' | 'workbook' | 'dashboard' | 'storyboard';
 
 export interface CacheSidecarMeta extends InstanceFingerprint {
   session_id: string;
@@ -42,6 +42,7 @@ const READ_TOOL_BY_KIND: Record<CacheArtifactKind, string> = {
   worksheet: 'get-worksheet-xml',
   workbook: 'get-workbook-xml',
   dashboard: 'get-dashboard-xml',
+  storyboard: 'get-storyboard-xml',
 };
 
 export function sidecarPath(cacheFile: string): string {

--- a/src/desktop/commands/workbook/loadDashboardXml.test.ts
+++ b/src/desktop/commands/workbook/loadDashboardXml.test.ts
@@ -1,6 +1,7 @@
 import { Err, Ok } from 'ts-results-es';
 
 import * as loggerModule from '../../../logging/logger.js';
+import invariant from '../../../utils/invariant.js';
 import { normalizeArray, parseXML } from '../../metadata/parser.js';
 import type { ParsedWindow } from '../../metadata/types.js';
 import { ToolExecutor } from '../../toolExecutor/toolExecutor.js';
@@ -82,9 +83,22 @@ describe('loadDashboardXml (External Client API transport)', () => {
         executeCommand,
         getWorkbookDocument,
         applyWorkbookDocument,
-        listDashboards: vi
-          .fn()
-          .mockResolvedValue(Ok({ dashboards: [{ id: 'dashboard-1', name: dashboardName }] })),
+        // This double implements the whole-workbook transport (getWorkbookDocument +
+        // applyWorkbookDocument) that flag-off callers (dashboard build/auto-apply,
+        // apply-dashboard-with-viewpoints) use directly — they never attempt the per-sheet route. Its
+        // list route returns `not-found` so the flag-on route-missing tests below (apply-dashboard /
+        // apply-storyboard, which DO attempt the per-sheet route) see `route-missing`. The per-sheet
+        // 'applied' path is covered in perSheetDocumentApply.test.ts.
+        listDashboards: vi.fn().mockResolvedValue(
+          Err({
+            type: 'command-failed',
+            error: {
+              code: 'not-found',
+              message: 'No route matches GET /v0/workbook/dashboards',
+              recoverable: false,
+            },
+          }),
+        ),
       } as unknown as ToolExecutor,
       calls,
     };
@@ -238,6 +252,137 @@ describe('loadDashboardXml (External Client API transport)', () => {
     expect(applyCall?.xml).toContain('name="Some Other DB"');
   });
 
+  // An executor whose per-sheet list route works but does NOT contain the target dashboard, so a
+  // flag-on apply-dashboard's tryApplyViaPerSheetRoute resolves `sheet-absent`. It still implements the
+  // whole-workbook transport that flag-off callers use directly (they never attempt the per-sheet
+  // route, so the list route stays untouched for them).
+  function absentDashboardExecutor(liveDashboardNames: string[]): {
+    executor: ToolExecutor;
+    calls: Array<{ kind: 'command' | 'apply'; xml?: string }>;
+  } {
+    const { executor, calls } = dispatchingExecutor(liveWorkbook(liveDashboardNames));
+    (executor as unknown as { listDashboards: unknown }).listDashboards = vi.fn().mockResolvedValue(
+      Ok({
+        dashboards: liveDashboardNames.map((name, i) => ({ id: `id-${i}`, name, hidden: false })),
+      }),
+    );
+    return { executor, calls };
+  }
+
+  it('surfaces sheet-absent (no whole-workbook fallback) when requireExistingSheet is set', async () => {
+    const { executor, calls } = absentDashboardExecutor(['Some Other DB']);
+
+    const result = await loadDashboardXml({
+      dashboardName,
+      xml: validXml,
+      executor,
+      signal: mockSignal,
+      focus: NO_FOCUS,
+      requireExistingSheet: true,
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      invariant(result.error.type === 'load-dashboard-xml-error');
+      expect(result.error.error.type).toBe('sheet-absent');
+      invariant(result.error.error.type === 'sheet-absent');
+      expect(result.error.error.message).toContain('dashboard');
+      expect(result.error.error.message).toContain('Sales Dashboard');
+    }
+    expect(calls.find((c) => c.kind === 'apply')).toBeUndefined();
+  });
+
+  it('surfaces a storyboard-scoped sheet-absent message when requireExistingSheet is set', async () => {
+    const { executor, calls } = absentDashboardExecutor([]);
+    (executor as unknown as { listStoryboards: unknown }).listStoryboards = vi
+      .fn()
+      .mockResolvedValue(Ok({ storyboards: [] }));
+
+    const result = await loadDashboardXml({
+      dashboardName,
+      xml: validXml,
+      executor,
+      signal: mockSignal,
+      focus: NO_FOCUS,
+      kind: 'storyboard',
+      requireExistingSheet: true,
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      invariant(result.error.type === 'load-dashboard-xml-error');
+      invariant(result.error.error.type === 'sheet-absent');
+      expect(result.error.error.message).toContain('storyboard');
+      // The storyboard recovery text must not steer to off-profile apply/list tools.
+      expect(result.error.error.message).not.toContain('apply-');
+      expect(result.error.error.message).not.toContain('list-');
+    }
+    expect(calls.find((c) => c.kind === 'apply')).toBeUndefined();
+  });
+
+  it('goes straight to the whole-workbook apply for an absent dashboard when requireExistingSheet is off', async () => {
+    const { executor, calls } = absentDashboardExecutor(['Some Other DB']);
+
+    const result = await loadDashboardXml({
+      dashboardName,
+      xml: validXml,
+      executor,
+      signal: mockSignal,
+      focus: NO_FOCUS,
+    });
+
+    expect(result.isOk()).toBe(true);
+    const applyCall = calls.find((c) => c.kind === 'apply');
+    expect(applyCall?.xml).toContain('name="Sales Dashboard"');
+    expect(applyCall?.xml).toContain('name="Some Other DB"');
+  });
+
+  // apply-dashboard/apply-storyboard are pure per-sheet applies: any non-`applied` outcome errors and
+  // never falls back to the whole-workbook re-post. When the per-sheet route is unavailable
+  // (dispatchingExecutor's list route returns `not-found` → route-missing) it must NOT quietly
+  // whole-workbook apply — even for an existing sheet.
+  it('errors and never whole-workbook applies when requireExistingSheet is set and the route is missing (absent name)', async () => {
+    const { executor, calls } = dispatchingExecutor(liveWorkbook(['Some Other DB']));
+
+    const result = await loadDashboardXml({
+      dashboardName,
+      xml: validXml,
+      executor,
+      signal: mockSignal,
+      focus: NO_FOCUS,
+      requireExistingSheet: true,
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      invariant(result.error.type === 'load-dashboard-xml-error');
+      expect(result.error.error.type).toBe('sheet-absent');
+    }
+    expect(calls.find((c) => c.kind === 'apply')).toBeUndefined();
+  });
+
+  it('errors and never whole-workbook applies when requireExistingSheet is set and the route is missing (existing dashboard)', async () => {
+    const { executor, calls } = dispatchingExecutor(liveWorkbook(['Sales Dashboard', 'Other DB']));
+
+    const result = await loadDashboardXml({
+      dashboardName,
+      xml: validXml,
+      executor,
+      signal: mockSignal,
+      focus: NO_FOCUS,
+      requireExistingSheet: true,
+    });
+
+    // Even though the dashboard exists live, apply-dashboard requires the per-sheet route — it does not
+    // silently re-post the whole workbook instead.
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      invariant(result.error.type === 'load-dashboard-xml-error');
+      expect(result.error.error.type).toBe('sheet-absent');
+    }
+    expect(calls.find((c) => c.kind === 'apply')).toBeUndefined();
+  });
+
   it('should return invalid-xml error when xml is empty', async () => {
     const mockExecutor = { executeCommand: vi.fn() } as unknown as ToolExecutor;
 
@@ -286,6 +431,17 @@ describe('loadDashboardXml (External Client API transport)', () => {
       error: { code: 'ERROR', message: 'Failed', recoverable: false },
     };
     const mockExecutor = {
+      // Route-missing list defers to the whole-workbook path, where the fetch below fails.
+      listDashboards: vi.fn().mockResolvedValue(
+        Err({
+          type: 'command-failed',
+          error: {
+            code: 'not-found',
+            message: 'No route matches GET /v0/workbook/dashboards',
+            recoverable: false,
+          },
+        }),
+      ),
       getWorkbookDocument: vi.fn().mockResolvedValue(Err(error)),
     } as unknown as ToolExecutor;
 

--- a/src/desktop/commands/workbook/loadDashboardXml.ts
+++ b/src/desktop/commands/workbook/loadDashboardXml.ts
@@ -16,6 +16,7 @@ import { type ApplyFocus } from './applyFocus.js';
 import { withApplyLock } from './applyMutex.js';
 import { getWorkbookXml } from './getWorkbookXml.js';
 import { applyWorkbookText } from './loadWorkbookXml.js';
+import { type PerSheetKind, tryApplyViaPerSheetRoute } from './perSheetDocumentApply.js';
 
 export type LoadDashboardXmlError =
   | { type: 'invalid-xml' }
@@ -28,7 +29,10 @@ export type LoadDashboardXmlError =
   // The load-dashboard command reported command-level completion, but Tableau
   // rejected the actual document load (surfaced in the response payload, not in
   // `status`). `message` carries Desktop's own error text.
-  | { type: 'load-rejected'; message: string };
+  | { type: 'load-rejected'; message: string }
+  // Only surfaced when a caller opts in with `requireExistingSheet` (apply-dashboard, apply-storyboard);
+  // flag-off callers take the whole-workbook path and never see this (create sheet and apply).
+  | { type: 'sheet-absent'; message: string };
 
 export interface LoadDashboardXmlOk {
   validationWarnings: ValidationIssue[];
@@ -104,16 +108,28 @@ function resolveCanonicalDashboardName(
   return Ok(xmlName);
 }
 
+type LoadDashboardKind = Extract<PerSheetKind, 'dashboard' | 'storyboard'>;
+
 export async function loadDashboardXml({
   dashboardName,
   xml,
   focus,
   executor,
   signal,
+  kind = 'dashboard',
+  requireExistingSheet = false,
 }: {
   dashboardName: string;
   xml: string;
   focus: ApplyFocus;
+  kind?: LoadDashboardKind;
+  // Picks the External Client API call this apply uses.
+  // On/True (apply-dashboard, apply-storyboard): replace an existing dashboard/storyboard by id via the
+  // per-sheet `/document` route, leaving other sheets untouched. That route is replace-only, so a name
+  // that resolves to no live sheet surfaces a `sheet-absent` error instead of creating one.
+  // Off/False (build-and-apply-dashboard, apply-dashboard-with-viewpoints): the dashboard may be net-new, so
+  // the whole-workbook re-post upserts it (appending when absent). That is the create path.
+  requireExistingSheet?: boolean;
 } & WithExecutorAndAbortSignal): Promise<LoadDashboardXmlResult> {
   xml = xml.trim();
   if (!xml || (!xml.startsWith('<?xml') && !xml.startsWith('<'))) {
@@ -169,9 +185,31 @@ export async function loadDashboardXml({
   const canonicalFocus: ApplyFocus =
     focus.navigate === 'artifact' ? { ...focus, sheetName: canonicalName } : focus;
 
-  // External Client API ("Athena V0") exposes no per-dashboard apply route, so applying a single
-  // dashboard re-posts the whole live workbook with just this dashboard swapped in (the POST
-  // replaces the open workbook wholesale, so anything omitted would be pruned).
+  if (requireExistingSheet) {
+    const perSheetResult = await withApplyLock(() =>
+      tryApplyViaPerSheetRoute({
+        kind,
+        sheetName: canonicalName,
+        fragmentXml: xml,
+        focus: canonicalFocus,
+        executor,
+        signal,
+      }),
+    );
+    if (perSheetResult.isErr()) {
+      return Err({ type: 'execute-command-error', error: perSheetResult.error });
+    }
+    if (perSheetResult.value !== 'applied') {
+      return Err({
+        type: 'load-dashboard-xml-error',
+        error: { type: 'sheet-absent', message: sheetAbsentMessage(kind, canonicalName) },
+      });
+    }
+    // Preflight warnings ride along so apply responses can compute the host
+    // verification receipt (W-23447506) without re-running validation.
+    return Ok({ validationWarnings: validation.issues });
+  }
+
   const result = await loadDashboardXmlViaExternalApi({
     dashboardName: canonicalName,
     xml,
@@ -185,6 +223,34 @@ export async function loadDashboardXml({
   // Preflight warnings ride along so apply responses can compute the host
   // verification receipt (W-23447506) without re-running validation.
   return Ok({ validationWarnings: validation.issues });
+}
+
+/**
+ * Apply an edited storyboard in place. A storyboard is a `<dashboard type='storyboard'>`, so this is
+ * {@link loadDashboardXml} with the storyboard per-sheet route.
+ */
+export async function loadStoryboardXml({
+  storyboardName,
+  xml,
+  focus,
+  executor,
+  signal,
+  requireExistingSheet = false,
+}: {
+  storyboardName: string;
+  xml: string;
+  focus: ApplyFocus;
+  requireExistingSheet?: boolean;
+} & WithExecutorAndAbortSignal): Promise<LoadDashboardXmlResult> {
+  return loadDashboardXml({
+    dashboardName: storyboardName,
+    xml,
+    focus,
+    executor,
+    signal,
+    kind: 'storyboard',
+    requireExistingSheet,
+  });
 }
 
 async function loadDashboardXmlViaExternalApi({
@@ -225,6 +291,21 @@ async function loadDashboardXmlViaExternalApi({
 
     return Ok.EMPTY;
   });
+}
+
+function sheetAbsentMessage(kind: LoadDashboardKind, canonicalName: string): string {
+  if (kind === 'storyboard') {
+    return (
+      `No storyboard named "${canonicalName}" is open to update. This updates an existing ` +
+      'storyboard in place and does not create one. FIX: verify the storyboard name and that it ' +
+      'exists in the open workbook.'
+    );
+  }
+  return (
+    `No dashboard named "${canonicalName}" is open to update. This updates an existing dashboard ` +
+    'in place and does not create one. FIX: check the name with list-dashboards, or create a new ' +
+    'dashboard with build-and-apply-dashboard.'
+  );
 }
 
 function sanitize(value: unknown): unknown {

--- a/src/desktop/commands/workbook/loadWorksheetXml.test.ts
+++ b/src/desktop/commands/workbook/loadWorksheetXml.test.ts
@@ -106,9 +106,22 @@ describe('loadWorksheetXml (External Client API transport)', () => {
         executeCommand,
         getWorkbookDocument,
         applyWorkbookDocument,
-        listWorksheets: vi
-          .fn()
-          .mockResolvedValue(Ok({ worksheets: [{ id: 'sheet-1', name: worksheetName }] })),
+        // This double implements the whole-workbook transport (getWorkbookDocument +
+        // applyWorkbookDocument) that flag-off callers (build-and-apply-worksheet, refine-worksheet)
+        // use directly — they never attempt the per-sheet route. Its list route returns `not-found`
+        // so the flag-on route-missing tests below (apply-worksheet, which DOES attempt the per-sheet
+        // route) see `route-missing`. The per-sheet 'applied' path is covered in
+        // perSheetDocumentApply.test.ts.
+        listWorksheets: vi.fn().mockResolvedValue(
+          Err({
+            type: 'command-failed',
+            error: {
+              code: 'not-found',
+              message: 'No route matches GET /v0/workbook/worksheets',
+              recoverable: false,
+            },
+          }),
+        ),
       } as unknown as ToolExecutor,
       calls,
     };
@@ -359,12 +372,127 @@ describe('loadWorksheetXml (External Client API transport)', () => {
     }
   });
 
+  // An executor whose per-sheet list route works but does NOT contain the target worksheet, so a
+  // flag-on apply-worksheet's tryApplyViaPerSheetRoute resolves `sheet-absent`. It still implements the
+  // whole-workbook transport that flag-off callers use directly (they never attempt the per-sheet
+  // route, so the list route stays untouched for them).
+  function absentSheetExecutor(liveWorksheetNames: string[]): {
+    executor: ToolExecutor;
+    calls: Array<{ kind: 'command' | 'apply'; xml?: string }>;
+  } {
+    const { executor, calls } = dispatchingExecutor(liveWorkbook(liveWorksheetNames));
+    (executor as unknown as { listWorksheets: unknown }).listWorksheets = vi.fn().mockResolvedValue(
+      Ok({
+        worksheets: liveWorksheetNames.map((name, i) => ({ id: `id-${i}`, name, hidden: false })),
+      }),
+    );
+    return { executor, calls };
+  }
+
+  it('surfaces sheet-absent (no whole-workbook fallback) when requireExistingSheet is set', async () => {
+    const { executor, calls } = absentSheetExecutor(['Some Other Sheet']);
+
+    const result = await loadWorksheetXml({
+      worksheetName,
+      xml: validXml,
+      executor,
+      signal: mockSignal,
+      focus: NO_FOCUS,
+      requireExistingSheet: true,
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      invariant(result.error.type === 'load-worksheet-xml-error');
+      expect(result.error.error.type).toBe('sheet-absent');
+    }
+    // The whole-workbook apply must NOT have run — apply-worksheet does not create a sheet.
+    expect(calls.find((c) => c.kind === 'apply')).toBeUndefined();
+  });
+
+  it('goes straight to the whole-workbook apply for an absent sheet when requireExistingSheet is off', async () => {
+    const { executor, calls } = absentSheetExecutor(['Some Other Sheet']);
+
+    const result = await loadWorksheetXml({
+      worksheetName,
+      xml: validXml,
+      executor,
+      signal: mockSignal,
+      focus: NO_FOCUS,
+    });
+
+    expect(result.isOk()).toBe(true);
+    // The flag-off caller never attempts the per-sheet route, so the net-new sheet is appended via the
+    // whole-workbook apply.
+    const applyCall = calls.find((c) => c.kind === 'apply');
+    expect(applyCall?.xml).toContain('name="Sheet 1"');
+    expect(applyCall?.xml).toContain('name="Some Other Sheet"');
+  });
+
+  // apply-worksheet is a pure per-sheet apply: any non-`applied` outcome errors and never falls back to
+  // the whole-workbook re-post. When the per-sheet route is unavailable (dispatchingExecutor's list
+  // route returns `not-found` → route-missing) it must NOT quietly whole-workbook apply — even for an
+  // existing sheet.
+  it('errors and never whole-workbook applies when requireExistingSheet is set and the route is missing (absent name)', async () => {
+    const { executor, calls } = dispatchingExecutor(liveWorkbook(['Some Other Sheet']));
+
+    const result = await loadWorksheetXml({
+      worksheetName,
+      xml: validXml,
+      executor,
+      signal: mockSignal,
+      focus: NO_FOCUS,
+      requireExistingSheet: true,
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      invariant(result.error.type === 'load-worksheet-xml-error');
+      expect(result.error.error.type).toBe('sheet-absent');
+    }
+    // The whole-workbook apply must NOT have run — apply-worksheet does not create a sheet.
+    expect(calls.find((c) => c.kind === 'apply')).toBeUndefined();
+  });
+
+  it('errors and never whole-workbook applies when requireExistingSheet is set and the route is missing (existing sheet)', async () => {
+    const { executor, calls } = dispatchingExecutor(liveWorkbook(['Sheet 1', 'Other']));
+
+    const result = await loadWorksheetXml({
+      worksheetName,
+      xml: validXml,
+      executor,
+      signal: mockSignal,
+      focus: NO_FOCUS,
+      requireExistingSheet: true,
+    });
+
+    // Even though the sheet exists live, apply-worksheet requires the per-sheet route — it does not
+    // silently re-post the whole workbook instead.
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      invariant(result.error.type === 'load-worksheet-xml-error');
+      expect(result.error.error.type).toBe('sheet-absent');
+    }
+    expect(calls.find((c) => c.kind === 'apply')).toBeUndefined();
+  });
+
   it('should return execute-command-error when the workbook fetch fails', async () => {
     const error = {
       type: 'command-failed' as const,
       error: { code: 'ERROR', message: 'Failed', recoverable: false },
     };
     const mockExecutor = {
+      // Route-missing list defers to the whole-workbook path, where the fetch below fails.
+      listWorksheets: vi.fn().mockResolvedValue(
+        Err({
+          type: 'command-failed',
+          error: {
+            code: 'not-found',
+            message: 'No route matches GET /v0/workbook/worksheets',
+            recoverable: false,
+          },
+        }),
+      ),
       getWorkbookDocument: vi.fn().mockResolvedValue(Err(error)),
     } as unknown as ToolExecutor;
 

--- a/src/desktop/commands/workbook/loadWorksheetXml.ts
+++ b/src/desktop/commands/workbook/loadWorksheetXml.ts
@@ -23,6 +23,7 @@ import { withApplyLock } from './applyMutex.js';
 import { getWorkbookXml } from './getWorkbookXml.js';
 import { getWorksheetFragment } from './getWorksheetXml.js';
 import { applyWorkbookText } from './loadWorkbookXml.js';
+import { tryApplyViaPerSheetRoute } from './perSheetDocumentApply.js';
 
 export type LoadWorksheetXmlError =
   | { type: 'invalid-xml' }
@@ -39,7 +40,10 @@ export type LoadWorksheetXmlError =
   // Apply succeeded but the post-apply readback proved Tableau silently dropped or
   // changed an intent-bearing node (the silently-dropped-pill killer, W4). `message`
   // carries the agent-facing fix recipe; `findings` the structured evidence.
-  | { type: 'readback-failed'; findings: ReadbackFinding[]; message: string };
+  | { type: 'readback-failed'; findings: ReadbackFinding[]; message: string }
+  // Only surfaced when a caller opts in with `requireExistingSheet` (apply-worksheet);
+  // flag-off callers take the whole-workbook path and never see this (create sheet and apply).
+  | { type: 'sheet-absent'; message: string };
 
 /** Non-fatal readback warnings surfaced on a successful apply (sort drops/changes). */
 export interface LoadWorksheetXmlOk {
@@ -202,6 +206,13 @@ function resolveCanonicalWorksheetName(
 
   return Ok(xmlName);
 }
+function worksheetAbsentMessage(canonicalName: string): string {
+  return (
+    `No worksheet named "${canonicalName}" is open to update. This updates an existing worksheet ` +
+    'in place and does not create one. FIX: check the name with list-worksheets, or create a new ' +
+    'worksheet with build-and-apply-worksheet.'
+  );
+}
 
 export async function loadWorksheetXml({
   worksheetName,
@@ -210,11 +221,19 @@ export async function loadWorksheetXml({
   executor,
   signal,
   readbackVerificationOut,
+  requireExistingSheet = false,
 }: {
   worksheetName: string;
   xml: string;
   focus: ApplyFocus;
   readbackVerificationOut?: ReadbackVerificationResult[];
+  // Picks the External Client API call this apply uses.
+  // On (apply-worksheet): replace an existing worksheet by id via the per-sheet `/document` route,
+  // leaving other sheets untouched. That route is replace-only, so a name that resolves to no live
+  // worksheet surfaces a `sheet-absent` error instead of creating one.
+  // Off (build-and-apply-worksheet, refine-worksheet): the worksheet may be net-new, so the
+  // whole-workbook re-post upserts it (appending when absent). That is the create path.
+  requireExistingSheet?: boolean;
 } & WithExecutorAndAbortSignal): Promise<LoadWorksheetXmlResult> {
   xml = xml.trim();
   if (!xml || (!xml.startsWith('<?xml') && !xml.startsWith('<'))) {
@@ -270,9 +289,42 @@ export async function loadWorksheetXml({
   const canonicalFocus: ApplyFocus =
     focus.navigate === 'artifact' ? { ...focus, sheetName: canonicalName } : focus;
 
-  // External Client API ("Athena V0") exposes no per-sheet apply route, so applying a single sheet
-  // re-posts the whole live workbook with just this sheet swapped in (the POST replaces the open
-  // workbook wholesale, so anything omitted would be pruned).
+  if (requireExistingSheet) {
+    return withApplyLock(async (): Promise<LoadWorksheetXmlResult> => {
+      const outcome = await tryApplyViaPerSheetRoute({
+        kind: 'worksheet',
+        sheetName: canonicalName,
+        fragmentXml: xml,
+        focus: canonicalFocus,
+        executor,
+        signal,
+      });
+      if (outcome.isErr()) {
+        return Err({ type: 'execute-command-error', error: outcome.error });
+      }
+      if (outcome.value !== 'applied') {
+        return Err({
+          type: 'load-worksheet-xml-error',
+          error: { type: 'sheet-absent', message: worksheetAbsentMessage(canonicalName) },
+        });
+      }
+      const verification = await verifyPostApplyWorksheetReadback(
+        canonicalName,
+        xml,
+        executor,
+        signal,
+      );
+      readbackVerificationOut?.push(publicReadbackVerificationResult(verification));
+      const outcomeResult = readbackOutcome(verification);
+      if (outcomeResult.isErr()) {
+        return outcomeResult;
+      }
+      // Preflight warnings ride along so apply responses can compute the host
+      // verification receipt (W-23447506) without re-running validation.
+      return Ok({ ...outcomeResult.value, validationWarnings: validation.issues });
+    });
+  }
+
   const result = await loadWorksheetXmlViaExternalApi({
     worksheetName: canonicalName,
     xml,

--- a/src/desktop/commands/workbook/perSheetDocumentApply.test.ts
+++ b/src/desktop/commands/workbook/perSheetDocumentApply.test.ts
@@ -1,0 +1,213 @@
+import { Err, Ok } from 'ts-results-es';
+
+import * as loggerModule from '../../../logging/logger.js';
+import { ToolExecutor } from '../../toolExecutor/toolExecutor.js';
+import { type PerSheetKind, tryApplyViaPerSheetRoute } from './perSheetDocumentApply.js';
+
+// Focus is a required argument at every write seam; suites not about navigation pass the
+// disposition that dispatches nothing.
+const NO_FOCUS = { navigate: 'none', reason: 'intermediate-leg' } as const;
+
+const routeMissing = {
+  type: 'command-failed' as const,
+  error: {
+    code: 'not-found',
+    message: 'No route matches GET /v0/workbook/worksheets',
+    recoverable: false,
+  },
+};
+
+type KindFixture = {
+  kind: PerSheetKind;
+  sheetName: string;
+  fragmentXml: string;
+  listMethod: 'listWorksheets' | 'listDashboards' | 'listStoryboards';
+  listValue: Record<string, Array<{ id: string; name: string }>>;
+  applyMethod: 'applyWorksheetDocument' | 'applyDashboardDocument' | 'applyStoryboardDocument';
+  id: string;
+};
+
+const FIXTURES: KindFixture[] = [
+  {
+    kind: 'worksheet',
+    sheetName: 'Sheet 1',
+    fragmentXml: "<worksheet name='Sheet 1'><table><rows /></table></worksheet>",
+    listMethod: 'listWorksheets',
+    listValue: { worksheets: [{ id: 'sheet-1', name: 'Sheet 1' }] },
+    applyMethod: 'applyWorksheetDocument',
+    id: 'sheet-1',
+  },
+  {
+    kind: 'dashboard',
+    sheetName: 'Sales Dashboard',
+    fragmentXml: "<dashboard name='Sales Dashboard'><zones /></dashboard>",
+    listMethod: 'listDashboards',
+    listValue: { dashboards: [{ id: 'dash-1', name: 'Sales Dashboard' }] },
+    applyMethod: 'applyDashboardDocument',
+    id: 'dash-1',
+  },
+  {
+    kind: 'storyboard',
+    sheetName: 'QBR Story',
+    fragmentXml: "<dashboard name='QBR Story' type='storyboard'><zones /></dashboard>",
+    listMethod: 'listStoryboards',
+    listValue: { storyboards: [{ id: 'story-1', name: 'QBR Story' }] },
+    applyMethod: 'applyStoryboardDocument',
+    id: 'story-1',
+  },
+];
+
+describe('tryApplyViaPerSheetRoute', () => {
+  const mockSignal = new AbortController().signal;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(loggerModule, 'log').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it.each(FIXTURES)(
+    'posts the $kind fragment as-is to its per-sheet route and reports applied',
+    async ({ kind, sheetName, fragmentXml, listMethod, listValue, applyMethod, id }) => {
+      const apply = vi
+        .fn()
+        .mockResolvedValue(Ok({ command_id: 'cmd-apply', status: 'completed', submitted_at: '' }));
+      const executeCommand = vi
+        .fn()
+        .mockResolvedValue(Ok({ command_id: 'cmd-ok', status: 'completed', submitted_at: '' }));
+      const executor = {
+        [listMethod]: vi.fn().mockResolvedValue(Ok(listValue)),
+        [applyMethod]: apply,
+        executeCommand,
+      } as unknown as ToolExecutor;
+
+      const result = await tryApplyViaPerSheetRoute({
+        kind,
+        sheetName,
+        fragmentXml,
+        focus: NO_FOCUS,
+        executor,
+        signal: mockSignal,
+      });
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value).toBe('applied');
+      }
+      // The route resolves by id, and the posted body is the sheet fragment as-is (Tableau Desktop
+      // wraps it into the live workbook server-side — the MCP does not build a <workbook> envelope).
+      expect(apply).toHaveBeenCalledTimes(1);
+      const [postedId, postedXml] = apply.mock.calls[0];
+      expect(postedId).toBe(id);
+      expect(postedXml).toBe(fragmentXml);
+      expect(postedXml).not.toContain('<workbook>');
+    },
+  );
+
+  it.each(FIXTURES)(
+    'reports sheet-absent for an unresolved $kind name without posting',
+    async ({ kind, fragmentXml, listMethod, applyMethod }) => {
+      const apply = vi.fn();
+      const executor = {
+        // Empty list: the name resolves to nothing, so the route (which cannot create) is skipped.
+        [listMethod]: vi.fn().mockResolvedValue(Ok({})),
+        [applyMethod]: apply,
+      } as unknown as ToolExecutor;
+
+      const result = await tryApplyViaPerSheetRoute({
+        kind,
+        sheetName: 'Nonexistent',
+        fragmentXml,
+        focus: NO_FOCUS,
+        executor,
+        signal: mockSignal,
+      });
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value).toBe('sheet-absent');
+      }
+      expect(apply).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(FIXTURES)(
+    'reports route-missing when the $kind list route is absent (old Desktop build)',
+    async ({ kind, sheetName, fragmentXml, listMethod, applyMethod }) => {
+      const apply = vi.fn();
+      const executor = {
+        [listMethod]: vi.fn().mockResolvedValue(Err(routeMissing)),
+        [applyMethod]: apply,
+      } as unknown as ToolExecutor;
+
+      const result = await tryApplyViaPerSheetRoute({
+        kind,
+        sheetName,
+        fragmentXml,
+        focus: NO_FOCUS,
+        executor,
+        signal: mockSignal,
+      });
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value).toBe('route-missing');
+      }
+      expect(apply).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(FIXTURES)(
+    'reports route-missing when the $kind POST route is absent but the list route is present',
+    async ({ kind, sheetName, fragmentXml, listMethod, listValue, applyMethod }) => {
+      const apply = vi.fn().mockResolvedValue(Err(routeMissing));
+      const executor = {
+        [listMethod]: vi.fn().mockResolvedValue(Ok(listValue)),
+        [applyMethod]: apply,
+      } as unknown as ToolExecutor;
+
+      const result = await tryApplyViaPerSheetRoute({
+        kind,
+        sheetName,
+        fragmentXml,
+        focus: NO_FOCUS,
+        executor,
+        signal: mockSignal,
+      });
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value).toBe('route-missing');
+      }
+      expect(apply).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it('surfaces a non-route list error instead of falling back', async () => {
+    const listError = {
+      type: 'command-failed' as const,
+      error: { code: 'boom', message: 'internal error', recoverable: false },
+    };
+    const executor = {
+      listWorksheets: vi.fn().mockResolvedValue(Err(listError)),
+      applyWorksheetDocument: vi.fn(),
+    } as unknown as ToolExecutor;
+
+    const result = await tryApplyViaPerSheetRoute({
+      kind: 'worksheet',
+      sheetName: 'Sheet 1',
+      fragmentXml: "<worksheet name='Sheet 1'><table /></worksheet>",
+      focus: NO_FOCUS,
+      executor,
+      signal: mockSignal,
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error).toEqual(listError);
+    }
+  });
+});

--- a/src/desktop/commands/workbook/perSheetDocumentApply.ts
+++ b/src/desktop/commands/workbook/perSheetDocumentApply.ts
@@ -1,0 +1,138 @@
+import { Err, Ok, Result } from 'ts-results-es';
+
+import { log } from '../../../logging/logger.js';
+import { ExternalApiToolExecutor } from '../../externalApi/externalApiToolExecutor.js';
+import { isRouteMissing, resolveItemByNameOrId } from '../../externalApi/toolUtils.js';
+import {
+  ExecuteCommandError,
+  WithExecutorAndAbortSignal,
+} from '../../toolExecutor/toolExecutor.js';
+import { type ApplyFocus, dispatchApplyFocus } from './applyFocus.js';
+
+export type PerSheetKind = 'worksheet' | 'dashboard' | 'storyboard';
+
+/**
+ * Outcome of trying to apply a single sheet through its dedicated per-sheet `/document` POST route.
+ *
+ * The route resolves the target by id and CANNOT create a sheet (an unknown id is a 404 / FAILED
+ * operation). Two non-`applied` outcomes report why the surgical POST did not land: the name did not
+ * resolve to a live sheet (`sheet-absent` — a net-new sheet, or a pre-existing ambiguity the
+ * whole-workbook upsert resolves by first-match).
+ */
+export type PerSheetApplyOutcome = 'applied' | 'sheet-absent' | 'route-missing';
+
+const ITEM_LABEL: Record<PerSheetKind, string> = {
+  worksheet: 'Worksheet',
+  dashboard: 'Dashboard',
+  storyboard: 'Storyboard',
+};
+
+/**
+ * Apply one edited sheet fragment in place via its dedicated per-sheet `/document` POST route.
+ *
+ * Resolves the sheet name to its live id first; a name that does not resolve, or a build that lacks the
+ * route, returns a non-`applied` outcome and the caller decides whether to surface it or fall back
+ * to the whole-workbook apply. On a successful POST it dispatches the requested focus (best-effort,
+ * never fails the landed apply).
+ */
+export async function tryApplyViaPerSheetRoute({
+  kind,
+  sheetName,
+  fragmentXml,
+  focus,
+  executor,
+  signal,
+}: {
+  kind: PerSheetKind;
+  sheetName: string;
+  fragmentXml: string;
+  focus: ApplyFocus;
+} & WithExecutorAndAbortSignal): Promise<Result<PerSheetApplyOutcome, ExecuteCommandError>> {
+  const client = executor as ExternalApiToolExecutor;
+
+  const listResult = await listSheetsOfKind(kind, client, signal);
+  if (listResult.isErr()) {
+    // A missing list route means the per-sheet POST route is missing too (they ship together) —
+    // let the caller take the whole-workbook path instead of surfacing a route error.
+    if (isRouteMissing(listResult.error)) {
+      return Ok('route-missing');
+    }
+    return Err(listResult.error);
+  }
+
+  const resolved = resolveItemByNameOrId(ITEM_LABEL[kind], sheetName, listResult.value);
+  if (resolved.isErr()) {
+    // Not found (net-new sheet) or an ambiguous name (which the whole-workbook upsert resolves by
+    // first-match): report `sheet-absent` and let the caller decide — surface it (in-place apply) or
+    // fall back to the whole-workbook apply (create-capable caller).
+    return Ok('sheet-absent');
+  }
+
+  // POST the sheet fragment as-is: Tableau Desktop wraps it into the live workbook on the per-sheet
+  // `/document` route, so the MCP does not build a workbook envelope.
+  const applyResult = await applyDocumentForKind(
+    kind,
+    resolved.value.id,
+    fragmentXml,
+    client,
+    signal,
+  );
+  if (applyResult.isErr()) {
+    // A build with the list route but not the POST route (unlikely) still falls back cleanly.
+    if (isRouteMissing(applyResult.error)) {
+      return Ok('route-missing');
+    }
+    return Err(applyResult.error);
+  }
+
+  log({
+    level: 'info',
+    message: `per-sheet ${kind} document apply completed`,
+    logger: 'workbookCommands',
+    data: { sheetName, id: resolved.value.id },
+  });
+
+  // The POST moves the view whether we ask or not, so state where it belongs. Never fails the
+  // apply that already landed.
+  await dispatchApplyFocus({ focus, postedXml: fragmentXml, executor, signal });
+
+  return Ok('applied');
+}
+
+async function listSheetsOfKind(
+  kind: PerSheetKind,
+  client: ExternalApiToolExecutor,
+  signal: AbortSignal,
+): Promise<Result<Array<{ id: string; name: string }>, ExecuteCommandError>> {
+  switch (kind) {
+    case 'worksheet': {
+      const result = await client.listWorksheets(signal);
+      return result.map((value) => value.worksheets ?? []);
+    }
+    case 'dashboard': {
+      const result = await client.listDashboards(signal);
+      return result.map((value) => value.dashboards ?? []);
+    }
+    case 'storyboard': {
+      const result = await client.listStoryboards(signal);
+      return result.map((value) => value.storyboards ?? []);
+    }
+  }
+}
+
+async function applyDocumentForKind(
+  kind: PerSheetKind,
+  id: string,
+  documentXml: string,
+  client: ExternalApiToolExecutor,
+  signal: AbortSignal,
+): Promise<Result<unknown, ExecuteCommandError>> {
+  switch (kind) {
+    case 'worksheet':
+      return client.applyWorksheetDocument(id, documentXml, signal);
+    case 'dashboard':
+      return client.applyDashboardDocument(id, documentXml, signal);
+    case 'storyboard':
+      return client.applyStoryboardDocument(id, documentXml, signal);
+  }
+}

--- a/src/desktop/externalApi/externalApiClient.test.ts
+++ b/src/desktop/externalApi/externalApiClient.test.ts
@@ -342,7 +342,8 @@ describe('ExternalApiClient', () => {
     const result = await client.getStoryboardDocument('story-qbr');
 
     expect(result.isOk()).toBe(true);
-    expect(result.unwrap().xml).toContain('<storyboard name="QBR Story"');
+    // A storyboard serializes as a `<dashboard type="storyboard">` inside a whole <workbook>.
+    expect(result.unwrap().xml).toContain('<dashboard name="QBR Story" type="storyboard"');
 
     const last = server.requests.at(-1);
     expect(last?.method).toBe('GET');

--- a/src/desktop/externalApi/externalApiClient.ts
+++ b/src/desktop/externalApi/externalApiClient.ts
@@ -138,6 +138,45 @@ export class ExternalApiClient {
     return this.parseEnvelope(response);
   }
 
+  async applyWorksheetDocument(
+    worksheetId: string,
+    xml: string,
+    signal?: AbortSignal,
+  ): Promise<Result<OperationEnvelope, ExternalApiError>> {
+    const response = await this.request('POST', buildWorksheetDocumentRoute(worksheetId), {
+      signal,
+      contentType: 'application/xml',
+      body: xml,
+    });
+    return this.parseEnvelope(response);
+  }
+
+  async applyDashboardDocument(
+    dashboardId: string,
+    xml: string,
+    signal?: AbortSignal,
+  ): Promise<Result<OperationEnvelope, ExternalApiError>> {
+    const response = await this.request('POST', buildDashboardDocumentRoute(dashboardId), {
+      signal,
+      contentType: 'application/xml',
+      body: xml,
+    });
+    return this.parseEnvelope(response);
+  }
+
+  async applyStoryboardDocument(
+    storyboardId: string,
+    xml: string,
+    signal?: AbortSignal,
+  ): Promise<Result<OperationEnvelope, ExternalApiError>> {
+    const response = await this.request('POST', buildStoryboardDocumentRoute(storyboardId), {
+      signal,
+      contentType: 'application/xml',
+      body: xml,
+    });
+    return this.parseEnvelope(response);
+  }
+
   async validateWorkbookDocument(
     xml: string,
     signal?: AbortSignal,

--- a/src/desktop/externalApi/externalApiToolExecutor.ts
+++ b/src/desktop/externalApi/externalApiToolExecutor.ts
@@ -213,8 +213,57 @@ export class ExternalApiToolExecutor extends ToolExecutor {
     xml: string,
     signal: AbortSignal,
   ): Promise<Result<ExecuteCommandResult<undefined>, ExecuteCommandError>> {
+    return this.applyDocument(
+      (client) => client.applyWorkbookDocument(xml, signal),
+      'apply-workbook-document',
+    );
+  }
+
+  async applyWorksheetDocument(
+    worksheetId: string,
+    xml: string,
+    signal: AbortSignal,
+  ): Promise<Result<ExecuteCommandResult<undefined>, ExecuteCommandError>> {
+    return this.applyDocument(
+      (client) => client.applyWorksheetDocument(worksheetId, xml, signal),
+      'apply-worksheet-document',
+    );
+  }
+
+  async applyDashboardDocument(
+    dashboardId: string,
+    xml: string,
+    signal: AbortSignal,
+  ): Promise<Result<ExecuteCommandResult<undefined>, ExecuteCommandError>> {
+    return this.applyDocument(
+      (client) => client.applyDashboardDocument(dashboardId, xml, signal),
+      'apply-dashboard-document',
+    );
+  }
+
+  async applyStoryboardDocument(
+    storyboardId: string,
+    xml: string,
+    signal: AbortSignal,
+  ): Promise<Result<ExecuteCommandResult<undefined>, ExecuteCommandError>> {
+    return this.applyDocument(
+      (client) => client.applyStoryboardDocument(storyboardId, xml, signal),
+      'apply-storyboard-document',
+    );
+  }
+
+  /**
+   * Shared document-apply pipeline for the whole-workbook and per-sheet POST routes: run the
+   * client call through withRescan, normalize the operation envelope, then fold it into a
+   * command-status result (envelope FAILED / Tableau error → command-failed). `command` labels
+   * the operation for logs and the synthetic command id.
+   */
+  private async applyDocument(
+    call: (client: ExternalApiClient) => Promise<Result<OperationEnvelope, ExternalApiError>>,
+    command: string,
+  ): Promise<Result<ExecuteCommandResult<undefined>, ExecuteCommandError>> {
     const outcomeResult = await this.withRescan(async (client) => {
-      const result = await client.applyWorkbookDocument(xml, signal);
+      const result = await call(client);
       if (result.isErr()) {
         return Err(result.error);
       }
@@ -224,7 +273,7 @@ export class ExternalApiToolExecutor extends ToolExecutor {
     if (outcomeResult.isErr()) {
       const mapped = mapClientError(outcomeResult.error, this.deps.pid);
       log({
-        message: 'Failed to apply workbook document via External Client API',
+        message: `Failed to ${command} via External Client API`,
         level: 'error',
         logger: LOGGER,
         data: mapped,
@@ -234,11 +283,11 @@ export class ExternalApiToolExecutor extends ToolExecutor {
 
     const statusResult = buildCommandStatus(outcomeResult.value, {
       namespace: 'external-api',
-      command: 'apply-workbook-document',
+      command,
     });
     if (statusResult.isErr()) {
       log({
-        message: 'Workbook document apply failed',
+        message: `Document apply failed: ${command}`,
         level: 'error',
         logger: LOGGER,
         data: statusResult.error,

--- a/src/desktop/externalApi/mockExternalApiServer.ts
+++ b/src/desktop/externalApi/mockExternalApiServer.ts
@@ -54,7 +54,14 @@ const DEFAULT_DASHBOARD_DOCUMENT_XML =
   '<?xml version="1.0"?><workbook><dashboards>' +
   '<dashboard name="Executive Dashboard"><zones><zone name="Sales by Region" /></zones></dashboard>' +
   '</dashboards></workbook>';
-const DEFAULT_STORYBOARD_XML = '<storyboard name="QBR Story"><story-points /></storyboard>';
+// A storyboard serializes as a `<dashboard type='storyboard'>` under `<dashboards>` within a whole
+// `<workbook>` document — the same envelope shape as a dashboard, not a bare `<storyboard>` element.
+// The document carries a sibling dashboard the slice must exclude by name.
+const DEFAULT_STORYBOARD_DOCUMENT_XML =
+  '<?xml version="1.0"?><workbook><dashboards>' +
+  '<dashboard name="Executive Dashboard"><zones><zone name="Sales by Region" /></zones></dashboard>' +
+  '<dashboard name="QBR Story" type="storyboard"><zones><zone name="Sales by Region" /></zones></dashboard>' +
+  '</dashboards></workbook>';
 const DEFAULT_WORKSHEETS = [
   {
     id: 'sheet-sales',
@@ -192,6 +199,40 @@ const sendProblem = (res: ServerResponse, status: number, code: string, detail: 
   res.end(
     JSON.stringify({ type: 'problem', title: detail, status, instance: '/v0/mock', detail, code }),
   );
+};
+
+// The per-sheet `/document` POST routes share the whole-workbook POST contract: reject a non-XML
+// content type (415), an empty body (400), or an unknown sheet id (404 — the route resolves by id
+// and cannot create), and otherwise return a succeeded operation envelope. `known` guards the id.
+const sendDocumentApply = (
+  res: ServerResponse,
+  contentType: string | undefined,
+  body: string,
+  id: string,
+  known: boolean,
+  kind: string,
+): void => {
+  if (!known) {
+    sendProblem(res, 404, 'sheet-not-found', `${kind} not found: ${id}`);
+    return;
+  }
+  const ct = (contentType ?? '').split(';')[0].trim();
+  if (ct !== 'application/xml' && ct !== 'text/xml') {
+    sendProblem(res, 415, 'unsupported-content-type', `Unsupported content type: ${ct}`);
+    return;
+  }
+  if (body.trim().length === 0) {
+    sendProblem(res, 400, 'invalid-request-body', 'Empty document body.');
+    return;
+  }
+  sendJson(res, 200, {
+    id: 'op-doc-1',
+    kind: `${kind.toLowerCase()}.document.apply`,
+    state: 'succeeded',
+    createdAt: '2026-07-07T10:00:00Z',
+    completedAt: '2026-07-07T10:00:01Z',
+    result: { bytesApplied: body.length },
+  });
 };
 
 // A 1x1 PNG, base64-encoded — enough to exercise the inline-image decode path.
@@ -362,36 +403,57 @@ export async function startMockExternalApiServer(
     }
 
     const worksheetDocumentMatch = path.match(/^\/v0\/workbook\/worksheets\/([^/]+)\/document$/);
-    if (method === 'GET' && worksheetDocumentMatch) {
+    if (worksheetDocumentMatch) {
       const worksheetId = decodeURIComponent(worksheetDocumentMatch[1]);
-      if (!DEFAULT_WORKSHEETS.some((worksheet) => worksheet.id === worksheetId)) {
-        sendProblem(res, 404, 'sheet-not-found', `Worksheet not found: ${worksheetId}`);
+      const known = DEFAULT_WORKSHEETS.some((worksheet) => worksheet.id === worksheetId);
+      if (method === 'GET') {
+        if (!known) {
+          sendProblem(res, 404, 'sheet-not-found', `Worksheet not found: ${worksheetId}`);
+          return;
+        }
+        sendXml(res, 200, DEFAULT_WORKSHEET_DOCUMENT_XML);
         return;
       }
-      sendXml(res, 200, DEFAULT_WORKSHEET_DOCUMENT_XML);
-      return;
+      if (method === 'POST') {
+        sendDocumentApply(res, contentType, body, worksheetId, known, 'Worksheet');
+        return;
+      }
     }
 
     const dashboardDocumentMatch = path.match(/^\/v0\/workbook\/dashboards\/([^/]+)\/document$/);
-    if (method === 'GET' && dashboardDocumentMatch) {
+    if (dashboardDocumentMatch) {
       const dashboardId = decodeURIComponent(dashboardDocumentMatch[1]);
-      if (!DEFAULT_DASHBOARDS.some((dashboard) => dashboard.id === dashboardId)) {
-        sendProblem(res, 404, 'sheet-not-found', `Dashboard not found: ${dashboardId}`);
+      const known = DEFAULT_DASHBOARDS.some((dashboard) => dashboard.id === dashboardId);
+      if (method === 'GET') {
+        if (!known) {
+          sendProblem(res, 404, 'sheet-not-found', `Dashboard not found: ${dashboardId}`);
+          return;
+        }
+        sendXml(res, 200, DEFAULT_DASHBOARD_DOCUMENT_XML);
         return;
       }
-      sendXml(res, 200, DEFAULT_DASHBOARD_DOCUMENT_XML);
-      return;
+      if (method === 'POST') {
+        sendDocumentApply(res, contentType, body, dashboardId, known, 'Dashboard');
+        return;
+      }
     }
 
     const storyboardDocumentMatch = path.match(/^\/v0\/workbook\/storyboards\/([^/]+)\/document$/);
-    if (method === 'GET' && storyboardDocumentMatch) {
+    if (storyboardDocumentMatch) {
       const storyboardId = decodeURIComponent(storyboardDocumentMatch[1]);
-      if (!DEFAULT_STORYBOARDS.some((storyboard) => storyboard.id === storyboardId)) {
-        sendProblem(res, 404, 'sheet-not-found', `Storyboard not found: ${storyboardId}`);
+      const known = DEFAULT_STORYBOARDS.some((storyboard) => storyboard.id === storyboardId);
+      if (method === 'GET') {
+        if (!known) {
+          sendProblem(res, 404, 'sheet-not-found', `Storyboard not found: ${storyboardId}`);
+          return;
+        }
+        sendXml(res, 200, DEFAULT_STORYBOARD_DOCUMENT_XML);
         return;
       }
-      sendXml(res, 200, DEFAULT_STORYBOARD_XML);
-      return;
+      if (method === 'POST') {
+        sendDocumentApply(res, contentType, body, storyboardId, known, 'Storyboard');
+        return;
+      }
     }
 
     const worksheetMatch = path.match(/^\/v0\/workbook\/worksheets\/([^/]+)$/);

--- a/src/desktop/metadata/dashboards.ts
+++ b/src/desktop/metadata/dashboards.ts
@@ -192,11 +192,11 @@ export function dashboardDocumentToFragment(
   return parseXML(documentXml).dashboard ? documentXml : null;
 }
 
-// The External Client API has no per-dashboard write route — applying one dashboard re-POSTs the
-// whole document, which Desktop treats as authoritative and replaces the open workbook with. So the
-// doc must carry the ENTIRE live workbook (worksheets included — the dashboard's zones reference
-// them by name) with only this dashboard swapped in; anything omitted would be pruned. Upsert by
-// name: replace the matching dashboard, or append it if absent. Windows are left intact.
+// The External Client API's whole-workbook POST route treats the posted document as authoritative
+// and replaces the open workbook with it. So the doc must carry the ENTIRE live workbook (worksheets
+// included — the dashboard's zones reference them by name) with only this dashboard swapped in;
+// anything omitted would be pruned. Upsert by name: replace the matching dashboard, or append it if
+// absent. Windows are left intact. This is the create path; the per-sheet route is replace-only.
 export function upsertDashboardIntoWorkbook(
   workbookXml: string,
   dashboardName: string,

--- a/src/desktop/metadata/sheets.ts
+++ b/src/desktop/metadata/sheets.ts
@@ -160,12 +160,12 @@ export function worksheetDocumentToFragment(documentXml: string, sheetName: stri
   return parseXML(documentXml).worksheet ? documentXml : null;
 }
 
-// The External Client API has no per-sheet write route — applying one sheet re-POSTs the whole
-// document, which Desktop treats as authoritative and replaces the open workbook with. So the doc
-// must carry the ENTIRE live workbook with only this sheet swapped in; anything omitted (sibling
-// sheets, dashboards) would be pruned. Upsert by name: replace the matching worksheet, or append
-// it if absent (a new sheet). Preserve existing windows and synthesize this sheet's window when
-// missing, because Tableau drops worksheets that lack a matching worksheet window.
+// The External Client API's whole-workbook POST route treats the posted document as authoritative
+// and replaces the open workbook with it. So the doc must carry the ENTIRE live workbook with only
+// this sheet swapped in; anything omitted (sibling sheets, dashboards) would be pruned. Upsert by
+// name: replace the matching worksheet, or append it if absent (a new sheet). Preserve existing
+// windows and synthesize this sheet's window when missing, because Tableau drops worksheets that
+// lack a matching worksheet window. This is the create path; the per-sheet route is replace-only.
 export function upsertSheetIntoWorkbook(
   workbookXml: string,
   sheetName: string,

--- a/src/errors/mcpToolError.ts
+++ b/src/errors/mcpToolError.ts
@@ -403,6 +403,19 @@ export class DashboardXmlLoadFailedError extends McpToolError {
   }
 }
 
+// A storyboard serializes as a `<dashboard type='storyboard'>`, so it shares the dashboard load
+// path and its error shape; only the error `type` differs so the agent sees a storyboard-scoped
+// failure rather than a misleading dashboard one.
+export class StoryboardXmlLoadFailedError extends McpToolError {
+  constructor(error: LoadDashboardXmlError) {
+    super({
+      type: 'load-storyboard-xml-error',
+      message: xmlLoadErrorMessage(error),
+      statusCode: 500,
+    });
+  }
+}
+
 export class FileReadError extends McpToolError {
   constructor(error: unknown) {
     super({

--- a/src/server.desktop.test.ts
+++ b/src/server.desktop.test.ts
@@ -210,11 +210,11 @@ describe('desktop tools/list serialized surface', () => {
     // guards that invariant). The full desktop surface is opt-in (TOOL_PROFILE=full), not
     // what clients see by default; its looser cap only catches runaway growth without
     // forcing valuable full-profile tools to be trimmed.
-    // Honest wire measurements are 29,463 bytes dynamic and 46,377 bytes full: the full
-    // surface rose by the two full-profile-only export-image tools.
+    // Honest wire measurements are 29,463 bytes dynamic and 46,872 bytes full: the full
+    // surface rose by the full-profile-only get-storyboard-xml and apply-storyboard tools.
     // Keep only a few bytes of ratchet headroom on each cap.
     expect(dynamicAuthoringTotal).toBeLessThanOrEqual(29_479);
-    expect(fullSurfaceTotal).toBeLessThanOrEqual(46_393);
+    expect(fullSurfaceTotal).toBeLessThanOrEqual(46_888);
   });
 });
 

--- a/src/tools/desktop/external-api/applyStoryboard.test.ts
+++ b/src/tools/desktop/external-api/applyStoryboard.test.ts
@@ -1,0 +1,180 @@
+import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { existsSync, readFileSync } from 'fs';
+import { Err, Ok } from 'ts-results-es';
+import { z } from 'zod';
+
+import * as cacheFingerprintModule from '../../../desktop/commands/workbook/cacheFingerprint.js';
+import * as loadDashboardXmlModule from '../../../desktop/commands/workbook/loadDashboardXml.js';
+import { DesktopCommandExecutionError, FileReadError } from '../../../errors/mcpToolError.js';
+import { DesktopMcpServer } from '../../../server.desktop.js';
+import invariant from '../../../utils/invariant.js';
+import { Provider } from '../../../utils/provider.js';
+import { TableauDesktopToolContext } from '../toolContext.js';
+import { getMockRequestHandlerExtra } from '../toolContext.mock.js';
+import { getApplyStoryboardTool } from './applyStoryboard.js';
+
+vi.mock('../../../desktop/commands/workbook/loadDashboardXml.js');
+vi.mock('fs');
+
+describe('applyStoryboardTool', () => {
+  const resultSchema = z.object({ message: z.string() });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should create a tool instance with correct properties', () => {
+    const tool = getApplyStoryboardTool(new DesktopMcpServer());
+    expect(tool.name).toBe('apply-storyboard');
+    expect(tool.description).toContain('Apply modified storyboard document to Tableau');
+    expect(tool.paramsSchema).toMatchObject({
+      session: expect.any(Object),
+      storyboardName: expect.any(Object),
+      storyboardFile: expect.any(Object),
+    });
+    expect(tool.annotations).toMatchObject({ readOnlyHint: false, destructiveHint: true });
+  });
+
+  it('applies the storyboard document via loadStoryboardXml', async () => {
+    const mockXml = '<dashboard name="QBR Story" type="storyboard"><zones></zones></dashboard>';
+    const loadSpy = vi
+      .spyOn(loadDashboardXmlModule, 'loadStoryboardXml')
+      .mockResolvedValue(Ok({ validationWarnings: [] }));
+
+    const result = await getToolResult({ storyboardXml: mockXml });
+
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+    const resultObj = resultSchema.parse(JSON.parse(result.content[0].text));
+    expect(resultObj.message).toContain('Successfully applied storyboard update');
+    expect(resultObj.message).toContain('HOST VERIFICATION — unverified');
+    expect(loadSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ storyboardName: 'QBR Story', xml: mockXml }),
+    );
+  });
+
+  it('refuses a file-mode apply when the cache sidecar fingerprint mismatches the session (W9)', async () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue(
+      '<dashboard name="QBR Story" type="storyboard"></dashboard>',
+    );
+    const sidecarSpy = vi.spyOn(cacheFingerprintModule, 'checkSidecar').mockReturnValue({
+      ok: false,
+      message: 'Cache produced by a different Desktop session — re-read in the current session.',
+    });
+    const loadSpy = vi
+      .spyOn(loadDashboardXmlModule, 'loadStoryboardXml')
+      .mockResolvedValue(Ok({ validationWarnings: [] }));
+
+    const result = await getToolResult({ storyboardFile: '/path/to/storyboard.xml' });
+
+    expect(result.isError).toBe(true);
+    invariant(result.content[0].type === 'text');
+    expect(result.content[0].text).toContain('different Desktop session');
+    expect(loadSpy).not.toHaveBeenCalled();
+    // Restore so the fail-open default holds for the other file-mode tests.
+    expect(sidecarSpy).toHaveBeenCalledWith(
+      '/path/to/storyboard.xml',
+      expect.any(String),
+      'storyboard',
+    );
+    sidecarSpy.mockRestore();
+  });
+
+  it('should return error when no storyboardFile is given', async () => {
+    const result = await getToolResult({});
+
+    expect(result.isError).toBe(true);
+    invariant(result.content[0].type === 'text');
+    expect(result.content[0].text).toContain('A non-empty storyboard file path is required');
+  });
+
+  it('should return error when storyboard file does not exist', async () => {
+    vi.mocked(existsSync).mockReturnValue(false);
+
+    const result = await getToolResult({ storyboardFile: '/nonexistent.xml' });
+
+    expect(result.isError).toBe(true);
+    invariant(result.content[0].type === 'text');
+    expect(result.content[0].text).toContain('Cached storyboard file not found');
+  });
+
+  it('should return error when file read fails', async () => {
+    const readError = new Error('Permission denied');
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockImplementation(() => {
+      throw readError;
+    });
+
+    const result = await getToolResult({ storyboardFile: '/path/to/storyboard.xml' });
+
+    expect(result.isError).toBe(true);
+    invariant(result.content[0].type === 'text');
+    expect(result.content[0].text).toBe(new FileReadError(readError).message);
+  });
+
+  it('should return error when loadStoryboardXml command fails', async () => {
+    const mockXml = '<dashboard name="QBR Story" type="storyboard"><zones></zones></dashboard>';
+    const error = {
+      type: 'execute-command-error' as const,
+      error: {
+        type: 'command-failed' as const,
+        error: { code: 'ERROR', message: 'Failed', recoverable: false },
+      },
+    };
+    vi.spyOn(loadDashboardXmlModule, 'loadStoryboardXml').mockResolvedValue(Err(error));
+
+    const result = await getToolResult({ storyboardXml: mockXml });
+
+    expect(result.isError).toBe(true);
+    invariant(result.content[0].type === 'text');
+    expect(result.content[0].text).toBe(new DesktopCommandExecutionError(error.error).message);
+  });
+
+  it('should pass the abort signal to loadStoryboardXml', async () => {
+    const mockXml = '<dashboard name="QBR Story" type="storyboard"><zones></zones></dashboard>';
+    const mockLoad = vi
+      .spyOn(loadDashboardXmlModule, 'loadStoryboardXml')
+      .mockResolvedValue(Ok({ validationWarnings: [] }));
+    const customSignal = new AbortController().signal;
+
+    await getToolResult({ storyboardXml: mockXml, customSignal });
+
+    expect(mockLoad).toHaveBeenCalledWith(
+      expect.objectContaining({ xml: mockXml, signal: customSignal }),
+    );
+  });
+});
+
+async function getToolResult({
+  session = '12345',
+  storyboardName = 'QBR Story',
+  storyboardFile,
+  storyboardXml,
+  mockExecutor = vi.fn().mockResolvedValue({}),
+  customSignal,
+}: {
+  session?: string;
+  storyboardName?: string;
+  storyboardFile?: string;
+  storyboardXml?: string;
+  mockExecutor?: TableauDesktopToolContext['getExecutor'];
+  customSignal?: AbortSignal;
+}): Promise<CallToolResult> {
+  const tool = getApplyStoryboardTool(new DesktopMcpServer());
+  const callback = await Provider.from(tool.callback);
+  // The tool takes no inline document. Tests that supply XML directly get a synthetic cache path
+  // backed by the fs mock, so they still exercise the apply leg.
+  if (storyboardXml !== undefined && storyboardFile === undefined) {
+    storyboardFile = '/cache/synthetic-storyboard.xml';
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue(storyboardXml);
+  }
+
+  const extra = {
+    ...getMockRequestHandlerExtra(),
+    getExecutor: mockExecutor,
+    ...(customSignal && { signal: customSignal }),
+  };
+  return await callback({ session, storyboardName, storyboardFile }, extra);
+}

--- a/src/tools/desktop/external-api/applyStoryboard.ts
+++ b/src/tools/desktop/external-api/applyStoryboard.ts
@@ -4,16 +4,16 @@ import { Ok } from 'ts-results-es';
 import { z } from 'zod';
 
 import { checkSidecar } from '../../../desktop/commands/workbook/cacheFingerprint.js';
-import { loadDashboardXml } from '../../../desktop/commands/workbook/loadDashboardXml.js';
+import { loadStoryboardXml } from '../../../desktop/commands/workbook/loadDashboardXml.js';
 import { currentEpisodeId, emitEpisodeEvent } from '../../../desktop/episode-events.js';
 import { resolveSession } from '../../../desktop/sessionResolution.js';
 import { formatDashboardPromiseCheck } from '../../../desktop/validation/promise-check.js';
 import {
   ArgsValidationError,
   CacheSessionMismatchError,
-  DashboardXmlLoadFailedError,
   DesktopCommandExecutionError,
   FileReadError,
+  StoryboardXmlLoadFailedError,
   WorkbookNotFoundError,
 } from '../../../errors/mcpToolError.js';
 import { DesktopMcpServer } from '../../../server.desktop.js';
@@ -21,19 +21,19 @@ import { DesktopTool } from '../tool.js';
 
 const paramsSchema = {
   session: z.string().optional(),
-  dashboardName: z.string(),
-  dashboardFile: z.string().optional(),
+  storyboardName: z.string(),
+  storyboardFile: z.string().optional(),
 };
 
-const title = 'Apply Dashboard';
-export const getApplyDashboardTool = (
+const title = 'Apply Storyboard';
+export const getApplyStoryboardTool = (
   server: DesktopMcpServer,
 ): DesktopTool<typeof paramsSchema> => {
-  const applyDashboardTool = new DesktopTool({
+  const applyStoryboardTool = new DesktopTool({
     server,
-    name: 'apply-dashboard',
+    name: 'apply-storyboard',
     title,
-    description: 'Apply modified dashboard layout to Tableau.',
+    description: 'Apply modified storyboard document to Tableau.',
     paramsSchema,
     annotations: {
       readOnlyHint: false,
@@ -41,37 +41,38 @@ export const getApplyDashboardTool = (
       destructiveHint: true,
       idempotentHint: false,
     },
-    callback: async ({ session, dashboardName, dashboardFile }, extra): Promise<CallToolResult> => {
-      return await applyDashboardTool.logAndExecute({
+    callback: async (
+      { session, storyboardName, storyboardFile },
+      extra,
+    ): Promise<CallToolResult> => {
+      return await applyStoryboardTool.logAndExecute({
         extra,
-        args: { session, dashboardName, dashboardFile },
+        args: { session, storyboardName, storyboardFile },
         callback: async () => {
-          // No inline document parameter: the cached file path IS the handle. Making the
-          // model retype a document cost ~190s of pure emission across six asks, and
-          // inline content carried no cache fingerprint, so it also skipped the
-          // cross-instance bleed guard below.
-          if (!dashboardFile?.trim()) {
+          // No inline document parameter: the cached file path IS the handle. Inline content
+          // carries no cache fingerprint, so it would also skip the cross-instance bleed guard below.
+          if (!storyboardFile?.trim()) {
             return new ArgsValidationError(
               [
-                'A non-empty dashboard file path is required.',
-                'Use a cached dashboard path, edit it with read-cached-xml and',
+                'A non-empty storyboard file path is required.',
+                'Use a cached storyboard path, edit it with read-cached-xml and',
                 'write-cached-xml, then pass that path here.',
               ].join(' '),
             ).toErr();
           }
 
-          if (!existsSync(dashboardFile)) {
+          if (!existsSync(storyboardFile)) {
             return new WorkbookNotFoundError(
               [
-                `Cached dashboard file not found: ${dashboardFile}`,
-                'Provide an existing cached dashboard path.',
+                `Cached storyboard file not found: ${storyboardFile}`,
+                'Provide an existing cached storyboard path.',
               ].join(' '),
             ).toErr();
           }
 
-          let dashboardXml: string;
+          let storyboardXml: string;
           try {
-            dashboardXml = readFileSync(dashboardFile, 'utf-8');
+            storyboardXml = readFileSync(storyboardFile, 'utf-8');
           } catch (error) {
             return new FileReadError(error).toErr();
           }
@@ -83,23 +84,22 @@ export const getApplyDashboardTool = (
           const resolvedSession = sessionResult.value;
 
           // Cross-instance cache-bleed guard (W9): refuse a cache file produced by a
-          // different (or restarted) Desktop session before applying it. Now that every
-          // apply goes through a cache file, no payload can skip this check.
-          const sidecar = checkSidecar(dashboardFile, resolvedSession, 'dashboard');
+          // different (or restarted) Desktop session before applying it.
+          const sidecar = checkSidecar(storyboardFile, resolvedSession, 'storyboard');
           if (!sidecar.ok) {
             return new CacheSessionMismatchError(sidecar.message!).toErr();
           }
 
           const executor = await extra.getExecutor(resolvedSession);
-          const result = await loadDashboardXml({
-            dashboardName,
-            xml: dashboardXml,
-            focus: { navigate: 'artifact', sheetName: dashboardName },
+          const result = await loadStoryboardXml({
+            storyboardName,
+            xml: storyboardXml,
+            focus: { navigate: 'artifact', sheetName: storyboardName },
             executor,
             signal: extra.signal,
-            // apply-dashboard updates an existing dashboard in place via the per-sheet `/document`
+            // apply-storyboard updates an existing storyboard in place via the per-sheet `/document`
             // route; a name that does not resolve surfaces as an error rather than creating a
-            // dashboard through the whole-workbook path.
+            // storyboard through the whole-workbook path.
             requireExistingSheet: true,
           });
 
@@ -109,16 +109,15 @@ export const getApplyDashboardTool = (
               case 'execute-command-error':
                 return new DesktopCommandExecutionError(error).toErr();
               case 'load-dashboard-xml-error':
-                return new DashboardXmlLoadFailedError(error).toErr();
+                return new StoryboardXmlLoadFailedError(error).toErr();
               default: {
                 const _: never = type;
               }
             }
           }
 
-          // Host verification receipt (W-23447506): dashboard applies have no
-          // structural readback, so say so honestly instead of implying full
-          // re-verification happened.
+          // Host verification receipt (W-23447506): storyboard applies have no structural
+          // readback, so say so honestly instead of implying full re-verification happened.
           const receipt = result.isOk()
             ? formatDashboardPromiseCheck(result.value.validationWarnings)
             : '';
@@ -127,19 +126,19 @@ export const getApplyDashboardTool = (
               type: 'apply_succeeded',
               session_id: resolvedSession,
               episode_id: currentEpisodeId(resolvedSession),
-              tool: 'apply-dashboard',
-              operation: 'load-dashboard',
+              tool: 'apply-storyboard',
+              operation: 'load-storyboard',
               promise_outcome: 'unverified',
             });
           }
 
           return new Ok({
-            message: `Successfully applied dashboard update for "${dashboardName}". The dashboard has been updated.${receipt}`,
+            message: `Successfully applied storyboard update for "${storyboardName}". The storyboard has been updated.${receipt}`,
           });
         },
       });
     },
   });
 
-  return applyDashboardTool;
+  return applyStoryboardTool;
 };

--- a/src/tools/desktop/external-api/externalApiTools.test.ts
+++ b/src/tools/desktop/external-api/externalApiTools.test.ts
@@ -239,15 +239,20 @@ describe('External API coverage tools', () => {
     }
   });
 
-  it('gets a storyboard document by name after resolving it to an id', async () => {
+  it('gets a storyboard document by name, sliced to its <dashboard> fragment', async () => {
     const harness = await startHarness(getStoryboardXmlTool);
     try {
-      const result = await harness.callTool({ storyboard: 'QBR Story' });
+      // A storyboard serializes as a `<dashboard type="storyboard">`; the whole-workbook document
+      // is sliced to that single fragment (the sibling dashboard is excluded by name).
+      const result = await harness.callTool({ storyboard: 'QBR Story', mode: 'inline' });
 
       expect(result.isError).toBe(false);
-      expect(
-        z.object({ storyboardXml: z.string() }).parse(parseResult(result)).storyboardXml,
-      ).toContain('<storyboard name="QBR Story"');
+      const storyboardXml = z
+        .object({ storyboardXml: z.string() })
+        .parse(parseResult(result)).storyboardXml;
+      expect(storyboardXml).toContain('name="QBR Story"');
+      expect(storyboardXml).toContain('type="storyboard"');
+      expect(storyboardXml).not.toContain('Executive Dashboard');
       expect(harness.server.requests.map((request) => request.path)).toEqual([
         '/v0/workbook/storyboards',
         '/v0/workbook/storyboards/story-qbr/document',

--- a/src/tools/desktop/external-api/getStoryboardXml.test.ts
+++ b/src/tools/desktop/external-api/getStoryboardXml.test.ts
@@ -1,0 +1,213 @@
+import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { Err, Ok } from 'ts-results-es';
+import { z } from 'zod';
+
+import * as loggerModule from '../../../logging/logger.js';
+import { DesktopMcpServer } from '../../../server.desktop.js';
+import invariant from '../../../utils/invariant.js';
+import { Provider } from '../../../utils/provider.js';
+import { TableauDesktopToolContext } from '../toolContext.js';
+import { getMockRequestHandlerExtra } from '../toolContext.mock.js';
+import { getStoryboardXmlTool } from './getStoryboardXml.js';
+
+vi.mock('fs');
+
+// A storyboard serializes as a `<dashboard type="storyboard">`, so its /document route returns a
+// whole <workbook>; the tool slices it to the single fragment by the resolved storyboard name.
+function storyboardDocument(name: string, filler = ''): string {
+  return (
+    '<?xml version="1.0"?><workbook><dashboards>' +
+    '<dashboard name="Executive Dashboard"><zones><zone name="Sales by Region" /></zones></dashboard>' +
+    `<dashboard name="${name}" type="storyboard"><zones><zone name="Sales by Region" />${filler}</zones></dashboard>` +
+    '</dashboards></workbook>'
+  );
+}
+
+describe('getStoryboardXmlTool', () => {
+  const fileResultSchema = z.object({
+    message: z.string(),
+    file: z.string(),
+    instructions: z.string(),
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // The cache write and sidecar stamp are exercised through the fs mock; keep the log quiet.
+    vi.spyOn(loggerModule, 'log').mockImplementation(() => undefined);
+  });
+
+  it('should create a tool instance with correct properties', () => {
+    const tool = getStoryboardXmlTool(new DesktopMcpServer());
+    expect(tool.name).toBe('get-storyboard-xml');
+    expect(tool.paramsSchema).toMatchObject({
+      session: expect.any(Object),
+      storyboard: expect.any(Object),
+      mode: expect.any(Object),
+    });
+    // The tool writes a cache file, so it is not read-only.
+    expect(tool.annotations).toMatchObject({ readOnlyHint: false });
+  });
+
+  it('writes the sliced fragment to a cache file and points at apply-storyboard (default mode)', async () => {
+    const result = await getToolResult({ storyboard: 'QBR Story' });
+
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+    const resultObj = fileResultSchema.parse(JSON.parse(result.content[0].text));
+    expect(resultObj.file).toContain('storyboard');
+    expect(resultObj.message).toContain('cache file');
+    expect(resultObj.message).toContain('QBR Story');
+    expect(resultObj.instructions).toContain('apply-storyboard');
+  });
+
+  it('returns the sliced fragment inline when mode is inline', async () => {
+    const result = await getToolResult({ storyboard: 'QBR Story', mode: 'inline' });
+
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+    const resultObj = z
+      .object({ message: z.string(), storyboardXml: z.string() })
+      .parse(JSON.parse(result.content[0].text));
+    expect(resultObj.message).toContain('inline');
+    expect(resultObj.storyboardXml).toContain('name="QBR Story"');
+    expect(resultObj.storyboardXml).toContain('type="storyboard"');
+    // The sibling dashboard is sliced out by name.
+    expect(resultObj.storyboardXml).not.toContain('Executive Dashboard');
+  });
+
+  it('forces file mode when the inline fragment exceeds the cap, regardless of requested mode', async () => {
+    const bigDocument = storyboardDocument('QBR Story', '<x>' + 'y'.repeat(20000) + '</x>');
+    const result = await getToolResult({ storyboard: 'QBR Story', mode: 'inline', bigDocument });
+
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+    const parsed = JSON.parse(result.content[0].text) as Record<string, unknown>;
+    expect(parsed.storyboardXml).toBeUndefined();
+    const resultObj = fileResultSchema.parse(parsed);
+    expect(resultObj.message).toContain('inline cap');
+    expect(resultObj.message).toContain('QBR Story');
+    expect(resultObj.instructions).toContain('cache read tool');
+  });
+
+  it('respects a smaller cap overridden via config', async () => {
+    const result = await getToolResult({ storyboard: 'QBR Story', mode: 'inline', capBytes: 8 });
+
+    invariant(result.content[0].type === 'text');
+    const parsed = JSON.parse(result.content[0].text) as Record<string, unknown>;
+    expect(parsed.storyboardXml).toBeUndefined();
+    expect(parsed.file).toBeDefined();
+  });
+
+  it('reports an honest too-new endpoint error when the storyboard list route is absent', async () => {
+    const result = await getToolResult({ storyboard: 'QBR Story', listRouteMissing: true });
+
+    expect(result.isError).toBe(true);
+    invariant(result.content[0].type === 'text');
+    expect(result.content[0].text).toContain('storyboard list');
+    expect(result.content[0].text).toContain('Do not retry');
+  });
+
+  it('reports an honest too-new endpoint error when the storyboard document route is absent', async () => {
+    const result = await getToolResult({ storyboard: 'QBR Story', documentRouteMissing: true });
+
+    expect(result.isError).toBe(true);
+    invariant(result.content[0].type === 'text');
+    expect(result.content[0].text).toContain('storyboard document');
+    expect(result.content[0].text).toContain('Do not retry');
+  });
+
+  it('passes the abort signal to both executor calls', async () => {
+    const customSignal = new AbortController().signal;
+    const { listStoryboards, getStoryboardDocument } = await getToolCalls({
+      storyboard: 'QBR Story',
+      customSignal,
+    });
+
+    expect(listStoryboards).toHaveBeenCalledWith(customSignal);
+    expect(getStoryboardDocument).toHaveBeenCalledWith('story-qbr', customSignal);
+  });
+});
+
+const routeMissing = {
+  type: 'command-failed' as const,
+  error: {
+    code: 'not-found',
+    message: 'No route matches GET /v0/workbook/storyboards',
+    recoverable: false,
+  },
+};
+
+function makeExecutor({
+  bigDocument,
+  listRouteMissing,
+  documentRouteMissing,
+}: {
+  bigDocument?: string;
+  listRouteMissing?: boolean;
+  documentRouteMissing?: boolean;
+}): {
+  executor: {
+    listStoryboards: ReturnType<typeof vi.fn>;
+    getStoryboardDocument: ReturnType<typeof vi.fn>;
+  };
+} {
+  const listStoryboards = vi
+    .fn()
+    .mockResolvedValue(
+      listRouteMissing
+        ? Err(routeMissing)
+        : Ok({ storyboards: [{ id: 'story-qbr', name: 'QBR Story', hidden: false }] }),
+    );
+  const getStoryboardDocument = vi
+    .fn()
+    .mockResolvedValue(
+      documentRouteMissing
+        ? Err(routeMissing)
+        : Ok({ xml: bigDocument ?? storyboardDocument('QBR Story') }),
+    );
+  return { executor: { listStoryboards, getStoryboardDocument } };
+}
+
+async function getToolResult(opts: {
+  session?: string;
+  storyboard: string;
+  mode?: 'file' | 'inline';
+  capBytes?: number;
+  bigDocument?: string;
+  listRouteMissing?: boolean;
+  documentRouteMissing?: boolean;
+  customSignal?: AbortSignal;
+}): Promise<CallToolResult> {
+  const { session = '12345', storyboard, mode = 'file', capBytes, customSignal } = opts;
+  const { executor } = makeExecutor(opts);
+  const tool = getStoryboardXmlTool(new DesktopMcpServer());
+  const callback = await Provider.from(tool.callback);
+  const base = getMockRequestHandlerExtra();
+  const extra = {
+    ...base,
+    getExecutor: vi
+      .fn()
+      .mockResolvedValue(executor) as unknown as TableauDesktopToolContext['getExecutor'],
+    ...(customSignal && { signal: customSignal }),
+    ...(capBytes !== undefined && { config: { ...base.config, inlineXmlMaxBytes: capBytes } }),
+  };
+  return await callback({ session, storyboard, mode }, extra);
+}
+
+async function getToolCalls(opts: { storyboard: string; customSignal?: AbortSignal }): Promise<{
+  listStoryboards: ReturnType<typeof vi.fn>;
+  getStoryboardDocument: ReturnType<typeof vi.fn>;
+}> {
+  const { executor } = makeExecutor({});
+  const tool = getStoryboardXmlTool(new DesktopMcpServer());
+  const callback = await Provider.from(tool.callback);
+  const extra = {
+    ...getMockRequestHandlerExtra(),
+    getExecutor: vi
+      .fn()
+      .mockResolvedValue(executor) as unknown as TableauDesktopToolContext['getExecutor'],
+    ...(opts.customSignal && { signal: opts.customSignal }),
+  };
+  await callback({ session: '12345', storyboard: opts.storyboard, mode: 'inline' }, extra);
+  return executor;
+}

--- a/src/tools/desktop/external-api/getStoryboardXml.ts
+++ b/src/tools/desktop/external-api/getStoryboardXml.ts
@@ -1,17 +1,39 @@
 import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { writeFileSync } from 'fs';
 import { Ok } from 'ts-results-es';
 import { z } from 'zod';
 
+import { formatArtifactSummary } from '../../../desktop/artifactSummary.js';
+import { DesktopCache } from '../../../desktop/cache.js';
+import { writeSidecar } from '../../../desktop/commands/workbook/cacheFingerprint.js';
+import {
+  buildInlineCapFileMessage,
+  isOverInlineXmlCap,
+  logInlineXmlCapHit,
+  xmlByteLength,
+} from '../../../desktop/inlineXmlCap.js';
+import { dashboardDocumentToFragment } from '../../../desktop/metadata/dashboards.js';
+import { resolveSession } from '../../../desktop/sessionResolution.js';
+import { DesktopCommandExecutionError, UnknownError } from '../../../errors/mcpToolError.js';
+import { log } from '../../../logging/logger.js';
 import { DesktopMcpServer } from '../../../server.desktop.js';
-import { runExternalApiReadTool } from '../externalApiReadHarness.js';
 import { DesktopTool } from '../tool.js';
-import { resolveItemByNameOrId } from './externalApiToolUtils.js';
+import {
+  endpointNotInThisBuild,
+  isRouteMissing,
+  resolveItemByNameOrId,
+} from './externalApiToolUtils.js';
 
 const paramsSchema = {
   session: z.string().optional().describe('Session ID; optional if pinned or unique.'),
   storyboard: z.string().describe('Storyboard name/id.'),
+  mode: z.enum(['file', 'inline']).optional().default('file'),
 };
 const title = 'Get Storyboard Document';
+
+type InlineResult = { storyboardXml: string };
+type FileResult = { file: string; instructions: string };
+type GetStoryboardXmlToolResult = { message: string } & (InlineResult | FileResult);
 
 export const getStoryboardXmlTool = (
   server: DesktopMcpServer,
@@ -23,51 +45,116 @@ export const getStoryboardXmlTool = (
     description: 'Return one storyboard document subtree.',
     paramsSchema,
     annotations: {
-      readOnlyHint: true,
+      readOnlyHint: false, // Writes to a cache file
       destructiveHint: false,
-      idempotentHint: true,
+      idempotentHint: false,
       openWorldHint: false,
     },
-    callback: async ({ session, storyboard }, extra): Promise<CallToolResult> => {
-      return await getStoryboardXml.logAndExecute({
+    callback: async ({ session, storyboard, mode }, extra): Promise<CallToolResult> => {
+      return await getStoryboardXml.logAndExecute<GetStoryboardXmlToolResult>({
         extra,
-        args: { session, storyboard },
+        args: { session, storyboard, mode },
         callback: async () => {
-          const result = await runExternalApiReadTool({
-            session,
-            extra,
-            callback: async (_executor, _signal, read) => {
-              const listResult = await read(
-                'storyboard list',
-                async (executor, signal) => await executor.listStoryboards(signal),
-              );
-              if (listResult.isErr()) {
-                return listResult;
-              }
+          const sessionResult = resolveSession(session);
+          if (sessionResult.isErr()) {
+            return sessionResult.error.toErr();
+          }
+          const resolvedSession = sessionResult.value;
+          const executor = await extra.getExecutor(resolvedSession);
 
-              const storyboardResult = resolveItemByNameOrId(
-                'Storyboard',
-                storyboard,
-                listResult.value.storyboards ?? [],
-              );
-              if (storyboardResult.isErr()) {
-                return storyboardResult.error.toErr();
-              }
-
-              return await read(
-                'storyboard document',
-                async (executor, signal) =>
-                  await executor.getStoryboardDocument(storyboardResult.value.id, signal),
-              );
-            },
-          });
-          if (result.isErr()) {
-            return result;
+          // A storyboard serializes as a `<dashboard type='storyboard'>`, so its `/document` route
+          // returns a whole `<workbook>` scoped to it — the same shape as a dashboard. Resolve the
+          // name to an id, fetch the document, then slice out the single `<dashboard>` fragment by
+          // the resolved name so callers get exactly what apply-storyboard expects.
+          const listResult = await executor.listStoryboards(extra.signal);
+          if (listResult.isErr()) {
+            if (isRouteMissing(listResult.error)) {
+              return endpointNotInThisBuild('storyboard list').toErr();
+            }
+            return new DesktopCommandExecutionError(listResult.error).toErr();
           }
 
-          return new Ok({
-            message: 'Storyboard document returned inline',
-            storyboardXml: result.value.xml,
+          const storyboardResult = resolveItemByNameOrId(
+            'Storyboard',
+            storyboard,
+            listResult.value.storyboards ?? [],
+          );
+          if (storyboardResult.isErr()) {
+            return storyboardResult.error.toErr();
+          }
+          const resolved = storyboardResult.value;
+
+          const documentResult = await executor.getStoryboardDocument(resolved.id, extra.signal);
+          if (documentResult.isErr()) {
+            if (isRouteMissing(documentResult.error)) {
+              return endpointNotInThisBuild('storyboard document').toErr();
+            }
+            return new DesktopCommandExecutionError(documentResult.error).toErr();
+          }
+
+          const storyboardXml = dashboardDocumentToFragment(
+            documentResult.value.xml,
+            resolved.name,
+          );
+          if (storyboardXml === null) {
+            return new UnknownError(
+              `No storyboard document subtree found for "${storyboard}".`,
+            ).toErr();
+          }
+
+          const bytes = xmlByteLength(storyboardXml);
+          const capBytes = extra.config.inlineXmlMaxBytes;
+          const capFired = mode === 'inline' && isOverInlineXmlCap(bytes, capBytes);
+
+          if (mode === 'inline' && !capFired) {
+            return new Ok({
+              message: `Storyboard document returned inline (${bytes} bytes)`,
+              storyboardXml,
+            });
+          }
+
+          const safeName = resolved.name.replace(/[^a-zA-Z0-9]/g, '_');
+          const cacheFile = new DesktopCache().getCacheFilePath({
+            prefix: `storyboard-${safeName}`,
+          });
+          writeFileSync(cacheFile, storyboardXml, 'utf-8');
+          // Stamp the producing session so apply-storyboard can refuse a cache from a
+          // different (or restarted) Desktop instance — cross-instance bleed guard (W9).
+          writeSidecar(cacheFile, resolvedSession);
+
+          if (capFired) {
+            logInlineXmlCapHit({ tool: 'get-storyboard-xml', bytes, capBytes, file: cacheFile });
+            return Ok({
+              message: buildInlineCapFileMessage({
+                // A storyboard has no dedicated ArtifactKind; it shares the dashboard summary shape.
+                kind: 'dashboard',
+                label: `Storyboard "${resolved.name}"`,
+                bytes,
+                capBytes,
+                xml: storyboardXml,
+                applyTool: 'apply-storyboard',
+                pathParam: 'storyboardFile',
+              }),
+              file: cacheFile,
+              instructions:
+                'This storyboard exceeds the inline cap. Use the cache read tool (with a dashboard ' +
+                'selector or startByte/endByte to read a slice), the cache write tool (same selector to ' +
+                'splice edits back), then call apply-storyboard with storyboardFile set to this file path.',
+            });
+          }
+
+          log({
+            message: `Saved storyboard document to cache file: ${cacheFile}`,
+            level: 'info',
+            logger: 'tool',
+            data: { file: cacheFile, size: bytes },
+          });
+
+          return Ok({
+            message: `Storyboard "${resolved.name}" saved to cache file (${bytes} bytes)\n\nArtifact summary:\n${formatArtifactSummary('dashboard', storyboardXml)}`,
+            file: cacheFile,
+            instructions:
+              'Use this file path with apply-storyboard instead of passing content directly.',
           });
         },
       });

--- a/src/tools/desktop/toolName.ts
+++ b/src/tools/desktop/toolName.ts
@@ -46,6 +46,7 @@ export const desktopToolNames = [
   'get-worksheet-info',
   'list-storyboards',
   'get-storyboard-xml',
+  'apply-storyboard',
   'get-api-root',
   'get-site-info',
   'get-dashboard-info',

--- a/src/tools/desktop/tools.ts
+++ b/src/tools/desktop/tools.ts
@@ -28,6 +28,7 @@ import { getWorkbookInventoryTool } from './data-source/getWorkbookInventory.js'
 import { getListSiteDatasourcesTool } from './data-source/listSiteDatasources.js';
 import { getListSiteWorkbooksTool } from './data-source/listSiteWorkbooks.js';
 import { getListWorkbookDatasourcesTool } from './data-source/listWorkbookDatasources.js';
+import { getApplyStoryboardTool } from './external-api/applyStoryboard.js';
 import { exportDashboardImageTool } from './external-api/exportDashboardImage.js';
 import { exportWorksheetImageTool } from './external-api/exportWorksheetImage.js';
 import { getApiRootTool } from './external-api/getApiRoot.js';
@@ -112,6 +113,7 @@ export const desktopToolFactories = [
   getWorksheetInfoTool,
   getListStoryboardsTool,
   getStoryboardXmlTool,
+  getApplyStoryboardTool,
   getApiRootTool,
   getSiteInfoTool,
   getDashboardInfoTool,

--- a/src/tools/desktop/worksheet/applyWorksheet.ts
+++ b/src/tools/desktop/worksheet/applyWorksheet.ts
@@ -102,6 +102,10 @@ export const getApplyWorksheetTool = (
             focus: { navigate: 'artifact', sheetName: worksheetName },
             executor,
             signal: extra.signal,
+            // apply-worksheet updates an existing worksheet in place via the per-sheet `/document`
+            // route; a name that does not resolve surfaces as an error rather than creating a sheet
+            // through the whole-workbook path (build-and-apply-worksheet owns net-new creation).
+            requireExistingSheet: true,
           });
 
           if (result.isErr()) {


### PR DESCRIPTION
## Decision

Apply now edits one sheet in place. The three apply tools (`apply-worksheet`, `apply-dashboard`, `apply-storyboard`) replace a single sheet **by id** through its dedicated per-sheet `/document` POST route instead of re-posting the whole workbook. This is the rule for the apply tools going forward, not a one-off.

The per-sheet route is **replace-only** — it resolves the target by id and cannot create a sheet. So a `requireExistingSheet` flag (set only by these three apply tools) gates two paths:

- **on** → apply by id via the per-sheet route, leaving sibling sheets untouched;
- **off** (`build-and-apply-worksheet`, `refine-worksheet`) → the whole-workbook upsert, which is the only create path.

A name that resolves to no live sheet now surfaces `sheet-absent` (with a fix hint) instead of silently creating one through the whole-workbook path.

## What changed

- **Per-sheet apply route.** New `tryApplyViaPerSheetRoute` resolves a sheet name to its live id, POSTs to the per-sheet `/document` route, and reports `applied` / `sheet-absent` / `route-missing` so the caller can surface the miss or fall back. Builds without the route fall back to the whole-workbook apply.
- **Storyboard apply.** New `apply-storyboard` tool. Storyboards serialize as `<dashboard type='storyboard'>`, so they reuse the dashboard load path via a `kind: 'storyboard'` thread.
- **Raw fragment on the wire.** The MCP POSTs the `<worksheet>`/`<dashboard>` fragment as-is; Tableau Desktop wraps it into the live workbook server-side on apply, so the MCP no longer builds a `<workbook>` envelope.

## Testing

- Unit suite green (per-sheet apply, storyboard tool, load paths, mock server, tool registration).
- `tsc` and lint clean.
