### PR TITLE
@W-23631239: Surface flow-run failure reasons in list-flow-runs and g…

### DIFF
--- a/docs/docs/tools/flows/get-flow.md
+++ b/docs/docs/tools/flows/get-flow.md
@@ -161,20 +161,70 @@ warning is emitted (verified live against Tableau REST 3.30).
 times") when this warning is present — the response is a window onto a longer history, not the
 complete record. Daily-running production flows can easily accumulate hundreds of runs per year.
 
+## Failure reasons (`mcp.failureSummary`)
+
+On Tableau REST API >= 3.30, a `Failed` run carries `failureReason: { available, message }` giving the
+cause of the failure. It is readable by any caller who can see the run — it comes from the flow's
+output-step errors, not the admin-only background job.
+
+When at least one returned run carries a reason, the tool also emits `mcp.failureSummary`, which
+groups those failures by reported message:
+
+- `failedRunCount` — `Failed` runs among the returned runs.
+- `failedFlowCount` — **distinct** flows with a failure. Here that is `1` (or `0` if Tableau omits
+  `flowId` on the runs), since this tool returns runs for a single flow; the field exists so the shape
+  matches [List Flow Runs](list-flow-runs.md#mcpfailuresummary) exactly.
+- `reasons` — one entry per distinct failure **message**, largest first, as
+  `{ message, available, runCount, flowIds }`. A group is not always a single root cause: several
+  distinct underlying errors can map to the same short localized message, and the REST API does not
+  expose the underlying error identifier.
+- `available: false` means Tableau could not determine the cause and `message` is a generic
+  placeholder. Do not present it as a diagnosis. This tool emits no run-history deep link of its own —
+  append `/runHistory` to the `webpageUrl` already in the response to open the flow's run history and
+  read the error in the Tableau UI.
+
+Because the counts cover all `Failed` runs while `reasons` covers only reason-bearing ones,
+`sum(reasons[].runCount)` can be less than `failedRunCount`. On servers below REST API 3.30 both
+`failureReason` and `mcp.failureSummary` are absent.
+
+```json
+{
+  "mcp": {
+    "failureSummary": {
+      "failedRunCount": 1,
+      "failedFlowCount": 1,
+      "reasons": [
+        {
+          "message": "Table \"orders\" was not found.",
+          "available": true,
+          "runCount": 1,
+          "flowIds": ["d00700fe-28a0-4ece-a7af-5543ddf38a82"]
+        }
+      ]
+    }
+  }
+}
+```
+
 ## Limitations
 
 A few things this tool deliberately does **not** expose in the current version:
 
-- **No error details for `Failed` flow runs.** The `flowRuns[*].status` field is available (e.g.
-  `Success`, `Failed`, `Cancelled`), but the underlying job error message is not surfaced by the
-  public Tableau REST API and is therefore not exposed here. To investigate a failure, inspect the
-  run in the Tableau Server / Cloud UI.
+- **Failure reasons need REST API >= 3.30, and only cover `Failed` runs.** On older servers
+  `failureReason` and [`mcp.failureSummary`](#failure-reasons-mcpfailuresummary) are simply omitted and
+  the response is unchanged. Even on 3.30+, there is no reason for a `Cancelled` run and nothing
+  explaining why a run is slow or stuck `InProgress`.
+- **A reason is a short message, not a log.** `failureReason.message` is a short localized cause. The
+  full underlying job error is not surfaced by the public Tableau REST API and reading it requires
+  site-administrator access. To investigate further, inspect the run in the Tableau Server / Cloud UI.
 - **No per-output-step run details.** The `flowRuns` field reflects ad-hoc runs returned by the
   public REST API; per-output-step success/failure breakdowns and timings are not included.
 - **No exact total-run count.** Tableau's Flow Runs endpoint does not expose a `totalAvailable`
   field, so the tool cannot report exactly how many runs exist beyond what was returned — only
   whether more do, via the [`FLOW_RUNS_TRUNCATED`](#run-history-truncation-flow_runs_truncated)
   warning. For deeper history queries, see the recovery actions on that warning.
+  `mcp.failureSummary`'s counts inherit this limit: they describe the returned runs only, so never
+  report them as the flow's total or historical failure rate.
 
 ## Example result
 
@@ -218,7 +268,33 @@ A few things this tool deliberately does **not** expose in the current version:
       "startedAt": "2025-04-01T10:00:00Z",
       "completedAt": "2025-04-01T10:05:00Z",
       "progress": 100
+    },
+    {
+      "id": "a2a2a2a2-2222-2222-2222-222222222222",
+      "flowId": "d00700fe-28a0-4ece-a7af-5543ddf38a82",
+      "status": "Failed",
+      "startedAt": "2025-03-31T10:00:00Z",
+      "completedAt": "2025-03-31T10:02:00Z",
+      "progress": 50,
+      "failureReason": {
+        "available": true,
+        "message": "Table \"orders\" was not found."
+      }
     }
-  ]
+  ],
+  "mcp": {
+    "failureSummary": {
+      "failedRunCount": 1,
+      "failedFlowCount": 1,
+      "reasons": [
+        {
+          "message": "Table \"orders\" was not found.",
+          "available": true,
+          "runCount": 1,
+          "flowIds": ["d00700fe-28a0-4ece-a7af-5543ddf38a82"]
+        }
+      ]
+    }
+  }
 }
 ```

--- a/docs/docs/tools/flows/list-flow-runs.md
+++ b/docs/docs/tools/flows/list-flow-runs.md
@@ -5,8 +5,9 @@ sidebar_position: 3
 # List Flow Runs
 
 Retrieves the run history (executions) of Tableau Prep flows on a site. Each flow run records one
-execution attempt with its status, start/finish timestamps, progress, the flow it belongs to, and
-the background job id.
+execution attempt with its status, start/finish timestamps, progress, the flow it belongs to, the
+background job id, and — for `Failed` runs on Tableau REST API >= 3.30 — a `failureReason` giving the
+cause of the failure.
 
 This is the dedicated, filterable, site-wide run-history tool:
 
@@ -25,7 +26,8 @@ When the MCP server authenticates with OAuth (connected-app JWT), this tool requ
 
 - `tableau:flow_runs:read`
 - `tableau:flows:read` — to resolve a failed run's flow `webpageUrl` into the run-history deep link
-  in `mcp.failureInsight`.
+  in [`mcp.failureInsight`](#failure-reporting). Only requested on that fallback path; when the runs
+  carry a resolved `failureReason` the tool makes no such call.
 - `tableau:mcp_site_settings:read`
 
 See [OAuth configuration](../../configuration/mcp-config/oauth.md) for how scopes are negotiated.
@@ -160,6 +162,57 @@ When `truncated` is `true`, report "at least N" — never invent a total.
 user. Translate it into one plain sentence — "These are all 12 matching runs" or "Here are the first
 50; more match" — and never surface the field names to the end user. :::
 
+## Failure reporting
+
+When the returned window contains a `Failed` run, the tool reports on it through up to two fields.
+`mcp.failureSummary` appears whenever a `Failed` run carries a reason; `mcp.failureInsight` is **added**
+whenever no reason resolves the failure. They therefore co-occur when every reason in the window is
+`available: false` — the summary counts the failures, the link is where the cause can actually be read.
+
+### `mcp.failureSummary`
+
+Present when the window's `Failed` runs carry a `failureReason` (Tableau REST API >= 3.30). It groups
+the window's failures by reported message, so a caller can tell one systemic problem from many
+unrelated ones without reading every record:
+
+- `failedRunCount` — `Failed` runs in the returned window.
+- `failedFlowCount` — **distinct** flows with a failure in that window.
+- `reasons` — one entry per distinct failure **message**, largest first, as
+  `{ message, available, runCount, flowIds }`. `runCount` is how many runs reported that message, and
+  `flowIds` lists the **distinct** flows it affected (its blast radius).
+
+A group is not always a single root cause. Tableau reports a short localized message, and several
+distinct underlying errors can map to the same one — a flow-execution failure and an authentication
+failure both surface as `Flow processing error`, for example. The underlying error identifier is not
+exposed by the REST API, so treat a group as one **symptom**, which may have more than one cause.
+- `available: false` means Tableau could not determine the cause and `message` is a generic
+  placeholder. Do not present it as a diagnosis. Unresolved groups are common on real sites, and are
+  often the largest — to investigate one, call [Get Flow](get-flow.md) on any of its `flowIds` and
+  append `/runHistory` to the returned `webpageUrl`.
+
+`failedRunCount` and `failedFlowCount` cover **all** `Failed` runs, while `reasons` covers only those
+carrying a reason, so `sum(reasons[].runCount)` can be less than `failedRunCount`. Both counts
+describe the returned window only — when `truncated` is `true` they are not site-wide failure totals
+or rates.
+
+### `mcp.failureInsight`
+
+The fallback, for failures that cannot explain themselves — either the server predates REST API 3.30
+(no `failureReason` at all) or every reason returned has `available: false`. It carries the same
+`failedRunCount` / `failedFlowCount` (identical values, since both fields count the same window), plus
+an `example` of `{ flowId, runHistoryUrl }` for one affected flow (the most-recent failure) when
+resolvable. Open `runHistoryUrl` in a browser and expand the failed run to read the error in the
+Tableau UI.
+
+Only one flow is resolved, which costs one extra
+[Query Flow](https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref_flow.htm#query_flow)
+call; use [Get Flow](get-flow.md) to resolve the others if `failedFlowCount` is greater than 1.
+
+In a **mixed** window — some reasons resolved, some not — this field is deliberately absent, since the
+resolved reasons already answer the question and the link would cost that extra call. An
+`available: false` group in such a window therefore has no link of its own; reach one through
+[Get Flow](get-flow.md) as described above.
+
 ## Bounded context (fail-closed)
 
 A flow run carries no project or tag, so when the server is restricted to a
@@ -172,8 +225,14 @@ itself).
 
 ## Limitations
 
-- **No error details for `Failed` runs.** The `status` is available, but the underlying job error
-  message is not surfaced by the public Tableau REST API. Inspect the run in the Tableau UI.
+- **Failure reasons need REST API >= 3.30, and only cover `Failed` runs.** On older servers
+  `failureReason` is absent entirely and the tool falls back to the
+  [`mcp.failureInsight`](#mcpfailureinsight) deep link. Even on 3.30+, there is no reason for a
+  `Cancelled` run and nothing explaining why a run is slow or stuck `InProgress`.
+- **A reason is a short message, not a log.** `failureReason.message` is a short localized cause. The
+  full underlying job error is not surfaced by the public REST API and reading it requires
+  site-administrator access to the job behind `backgroundJobId`. Inspect the run in the Tableau UI for
+  the detail.
 - **No exact total-run count.** The endpoint does not expose `totalAvailable`; the tool reports only
   whether more runs exist via `truncated`.
 
@@ -196,6 +255,68 @@ itself).
     "resultInfo": {
       "returnedCount": 1,
       "truncated": false
+    }
+  }
+}
+```
+
+With a failure, on Tableau REST API >= 3.30:
+
+```json
+{
+  "flowRuns": [
+    {
+      "id": "a2a2a2a2-2222-2222-2222-222222222222",
+      "flowId": "d00700fe-28a0-4ece-a7af-5543ddf38a82",
+      "status": "Failed",
+      "startedAt": "2025-04-02T10:00:00Z",
+      "completedAt": "2025-04-02T10:01:00Z",
+      "progress": 100,
+      "backgroundJobId": "b3b3b3b3-3333-3333-3333-333333333333",
+      "failureReason": {
+        "available": true,
+        "message": "Table \"orders\" was not found."
+      }
+    }
+  ],
+  "mcp": {
+    "resultInfo": {
+      "returnedCount": 1,
+      "truncated": false
+    },
+    "failureSummary": {
+      "failedRunCount": 1,
+      "failedFlowCount": 1,
+      "reasons": [
+        {
+          "message": "Table \"orders\" was not found.",
+          "available": true,
+          "runCount": 1,
+          "flowIds": ["d00700fe-28a0-4ece-a7af-5543ddf38a82"]
+        }
+      ]
+    }
+  }
+}
+```
+
+On a server below REST API 3.30 the same window has no `failureReason` and the tool returns the deep
+link instead:
+
+```json
+{
+  "mcp": {
+    "resultInfo": {
+      "returnedCount": 1,
+      "truncated": false
+    },
+    "failureInsight": {
+      "failedRunCount": 1,
+      "failedFlowCount": 1,
+      "example": {
+        "flowId": "d00700fe-28a0-4ece-a7af-5543ddf38a82",
+        "runHistoryUrl": "https://my.tableau.example.com/#/site/mysite/flows/96151/runHistory"
+      }
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "4.0.6",
+  "version": "4.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "4.0.6",
+      "version": "4.0.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1095.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "4.0.6",
+  "version": "4.0.7",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/src/sdks/tableau/types/flow.test.ts
+++ b/src/sdks/tableau/types/flow.test.ts
@@ -1,0 +1,84 @@
+import { flowRunSchema } from './flow.js';
+
+describe('flowRunSchema', () => {
+  const baseRun = {
+    id: 'a1111111-1111-1111-1111-111111111111',
+    flowId: 'd00700fe-28a0-4ece-a7af-5543ddf38a82',
+    status: 'Failed',
+    startedAt: '2025-06-05T10:00:00Z',
+    completedAt: '2025-06-05T10:01:00Z',
+  };
+
+  describe('failureReason', () => {
+    it('is omitted when the server does not return it', () => {
+      const run = flowRunSchema.parse(baseRun);
+      expect(run.failureReason).toBeUndefined();
+    });
+
+    it('parses a resolved reason', () => {
+      const run = flowRunSchema.parse({
+        ...baseRun,
+        failureReason: { available: true, message: 'Table "orders" was not found.' },
+      });
+
+      expect(run.failureReason).toEqual({
+        available: true,
+        message: 'Table "orders" was not found.',
+      });
+    });
+
+    it('parses an unresolved reason', () => {
+      const run = flowRunSchema.parse({
+        ...baseRun,
+        failureReason: { available: false, message: 'Error in flow steps' },
+      });
+
+      expect(run.failureReason).toEqual({ available: false, message: 'Error in flow steps' });
+    });
+
+    // Tableau serializes XML attributes as strings, so `available` can arrive as
+    // "true"/"false" rather than as a real boolean.
+    it.each([
+      ['"true"', 'true', true],
+      ['"false"', 'false', false],
+      ['" False "', ' False ', false],
+    ])('reads a string %s as %s', (_label, available, expected) => {
+      const run = flowRunSchema.parse({
+        ...baseRun,
+        failureReason: { available, message: 'Error in flow steps' },
+      });
+
+      expect(run.failureReason?.available).toBe(expected);
+    });
+
+    // Resolving to `false` (not `undefined`) is what keeps the caller on the UI
+    // fallback path instead of asserting a cause it cannot support.
+    it.each([
+      ['junk', 'perhaps'],
+      ['null', null],
+      ['absent', undefined],
+    ])('resolves %s availability to false, never undefined', (_label, available) => {
+      const run = flowRunSchema.parse({
+        ...baseRun,
+        failureReason: { available, message: 'Error in flow steps' },
+      });
+
+      expect(run.failureReason?.available).toBe(false);
+    });
+
+    // A malformed reason must not fail the whole Get Flow Runs response — this is
+    // a Zodios response schema, so throwing here would lose every run in the
+    // window over one bad sidecar field. Degrading to absent puts the caller on
+    // the UI-deep-link fallback, which is the intended no-reason behavior.
+    it.each([
+      ['no message', { available: true }],
+      ['a non-string message', { available: true, message: 42 }],
+      ['a non-object reason', 'Error in flow steps'],
+    ])('drops a reason with %s rather than failing the run', (_label, failureReason) => {
+      const run = flowRunSchema.parse({ ...baseRun, failureReason });
+
+      expect(run.failureReason).toBeUndefined();
+      expect(run.id).toBe(baseRun.id);
+    });
+  });
+});

--- a/src/sdks/tableau/types/flow.ts
+++ b/src/sdks/tableau/types/flow.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 
+import { looseBooleanFalsy } from './looseBoolean.js';
 import { projectSchema } from './project.js';
 import { tagsSchema } from './tags.js';
 
@@ -99,6 +100,25 @@ export const flowParameterRunSchema = z.object({
 
 export type FlowParameterRun = z.infer<typeof flowParameterRunSchema>;
 
+/**
+ * Why a `Failed` flow run failed. Requires Tableau REST API 3.30 or later and is
+ * present ONLY on runs whose status is `Failed`, so absence is meaningful rather
+ * than exceptional and needs no version gate at the call site.
+ *
+ * Derived from the flow's output-step run errors (not the background job), which
+ * is what makes it readable by non-admin callers.
+ *
+ * `available: true` carries a specific localized cause. `available: false` means
+ * Tableau could not determine one and `message` is a generic placeholder, so
+ * callers must not present it as a diagnosis.
+ */
+export const flowRunFailureReasonSchema = z.object({
+  available: looseBooleanFalsy,
+  message: z.string(),
+});
+
+export type FlowRunFailureReason = z.infer<typeof flowRunFailureReasonSchema>;
+
 export const flowRunSchema = z.object({
   id: z.string(),
   flowId: z.string().optional(),
@@ -107,6 +127,11 @@ export const flowRunSchema = z.object({
   completedAt: z.string().optional(),
   progress: z.coerce.number().optional(),
   backgroundJobId: z.string().optional(),
+  // `.catch` degrades a malformed reason to absent rather than throwing. This is a
+  // Zodios RESPONSE schema, so without it one bad record would fail the entire
+  // Get Flow Runs call over a sidecar field the caller never asked for. Absent is
+  // a state every consumer already handles: it falls back to the UI deep link.
+  failureReason: flowRunFailureReasonSchema.optional().catch(undefined),
   flowParameterRuns: z
     .object({
       parameterRuns: z.array(flowParameterRunSchema).optional(),

--- a/src/sdks/tableau/types/looseBoolean.test.ts
+++ b/src/sdks/tableau/types/looseBoolean.test.ts
@@ -1,0 +1,56 @@
+import { z } from 'zod';
+
+import { looseBooleanFalsy } from './looseBoolean.js';
+
+describe('looseBooleanFalsy', () => {
+  it.each([
+    ['a real true', true, true],
+    ['a real false', false, false],
+    ['the string "true"', 'true', true],
+    ['the string "false"', 'false', false],
+    ['mixed case "False"', 'False', false],
+    ['mixed case "TRUE"', 'TRUE', true],
+    ['padded " TRUE "', ' TRUE ', true],
+    ['padded " false "', ' false ', false],
+  ])('parses %s', (_label, input, expected) => {
+    expect(looseBooleanFalsy.parse(input)).toBe(expected);
+  });
+
+  // The whole reason this schema exists: z.coerce.boolean() maps "false" to true,
+  // which would invert every caller's fallback branch.
+  it('does not coerce the string "false" to true the way z.coerce.boolean does', () => {
+    expect(z.coerce.boolean().parse('false')).toBe(true);
+    expect(looseBooleanFalsy.parse('false')).toBe(false);
+  });
+
+  it.each([
+    ['junk text', 'maybe'],
+    ['an empty string', ''],
+    ['null', null],
+    ['undefined', undefined],
+    ['a number', 1],
+    ['an object', { nested: true }],
+    ['an array', [true]],
+  ])('resolves %s to false rather than undefined', (_label, input) => {
+    const parsed = looseBooleanFalsy.parse(input);
+    expect(parsed).toBe(false);
+    expect(parsed).not.toBeUndefined();
+  });
+
+  it('keeps the key required on the output side while allowing it to be absent on the input side', () => {
+    const schema = z.object({ available: looseBooleanFalsy });
+
+    // An absent key parses and lands `false` rather than `undefined`.
+    expect(schema.parse({})).toEqual({ available: false });
+
+    // Permissive in: the input type accepts the key being absent.
+    const input: z.input<typeof schema> = {};
+    expect(schema.parse(input)).toEqual({ available: false });
+
+    // Definite out: the output type is a required boolean, so this assignment
+    // compiles. If a future reshape made `available` optional, this line would
+    // stop compiling — which is the point.
+    const output: { available: boolean } = schema.parse({ available: 'true' });
+    expect(output.available).toBe(true);
+  });
+});

--- a/src/sdks/tableau/types/looseBoolean.ts
+++ b/src/sdks/tableau/types/looseBoolean.ts
@@ -1,0 +1,33 @@
+import { z } from 'zod';
+
+/**
+ * Parses a boolean that may arrive as a real boolean or as a string, resolving
+ * anything unrecognized (or absent) to `false`.
+ *
+ * Do NOT use `z.coerce.boolean()` here: coercion delegates to `Boolean(value)`,
+ * which maps the string "false" to `true` and would invert the caller's branch.
+ *
+ * The `false` fallback lives inside the transform rather than in a trailing
+ * `.catch()` / `.default()`, neither of which would fire: on a `z.unknown()`
+ * base a transform returning `undefined` still *succeeds*, so `.catch()` never
+ * sees a failure, and `.default()` only substitutes for an `undefined` input.
+ *
+ * Because the transform's output type is `boolean`, a field using this schema
+ * infers as a REQUIRED `boolean` on the output side while still accepting an
+ * absent key on the input side.
+ */
+export const looseBooleanFalsy = z.unknown().transform((value) => {
+  if (typeof value === 'boolean') {
+    return value;
+  }
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+    if (normalized === 'true') {
+      return true;
+    }
+    if (normalized === 'false') {
+      return false;
+    }
+  }
+  return false;
+});

--- a/src/tools/web/flows/flowRunFailure.test.ts
+++ b/src/tools/web/flows/flowRunFailure.test.ts
@@ -1,0 +1,212 @@
+import { FlowRun } from '../../../sdks/tableau/types/flow.js';
+import { buildRunHistoryUrl, needsUiFallback, summarizeFlowRunFailures } from './flowRunFailure.js';
+import {
+  mockFlowRunFlowIds,
+  mockFlowRuns,
+  mockFlowRunsUnresolvedFailure,
+  mockFlowRunsWithFailureReasons,
+} from './listFlowRuns/mockFlowRuns.js';
+
+const { FLOW_A, FLOW_B, FLOW_C } = mockFlowRunFlowIds;
+
+function failedRun(overrides: Partial<FlowRun> & { id: string }): FlowRun {
+  return { status: 'Failed', ...overrides };
+}
+
+describe('summarizeFlowRunFailures', () => {
+  it('returns undefined when there are no runs at all', () => {
+    expect(summarizeFlowRunFailures([])).toBeUndefined();
+  });
+
+  it('returns undefined when no run failed', () => {
+    const runs = mockFlowRuns.filter((run) => run.status !== 'Failed');
+    expect(summarizeFlowRunFailures(runs)).toBeUndefined();
+  });
+
+  // A pre-3.30 server: failures exist but carry no reason, so the caller stays on
+  // its existing no-reason path.
+  it('returns undefined when failed runs carry no failureReason', () => {
+    expect(summarizeFlowRunFailures(mockFlowRuns)).toBeUndefined();
+  });
+
+  it('groups reasons by message, biggest first', () => {
+    const summary = summarizeFlowRunFailures(mockFlowRunsWithFailureReasons);
+
+    expect(summary).toEqual({
+      failedRunCount: 6,
+      failedFlowCount: 3,
+      reasons: [
+        {
+          // Ascending, so FLOW_B ("c1e8...") precedes FLOW_A ("d007...").
+          message: 'Table "orders" was not found.',
+          available: true,
+          runCount: 3,
+          flowIds: [FLOW_B, FLOW_A],
+        },
+        {
+          message: 'Connection to mySQLServer timed out.',
+          available: true,
+          runCount: 1,
+          flowIds: [FLOW_C],
+        },
+        {
+          message: 'Error in flow steps',
+          available: false,
+          runCount: 1,
+          flowIds: [FLOW_C],
+        },
+      ],
+    });
+  });
+
+  it('de-duplicates flowIds so a flow failing repeatedly for one cause appears once', () => {
+    const summary = summarizeFlowRunFailures(mockFlowRunsWithFailureReasons);
+    const topReason = summary!.reasons[0];
+
+    // FLOW_A failed twice for this cause; FLOW_B once.
+    expect(topReason.runCount).toBe(3);
+    expect(topReason.flowIds).toEqual([FLOW_B, FLOW_A]);
+  });
+
+  it('counts every failed run in the window, not only reason-bearing ones', () => {
+    const summary = summarizeFlowRunFailures(mockFlowRunsWithFailureReasons)!;
+    const groupedRunCount = summary.reasons.reduce((sum, reason) => sum + reason.runCount, 0);
+
+    // The invariant callers rely on. Strictly less here, because one failed run
+    // carries no reason — it counts toward the total but joins no group.
+    expect(groupedRunCount).toBeLessThan(summary.failedRunCount);
+    expect(summary.failedRunCount).toBe(6);
+    expect(groupedRunCount).toBe(5);
+  });
+
+  it('matches the grouped count exactly when every failed run carries a reason', () => {
+    const runs = mockFlowRunsWithFailureReasons.filter(
+      (run) => run.status !== 'Failed' || run.failureReason !== undefined,
+    );
+
+    const summary = summarizeFlowRunFailures(runs)!;
+    const groupedRunCount = summary.reasons.reduce((sum, reason) => sum + reason.runCount, 0);
+
+    expect(groupedRunCount).toBe(summary.failedRunCount);
+  });
+
+  it('ignores runs that did not fail', () => {
+    const summary = summarizeFlowRunFailures([
+      ...mockFlowRunsWithFailureReasons,
+      {
+        id: 'aaaaaaaa-0000-0000-0000-000000000000',
+        flowId: 'f0f0f0f0-0000-0000-0000-000000000000',
+        status: 'Success',
+        // A non-Failed run should never contribute, even if it somehow carries one.
+        failureReason: { available: true, message: 'Should be ignored.' },
+      },
+    ])!;
+
+    expect(summary.failedRunCount).toBe(6);
+    expect(summary.reasons.map((reason) => reason.message)).not.toContain('Should be ignored.');
+  });
+
+  it('keys groups on the (message, available) pair so availability stays well-defined', () => {
+    const summary = summarizeFlowRunFailures([
+      failedRun({ id: 'r1', flowId: FLOW_A, failureReason: { available: true, message: 'Same' } }),
+      failedRun({ id: 'r2', flowId: FLOW_B, failureReason: { available: false, message: 'Same' } }),
+    ])!;
+
+    expect(summary.reasons).toHaveLength(2);
+    expect(summary.reasons.map((reason) => reason.available)).toEqual([true, false]);
+  });
+
+  // Without the third sort key these two groups tie on both count and message and
+  // would fall back to input order, so the two tools could disagree.
+  it('breaks a count-and-message tie on availability, resolved first', () => {
+    // Same flow throughout, so the two groups differ ONLY in `available` and the
+    // comparison below isolates ordering.
+    const unresolvedFirst = summarizeFlowRunFailures([
+      failedRun({ id: 'r1', flowId: FLOW_A, failureReason: { available: false, message: 'Same' } }),
+      failedRun({ id: 'r2', flowId: FLOW_A, failureReason: { available: true, message: 'Same' } }),
+    ])!;
+    const resolvedFirst = summarizeFlowRunFailures([
+      failedRun({ id: 'r1', flowId: FLOW_A, failureReason: { available: true, message: 'Same' } }),
+      failedRun({ id: 'r2', flowId: FLOW_A, failureReason: { available: false, message: 'Same' } }),
+    ])!;
+
+    expect(unresolvedFirst.reasons.map((reason) => reason.available)).toEqual([true, false]);
+    // Input order must not leak into the output, or the two tools could disagree.
+    expect(resolvedFirst.reasons).toEqual(unresolvedFirst.reasons);
+  });
+
+  it('treats an empty message as reason-bearing', () => {
+    const summary = summarizeFlowRunFailures([
+      failedRun({ id: 'r1', flowId: FLOW_A, failureReason: { available: true, message: '' } }),
+    ])!;
+
+    expect(summary.reasons).toEqual([
+      { message: '', available: true, runCount: 1, flowIds: [FLOW_A] },
+    ]);
+  });
+
+  it('omits a missing flowId from the blast radius without dropping the run', () => {
+    const summary = summarizeFlowRunFailures([
+      failedRun({ id: 'r1', failureReason: { available: true, message: 'No flow id' } }),
+    ])!;
+
+    expect(summary.failedRunCount).toBe(1);
+    expect(summary.failedFlowCount).toBe(0);
+    expect(summary.reasons[0]).toEqual({
+      message: 'No flow id',
+      available: true,
+      runCount: 1,
+      flowIds: [],
+    });
+  });
+});
+
+describe('needsUiFallback', () => {
+  it('is false when nothing failed', () => {
+    expect(needsUiFallback([])).toBe(false);
+    expect(needsUiFallback(mockFlowRuns.filter((run) => run.status !== 'Failed'))).toBe(false);
+  });
+
+  it('is true when a failure carries no reason at all', () => {
+    expect(needsUiFallback(mockFlowRuns)).toBe(true);
+  });
+
+  // The case a naive "skip the fallback whenever reasons exist" gets wrong: the
+  // placeholder message is not a diagnosis, so the deep link is still needed.
+  it('is true when every reason in the window is unresolved', () => {
+    expect(needsUiFallback(mockFlowRunsUnresolvedFailure)).toBe(true);
+  });
+
+  it('is false as soon as one failure has a resolved reason', () => {
+    expect(needsUiFallback(mockFlowRunsWithFailureReasons)).toBe(false);
+  });
+
+  it('is false when a resolved reason sits alongside unresolved and reason-less failures', () => {
+    expect(
+      needsUiFallback([
+        ...mockFlowRunsUnresolvedFailure,
+        failedRun({ id: 'r1', flowId: FLOW_B }),
+        failedRun({
+          id: 'r2',
+          flowId: FLOW_A,
+          failureReason: { available: true, message: 'Resolved' },
+        }),
+      ]),
+    ).toBe(false);
+  });
+});
+
+describe('buildRunHistoryUrl', () => {
+  it('appends the run-history tab', () => {
+    expect(buildRunHistoryUrl('http://tpqawin01/#/flows/3')).toBe(
+      'http://tpqawin01/#/flows/3/runHistory',
+    );
+  });
+
+  it.each([
+    ['one trailing slash', 'http://host/#/flows/3/'],
+    ['several', 'http://host/#/flows/3///'],
+  ])('strips %s before appending', (_label, webpageUrl) => {
+    expect(buildRunHistoryUrl(webpageUrl)).toBe('http://host/#/flows/3/runHistory');
+  });
+});

--- a/src/tools/web/flows/flowRunFailure.ts
+++ b/src/tools/web/flows/flowRunFailure.ts
@@ -1,0 +1,161 @@
+import { FlowRun } from '../../../sdks/tableau/types/flow.js';
+
+/**
+ * One distinct failure cause within a window of flow runs, with how many runs and
+ * which flows it affected. `available: false` means Tableau could not determine
+ * the cause and `message` is a generic placeholder.
+ */
+export type FlowRunFailureReasonGroup = {
+  message: string;
+  available: boolean;
+  // Number of `Failed` runs in the window that reported this exact reason.
+  runCount: number;
+  // DISTINCT flows affected by this reason, ascending. The blast radius of one cause.
+  flowIds: string[];
+};
+
+/**
+ * Failures for a window of flow runs, grouped by reported message so a caller can
+ * tell one systemic problem from many unrelated ones without reading every record.
+ *
+ * `failedRunCount` / `failedFlowCount` describe ALL `Failed` runs in the window,
+ * including any that carry no `failureReason` — deliberately the same definition
+ * `buildFailureInsight` uses, so the two fields never disagree about one window.
+ * Consequently `sum(reasons[].runCount) <= failedRunCount`.
+ */
+export type FlowRunFailureSummary = {
+  failedRunCount: number;
+  failedFlowCount: number;
+  reasons: FlowRunFailureReasonGroup[];
+};
+
+// Joins the two group-key fields. A character that cannot appear in a message, so
+// the key stays unambiguous even if the prefix is ever widened beyond the two
+// boolean spellings (which alone could not collide).
+const GROUP_KEY_SEPARATOR = '\u0000';
+
+/**
+ * The window's failed runs. Shared with `buildFailureInsight` so `failedRunCount`
+ * and `failedFlowCount` have ONE definition and the two fields can never disagree
+ * about the same window.
+ */
+export function getFailedRuns(flowRuns: FlowRun[]): FlowRun[] {
+  return flowRuns.filter((run) => run.status === 'Failed');
+}
+
+/** Distinct flows among the given runs, skipping any run with no `flowId`. */
+export function countDistinctFlows(runs: FlowRun[]): number {
+  return new Set(runs.map((run) => run.flowId).filter((id): id is string => id !== undefined)).size;
+}
+
+function compareStrings(a: string, b: string): number {
+  if (a < b) {
+    return -1;
+  }
+  return a > b ? 1 : 0;
+}
+
+/**
+ * Group the window's failure reasons by reported message.
+ *
+ * A group is a symptom, not necessarily a root cause: Tableau resolves the message
+ * from a localization key, and distinct underlying errors can share one key's short
+ * message (a flow-execution failure and an authentication failure both render as
+ * "Flow processing error"). The key itself is not exposed by the REST API, so the
+ * message is the finest grain available to group on.
+ *
+ * Returns `undefined` when no `Failed` run carries a `failureReason` — either the
+ * window has no failures at all, or the server predates REST API 3.30. Both cases
+ * leave the caller on its existing no-reason path.
+ */
+export function summarizeFlowRunFailures(flowRuns: FlowRun[]): FlowRunFailureSummary | undefined {
+  const failedRuns = getFailedRuns(flowRuns);
+
+  // Keyed on the (message, available) PAIR rather than the message alone: two
+  // runs could in principle share a message while disagreeing on availability,
+  // and keying on the pair keeps each group's `available` well-defined by
+  // construction instead of depending on which run was seen first.
+  const groups = new Map<
+    string,
+    { message: string; available: boolean; runCount: number; flowIds: Set<string> }
+  >();
+
+  for (const run of failedRuns) {
+    const reason = run.failureReason;
+    if (!reason) {
+      continue;
+    }
+
+    const key = `${String(reason.available)}${GROUP_KEY_SEPARATOR}${reason.message}`;
+    let group = groups.get(key);
+    if (!group) {
+      group = {
+        message: reason.message,
+        available: reason.available,
+        runCount: 0,
+        flowIds: new Set<string>(),
+      };
+      groups.set(key, group);
+    }
+
+    group.runCount += 1;
+    if (run.flowId !== undefined) {
+      group.flowIds.add(run.flowId);
+    }
+  }
+
+  if (groups.size === 0) {
+    return undefined;
+  }
+
+  const reasons = [...groups.values()]
+    .map((group) => ({
+      message: group.message,
+      available: group.available,
+      runCount: group.runCount,
+      flowIds: [...group.flowIds].sort(),
+    }))
+    // Biggest cause first. `message` then `available` complete a total order —
+    // without the third key, two groups sharing a count and a message would fall
+    // back to insertion order and could differ between callers. Message ordering
+    // compares codepoints rather than using localeCompare, which can return 0 for
+    // distinct strings (e.g. precomposed vs. combining accents) and so would leave
+    // the order incomplete for exactly the case the third key exists to fix.
+    .sort(
+      (a, b) =>
+        b.runCount - a.runCount ||
+        compareStrings(a.message, b.message) ||
+        Number(b.available) - Number(a.available),
+    );
+
+  return {
+    failedRunCount: failedRuns.length,
+    failedFlowCount: countDistinctFlows(failedRuns),
+    reasons,
+  };
+}
+
+/**
+ * Whether the caller still needs the Tableau UI deep link to explain a failure.
+ *
+ * True when the window holds a `Failed` run but nothing in it carries a resolved
+ * cause. Note that reasons with `available: false` do NOT satisfy the caller: the
+ * placeholder message is not a diagnosis, so those windows still need the link.
+ */
+export function needsUiFallback(flowRuns: FlowRun[]): boolean {
+  const failedRuns = getFailedRuns(flowRuns);
+  if (failedRuns.length === 0) {
+    return false;
+  }
+  return !failedRuns.some((run) => run.failureReason?.available === true);
+}
+
+/**
+ * A flow's run-history page, which lists its runs and lets the user expand a
+ * failed one to read the error. `webpageUrl` is the flow's UI page in numeric-id
+ * form (e.g. .../#/site/<site>/flows/<id>); its run-history tab is that page plus
+ * "/runHistory" (matching what the Tableau UI links to).
+ */
+export function buildRunHistoryUrl(webpageUrl: string): string {
+  return `${webpageUrl.replace(/\/+$/, '')}/runHistory`;
+}

--- a/src/tools/web/flows/getFlow/getFlow.test.ts
+++ b/src/tools/web/flows/getFlow/getFlow.test.ts
@@ -6,7 +6,13 @@ import invariant from '../../../../utils/invariant.js';
 import { Provider } from '../../../../utils/provider.js';
 import { getMockRequestHandlerExtra } from '../../toolContext.mock.js';
 import { getGetFlowTool } from './getFlow.js';
-import { mockConnections, mockFlow, mockFlowRuns, mockOutputSteps } from './mockFlow.js';
+import {
+  mockConnections,
+  mockFlow,
+  mockFlowRuns,
+  mockFlowRunsWithFailureReason,
+  mockOutputSteps,
+} from './mockFlow.js';
 
 const mocks = vi.hoisted(() => ({
   mockQueryFlow: vi.fn(),
@@ -230,6 +236,115 @@ describe('getFlowTool', () => {
     // but never an actual password string. Make sure that contract holds.
     expect(result.content[0].text).not.toMatch(/"password"\s*:\s*"[^"]+"/);
     expect(result.content[0].text).not.toMatch(/X-Tableau-Auth/);
+  });
+
+  // ------------------------------------------------------------------------
+  // failureSummary — and the four states of the optional `mcp` container
+  // ------------------------------------------------------------------------
+  // `mcp` holds two independent optional members, so all four combinations must
+  // be correct. The no-warnings/no-summary case is the AC3 guarantee for this
+  // tool: the key is absent entirely, exactly as before this field existed.
+  describe('failureSummary', () => {
+    it('groups the failure causes of the returned runs', async () => {
+      mocks.mockQueryFlow.mockResolvedValue({ flow: mockFlow, outputSteps: mockOutputSteps });
+      mocks.mockQueryFlowConnections.mockResolvedValue(mockConnections);
+      mocks.mockGetFlowRuns.mockResolvedValue(mockFlowRunsWithFailureReason);
+
+      const result = await getToolResult({ flowId: mockFlow.id });
+      expect(result.isError).toBe(false);
+      invariant(result.content[0].type === 'text');
+      const parsed = JSON.parse(result.content[0].text);
+
+      expect(parsed.mcp.failureSummary).toEqual({
+        failedRunCount: 1,
+        failedFlowCount: 1,
+        reasons: [
+          {
+            message: 'Table "orders" was not found.',
+            available: true,
+            runCount: 1,
+            flowIds: [mockFlow.id],
+          },
+        ],
+      });
+      expect(parsed.mcp.warnings).toBeUndefined();
+    });
+
+    it('omits the whole mcp container when there are no warnings and no reasons', async () => {
+      mocks.mockQueryFlow.mockResolvedValue({ flow: mockFlow, outputSteps: mockOutputSteps });
+      mocks.mockQueryFlowConnections.mockResolvedValue(mockConnections);
+      // Includes a Failed run, but with no reason — a pre-3.30 server.
+      mocks.mockGetFlowRuns.mockResolvedValue(mockFlowRuns);
+
+      const result = await getToolResult({ flowId: mockFlow.id });
+      expect(result.isError).toBe(false);
+      invariant(result.content[0].type === 'text');
+      const parsed = JSON.parse(result.content[0].text);
+
+      expect(parsed.mcp).toBeUndefined();
+      expect(result.content[0].text).not.toContain('failureSummary');
+    });
+
+    it('emits warnings alone when a sidecar fails and no run carries a reason', async () => {
+      mocks.mockQueryFlow.mockResolvedValue({ flow: mockFlow, outputSteps: mockOutputSteps });
+      mocks.mockQueryFlowConnections.mockRejectedValue(new Error('Connections forbidden'));
+      mocks.mockGetFlowRuns.mockResolvedValue(mockFlowRuns);
+
+      const result = await getToolResult({ flowId: mockFlow.id });
+      expect(result.isError).toBe(false);
+      invariant(result.content[0].type === 'text');
+      const parsed = JSON.parse(result.content[0].text);
+
+      expect(parsed.mcp.warnings).toHaveLength(1);
+      expect(parsed.mcp.failureSummary).toBeUndefined();
+    });
+
+    it('emits warnings and the summary together', async () => {
+      mocks.mockQueryFlow.mockResolvedValue({ flow: mockFlow, outputSteps: mockOutputSteps });
+      mocks.mockQueryFlowConnections.mockRejectedValue(new Error('Connections forbidden'));
+      mocks.mockGetFlowRuns.mockResolvedValue(mockFlowRunsWithFailureReason);
+
+      const result = await getToolResult({ flowId: mockFlow.id });
+      expect(result.isError).toBe(false);
+      invariant(result.content[0].type === 'text');
+      const parsed = JSON.parse(result.content[0].text);
+
+      expect(parsed.mcp.warnings).toHaveLength(1);
+      expect(parsed.mcp.failureSummary.reasons).toHaveLength(1);
+    });
+
+    it('omits the summary when flow runs were not requested', async () => {
+      mocks.mockQueryFlow.mockResolvedValue({ flow: mockFlow, outputSteps: mockOutputSteps });
+      mocks.mockQueryFlowConnections.mockResolvedValue(mockConnections);
+
+      const result = await getToolResult({ flowId: mockFlow.id, includeFlowRuns: false });
+      expect(result.isError).toBe(false);
+      invariant(result.content[0].type === 'text');
+      const parsed = JSON.parse(result.content[0].text);
+
+      expect(parsed.mcp).toBeUndefined();
+      expect(mocks.mockGetFlowRuns).not.toHaveBeenCalled();
+    });
+
+    // `available: false` still gets grouped — get-flow has no deep-link fallback,
+    // so the placeholder is all it can offer, flagged as unresolved.
+    it('reports an unresolved reason as available false', async () => {
+      mocks.mockQueryFlow.mockResolvedValue({ flow: mockFlow, outputSteps: mockOutputSteps });
+      mocks.mockQueryFlowConnections.mockResolvedValue(mockConnections);
+      mocks.mockGetFlowRuns.mockResolvedValue([
+        { ...mockFlowRuns[1], failureReason: { available: false, message: 'Error in flow steps' } },
+      ]);
+
+      const result = await getToolResult({ flowId: mockFlow.id });
+      expect(result.isError).toBe(false);
+      invariant(result.content[0].type === 'text');
+      const parsed = JSON.parse(result.content[0].text);
+
+      expect(parsed.mcp.failureSummary.reasons[0].available).toBe(false);
+      expect(parsed.mcp.failureSummary.reasons[0].message).toBe('Error in flow steps');
+      // This tool never emits the list-flow-runs deep link.
+      expect(parsed.mcp.failureInsight).toBeUndefined();
+    });
   });
 
   // ------------------------------------------------------------------------

--- a/src/tools/web/flows/getFlow/getFlow.ts
+++ b/src/tools/web/flows/getFlow/getFlow.ts
@@ -23,6 +23,7 @@ import { getExceptionMessage } from '../../../../utils/getExceptionMessage.js';
 import { getHttpStatus } from '../../../../utils/getHttpStatus.js';
 import { resourceAccessChecker } from '../../resourceAccessChecker.js';
 import { WebTool } from '../../tool.js';
+import { FlowRunFailureSummary, summarizeFlowRunFailures } from '../flowRunFailure.js';
 
 const FLOW_RUN_LIMIT_MAX = 100;
 
@@ -67,8 +68,12 @@ export type GetFlowResult = Flow & {
   outputSteps: FlowOutputStep[];
   connections?: FlowConnection[];
   flowRuns?: FlowRun[];
+  // Both members are optional and the container itself is omitted when neither
+  // applies, so a flow with no warnings and no failures emits no `mcp` key at all
+  // — exactly as it did before `failureSummary` existed.
   mcp?: {
-    warnings: GetFlowWarning[];
+    warnings?: GetFlowWarning[];
+    failureSummary?: FlowRunFailureSummary;
   };
 };
 
@@ -86,7 +91,8 @@ export const getGetFlowTool = (server: WebMcpServer): WebTool<typeof paramsSchem
   - Flow metadata: id, name, description, webpageUrl, fileType, createdAt, updatedAt, project, owner, tags, parameters.
   - \`outputSteps\`: array of \`{id, name}\` for each output step in the flow.
   - \`connections\` (when \`includeConnections=true\`): array of input data connections (id, type, serverAddress, userName, embedPassword).
-  - \`flowRuns\` (when \`includeFlowRuns=true\`, on Tableau versions that support the flow-runs endpoint): up to \`flowRunLimit\` most-recent flow runs (id, status, startedAt, completedAt, progress, backgroundJobId), newest first.
+  - \`flowRuns\` (when \`includeFlowRuns=true\`, on Tableau versions that support the flow-runs endpoint): up to \`flowRunLimit\` most-recent flow runs (id, status, startedAt, completedAt, progress, backgroundJobId, and \`failureReason\` on \`Failed\` runs), newest first. \`failureReason: { available, message }\` gives the cause of a failure and requires Tableau REST API **3.30+**; on older servers it is absent. \`available: false\` means Tableau could not determine the cause and \`message\` is a generic placeholder — do NOT present it as a diagnosis.
+  - \`mcp.failureSummary\` (only when the returned runs include a \`Failed\` run carrying a \`failureReason\`): that window's failures, grouped by reported message. \`failedRunCount\` and \`failedFlowCount\` cover ALL \`Failed\` runs returned; \`reasons\` holds one entry per distinct failure *message*, biggest first, as \`{ message, available, runCount, flowIds }\` where \`flowIds\` are the DISTINCT flows that the message affected. A group is not always a single root cause — different underlying errors can share one short localized message. Identical in shape to the field \`list-flow-runs\` returns. Because the counts cover all failed runs while \`reasons\` covers only reason-bearing ones, \`sum(reasons[].runCount)\` can be less than \`failedRunCount\`. This tool emits no run-history deep link of its own: for an \`available: false\` group, append \`/runHistory\` to this response's \`webpageUrl\` to reach the flow's run-history page and read the error there.
   - \`mcp.warnings\` (only when warnings are emitted): list of non-fatal issues. Warning types include:
     - \`SIDECAR_FETCH_FAILED\`: an optional sidecar fetch (connections or runs) failed; the rest of the response is still valid.
     - \`VERSION_GATE_SKIPPED\`: this Tableau version does not support the flow-runs endpoint.
@@ -104,9 +110,9 @@ export const getGetFlowTool = (server: WebMcpServer): WebTool<typeof paramsSchem
   A single call returns at most \`flowRunLimit\` runs (newest first). If the flow has more, the response carries a \`FLOW_RUNS_TRUNCATED\` warning — the ONLY signal that the window is partial, so never report a truncated window as the complete history. To see more: re-call with a higher \`flowRunLimit\` (max 100); for deeper history or a specific date range, use the Tableau Flow Runs REST API directly (\`filter=flowId:eq:<id>\` with \`pageNumber\` pagination, or a \`startedAt\` date filter).
 
   **Limitations**
-  - Error details for \`Failed\` flow runs are not exposed in this version of the tool. The \`status\` field is available; the underlying job error message is not.
+  - Failure reasons cover \`Failed\` runs only, and only on REST API 3.30+. There is nothing for \`Cancelled\` runs, and nothing that explains why a run is slow or stuck \`InProgress\`. \`message\` is a short localized reason, not a stack trace or job log — the full underlying job error still requires **site-administrator** access. On servers below 3.30, \`failureReason\` and \`mcp.failureSummary\` are simply omitted and the response is unchanged.
   - The \`flowRuns\` field reflects ad-hoc runs returned by the public REST API; per-output-step details are not included.
-  - A single call returns at most 100 \`flowRuns\` (\`flowRunLimit\` max). Tableau's Flow Runs endpoint does not expose a total-count field, so the tool cannot tell you exactly how many runs exist beyond what was returned — only that more do (via the \`FLOW_RUNS_TRUNCATED\` warning).
+  - A single call returns at most 100 \`flowRuns\` (\`flowRunLimit\` max). Tableau's Flow Runs endpoint does not expose a total-count field, so the tool cannot tell you exactly how many runs exist beyond what was returned — only that more do (via the \`FLOW_RUNS_TRUNCATED\` warning). \`mcp.failureSummary\`'s counts inherit this limit: they describe the returned window only, so never report them as a flow's total or historical failure rate.
 
   **Example Usage**
   - Get a flow's metadata and output steps only (cheapest call, no sidecars):
@@ -262,12 +268,22 @@ export const getGetFlowTool = (server: WebMcpServer): WebTool<typeof paramsSchem
                   }
                 }
 
+                // Same grouping helper list-flow-runs uses, so both tools emit an
+                // identical `failureSummary`. The runs are already in hand, so
+                // this costs no extra request.
+                const failureSummary = flowRuns ? summarizeFlowRunFailures(flowRuns) : undefined;
+
+                const mcp = {
+                  ...(warnings.length > 0 && { warnings }),
+                  ...(failureSummary !== undefined && { failureSummary }),
+                };
+
                 const result: GetFlowResult = {
                   ...flow,
                   outputSteps,
                   ...(connections !== undefined && { connections }),
                   ...(flowRuns !== undefined && { flowRuns }),
-                  ...(warnings.length > 0 && { mcp: { warnings } }),
+                  ...(Object.keys(mcp).length > 0 && { mcp }),
                 };
 
                 return result;

--- a/src/tools/web/flows/getFlow/mockFlow.ts
+++ b/src/tools/web/flows/getFlow/mockFlow.ts
@@ -33,6 +33,11 @@ export const mockConnections = [
   },
 ] satisfies Array<FlowConnection>;
 
+/**
+ * Baseline runs, deliberately WITHOUT any `failureReason` — the shape a pre-3.30
+ * server returns. Existing tests assert the no-reason behavior against this, which
+ * is the AC3 regression baseline, so do not add reasons here.
+ */
 export const mockFlowRuns = [
   {
     id: 'a1a1a1a1-1111-1111-1111-111111111111',
@@ -51,5 +56,14 @@ export const mockFlowRuns = [
     completedAt: '2025-03-31T10:02:00Z',
     progress: 50,
     backgroundJobId: 'b2b2b2b2-2222-2222-2222-222222222222',
+  },
+] satisfies Array<FlowRun>;
+
+/** The same window as `mockFlowRuns`, but on a REST 3.30+ server. */
+export const mockFlowRunsWithFailureReason = [
+  mockFlowRuns[0],
+  {
+    ...mockFlowRuns[1],
+    failureReason: { available: true, message: 'Table "orders" was not found.' },
   },
 ] satisfies Array<FlowRun>;

--- a/src/tools/web/flows/listFlowRuns/listFlowRuns.test.ts
+++ b/src/tools/web/flows/listFlowRuns/listFlowRuns.test.ts
@@ -8,7 +8,14 @@ import invariant from '../../../../utils/invariant.js';
 import { Provider } from '../../../../utils/provider.js';
 import { getMockRequestHandlerExtra } from '../../toolContext.mock.js';
 import { constrainFlowRuns, getListFlowRunsTool } from './listFlowRuns.js';
-import { mockFlowRuns } from './mockFlowRuns.js';
+import {
+  mockFlowRunFlowIds,
+  mockFlowRuns,
+  mockFlowRunsUnresolvedFailure,
+  mockFlowRunsWithFailureReasons,
+} from './mockFlowRuns.js';
+
+const { FLOW_A, FLOW_B } = mockFlowRunFlowIds;
 
 const mocks = vi.hoisted(() => ({
   mockGetFlowRuns: vi.fn(),
@@ -579,6 +586,94 @@ describe('listFlowRunsTool', () => {
     });
   });
 
+  describe('failureSummary', () => {
+    it('groups the window failure causes when the runs carry reasons', async () => {
+      mocks.mockGetFlowRuns.mockResolvedValue(mockFlowRunsWithFailureReasons);
+      const result = await getToolResult({});
+      expect(result.isError).toBe(false);
+      invariant(result.content[0].type === 'text');
+      const payload = JSON.parse(result.content[0].text);
+
+      expect(payload.mcp.failureSummary.failedRunCount).toBe(6);
+      expect(payload.mcp.failureSummary.failedFlowCount).toBe(3);
+      expect(payload.mcp.failureSummary.reasons[0]).toEqual({
+        message: 'Table "orders" was not found.',
+        available: true,
+        runCount: 3,
+        // Ascending, so FLOW_B ("c1e8...") precedes FLOW_A ("d007...").
+        flowIds: [FLOW_B, FLOW_A],
+      });
+    });
+
+    it('skips the fallback REST call when a failure has a resolved reason', async () => {
+      mocks.mockGetFlowRuns.mockResolvedValue(mockFlowRunsWithFailureReasons);
+      const result = await getToolResult({});
+      expect(result.isError).toBe(false);
+      invariant(result.content[0].type === 'text');
+      const payload = JSON.parse(result.content[0].text);
+
+      expect(payload.mcp.failureSummary).toBeDefined();
+      expect(payload.mcp.failureInsight).toBeUndefined();
+      expect(mocks.mockQueryFlow).not.toHaveBeenCalled();
+    });
+
+    // The half a naive "skip the fallback whenever reasons exist" gets wrong: an
+    // unresolved reason is a placeholder, so the deep link is still needed.
+    it('still resolves the deep link when every reason in the window is unresolved', async () => {
+      mocks.mockGetFlowRuns.mockResolvedValue(mockFlowRunsUnresolvedFailure);
+      const result = await getToolResult({});
+      expect(result.isError).toBe(false);
+      invariant(result.content[0].type === 'text');
+      const payload = JSON.parse(result.content[0].text);
+
+      expect(payload.mcp.failureSummary.reasons).toEqual([
+        { message: 'Error in flow steps', available: false, runCount: 1, flowIds: [FLOW_A] },
+      ]);
+      expect(payload.mcp.failureInsight.example.runHistoryUrl).toBe(
+        `${FLOW_WEBPAGE_URL}/runHistory`,
+      );
+      expect(mocks.mockQueryFlow).toHaveBeenCalledTimes(1);
+
+      // Both fields describe the same window, so their counts must agree — they
+      // share one definition of "failed run" precisely so this cannot drift.
+      expect(payload.mcp.failureInsight.failedRunCount).toBe(
+        payload.mcp.failureSummary.failedRunCount,
+      );
+      expect(payload.mcp.failureInsight.failedFlowCount).toBe(
+        payload.mcp.failureSummary.failedFlowCount,
+      );
+    });
+
+    // AC3: on a pre-3.30 server nothing about the response changes.
+    it('emits no failureSummary and keeps the deep link when no run carries a reason', async () => {
+      mocks.mockGetFlowRuns.mockResolvedValue(mockFlowRuns);
+      const result = await getToolResult({ filter: `flowId:eq:${FLOW_ID}` });
+      expect(result.isError).toBe(false);
+      invariant(result.content[0].type === 'text');
+      const payload = JSON.parse(result.content[0].text);
+
+      expect(payload.mcp.failureSummary).toBeUndefined();
+      expect(payload.mcp.failureInsight).toEqual({
+        failedRunCount: 1,
+        failedFlowCount: 1,
+        example: { flowId: FLOW_ID, runHistoryUrl: `${FLOW_WEBPAGE_URL}/runHistory` },
+      });
+      expect(mocks.mockQueryFlow).toHaveBeenCalledTimes(1);
+    });
+
+    it('emits neither failure field when nothing failed', async () => {
+      mocks.mockGetFlowRuns.mockResolvedValue(buildRuns(3, 'Success'));
+      const result = await getToolResult({});
+      expect(result.isError).toBe(false);
+      invariant(result.content[0].type === 'text');
+      const payload = JSON.parse(result.content[0].text);
+
+      expect(payload.mcp.failureSummary).toBeUndefined();
+      expect(payload.mcp.failureInsight).toBeUndefined();
+      expect(mocks.mockQueryFlow).not.toHaveBeenCalled();
+    });
+  });
+
   describe('constrainFlowRuns', () => {
     it('returns the baseline empty message when no runs are found', () => {
       const result = constrainFlowRuns({
@@ -674,6 +769,38 @@ describe('listFlowRunsTool', () => {
         boundedContext: { ...NO_BOUNDED_CONTEXT, projectIds: new Set(['p1']) },
       });
       // Bounded context fails closed → empty result, so no link leaks out.
+      invariant(result.type === 'empty');
+    });
+
+    it('passes failureSummary through on the success path', () => {
+      const failureSummary = {
+        failedRunCount: 2,
+        failedFlowCount: 1,
+        reasons: [{ message: 'Boom', available: true, runCount: 2, flowIds: [FLOW_ID] }],
+      };
+      const result = constrainFlowRuns({
+        result: {
+          flowRuns: mockFlowRuns,
+          mcp: { resultInfo: { returnedCount: 3, truncated: false }, failureSummary },
+        },
+        boundedContext: NO_BOUNDED_CONTEXT,
+      });
+      invariant(result.type === 'success');
+      expect(result.result.mcp.failureSummary).toEqual(failureSummary);
+    });
+
+    it('drops failureSummary when a bounded context forces an empty result', () => {
+      const result = constrainFlowRuns({
+        result: {
+          flowRuns: mockFlowRuns,
+          mcp: {
+            resultInfo: { returnedCount: 3, truncated: false },
+            failureSummary: { failedRunCount: 1, failedFlowCount: 1, reasons: [] },
+          },
+        },
+        boundedContext: { ...NO_BOUNDED_CONTEXT, projectIds: new Set(['p1']) },
+      });
+      // No failure detail leaks out of a fail-closed result.
       invariant(result.type === 'empty');
     });
   });

--- a/src/tools/web/flows/listFlowRuns/listFlowRuns.ts
+++ b/src/tools/web/flows/listFlowRuns/listFlowRuns.ts
@@ -17,6 +17,14 @@ import { genericFilterDescription } from '../../genericFilterDescription.js';
 import { ConstrainedResult, WebTool } from '../../tool.js';
 import { TableauWebRequestHandlerExtra } from '../../toolContext.js';
 import { extractEqValue, looksLikeUuid } from '../flowFilterUtils.js';
+import {
+  buildRunHistoryUrl,
+  countDistinctFlows,
+  FlowRunFailureSummary,
+  getFailedRuns,
+  needsUiFallback,
+  summarizeFlowRunFailures,
+} from '../flowRunFailure.js';
 import { buildTruncationInfo, ListFlowsTruncationReason } from '../listFlows/listFlows.js';
 import { parseAndValidateFlowRunsFilterString } from './flowRunsFilterUtils.js';
 
@@ -56,13 +64,19 @@ export type ListFlowRunsResultInfo = {
 };
 
 /**
- * Pointer to investigate flow-run failures in the Tableau UI. The Get Flow Runs
- * endpoint never returns *why* a run failed, so when the returned window holds
- * one or more `Failed` runs the tool resolves ONE affected flow's `webpageUrl`
- * (via Query Flow) into a run-history deep link the caller can open to read the
- * error. Only one example is resolved (a single extra REST call); `failedFlowCount`
- * tells the caller how many other flows failed so it can offer to fetch their
- * links (via get-flow) on request.
+ * FALLBACK pointer to investigate flow-run failures in the Tableau UI, for when
+ * the runs themselves cannot explain the failure — either the server predates
+ * REST API 3.30 (no `failureReason` at all) or every reason it returned has
+ * `available: false`, whose message is a placeholder rather than a cause.
+ *
+ * On that path the tool resolves ONE affected flow's `webpageUrl` (via Query
+ * Flow) into a run-history deep link the caller can open to read the error. Only
+ * one example is resolved (a single extra REST call); `failedFlowCount` tells the
+ * caller how many other flows failed so it can offer to fetch their links (via
+ * get-flow) on request.
+ *
+ * When a resolved reason IS available, `mcp.failureSummary` answers the question
+ * directly and this field — along with its extra REST call — is skipped.
  */
 export type ListFlowRunsFailureInsight = {
   // Number of `Failed` runs within the returned (post-limit) window.
@@ -85,13 +99,17 @@ export type ListFlowRunsFailureInsight = {
  * does not return a server-side count, so completeness is reported via the
  * `truncated` flag (computed with a "+1 probe") only.
  *
- * `mcp.failureInsight` is present ONLY when the returned window contains a
- * `Failed` run (the API hides failure reasons, so this links to the UI page).
+ * `mcp.failureSummary` is present whenever a `Failed` run carries a
+ * `failureReason` (REST API 3.30+). `mcp.failureInsight` is ADDED when no reason
+ * resolves the failure (see needsUiFallback), so a window whose reasons are all
+ * `available: false` carries both: the summary counts the failures, the link is
+ * where the actual cause can be read.
  */
 export type ListFlowRunsResult = {
   flowRuns: FlowRun[];
   mcp: {
     resultInfo: ListFlowRunsResultInfo;
+    failureSummary?: FlowRunFailureSummary;
     failureInsight?: ListFlowRunsFailureInsight;
   };
 };
@@ -110,14 +128,14 @@ export const getListFlowRunsTool = (server: WebMcpServer): WebTool<typeof params
     name: 'list-flow-runs',
     disabled: !config.flowToolsEnabled,
     description: `
-  Retrieves the run history (executions) of Tableau Prep flows on a site. Each flow run records one execution attempt with its \`status\` (Pending, InProgress, Success, Failed, Cancelled), \`startedAt\`/\`completedAt\` timestamps, \`progress\`, the \`flowId\` it belongs to, and the \`backgroundJobId\`. Use this tool to answer questions about flow execution outcomes — e.g. "which flows failed recently", "show the run history for flow X", "what's still running".
+  Retrieves the run history (executions) of Tableau Prep flows on a site. Each flow run records one execution attempt with its \`status\` (Pending, InProgress, Success, Failed, Cancelled), \`startedAt\`/\`completedAt\` timestamps, \`progress\`, the \`flowId\` it belongs to, the \`backgroundJobId\`, and — on \`Failed\` runs, REST API 3.30+ — a \`failureReason\` giving the cause. Use this tool to answer questions about flow execution outcomes — e.g. "why did my flow fail", "which flows failed recently and why", "show the run history for flow X", "what's still running".
 
   **This vs. get-flow / list-flows**
   - \`list-flows\` lists flow *definitions* (metadata), not executions.
   - \`get-flow\` returns recent runs for ONE flow (capped, as a sidecar). \`list-flow-runs\` is the dedicated, filterable, site-wide run history — use it for cross-flow questions ("all failures today") or deeper single-flow history.
 
   **What a run record does NOT include**
-  - **Failure reason:** a run reports only its \`status\`, never *why* it failed — the run data carries no error message. A failed run's \`backgroundJobId\` identifies the underlying background job that holds the error detail, but reading that detail requires Tableau **site-administrator** access. \`backgroundJobId\` is populated only for recent runs. As a workaround, when the returned window contains \`Failed\` runs the tool resolves a **run-history deep link** for one affected flow into \`mcp.failureInsight\` — open it in Tableau to read the error there (see Response Shape).
+  - **Failure reason — mostly now available.** On Tableau REST API **3.30+**, a \`Failed\` run carries \`failureReason: { available, message }\` giving the cause directly, readable by any caller (it comes from the flow's output-step errors, not the admin-only background job). Residual gaps: (1) only \`Failed\` runs get one — there is nothing for \`Cancelled\`, and nothing that explains why a run is slow or stuck \`InProgress\`; (2) \`message\` is a short localized reason, NOT a stack trace or job log — the full job detail behind \`backgroundJobId\` still requires **site-administrator** access (and \`backgroundJobId\` is populated only for recent runs); (3) \`available: false\` means Tableau could not determine the cause and \`message\` is a generic placeholder. On servers **below 3.30** the field is absent entirely. Whenever a reason is missing or unresolved, the tool falls back to a **run-history deep link** in \`mcp.failureInsight\` — open it in Tableau to read the error there (see Response Shape).
   - **Trigger origin:** a run does not record whether it was started by a *schedule* or *ad-hoc / on-demand*, and there is no field to filter scheduled-only runs. To see which flows have schedules, use \`list-flow-tasks\`.
 
   **Caller-role visibility**
@@ -133,12 +151,17 @@ export const getListFlowRunsTool = (server: WebMcpServer): WebTool<typeof params
       - \`"default-cap"\` — you supplied no \`limit\` and no admin cap is set, so the tool returned the newest ${DEFAULT_FLOW_RUNS_LIMIT} runs as a safety default (flow runs can be very numerous); pass a higher \`limit\` and/or a narrower \`filter\` to get more.
       - \`"admin-cap"\` — a site-administrator per-call cap (\`MAX_RESULT_LIMIT[S]\`) cut it short; narrow the \`filter\` (e.g. a tighter \`startedAt\` window or a single \`flowId\`) or ask an admin to raise the cap.
   - There is NO \`totalAvailable\` — the Tableau Flow Runs endpoint does not return a total count. When \`truncated\` is \`true\`, report "at least N" (never invent a total).
-  - \`mcp.failureInsight\` (present ONLY when the returned window contains at least one \`Failed\` run): a pointer to investigate failures in the Tableau UI, since the API does not expose the error message. Fields:
+  - \`mcp.failureSummary\` (present when the window's \`Failed\` runs carry a \`failureReason\`, i.e. REST API 3.30+): the window's failures grouped by reported message so you can tell one systemic problem from many unrelated ones. Fields:
       - \`failedRunCount\` — number of \`Failed\` runs in the returned window.
       - \`failedFlowCount\` — number of DISTINCT flows with a failure in that window.
+      - \`reasons\` — one entry per distinct failure *message*, biggest first: \`{ message, available, runCount, flowIds }\`. \`runCount\` is how many runs reported that message and \`flowIds\` are the DISTINCT flows it affected (its blast radius). A group is not always a single root cause: Tableau reports a short localized message, and different underlying errors can share one (e.g. a flow-execution failure and an authentication failure both surface as "Flow processing error"), so treat a group as one symptom that may have more than one cause. \`available: false\` means the cause could not be determined and \`message\` is a generic placeholder — do NOT present it as a diagnosis. Unresolved groups are common and often the largest; to investigate one, call \`get-flow\` on any of its \`flowIds\` and append \`/runHistory\` to the returned \`webpageUrl\` to get that flow's run-history page.
+      - Because the top-level counts cover ALL \`Failed\` runs while \`reasons\` covers only those carrying a reason, \`sum(reasons[].runCount)\` can be less than \`failedRunCount\`.
+  - \`mcp.failureInsight\` (the FALLBACK, present when the window has a \`Failed\` run that nothing can explain — no \`failureReason\`, or none with \`available: true\`): a pointer to investigate in the Tableau UI. Fields:
+      - \`failedRunCount\` / \`failedFlowCount\` — as above, and always equal to \`failureSummary\`'s when both fields are present.
       - \`example\` (when resolvable) — \`{ flowId, runHistoryUrl }\` for ONE affected flow (the most-recent failure); open \`runHistoryUrl\` in a browser and expand the failed run to read why it failed.
+  - **The two can co-occur.** \`failureSummary\` appears whenever a reason exists; \`failureInsight\` is added whenever none resolves. So a window whose reasons are ALL \`available: false\` carries both — treat the summary as a count of what failed and the link as where the cause actually lives. In a MIXED window (some reasons resolved, some not) \`failureInsight\` is deliberately absent, so an \`available: false\` group there has no link of its own — use the \`get-flow\` route above to reach one.
 
-  **Reporting to the user (every call):** translate \`mcp.resultInfo\` into one plain sentence — never say "resultInfo". \`truncated:false\` → "these are all N matching runs". \`"requested-limit"\` → "here are N; more match — say if you want the rest". \`"default-cap"\` → "here are the newest N; more runs exist — say if you want a larger set (or narrow by flow/date)". \`"admin-cap"\` → "here are N; a site limit caps results per call — I can narrow the search, or an admin can raise the cap". When \`mcp.failureInsight\` is present, also note that the API can't return the failure reason but it is viewable in Tableau, and share \`example.runHistoryUrl\`; if \`failedFlowCount\` > 1, add that this link is for one of N affected flows and offer to fetch the others (resolve each via \`get-flow\`). Also surface the **Caller-role visibility** limit when presenting results: these runs cover ONLY flows the user can *run* (the Execute / "Run Flow Now" capability), not flows they can only view — so a flow they can see in the Tableau web UI may be missing here. Call this out especially on empty or unexpectedly short results, or when the user asks for "all" failures. (Site/server administrators are exempt — they get runs for every flow, so do not state this limit to an admin caller.)
+  **Reporting to the user (every call):** translate \`mcp.resultInfo\` into one plain sentence — never say "resultInfo". \`truncated:false\` → "these are all N matching runs". \`"requested-limit"\` → "here are N; more match — say if you want the rest". \`"default-cap"\` → "here are the newest N; more runs exist — say if you want a larger set (or narrow by flow/date)". \`"admin-cap"\` → "here are N; a site limit caps results per call — I can narrow the search, or an admin can raise the cap". When \`mcp.failureSummary\` is present, lead with the biggest cause with \`available: true\` and its \`runCount\` ("38 of the 43 failures are <message>"), and when one reason's \`flowIds\` covers several flows say so — that shared cause is usually the thing worth fixing first. For a reason with \`available: false\`, say the cause could not be determined and never repeat the placeholder \`message\` as if it were the diagnosis; when no \`mcp.failureInsight\` accompanies it, offer to fetch that group's run-history link (\`get-flow\` on one of its \`flowIds\`, then \`webpageUrl\` + \`/runHistory\`) instead of only naming Tableau. When \`mcp.failureInsight\` is present, note that these failures have no resolved reason from the API but are viewable in Tableau, and share \`example.runHistoryUrl\`; if \`failedFlowCount\` > 1, add that this link is for one of N affected flows and offer to fetch the others (resolve each via \`get-flow\`). When BOTH fields are present, every reason in the window is a placeholder: give the counts from \`failureSummary\` and send the user to \`example.runHistoryUrl\` for the cause — do not present a placeholder \`message\` as the answer. When \`truncated\` is \`true\`, \`failedRunCount\` and \`failedFlowCount\` describe ONLY the returned window — present them as "N in this window", never as a site-wide failure count or rate. Also surface the **Caller-role visibility** limit when presenting results: these runs cover ONLY flows the user can *run* (the Execute / "Run Flow Now" capability), not flows they can only view — so a flow they can see in the Tableau web UI may be missing here. Call this out especially on empty or unexpectedly short results, or when the user asks for "all" failures. (Site/server administrators are exempt — they get runs for every flow, so do not state this limit to an admin caller.)
 
   **Response-Size Guidance** — flow runs accumulate quickly on active sites, so favour narrow calls:
   - Single-flow history: \`filter: "flowId:eq:<uuid>"\` (+ optional \`limit\`).
@@ -275,12 +298,18 @@ export const getListFlowRunsTool = (server: WebMcpServer): WebTool<typeof params
                 const finalTruncationReason: ListFlowRunsTruncationReason | undefined =
                   truncated && usedDefaultBackstop ? 'default-cap' : truncationReason;
 
-                // If the window holds any Failed runs, resolve a UI run-history
-                // link for one of them (the API can't tell the caller WHY a run
-                // failed). Computed unconditionally here; constrainFlowRuns drops
-                // it on the empty / bounded-context paths so the gate stays in one
-                // place. Best-effort — see buildFailureInsight.
-                const failureInsight = await buildFailureInsight({ flowRuns, extra });
+                // Group the window's failure causes, when the runs carry any.
+                const failureSummary = summarizeFlowRunFailures(flowRuns);
+
+                // Only fall back to a UI run-history link when the runs cannot
+                // explain themselves — no `failureReason` at all, or none with
+                // `available: true`. This gate is what keeps the extra Query Flow
+                // call off the common path. constrainFlowRuns still drops the
+                // field on the empty / bounded-context paths so that gate stays
+                // in one place. Best-effort — see buildFailureInsight.
+                const failureInsight = needsUiFallback(flowRuns)
+                  ? await buildFailureInsight({ flowRuns, extra })
+                  : undefined;
 
                 return {
                   flowRuns,
@@ -290,6 +319,7 @@ export const getListFlowRunsTool = (server: WebMcpServer): WebTool<typeof params
                       truncated,
                       ...(finalTruncationReason && { truncationReason: finalTruncationReason }),
                     },
+                    ...(failureSummary && { failureSummary }),
                     ...(failureInsight && { failureInsight }),
                   },
                 } satisfies ListFlowRunsResult;
@@ -338,15 +368,17 @@ function compareByRecencyDesc(a: FlowRun, b: FlowRun): number {
 }
 
 /**
- * When the returned window contains one or more `Failed` runs, build a pointer
- * the caller can use to investigate WHY in the Tableau UI — the Get Flow Runs
- * endpoint never returns an error message. We resolve ONE example failed flow's
- * `webpageUrl` (via the Query Flow endpoint) and turn it into a run-history deep
- * link (`webpageUrl + "/runHistory"`); that page lists the flow's runs and lets
- * the user expand a failed run to read its error. Only one flow is resolved (the
- * most-recent failure in the window) to keep this to a single extra REST call —
- * `failedFlowCount` tells the caller how many other flows failed so it can offer
- * to fetch their links (via get-flow) on request.
+ * Build a pointer the caller can use to investigate WHY in the Tableau UI, for
+ * windows whose `Failed` runs cannot explain themselves. Callers must gate this
+ * on needsUiFallback — when a resolved `failureReason` is present the summary
+ * answers the question and this extra REST call is unnecessary.
+ *
+ * We resolve ONE example failed flow's `webpageUrl` (via the Query Flow endpoint)
+ * and turn it into a run-history deep link; that page lists the flow's runs and
+ * lets the user expand a failed run to read its error. Only one flow is resolved
+ * (the most-recent failure in the window) to keep this to a single extra REST
+ * call — `failedFlowCount` tells the caller how many other flows failed so it can
+ * offer to fetch their links (via get-flow) on request.
  *
  * Returns `undefined` when the window has no failures. Best-effort otherwise: any
  * failure to resolve the example link is swallowed (the runs are the primary
@@ -360,14 +392,10 @@ async function buildFailureInsight({
   flowRuns: FlowRun[];
   extra: TableauWebRequestHandlerExtra;
 }): Promise<ListFlowRunsFailureInsight | undefined> {
-  const failedRuns = flowRuns.filter((run) => run.status === 'Failed');
+  const failedRuns = getFailedRuns(flowRuns);
   if (failedRuns.length === 0) {
     return undefined;
   }
-
-  const failedFlowIds = new Set(
-    failedRuns.map((run) => run.flowId).filter((id): id is string => id !== undefined),
-  );
 
   // The window is ordered newest-first (default sort), so the first failed run
   // with a flowId is the most-recent failure — the best single example.
@@ -389,10 +417,7 @@ async function buildFailureInsight({
       if (flow.webpageUrl) {
         example = {
           flowId: exampleFlowId,
-          // `webpageUrl` is the flow's UI page in numeric-id form
-          // (e.g. .../#/site/<site>/flows/<id>); its run-history tab is that
-          // page + "/runHistory" (matches what the Tableau UI links to).
-          runHistoryUrl: `${flow.webpageUrl.replace(/\/+$/, '')}/runHistory`,
+          runHistoryUrl: buildRunHistoryUrl(flow.webpageUrl),
         };
       }
     } catch {
@@ -402,7 +427,7 @@ async function buildFailureInsight({
 
   return {
     failedRunCount: failedRuns.length,
-    failedFlowCount: failedFlowIds.size,
+    failedFlowCount: countDistinctFlows(failedRuns),
     ...(example && { example }),
   };
 }
@@ -488,7 +513,11 @@ export function constrainFlowRuns({
   // can pass a bare `{ flowRuns }`.
   result: {
     flowRuns: FlowRun[];
-    mcp?: { resultInfo?: ListFlowRunsResultInfo; failureInsight?: ListFlowRunsFailureInsight };
+    mcp?: {
+      resultInfo?: ListFlowRunsResultInfo;
+      failureSummary?: FlowRunFailureSummary;
+      failureInsight?: ListFlowRunsFailureInsight;
+    };
   };
   boundedContext: BoundedContext;
   validatedFilter?: string;
@@ -519,6 +548,7 @@ export function constrainFlowRuns({
 
   const truncated = result.mcp?.resultInfo?.truncated ?? false;
   const truncationReason = result.mcp?.resultInfo?.truncationReason;
+  const failureSummary = result.mcp?.failureSummary;
   const failureInsight = result.mcp?.failureInsight;
 
   return {
@@ -531,6 +561,7 @@ export function constrainFlowRuns({
           truncated,
           ...(truncationReason && { truncationReason }),
         },
+        ...(failureSummary && { failureSummary }),
         ...(failureInsight && { failureInsight }),
       },
     },

--- a/src/tools/web/flows/listFlowRuns/mockFlowRuns.ts
+++ b/src/tools/web/flows/listFlowRuns/mockFlowRuns.ts
@@ -1,5 +1,14 @@
 import { FlowRun } from '../../../../sdks/tableau/types/flow.js';
 
+const FLOW_A = 'd00700fe-28a0-4ece-a7af-5543ddf38a82';
+const FLOW_B = 'c1e82fe3-e7cf-4bd5-afd3-799b1e8aac27';
+const FLOW_C = 'e2f93ba4-9c17-4bd5-afd3-799b1e8aac99';
+
+/**
+ * Baseline runs, deliberately WITHOUT any `failureReason` — the shape a pre-3.30
+ * server returns. Existing tests assert the no-reason behavior against this, which
+ * is the AC3 regression baseline, so do not add reasons here.
+ */
 export const mockFlowRuns = [
   {
     id: 'a1111111-1111-1111-1111-111111111111',
@@ -28,3 +37,94 @@ export const mockFlowRuns = [
     backgroundJobId: 'job-3333',
   },
 ] satisfies Array<FlowRun>;
+
+/**
+ * A REST 3.30+ window exercising every grouping case at once: one cause repeated
+ * across two flows (three runs), a second resolved cause, an unresolved
+ * (`available: false`) cause, and a `Failed` run carrying no reason at all.
+ *
+ * Expected summary: `failedRunCount` 6, `failedFlowCount` 3, and three reason
+ * groups summing to 5 runs — deliberately less than 6, since the reason-less run
+ * counts toward the total but joins no group.
+ */
+export const mockFlowRunsWithFailureReasons = [
+  {
+    id: 'f1111111-1111-1111-1111-111111111111',
+    flowId: FLOW_A,
+    status: 'Failed',
+    startedAt: '2025-06-05T10:00:00Z',
+    completedAt: '2025-06-05T10:01:00Z',
+    progress: 100,
+    failureReason: { available: true, message: 'Table "orders" was not found.' },
+  },
+  {
+    id: 'f2222222-2222-2222-2222-222222222222',
+    flowId: FLOW_B,
+    status: 'Failed',
+    startedAt: '2025-06-04T10:00:00Z',
+    completedAt: '2025-06-04T10:01:00Z',
+    progress: 100,
+    failureReason: { available: true, message: 'Table "orders" was not found.' },
+  },
+  {
+    id: 'f3333333-3333-3333-3333-333333333333',
+    flowId: FLOW_A,
+    status: 'Failed',
+    startedAt: '2025-06-03T10:00:00Z',
+    completedAt: '2025-06-03T10:01:00Z',
+    progress: 100,
+    failureReason: { available: true, message: 'Table "orders" was not found.' },
+  },
+  {
+    id: 'f4444444-4444-4444-4444-444444444444',
+    flowId: FLOW_C,
+    status: 'Failed',
+    startedAt: '2025-06-02T10:00:00Z',
+    completedAt: '2025-06-02T10:01:00Z',
+    progress: 100,
+    failureReason: { available: true, message: 'Connection to mySQLServer timed out.' },
+  },
+  {
+    id: 'f5555555-5555-5555-5555-555555555555',
+    flowId: FLOW_C,
+    status: 'Failed',
+    startedAt: '2025-06-01T10:00:00Z',
+    completedAt: '2025-06-01T10:01:00Z',
+    progress: 100,
+    failureReason: { available: false, message: 'Error in flow steps' },
+  },
+  {
+    id: 'f6666666-6666-6666-6666-666666666666',
+    flowId: FLOW_B,
+    status: 'Failed',
+    startedAt: '2025-05-31T10:00:00Z',
+    completedAt: '2025-05-31T10:01:00Z',
+    progress: 100,
+  },
+  {
+    id: 'f7777777-7777-7777-7777-777777777777',
+    flowId: FLOW_A,
+    status: 'Success',
+    startedAt: '2025-05-30T10:00:00Z',
+    completedAt: '2025-05-30T10:05:00Z',
+    progress: 100,
+  },
+] satisfies Array<FlowRun>;
+
+/**
+ * A window whose only failure reason is unresolved. The tool must still fall back
+ * to the UI deep link here: the placeholder message is not a diagnosis.
+ */
+export const mockFlowRunsUnresolvedFailure = [
+  {
+    id: 'f8888888-8888-8888-8888-888888888888',
+    flowId: FLOW_A,
+    status: 'Failed',
+    startedAt: '2025-06-06T10:00:00Z',
+    completedAt: '2025-06-06T10:01:00Z',
+    progress: 100,
+    failureReason: { available: false, message: 'Error in flow steps' },
+  },
+] satisfies Array<FlowRun>;
+
+export const mockFlowRunFlowIds = { FLOW_A, FLOW_B, FLOW_C };


### PR DESCRIPTION
## Description

Surfaces REST API 3.30's `failureReason` on failed flow runs in `list-flow-runs` and
`get-flow`, so both tools can report why a run failed instead of only that it did.

- Adds `failureReason` to the flow-run schema. `available` accepts a real boolean or the
  strings `"true"`/`"false"`, and a malformed reason degrades to absent rather than failing
  the whole Get Flow Runs call.
- Adds `mcp.failureSummary` to both tools: the window's failures grouped by reported
  message, with `runCount` and the distinct `flowIds` affected. Both tools share one
  grouping helper, so their summaries are identical for the same runs.
- Gates the existing `mcp.failureInsight` deep link so it is emitted only when nothing in
  the window resolves a cause, saving a Query Flow call on the common path.

No breaking changes. Output is unchanged when no reason comes back, i.e. servers below 3.30
or windows with no failures.

## Motivation and Context

A failed flow run reported only `status: "Failed"`, so an agent could not answer the first
question users ask — "why did my flow run fail?" The only recourse was a deep link that
pushes the person into the Tableau UI. The reason previously required the admin-only
background job; 3.30 sources it from the flow's output-step errors instead, so any caller
who can see a run can now read it.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## How Has This Been Tested?

- **Unit:** new tests for the schema (boolean and string `available`, malformed-reason
  degradation), the grouping helper, and both tools — covering the deep-link gate in both
  directions and a regression test for the unchanged no-reason path. Full suite green:
  2736 tests, plus `eslint` and `tsc --noEmit`.
- **Live:** verified against a 3.30+ site with 39 assertions covering schema parsing,
  summary invariants, the gate in both directions, cross-tool summary identity, and the
  no-failure paths.

## Related Issues

Closes #707

## Checklist

- [x] I have updated the version in the package.json file by using `npm run version`. For example,
      use `npm run version:patch` for a patch version bump.
- [x] I have made any necessary changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have documented any breaking changes in the PR description. For example, renaming a config
      environment variable or changing its default value.

## Contributor Agreement

By submitting this pull request, I confirm that:

- [x] I have read the [CONTRIBUTING guidelines](../../CONTRIBUTING.md) for this project and followed
      its Contribution Checklist.
