### PR TITLE
fix(desktop): exempt published-datasource (sqlproxy) connections from connections-not-authorable

### DIFF
--- a/src/desktop/validation/rules/connectionsNotAuthorable.test.ts
+++ b/src/desktop/validation/rules/connectionsNotAuthorable.test.ts
@@ -73,6 +73,19 @@ describe('connections-not-authorable rule', () => {
     expect(connectionsNotAuthorableRule.validate(xml)).toEqual([]);
   });
 
+  it('a bare published-datasource (sqlproxy) connection is NOT rejected — it is a genuine Desktop shape', () => {
+    const xml = `<?xml version="1.0"?>
+<workbook>
+  <datasources>
+    <datasource caption="GUS-Work" name="sqlproxy.1bzmspu1v78e5817xecku1rmnq6s">
+      <connection channel="https" class="sqlproxy" composed-connection-name="sqlproxy.1bzmspu1v78e5817xecku1rmnq6s"
+        dbname="GUS-Work" port="443" server="10ax.online.tableau.com" username="user" />
+    </datasource>
+  </datasources>
+</workbook>`;
+    expect(connectionsNotAuthorableRule.validate(xml)).toEqual([]);
+  });
+
   it('a fragment with no <connection> element at all is never flagged', () => {
     const xml = `<?xml version="1.0"?>
 <worksheet name="Sheet 1">

--- a/src/desktop/validation/rules/connectionsNotAuthorable.ts
+++ b/src/desktop/validation/rules/connectionsNotAuthorable.ts
@@ -88,9 +88,13 @@ export const connectionsNotAuthorableRule: ValidationRule = {
     //
     // 1. A bare/legacy top-level connection that is NOT the modern federated wrapper —
     // exactly the hand-authored-from-.tds shape (known-bad).
+    //
+    // EXCEPTION: `class='sqlproxy'` is a published-datasource proxy — the shape Desktop
+    // serializes for a server/Cloud datasource. It round-trips on a live readback and the
+    // federated+named-connection minting scheme doesn't apply to it, so it is exempt.
     const bareConnections = xpath.select(
-      "/workbook/datasources/datasource/connection[not(@class='federated')] | " +
-        "/datasource/connection[not(@class='federated')]",
+      "/workbook/datasources/datasource/connection[not(@class='federated') and not(@class='sqlproxy')] | " +
+        "/datasource/connection[not(@class='federated') and not(@class='sqlproxy')]",
       doc as unknown as Node,
     ) as Element[];
     for (const conn of bareConnections) {


### PR DESCRIPTION
## Decision
`connections-not-authorable` should exempt `class='sqlproxy'` — the connection shape Tableau serializes for a **published (server/Cloud) datasource** — alongside `federated`. This is a new rule the codebase keeps: sqlproxy is a legitimate Desktop-emitted shape, not the hand-authored/copied-from-.tds connection the rule targets.

## Why
The rule rejects any bare top-level `<connection>` that isn't `class='federated'`. A published datasource serializes as a bare `<connection class='sqlproxy' composed-connection-name='sqlproxy.<id>' server='...online.tableau.com'/>` with no `<named-connections>` wrapper. That round-trips on a live readback, and the federated+named-connection id-minting scheme doesn't apply to server-published connections — so authoring against a published datasource was being false-rejected at preflight.

## Change
Add `and not(@class='sqlproxy')` to both selectors in the bare-connection check, plus a test that a bare sqlproxy connection is not flagged.

## Risk
The rule is a preflight helper, not a correctness or security check. Worst case: a genuinely broken sqlproxy connection fails when Tableau connects, instead of being caught early — a fair trade for enabling published-datasource authoring. Reviewed by Matt Filbert (rule owner), who confirmed nothing else relies on this rule catching sqlproxy. Note: sqlproxy now passes preflight with no second structural check (federated still gets the named-connection id check).

All 59 connections-not-authorable tests pass.