### PR TITLE
refactor(desktop): route worksheet/dashboard list reads through the shared read harness

### DIFF
--- a/src/tools/desktop/workbook/listDashboards.test.ts
+++ b/src/tools/desktop/workbook/listDashboards.test.ts
@@ -3,6 +3,7 @@ import { Err, Ok } from 'ts-results-es';
 import { z } from 'zod';
 
 import * as listDashboardsModule from '../../../desktop/commands/workbook/listDashboards.js';
+import * as sessionResolution from '../../../desktop/sessionResolution.js';
 import { DesktopCommandExecutionError } from '../../../errors/mcpToolError.js';
 import { DesktopMcpServer } from '../../../server.desktop.js';
 import invariant from '../../../utils/invariant.js';
@@ -12,6 +13,7 @@ import { getMockRequestHandlerExtra } from '../toolContext.mock.js';
 import { getListDashboardsTool } from './listDashboards.js';
 
 vi.mock('../../../desktop/commands/workbook/listDashboards.js');
+vi.mock('../../../desktop/sessionResolution.js');
 
 describe('listDashboardsTool', () => {
   const resultSchema = z.object({
@@ -21,6 +23,7 @@ describe('listDashboardsTool', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(sessionResolution.resolveSession).mockReturnValue(Ok('999'));
   });
 
   it('should create a tool instance with correct properties', () => {
@@ -109,6 +112,26 @@ describe('listDashboardsTool', () => {
     expect(result.isError).toBe(true);
     invariant(result.content[0].type === 'text');
     expect(result.content[0].text).toBe(new DesktopCommandExecutionError(error).message);
+  });
+
+  it('maps a route-missing error to an honest endpoint-not-in-this-build 404', async () => {
+    vi.spyOn(listDashboardsModule, 'listDashboards').mockResolvedValue(
+      Err({
+        type: 'command-failed',
+        error: {
+          code: 'not-found',
+          message: 'No route matches GET /v0/workbook/dashboards',
+          recoverable: false,
+        },
+      }),
+    );
+
+    const result = await getToolResult({ session: '12345', mockExecutor: vi.fn() });
+
+    expect(result.isError).toBe(true);
+    invariant(result.content[0].type === 'text');
+    expect(result.content[0].text).toContain('dashboard list endpoint');
+    expect(result.content[0].text).toContain('Do not retry');
   });
 
   it('should pass the abort signal to listDashboards command', async () => {

--- a/src/tools/desktop/workbook/listDashboards.ts
+++ b/src/tools/desktop/workbook/listDashboards.ts
@@ -2,9 +2,8 @@ import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
 
 import { listDashboards } from '../../../desktop/commands/workbook/listDashboards.js';
-import { resolveSession } from '../../../desktop/sessionResolution.js';
-import { DesktopCommandExecutionError } from '../../../errors/mcpToolError.js';
 import { DesktopMcpServer } from '../../../server.desktop.js';
+import { runExternalApiReadTool } from '../externalApiReadHarness.js';
 import { DesktopTool } from '../tool.js';
 
 const paramsSchema = {
@@ -31,21 +30,13 @@ export const getListDashboardsTool = (
       return await listDashboardsTool.logAndExecute({
         extra,
         args: { session },
-        callback: async () => {
-          const sessionResult = resolveSession(session);
-          if (sessionResult.isErr()) {
-            return sessionResult.error.toErr();
-          }
-          const resolvedSession = sessionResult.value;
-          const executor = await extra.getExecutor(resolvedSession);
-          const result = await listDashboards({ executor, signal: extra.signal });
-
-          if (result.isErr()) {
-            return new DesktopCommandExecutionError(result.error).toErr();
-          }
-
-          return result;
-        },
+        callback: async () =>
+          await runExternalApiReadTool({
+            session,
+            extra,
+            callback: async (executor, signal, read) =>
+              await read('dashboard list', async () => await listDashboards({ executor, signal })),
+          }),
       });
     },
   });

--- a/src/tools/desktop/workbook/listWorksheets.test.ts
+++ b/src/tools/desktop/workbook/listWorksheets.test.ts
@@ -3,6 +3,7 @@ import { Err, Ok } from 'ts-results-es';
 import { z } from 'zod';
 
 import * as listWorksheetsModule from '../../../desktop/commands/workbook/listWorksheets.js';
+import * as sessionResolution from '../../../desktop/sessionResolution.js';
 import { DesktopCommandExecutionError } from '../../../errors/mcpToolError.js';
 import { DesktopMcpServer } from '../../../server.desktop.js';
 import invariant from '../../../utils/invariant.js';
@@ -12,6 +13,7 @@ import { getMockRequestHandlerExtra } from '../toolContext.mock.js';
 import { getListWorksheetsTool } from './listWorksheets.js';
 
 vi.mock('../../../desktop/commands/workbook/listWorksheets.js');
+vi.mock('../../../desktop/sessionResolution.js');
 
 describe('listWorksheetsTool', () => {
   const resultSchema = z.object({
@@ -21,6 +23,7 @@ describe('listWorksheetsTool', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(sessionResolution.resolveSession).mockReturnValue(Ok('999'));
   });
 
   it('should create a tool instance with correct properties', () => {
@@ -112,6 +115,26 @@ describe('listWorksheetsTool', () => {
     expect(result.isError).toBe(true);
     invariant(result.content[0].type === 'text');
     expect(result.content[0].text).toBe(new DesktopCommandExecutionError(error).message);
+  });
+
+  it('maps a route-missing error to an honest endpoint-not-in-this-build 404', async () => {
+    vi.spyOn(listWorksheetsModule, 'listWorksheets').mockResolvedValue(
+      Err({
+        type: 'command-failed',
+        error: {
+          code: 'not-found',
+          message: 'No route matches GET /v0/workbook/worksheets',
+          recoverable: false,
+        },
+      }),
+    );
+
+    const result = await getToolResult({ session: '12345', mockExecutor: vi.fn() });
+
+    expect(result.isError).toBe(true);
+    invariant(result.content[0].type === 'text');
+    expect(result.content[0].text).toContain('worksheet list endpoint');
+    expect(result.content[0].text).toContain('Do not retry');
   });
 
   it('should pass the abort signal to listWorksheets command', async () => {

--- a/src/tools/desktop/workbook/listWorksheets.ts
+++ b/src/tools/desktop/workbook/listWorksheets.ts
@@ -2,9 +2,8 @@ import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
 
 import { listWorksheets } from '../../../desktop/commands/workbook/listWorksheets.js';
-import { resolveSession } from '../../../desktop/sessionResolution.js';
-import { DesktopCommandExecutionError } from '../../../errors/mcpToolError.js';
 import { DesktopMcpServer } from '../../../server.desktop.js';
+import { runExternalApiReadTool } from '../externalApiReadHarness.js';
 import { DesktopTool } from '../tool.js';
 
 const paramsSchema = {
@@ -31,21 +30,13 @@ export const getListWorksheetsTool = (
       return await listWorksheetsTool.logAndExecute({
         extra,
         args: { session },
-        callback: async () => {
-          const sessionResult = resolveSession(session);
-          if (sessionResult.isErr()) {
-            return sessionResult.error.toErr();
-          }
-          const resolvedSession = sessionResult.value;
-          const executor = await extra.getExecutor(resolvedSession);
-          const result = await listWorksheets({ executor, signal: extra.signal });
-
-          if (result.isErr()) {
-            return new DesktopCommandExecutionError(result.error).toErr();
-          }
-
-          return result;
-        },
+        callback: async () =>
+          await runExternalApiReadTool({
+            session,
+            extra,
+            callback: async (executor, signal, read) =>
+              await read('worksheet list', async () => await listWorksheets({ executor, signal })),
+          }),
       });
     },
   });


### PR DESCRIPTION
## What

Route `list-worksheets` and `list-dashboards` through `runExternalApiReadTool`, the same shared External Client API read harness the other ~17 desktop reads already use. Before this, those two tools hand-rolled their own `resolveSession → getExecutor → error-wrap` boilerplate, so a fix applied at the harness (e.g. the route-missing → honest `endpoint-not-in-this-build` 404 mapping) reached every read *except* these two.

## Why

Goal 2 of the External API refactor: one central place for External API reads, so a fix lands everywhere instead of "some get fixed up and some don't." This is the read-path half; the apply-path readback gateway shipped separately (#691, Slice A).

## Decision the reviewer must accept

This is now a **rule the codebase keeps**: every External Client API read goes through `runExternalApiReadTool`. No behavior change for callers — the success payloads are identical; the only observable difference is that a missing route now yields the harness's honest 404 (added as a test on each tool).

Behavior-preserving; verified green (tsc + full lint + the two tools' unit tests, which now also assert the route-missing mapping).

🤖 Generated with [Claude Code](https://claude.com/claude-code)