### PR TITLE
feat(desktop): return candidates from slim field listing

### DIFF
--- a/src/server.desktop.test.ts
+++ b/src/server.desktop.test.ts
@@ -210,11 +210,11 @@ describe('desktop tools/list serialized surface', () => {
     // guards that invariant). The full desktop surface is opt-in (TOOL_PROFILE=full), not
     // what clients see by default; its looser cap only catches runaway growth without
     // forcing valuable full-profile tools to be trimmed.
-    // Honest wire measurements are 29,463 bytes dynamic and 46,377 bytes full: the full
-    // surface rose by the two full-profile-only export-image tools.
+    // Honest wire measurements are 29,693 bytes dynamic and 46,607 bytes full after replacing
+    // list-available-fields' old slim schema with compact insight candidate tuples.
     // Keep only a few bytes of ratchet headroom on each cap.
-    expect(dynamicAuthoringTotal).toBeLessThanOrEqual(29_479);
-    expect(fullSurfaceTotal).toBeLessThanOrEqual(46_393);
+    expect(dynamicAuthoringTotal).toBeLessThanOrEqual(29_709);
+    expect(fullSurfaceTotal).toBeLessThanOrEqual(46_623);
   });
 });
 
@@ -525,8 +525,8 @@ describe('selectToolsForProfile (TOOL_PROFILE, W60 spike lever 1 / preamble P1)'
     }
     // A lean surface must have generous headroom — this is a structural win, not a
     // describe-stub squeeze. If this ever approaches 46k something is very wrong.
-    // Raised with the signed-off bind-template describes (2026-07-27, #643 review fold).
-    expect(total).toBeLessThanOrEqual(29_480);
+    // list-available-fields serves both full exploration and slim headless field selection.
+    expect(total).toBeLessThanOrEqual(29_710);
   });
 
   it('unset ("") profile returns the lean dynamic-authoring native surface — the singer sings native by default', () => {

--- a/src/tools/desktop/fields/listAvailableFields.test.ts
+++ b/src/tools/desktop/fields/listAvailableFields.test.ts
@@ -89,6 +89,8 @@ describe('listAvailableFieldsTool', () => {
       session: expect.any(Object),
       workbookFile: expect.any(Object),
       verbosity: expect.any(Object),
+      hasLuid: expect.any(Object),
+      luids: expect.any(Object),
     });
     expect(paramsSchema.verbosity.description).toContain('full (default)');
     expect(paramsSchema.verbosity.description).toContain('slim');
@@ -280,29 +282,23 @@ describe('listAvailableFieldsTool', () => {
   });
 
   const slimBodySchema = z.object({
-    count: z.number(),
     datasources: z.array(
       z.object({
-        datasource: z.string().nullable(),
-        contentUrl: z.string().optional(),
-        fields: z.array(
-          z.object({
-            caption: z.string(),
-            localName: z.string(),
-            columnInstanceName: z.string(),
-            derivation: z.string(),
-            type: z.string(),
-            typePivot: z.string(),
-            role: z.string(),
-            datatype: z.string().optional(),
-            isAggregated: z.boolean().optional(),
-          }),
+        datasource: z.string(),
+        name: z.string().optional(),
+        luid: z.string().optional(),
+        measures: z.array(
+          z.tuple([z.string(), z.string(), z.string(), z.enum(['base', 'aggregatedCalc'])]),
+        ),
+        timeDimensions: z.array(z.tuple([z.string(), z.string(), z.enum(['date', 'datetime'])])),
+        breakdownDimensions: z.array(
+          z.tuple([z.string(), z.string(), z.enum(['nominal', 'ordinal'])]),
         ),
       }),
     ),
   });
 
-  it('verbosity=slim returns compact grouped fields with no ASCII table', async () => {
+  it('verbosity=slim returns compact candidate tuples with no ASCII table', async () => {
     vi.mocked(existsSync).mockReturnValue(true);
     vi.mocked(readFileSync).mockReturnValue('<workbook/>');
     vi.mocked(metadataModule.listAvailableFields).mockReturnValue(mockFields as any);
@@ -313,49 +309,22 @@ describe('listAvailableFieldsTool', () => {
     invariant(result.content[0].type === 'text');
     const body = slimBodySchema.parse(JSON.parse(result.content[0].text));
 
-    // No human-readable table; a single datasource is still the grouped shape
-    // (one group) so callers always parse the same structure.
     expect('message' in body).toBe(false);
     expect('fields' in body).toBe(false);
-    expect(body.count).toBe(2);
+    expect('count' in body).toBe(false);
     expect(body.datasources).toHaveLength(1);
-    expect(body.datasources[0].datasource).toBe('Sample - Superstore');
-    // Published datasource → contentUrl surfaced once on the group (the input
-    // resolve-datasource-luid needs), not repeated per field.
-    expect(body.datasources[0].contentUrl).toBe('SuperstoreDS');
-    const groupFields = body.datasources[0].fields;
-    expect(groupFields).toHaveLength(2);
-    // caption falls back to the bracket-stripped columnName when caption is absent.
-    expect(groupFields[0]).toMatchObject({
-      caption: 'Profit',
-      localName: 'Profit',
-      columnInstanceName: '[sum:Profit:qk]',
-      derivation: 'Sum',
-      type: 'quantitative',
-      typePivot: 'qk',
-      role: 'measure',
-      datatype: 'real',
+    expect(body.datasources[0]).toEqual({
+      datasource: 'Sample - Superstore',
+      measures: [['Profit', 'Profit', 'Sum', 'base']],
+      timeDimensions: [],
+      breakdownDimensions: [['Category', 'Category', 'nominal']],
     });
-    expect(groupFields[1]).toMatchObject({
-      caption: 'Category',
-      localName: 'Category',
-      columnInstanceName: '[none:Category:nk]',
-      derivation: 'None',
-      type: 'nominal',
-      typePivot: 'nk',
-      role: 'dimension',
-      datatype: 'string',
-    });
-    // Slim keeps enough metadata to construct [datasource].[derivation:LocalName:typePivot],
-    // while omitting the full column_ref and less common verbose metadata.
-    const first = groupFields[0] as Record<string, unknown>;
-    expect(first.column_ref).toBeUndefined();
-    expect(first.name).toBeUndefined();
-    expect(first.datasource).toBeUndefined();
-    expect(first.semanticRole).toBeUndefined();
+    expect(JSON.stringify(body)).not.toContain('contentUrl');
+    expect(JSON.stringify(body)).not.toContain('columnInstanceName');
+    expect(JSON.stringify(body)).not.toContain('column_ref');
   });
 
-  it('verbosity=slim carries usr derivation metadata for already-aggregated calc fields', async () => {
+  it('verbosity=slim marks already-aggregated calculation measures', async () => {
     const aggregatedCalcFields = [
       {
         ...mockFields[0],
@@ -377,23 +346,12 @@ describe('listAvailableFieldsTool', () => {
     expect(result.isError).toBe(false);
     invariant(result.content[0].type === 'text');
     const body = slimBodySchema.parse(JSON.parse(result.content[0].text));
-    const calc = body.datasources[0].fields[0] as Record<string, unknown>;
-    expect(calc).toMatchObject({
-      caption: 'Profit Ratio',
-      localName: 'Calculation_123',
-      columnInstanceName: '[usr:Calculation_123:qk]',
-      derivation: 'User',
-      type: 'quantitative',
-      typePivot: 'qk',
-      role: 'measure',
-      datatype: 'real',
-      isAggregated: true,
-    });
-    expect(calc.column_ref).toBeUndefined();
-    expect(calc.formula).toBeUndefined();
+    expect(body.datasources[0].measures).toEqual([
+      ['Profit Ratio', 'Calculation_123', 'User', 'aggregatedCalc'],
+    ]);
   });
 
-  it('verbosity=slim on an empty workbook returns count 0 and no datasource groups', async () => {
+  it('verbosity=slim on an empty workbook returns no datasource groups', async () => {
     vi.mocked(existsSync).mockReturnValue(true);
     vi.mocked(readFileSync).mockReturnValue('<workbook/>');
     vi.mocked(metadataModule.listAvailableFields).mockReturnValue([]);
@@ -403,17 +361,10 @@ describe('listAvailableFieldsTool', () => {
     expect(result.isError).toBe(false);
     invariant(result.content[0].type === 'text');
     const body = slimBodySchema.parse(JSON.parse(result.content[0].text));
-    expect(body.count).toBe(0);
     expect(body.datasources).toHaveLength(0);
   });
 
-  it('verbosity=slim groups fields by datasource across multiple datasources', async () => {
-    // Two datasources, including a SAME caption ('Profit') in each — the case
-    // where hoisting fields[0].datasource would misattribute the second and
-    // erase the only disambiguator. Grouping carries the datasource once per
-    // group rather than repeating it on every field.
-    // Two datasources: 'Sample - Superstore' is PUBLISHED (has a contentUrl),
-    // 'Finance Extract' is EMBEDDED (contentUrl undefined). Both have a 'Profit'.
+  it('verbosity=slim groups candidate tuples across multiple datasources', async () => {
     const multiDatasourceFields = [
       {
         ...mockFields[0],
@@ -440,28 +391,17 @@ describe('listAvailableFieldsTool', () => {
     invariant(result.content[0].type === 'text');
     const body = slimBodySchema.parse(JSON.parse(result.content[0].text));
 
-    // Grouped shape (no top-level `datasource`, no flat `fields`) when >1 datasource.
-    expect('datasource' in body).toBe(false);
-    expect('fields' in body).toBe(false);
-    expect(body.count).toBe(4);
     expect(body.datasources.map((g) => g.datasource)).toEqual([
       'Sample - Superstore',
       'Finance Extract',
     ]);
-    // contentUrl per group: present for the published one, omitted for the embedded one.
-    expect(body.datasources[0].contentUrl).toBe('SuperstoreDS');
-    expect(body.datasources[1].contentUrl).toBeUndefined();
-    // The two same-caption 'Profit' fields stay distinct — one per group.
-    expect(body.datasources[0].fields.map((f) => f.caption)).toEqual(['Profit', 'Category']);
-    expect(body.datasources[1].fields.map((f) => f.caption)).toEqual(['Profit', 'Region']);
-    // The datasource string is NOT repeated on individual fields.
-    expect((body.datasources[0].fields[0] as Record<string, unknown>).datasource).toBeUndefined();
+    expect(body.datasources[0].measures).toEqual([['Profit', 'Profit', 'Sum', 'base']]);
+    expect(body.datasources[0].breakdownDimensions).toEqual([['Category', 'Category', 'nominal']]);
+    expect(body.datasources[1].measures).toEqual([['Profit', 'Profit', 'Sum', 'base']]);
+    expect(body.datasources[1].breakdownDimensions).toEqual([['Region', 'Category', 'nominal']]);
   });
 
-  it('verbosity=slim without workbookFile groups fields from the live session workbook', async () => {
-    // Slim over the live-session path (session, no workbookFile): reads the
-    // resolved live workbook, never the file cache, and still returns the
-    // grouped slim shape. 'Fresh DS' is embedded (no contentUrl).
+  it('verbosity=slim without workbookFile projects the live session workbook', async () => {
     vi.mocked(getWorkbookXmlModule.getWorkbookXml).mockResolvedValue(Ok(LIVE_XML));
     vi.mocked(metadataModule.listAvailableFields).mockReturnValue(mockLiveFields as any);
     const mockExecutor = {} as any;
@@ -476,28 +416,15 @@ describe('listAvailableFieldsTool', () => {
     invariant(result.content[0].type === 'text');
     const body = slimBodySchema.parse(JSON.parse(result.content[0].text));
 
-    // Grouped slim shape, not the ASCII-table shape.
-    expect('message' in body).toBe(false);
-    expect('fields' in body).toBe(false);
-    expect(body.count).toBe(1);
-    expect(body.datasources).toHaveLength(1);
-    expect(body.datasources[0].datasource).toBe('Fresh DS');
-    // Embedded datasource → no contentUrl on the group.
-    expect(body.datasources[0].contentUrl).toBeUndefined();
-    expect(body.datasources[0].fields).toEqual([
+    expect(body.datasources).toEqual([
       {
-        caption: 'Sales',
-        localName: 'Sales',
-        columnInstanceName: '[sum:Sales:qk]',
-        derivation: 'Sum',
-        type: 'quantitative',
-        typePivot: 'qk',
-        role: 'measure',
-        datatype: 'real',
+        datasource: 'Fresh DS',
+        measures: [['Sales', 'Sales', 'Sum', 'base']],
+        timeDimensions: [],
+        breakdownDimensions: [],
       },
     ]);
 
-    // Live-session path: read from the executor's workbook, never the file cache.
     expect(existsSync).not.toHaveBeenCalled();
     expect(readFileSync).not.toHaveBeenCalled();
     expect(extra.getExecutor).toHaveBeenCalledWith(SESSION);
@@ -507,23 +434,214 @@ describe('listAvailableFieldsTool', () => {
     });
     expect(metadataModule.listAvailableFields).toHaveBeenCalledWith(LIVE_XML);
   });
+
+  it('rejects LUID filtering unless slim output is requested', async () => {
+    const result = await getResult({ hasLuid: true });
+
+    expect(result.isError).toBe(true);
+    invariant(result.content[0].type === 'text');
+    expect(result.content[0].text).toContain('require verbosity: slim');
+  });
+
+  it('rejects luids unless hasLuid is true', async () => {
+    const result = await getResult({ verbosity: 'slim', luids: ['luid-superstore'] });
+
+    expect(result.isError).toBe(true);
+    invariant(result.content[0].type === 'text');
+    expect(result.content[0].text).toContain('luids requires hasLuid: true');
+  });
+
+  it.each([{ hasLuid: true }, { hasLuid: true, luids: [] }])(
+    'returns every LUID-backed datasource for slim output',
+    async ({ hasLuid, luids }) => {
+      const { extra, listWorkbookDatasources } = mockLiveWorkbookDatasourceMetadata([
+        { luid: 'luid-superstore', name: 'Sample - Superstore' },
+        { luid: null, name: 'Embedded' },
+      ]);
+
+      const result = await getResult({
+        session: SESSION,
+        verbosity: 'slim',
+        hasLuid,
+        luids,
+        extra,
+      });
+
+      const body = slimBodySchema.parse(parseBody(result));
+      expect(body.datasources).toEqual([
+        expect.objectContaining({
+          datasource: 'Sample - Superstore',
+          name: 'Sample - Superstore',
+          luid: 'luid-superstore',
+        }),
+      ]);
+      expect(listWorkbookDatasources).toHaveBeenCalledWith(extra.signal);
+    },
+  );
+
+  it('filters slim output by a requested LUID', async () => {
+    const workbookFields = [
+      ...mockFields,
+      { ...mockFields[0], datasource: 'Finance', caption: 'Revenue' },
+    ];
+    const { extra } = mockLiveWorkbookDatasourceMetadata(
+      [
+        { luid: 'luid-superstore', name: 'Sample - Superstore' },
+        { luid: 'luid-finance', name: 'Finance' },
+      ],
+      workbookFields,
+    );
+
+    const result = await getResult({
+      session: SESSION,
+      verbosity: 'slim',
+      hasLuid: true,
+      luids: ['luid-finance'],
+      extra,
+    });
+
+    expect(slimBodySchema.parse(parseBody(result)).datasources).toEqual([
+      expect.objectContaining({ datasource: 'Finance', luid: 'luid-finance' }),
+    ]);
+  });
+
+  it('rejects a published and embedded datasource sharing the same identity', async () => {
+    const { extra } = mockLiveWorkbookDatasourceMetadata([
+      { luid: null, name: 'Sample - Superstore' },
+      { luid: 'luid-published', caption: 'Sample - Superstore' },
+    ]);
+
+    const result = await getResult({
+      session: SESSION,
+      verbosity: 'slim',
+      hasLuid: true,
+      extra,
+    });
+
+    expect(result.isError).toBe(true);
+    invariant(result.content[0].type === 'text');
+    expect(result.content[0].text).toContain('matched multiple workbook datasources');
+    expect(result.content[0].text).toContain('<no LUID>, luid-published');
+  });
+
+  it('ignores unrelated ambiguity for a targeted LUID', async () => {
+    const workbookFields = [
+      ...mockFields,
+      { ...mockFields[0], datasource: 'Finance', caption: 'Revenue' },
+    ];
+    const { extra } = mockLiveWorkbookDatasourceMetadata(
+      [
+        { luid: 'luid-one', name: 'Sample - Superstore' },
+        { luid: 'luid-two', caption: 'Sample - Superstore' },
+        { luid: 'luid-finance', name: 'Finance' },
+      ],
+      workbookFields,
+    );
+
+    const result = await getResult({
+      session: SESSION,
+      verbosity: 'slim',
+      hasLuid: true,
+      luids: ['luid-finance'],
+      extra,
+    });
+
+    expect(slimBodySchema.parse(parseBody(result)).datasources).toEqual([
+      expect.objectContaining({ datasource: 'Finance', luid: 'luid-finance' }),
+    ]);
+  });
+
+  it.each([undefined, '', 'default'])(
+    'rejects cached-workbook LUID filtering without an explicit session (%s)',
+    async (session) => {
+      const result = await getResult({
+        workbookFile: WORKBOOK_FILE,
+        session,
+        verbosity: 'slim',
+        hasLuid: true,
+      });
+
+      expect(result.isError).toBe(true);
+      invariant(result.content[0].type === 'text');
+      expect(result.content[0].text).toContain(
+        'LUID filtering with workbookFile requires an explicit live session',
+      );
+    },
+  );
+
+  it('identifies a Desktop build without workbook datasource metadata', async () => {
+    vi.mocked(getWorkbookXmlModule.getWorkbookXml).mockResolvedValue(Ok(LIVE_XML));
+    vi.mocked(metadataModule.listAvailableFields).mockReturnValue(mockFields as any);
+    const listWorkbookDatasources = vi.fn().mockResolvedValue(
+      new Err({
+        type: 'command-failed',
+        error: { code: 'not-found', message: 'No route matches GET /v0/workbook/datasources' },
+      }),
+    );
+    const extra = {
+      ...getMockRequestHandlerExtra(),
+      getExecutor: vi.fn().mockResolvedValue({ listWorkbookDatasources } as any),
+    };
+
+    const result = await getResult({
+      session: SESSION,
+      verbosity: 'slim',
+      hasLuid: true,
+      extra,
+    });
+
+    expect(result.isError).toBe(true);
+    invariant(result.content[0].type === 'text');
+    expect(result.content[0].text).toContain(
+      'does not serve the workbook datasources endpoint yet',
+    );
+  });
 });
+
+function mockLiveWorkbookDatasourceMetadata(
+  workbookDatasources: any[],
+  workbookFields: any[] = mockFields,
+): {
+  extra: ReturnType<typeof getMockRequestHandlerExtra>;
+  listWorkbookDatasources: ReturnType<typeof vi.fn>;
+} {
+  vi.mocked(getWorkbookXmlModule.getWorkbookXml).mockResolvedValue(Ok(LIVE_XML));
+  vi.mocked(metadataModule.listAvailableFields).mockReturnValue(workbookFields as any);
+  const listWorkbookDatasources = vi
+    .fn()
+    .mockResolvedValue(Ok({ datasources: workbookDatasources }));
+  const extra = {
+    ...getMockRequestHandlerExtra(),
+    getExecutor: vi.fn().mockResolvedValue({ listWorkbookDatasources } as any),
+  };
+  return { extra, listWorkbookDatasources };
+}
+
+function parseBody(result: CallToolResult): any {
+  expect(result.isError).toBe(false);
+  invariant(result.content[0].type === 'text');
+  return JSON.parse(result.content[0].text);
+}
 
 async function getResult({
   workbookFile,
   session,
   verbosity,
+  hasLuid,
+  luids,
   extra,
 }: {
   workbookFile?: string;
   session?: string;
   verbosity?: 'slim' | 'full';
+  hasLuid?: boolean;
+  luids?: string[];
   extra?: ReturnType<typeof getMockRequestHandlerExtra>;
 }): Promise<CallToolResult> {
   const tool = getListAvailableFieldsTool(new DesktopMcpServer());
   const callback = await Provider.from(tool.callback);
   return await callback(
-    { session, workbookFile, verbosity },
+    { session, workbookFile, verbosity, hasLuid, luids },
     extra ?? getMockRequestHandlerExtra(),
   );
 }

--- a/src/tools/desktop/fields/listAvailableFields.ts
+++ b/src/tools/desktop/fields/listAvailableFields.ts
@@ -4,15 +4,22 @@ import { Ok } from 'ts-results-es';
 import { z } from 'zod';
 
 import { getWorkbookXml } from '../../../desktop/commands/workbook/getWorkbookXml.js';
+import { endpointNotInThisBuild, isRouteMissing } from '../../../desktop/externalApi/toolUtils.js';
 import { listAvailableFields } from '../../../desktop/metadata/index.js';
 import { resolveSession } from '../../../desktop/sessionResolution.js';
 import {
+  ArgsValidationError,
   DesktopCommandExecutionError,
   FileReadError,
   McpToolError,
 } from '../../../errors/mcpToolError.js';
 import { DesktopMcpServer } from '../../../server.desktop.js';
 import { DesktopTool } from '../tool.js';
+import {
+  filterListAvailableFieldsSlimByLuid,
+  ListAvailableFieldsSlimResult,
+  projectListAvailableFieldsSlim,
+} from './listAvailableFieldsSlim.js';
 import { refreshWorkbookCache } from './refreshWorkbookCache.js';
 
 const paramsSchema = {
@@ -21,7 +28,9 @@ const paramsSchema = {
   verbosity: z
     .enum(['slim', 'full'])
     .optional()
-    .describe('full (default): table + column_ref. slim: grouped ref parts, no column_ref.'),
+    .describe('full (default): table + fields. slim: candidate tuples by datasource.'),
+  hasLuid: z.boolean().optional().describe('Slim: LUID-backed only; live required.'),
+  luids: z.array(z.string().min(1)).optional().describe('Slim: LUIDs; [] all; any miss errors.'),
 };
 
 class WorkbookFileNotFoundError extends McpToolError {
@@ -47,12 +56,6 @@ const typeAbbrev = (type: string): string => {
   return type;
 };
 
-const typePivot = (type: string): string => {
-  if (type === 'quantitative') return 'qk';
-  if (type === 'ordinal') return 'ok';
-  return 'nk';
-};
-
 const tableauDatatypeLabel = (datatype?: string): string => {
   switch (datatype) {
     case 'integer':
@@ -72,35 +75,9 @@ const tableauDatatypeLabel = (datatype?: string): string => {
   }
 };
 
-interface SlimField {
-  caption: string;
-  localName: string;
-  columnInstanceName: string;
-  derivation: string;
-  type: string;
-  typePivot: string;
-  role: string;
-  datatype?: string;
-  isAggregated?: boolean;
-}
-
-/** One datasource's slim fields. Slim always groups by datasource. */
-interface SlimDatasourceGroup {
-  datasource: string | null;
-  // The datasource's contentUrl when it's a published datasource — the input
-  // resolve-datasource-luid needs to get the server LUID. Omitted for
-  // embedded/local datasources (no server copy, so no contentUrl).
-  contentUrl?: string;
-  fields: SlimField[];
-}
-
 type ListAvailableFieldsResult =
   | { message: string; fields: ReturnType<typeof listAvailableFields> }
-  // Slim: fields grouped by datasource so the datasource name is carried once
-  // per group, never repeated on every field (keeps slim small). Always this
-  // shape — even for a single datasource (one group) — so callers parse one
-  // consistent structure.
-  | { count: number; datasources: SlimDatasourceGroup[] };
+  | ListAvailableFieldsSlimResult;
 
 const title = 'List All Available Fields in Workbook Datasources';
 export const getListAvailableFieldsTool = (
@@ -113,7 +90,7 @@ export const getListAvailableFieldsTool = (
     description: [
       'List datasource fields for exploration/field questions/non-template authoring.',
       'Available anytime; not needed before bind-template.',
-      'Full gives column_ref; slim ref parts.',
+      'Full gives column_ref; slim gives insight candidate tuples.',
     ].join(' '),
     paramsSchema,
     annotations: {
@@ -122,24 +99,46 @@ export const getListAvailableFieldsTool = (
       idempotentHint: true,
       openWorldHint: false,
     },
-    callback: async ({ session, workbookFile, verbosity }, extra): Promise<CallToolResult> => {
+    callback: async (
+      { session, workbookFile, verbosity, hasLuid, luids },
+      extra,
+    ): Promise<CallToolResult> => {
       return await listAvailableFieldsTool.logAndExecute<ListAvailableFieldsResult>({
         extra,
-        args: { session, workbookFile, verbosity },
+        args: { session, workbookFile, verbosity, hasLuid, luids },
         callback: async () => {
+          if (luids !== undefined && hasLuid !== true) {
+            return new ArgsValidationError('luids requires hasLuid: true.').toErr();
+          }
+          if ((hasLuid !== undefined || luids !== undefined) && verbosity !== 'slim') {
+            return new ArgsValidationError('hasLuid and luids require verbosity: slim.').toErr();
+          }
+
           const cacheWorkbookFile = workbookFile?.trim() ? workbookFile : undefined;
+          const explicitSession = session?.trim();
+          if (
+            hasLuid === true &&
+            cacheWorkbookFile &&
+            (!explicitSession || explicitSession.toLowerCase() === 'default')
+          ) {
+            return new ArgsValidationError(
+              'LUID filtering with workbookFile requires an explicit live session.',
+            ).toErr();
+          }
 
           if (cacheWorkbookFile && !existsSync(cacheWorkbookFile)) {
             return new WorkbookFileNotFoundError(cacheWorkbookFile).toErr();
           }
 
           let workbookXml: string;
+          let resolvedSession: string | undefined;
+          let executor: Awaited<ReturnType<typeof extra.getExecutor>> | undefined;
           if (session || cacheWorkbookFile === undefined) {
             const sessionResult = resolveSession(session);
             if (sessionResult.isErr()) {
               return sessionResult.error.toErr();
             }
-            const resolvedSession = sessionResult.value;
+            resolvedSession = sessionResult.value;
 
             if (cacheWorkbookFile) {
               // Shared refresh seam (W-23447478): resolve-field reuses the identical
@@ -156,7 +155,7 @@ export const getListAvailableFieldsTool = (
               }
               workbookXml = refresh.xml;
             } else {
-              const executor = await extra.getExecutor(resolvedSession);
+              executor = await extra.getExecutor(resolvedSession);
               const liveWorkbook = await getWorkbookXml({ executor, signal: extra.signal });
               if (liveWorkbook.isErr()) {
                 return new DesktopCommandExecutionError(liveWorkbook.error).toErr();
@@ -173,48 +172,31 @@ export const getListAvailableFieldsTool = (
 
           const fields = listAvailableFields(workbookXml);
 
-          // Slim: no table and no full column_ref, but keep the ingredients
-          // needed to construct [datasource].[derivation:LocalName:typePivot].
-          //
-          // `listAvailableFields` spans ALL datasources (one flat array, each
-          // field carrying its own datasource). Slim always GROUPS by
-          // datasource — one group per datasource, in first-seen order — so the
-          // datasource name is carried once per group rather than hoisted (which
-          // would misattribute every field past the first in a multi-datasource
-          // workbook and erase the only disambiguator for same-caption fields)
-          // or repeated per field (which would bloat slim). A single-datasource
-          // workbook is just one group, so callers always parse one shape.
           if (verbosity === 'slim') {
-            const toSlimField = (f: (typeof fields)[number]): SlimField => {
-              const localName = f.columnName.replace(/^\[|\]$/g, '');
-              return {
-                caption: f.caption || localName,
-                localName,
-                columnInstanceName: f.columnInstanceName,
-                derivation: f.derivation,
-                type: f.type,
-                typePivot: typePivot(f.type),
-                role: f.role,
-                datatype: f.datatype,
-                ...(f.isAggregated ? { isAggregated: true } : {}),
-              };
-            };
+            const result = projectListAvailableFieldsSlim(fields);
+            if (hasLuid !== true) return new Ok(result);
 
-            // Group by datasource name (first-seen order). Each group also
-            // carries the datasource's contentUrl (same for all its fields) —
-            // present only for published datasources.
-            const groups = new Map<string | null, SlimDatasourceGroup>();
-            for (const f of fields) {
-              let group = groups.get(f.datasource);
-              if (!group) {
-                group = { datasource: f.datasource, contentUrl: f.contentUrl, fields: [] };
-                groups.set(f.datasource, group);
+            if (executor === undefined) {
+              if (resolvedSession === undefined) {
+                return new ArgsValidationError(
+                  'LUID filtering requires a live Desktop session.',
+                ).toErr();
               }
-              group.fields.push(toSlimField(f));
+              executor = await extra.getExecutor(resolvedSession);
             }
-            return new Ok({
-              count: fields.length,
-              datasources: Array.from(groups.values()),
+
+            const workbookDatasourceResult = await executor.listWorkbookDatasources(extra.signal);
+            if (workbookDatasourceResult.isErr()) {
+              if (isRouteMissing(workbookDatasourceResult.error)) {
+                return endpointNotInThisBuild('workbook datasources').toErr();
+              }
+              return new DesktopCommandExecutionError(workbookDatasourceResult.error).toErr();
+            }
+
+            return filterListAvailableFieldsSlimByLuid({
+              result,
+              workbookDatasources: workbookDatasourceResult.value.datasources ?? [],
+              luids: luids ?? [],
             });
           }
 

--- a/src/tools/desktop/fields/listAvailableFieldsSlim.test.ts
+++ b/src/tools/desktop/fields/listAvailableFieldsSlim.test.ts
@@ -1,0 +1,221 @@
+import {
+  filterListAvailableFieldsSlimByLuid,
+  projectListAvailableFieldsSlim,
+} from './listAvailableFieldsSlim.js';
+
+const baseField = {
+  datasource: 'Sample - Superstore',
+  columnName: '[Profit]',
+  columnInstanceName: '[sum:Profit:qk]',
+  derivation: 'Sum',
+  type: 'quantitative',
+  role: 'measure',
+  datatype: 'real',
+  caption: 'Profit',
+  isAggregated: false,
+  column_ref: '[Sample - Superstore].[sum:Profit:qk]',
+};
+
+describe('listAvailableFieldsSlim', () => {
+  it('projects only insight-compatible candidates into compact tuples', () => {
+    const fields = [
+      baseField,
+      {
+        ...baseField,
+        columnName: '[Calculation_123]',
+        caption: 'Profit Ratio',
+        isAggregated: true,
+      },
+      {
+        ...baseField,
+        columnName: '[Order Date]',
+        caption: 'Order Date',
+        derivation: 'None',
+        type: 'ordinal',
+        role: 'dimension',
+        datatype: 'date',
+      },
+      {
+        ...baseField,
+        columnName: '[Category]',
+        caption: 'Category',
+        derivation: 'None',
+        type: 'nominal',
+        role: 'dimension',
+        datatype: 'string',
+      },
+      {
+        ...baseField,
+        columnName: '[Text Measure]',
+        caption: 'Text Measure',
+        datatype: 'string',
+      },
+    ] as any;
+
+    expect(projectListAvailableFieldsSlim(fields)).toEqual({
+      datasources: [
+        {
+          datasource: 'Sample - Superstore',
+          measures: [
+            ['Profit', 'Profit', 'Sum', 'base'],
+            ['Profit Ratio', 'Calculation_123', 'User', 'aggregatedCalc'],
+          ],
+          timeDimensions: [['Order Date', 'Order Date', 'date']],
+          breakdownDimensions: [['Category', 'Category', 'nominal']],
+        },
+      ],
+    });
+  });
+
+  it('resolves modern workbook datasource IDs before friendly-name fallback', () => {
+    const result = filterListAvailableFieldsSlimByLuid({
+      result: projectListAvailableFieldsSlim([
+        { ...baseField, datasource: 'federated.abc123' },
+      ] as any),
+      workbookDatasources: [
+        {
+          id: 'federated.abc123',
+          name: 'Published Superstore',
+          caption: 'Sample - Superstore',
+          luid: 'luid-superstore',
+        },
+        {
+          name: 'federated.abc123',
+          luid: 'luid-friendly-collision',
+        },
+      ],
+      luids: [],
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) throw result.error;
+    expect(result.value.datasources).toEqual([
+      expect.objectContaining({
+        datasource: 'federated.abc123',
+        name: 'Sample - Superstore',
+        luid: 'luid-superstore',
+      }),
+    ]);
+  });
+
+  it('falls back to an exact unique workbook datasource name or caption', () => {
+    const result = filterListAvailableFieldsSlimByLuid({
+      result: projectListAvailableFieldsSlim([baseField] as any),
+      workbookDatasources: [
+        {
+          name: 'Published Superstore',
+          caption: 'Sample - Superstore',
+          luid: 'luid-superstore',
+        },
+      ],
+      luids: [],
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) throw result.error;
+    expect(result.value.datasources[0]).toMatchObject({
+      name: 'Sample - Superstore',
+      luid: 'luid-superstore',
+    });
+  });
+
+  it('rejects a published and embedded datasource sharing a fallback identity', () => {
+    const result = filterListAvailableFieldsSlimByLuid({
+      result: projectListAvailableFieldsSlim([baseField] as any),
+      workbookDatasources: [
+        { name: 'Sample - Superstore', luid: null },
+        { caption: 'Sample - Superstore', luid: 'luid-published' },
+      ],
+      luids: [],
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isOk()) throw new Error('Expected an ambiguity error');
+    expect(result.error.message).toContain('matched multiple workbook datasources');
+    expect(result.error.message).toContain('<no LUID>, luid-published');
+  });
+
+  it('does not let a requested LUID relabel an ambiguous field group', () => {
+    const result = filterListAvailableFieldsSlimByLuid({
+      result: projectListAvailableFieldsSlim([baseField] as any),
+      workbookDatasources: [
+        { name: 'Sample - Superstore', luid: null },
+        { caption: 'Sample - Superstore', luid: 'luid-published' },
+      ],
+      luids: ['luid-published'],
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isOk()) throw new Error('Expected an ambiguity error');
+    expect(result.error.message).toContain('matched multiple workbook datasources');
+  });
+
+  it('ignores unrelated ambiguity for a targeted LUID', () => {
+    const result = filterListAvailableFieldsSlimByLuid({
+      result: projectListAvailableFieldsSlim([
+        baseField,
+        { ...baseField, datasource: 'Finance', columnName: '[Revenue]', caption: 'Revenue' },
+      ] as any),
+      workbookDatasources: [
+        { name: 'Sample - Superstore', luid: 'luid-one' },
+        { caption: 'Sample - Superstore', luid: 'luid-two' },
+        { name: 'Finance', luid: 'luid-finance' },
+      ],
+      luids: ['luid-finance'],
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) throw result.error;
+    expect(result.value.datasources).toEqual([
+      expect.objectContaining({ datasource: 'Finance', luid: 'luid-finance' }),
+    ]);
+  });
+
+  it('reports requested LUIDs that have no matching field group', () => {
+    const result = filterListAvailableFieldsSlimByLuid({
+      result: projectListAvailableFieldsSlim([baseField] as any),
+      workbookDatasources: [{ name: 'Sample - Superstore', luid: 'luid-superstore' }],
+      luids: ['luid-missing'],
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isOk()) throw new Error('Expected a missing-LUID error');
+    expect(result.error.message).toContain('No workbook datasource fields matched LUIDs');
+    expect(result.error.message).toContain('luid-missing');
+  });
+
+  it('reports a total datasource identity mismatch instead of returning an empty success', () => {
+    const result = filterListAvailableFieldsSlimByLuid({
+      result: projectListAvailableFieldsSlim([
+        { ...baseField, datasource: 'federated.abc123' },
+      ] as any),
+      workbookDatasources: [
+        {
+          id: 'wb-ds-superstore',
+          name: 'Published Superstore',
+          caption: 'Superstore',
+          luid: 'luid-superstore',
+        },
+      ],
+      luids: [],
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isOk()) throw new Error('Expected an identity-mismatch error');
+    expect(result.error.message).toContain('Could not match workbook field datasource identities');
+    expect(result.error.message).toContain('federated.abc123');
+    expect(result.error.message).toContain('wb-ds-superstore');
+  });
+
+  it('does not treat an empty LUID as LUID-backed', () => {
+    const result = filterListAvailableFieldsSlimByLuid({
+      result: projectListAvailableFieldsSlim([baseField] as any),
+      workbookDatasources: [{ name: 'Sample - Superstore', luid: '' }],
+      luids: [],
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) throw result.error;
+    expect(result.value).toEqual({ datasources: [] });
+  });
+});

--- a/src/tools/desktop/fields/listAvailableFieldsSlim.ts
+++ b/src/tools/desktop/fields/listAvailableFieldsSlim.ts
@@ -1,0 +1,177 @@
+import { Ok, Result } from 'ts-results-es';
+
+import { DatasourceItem } from '../../../desktop/externalApi/types.js';
+import { listAvailableFields } from '../../../desktop/metadata/index.js';
+import { ArgsValidationError, McpToolError } from '../../../errors/mcpToolError.js';
+
+type MeasureCandidate = [
+  caption: string,
+  localName: string,
+  aggregation: string,
+  fieldKind: 'base' | 'aggregatedCalc',
+];
+type TimeDimensionCandidate = [caption: string, localName: string, dateType: 'date' | 'datetime'];
+type BreakdownDimensionCandidate = [
+  caption: string,
+  localName: string,
+  categoryType: 'nominal' | 'ordinal',
+];
+
+interface DatasourceFieldCandidateGroup {
+  datasource: string;
+  name?: string;
+  luid?: string;
+  measures: MeasureCandidate[];
+  timeDimensions: TimeDimensionCandidate[];
+  breakdownDimensions: BreakdownDimensionCandidate[];
+}
+
+export interface ListAvailableFieldsSlimResult {
+  datasources: DatasourceFieldCandidateGroup[];
+}
+
+function isNumericDatatype(datatype?: string): boolean {
+  return datatype === 'integer' || datatype === 'real' || datatype === 'number';
+}
+
+function isDateDatatype(datatype?: string): datatype is 'date' | 'datetime' {
+  return datatype === 'date' || datatype === 'datetime';
+}
+
+function isCategoryType(type: string): type is 'nominal' | 'ordinal' {
+  return type === 'nominal' || type === 'ordinal';
+}
+
+/** Project the verbose workbook field model into compact datasource groups. */
+export function projectListAvailableFieldsSlim(
+  fields: ReturnType<typeof listAvailableFields>,
+): ListAvailableFieldsSlimResult {
+  const groups = new Map<string, DatasourceFieldCandidateGroup>();
+
+  for (const field of fields) {
+    let group = groups.get(field.datasource);
+    if (!group) {
+      group = {
+        datasource: field.datasource,
+        measures: [],
+        timeDimensions: [],
+        breakdownDimensions: [],
+      };
+      groups.set(field.datasource, group);
+    }
+
+    const localName = field.columnName.replace(/^\[|\]$/g, '');
+    const caption = field.caption || localName;
+
+    if (field.role === 'measure' && isNumericDatatype(field.datatype)) {
+      group.measures.push([
+        caption,
+        localName,
+        field.isAggregated ? 'User' : field.derivation,
+        field.isAggregated ? 'aggregatedCalc' : 'base',
+      ]);
+      continue;
+    }
+
+    if (field.role !== 'dimension') continue;
+
+    if (isDateDatatype(field.datatype)) {
+      group.timeDimensions.push([caption, localName, field.datatype]);
+      continue;
+    }
+
+    if (isCategoryType(field.type)) {
+      group.breakdownDimensions.push([caption, localName, field.type]);
+    }
+  }
+
+  return { datasources: Array.from(groups.values()) };
+}
+
+export function filterListAvailableFieldsSlimByLuid({
+  result,
+  workbookDatasources,
+  luids,
+}: {
+  result: ListAvailableFieldsSlimResult;
+  workbookDatasources: DatasourceItem[];
+  luids: string[];
+}): Result<ListAvailableFieldsSlimResult, McpToolError> {
+  const requestedLuids = new Set(luids);
+  const datasources: DatasourceFieldCandidateGroup[] = [];
+  let matchedWorkbookIdentity = false;
+
+  for (const group of result.datasources) {
+    // Workbook fields carry the datasource's internal name, which the API exposes as `id`
+    // for modern federated datasources. Friendly name/caption matching is the legacy fallback.
+    const idMatches = workbookDatasources.filter(
+      (datasource) => datasource.id === group.datasource,
+    );
+    const matchingDatasources =
+      idMatches.length > 0
+        ? idMatches
+        : workbookDatasources.filter(
+            (datasource) =>
+              datasource.name === group.datasource || datasource.caption === group.datasource,
+          );
+    if (matchingDatasources.length > 0) matchedWorkbookIdentity = true;
+    const luidBackedMatches = matchingDatasources.filter(
+      (datasource): datasource is DatasourceItem & { luid: string } =>
+        typeof datasource.luid === 'string' && datasource.luid.length > 0,
+    );
+
+    if (luidBackedMatches.length === 0) continue;
+    if (
+      requestedLuids.size > 0 &&
+      !luidBackedMatches.some((datasource) => requestedLuids.has(datasource.luid))
+    ) {
+      continue;
+    }
+
+    if (matchingDatasources.length > 1) {
+      const identities = matchingDatasources.map((datasource) =>
+        typeof datasource.luid === 'string' ? datasource.luid : '<no LUID>',
+      );
+      return new ArgsValidationError(
+        `Datasource "${group.datasource}" matched multiple workbook datasources: ${identities.join(', ')}.`,
+      ).toErr();
+    }
+
+    const luid = luidBackedMatches[0].luid;
+    const name = luidBackedMatches[0].caption ?? luidBackedMatches[0].name ?? group.datasource;
+    datasources.push({ ...group, name, luid });
+  }
+
+  if (
+    requestedLuids.size === 0 &&
+    result.datasources.length > 0 &&
+    workbookDatasources.length > 0 &&
+    !matchedWorkbookIdentity
+  ) {
+    const fieldIdentities = result.datasources.map(({ datasource }) => datasource);
+    const workbookIdentities = workbookDatasources.flatMap(({ id, name, caption }) =>
+      [id, name, caption].filter((identity): identity is string => Boolean(identity)),
+    );
+    return new ArgsValidationError(
+      `Could not match workbook field datasource identities (${fieldIdentities.join(', ')}) to workbook datasource metadata (${workbookIdentities.join(', ')}).`,
+    ).toErr();
+  }
+
+  if (requestedLuids.size > 0) {
+    const matchedLuids = new Set(datasources.map((datasource) => datasource.luid));
+    const unmatchedLuids = luids.filter((luid) => !matchedLuids.has(luid));
+    if (unmatchedLuids.length > 0) {
+      const matched = [...matchedLuids].filter((luid): luid is string => luid !== undefined);
+      return new ArgsValidationError(
+        [
+          `No workbook datasource fields matched LUIDs: ${unmatchedLuids.join(', ')}.`,
+          matched.length > 0 ? `Matched LUIDs: ${matched.join(', ')}.` : '',
+        ]
+          .filter(Boolean)
+          .join(' '),
+      ).toErr();
+    }
+  }
+
+  return new Ok({ datasources });
+}


### PR DESCRIPTION
## Decision

RULE WE NOW KEEP: `list-available-fields` with `verbosity: \"slim\"` returns compact insight candidates, and its optional `hasLuid`/`luids` filters resolve published datasource identities without a second MCP tool call.

## Description

- Replace the existing slim field-object response with compact measure, time-dimension, and breakdown-dimension tuples.
- Add slim-only `hasLuid` and `luids` filters backed by workbook datasource metadata.
- Include the friendly datasource name and LUID on filtered groups.
- Match modern datasource IDs first, fall back to exact name/caption matches, and fail closed on ambiguity or total identity mismatch.
- Keep the full/default `list-available-fields` response unchanged.

## Motivation and Context

The headless insight flow currently needs separate field and datasource discovery calls. Returning candidate tuples and published identity from the existing slim mode removes that extra call without adding another tool to the Desktop surface.

This intentionally changes the existing `verbosity: \"slim\"` response shape. The paired UI MR consumes the new contract and must land after this PR.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## How Has This Been Tested?

- `npx vitest run src/tools/desktop/fields/listAvailableFieldsSlim.test.ts src/tools/desktop/fields/listAvailableFields.test.ts` — 35 tests passed.
- `npx tsc --noEmit` — passed.
- ESLint on the changed field-listing files — passed.
- `npm run build:desktop` — passed.
- Live Desktop MCP calls verified all-LUID and targeted-LUID filtering, compact tuples, friendly datasource names, and exact LUID results.
- Security review found no medium-or-higher issues.

## Related Issues

- W-23653470
- Paired UI MR: https://gitlab.tableausoftware.com/browser-clients/tab-agent-south-ui/-/merge_requests/47
- Replaces #701, which GitHub closed when its cross-fork source branch was renamed.

## Checklist

- [ ] I have updated the version in the package.json file by using `npm run version`. For example,
      use `npm run version:patch` for a patch version bump.
- [ ] I have made any necessary changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing focused unit tests pass locally with my changes
- [x] I have documented the breaking slim-response change in this PR description

## Contributor Agreement

By submitting this pull request, I confirm that:

- [x] I have read the [CONTRIBUTING guidelines](../../CONTRIBUTING.md) for this project and followed
      its Contribution Checklist.

Made with [Cursor](https://cursor.com)