### PR TITLE
feat(desktop): add undo/redo workbook tools over External Client API :undo/:redo routes

### DIFF
--- a/src/desktop/externalApi/externalApiClient.ts
+++ b/src/desktop/externalApi/externalApiClient.ts
@@ -246,6 +246,16 @@ export class ExternalApiClient {
     return this.parseEnvelope(response, signal);
   }
 
+  async undo(signal?: AbortSignal): Promise<Result<OperationEnvelope, ExternalApiError>> {
+    const response = await this.request('POST', EXTERNAL_API_ROUTES.workbookUndo, { signal });
+    return this.parseEnvelope(response, signal);
+  }
+
+  async redo(signal?: AbortSignal): Promise<Result<OperationEnvelope, ExternalApiError>> {
+    const response = await this.request('POST', EXTERNAL_API_ROUTES.workbookRedo, { signal });
+    return this.parseEnvelope(response, signal);
+  }
+
   async fetchOpenApi(signal?: AbortSignal): Promise<Result<unknown, ExternalApiError>> {
     const response = await this.request('GET', EXTERNAL_API_ROUTES.openapi, { signal });
     if (response.isErr()) {

--- a/src/desktop/externalApi/externalApiContract.test.ts
+++ b/src/desktop/externalApi/externalApiContract.test.ts
@@ -177,6 +177,8 @@ describe('external client API contract (captured openapi fixture)', () => {
       EXTERNAL_API_ROUTES.workbookDocumentValidate,
       EXTERNAL_API_ROUTES.workbookStoryboards,
       EXTERNAL_API_ROUTES.workbookWorksheets,
+      EXTERNAL_API_ROUTES.workbookUndo,
+      EXTERNAL_API_ROUTES.workbookRedo,
       EXTERNAL_API_ROUTES.dashboardById,
       EXTERNAL_API_ROUTES.dashboardDocument,
       EXTERNAL_API_ROUTES.storyboardById,

--- a/src/desktop/externalApi/externalApiToolExecutor.ts
+++ b/src/desktop/externalApi/externalApiToolExecutor.ts
@@ -296,6 +296,18 @@ export class ExternalApiToolExecutor extends ToolExecutor {
     return statusResult;
   }
 
+  async undo(
+    signal: AbortSignal,
+  ): Promise<Result<ExecuteCommandResult<undefined>, ExecuteCommandError>> {
+    return this.applyDocument((client) => client.undo(signal), 'undo');
+  }
+
+  async redo(
+    signal: AbortSignal,
+  ): Promise<Result<ExecuteCommandResult<undefined>, ExecuteCommandError>> {
+    return this.applyDocument((client) => client.redo(signal), 'redo');
+  }
+
   async health(signal: AbortSignal): Promise<Result<{ healthy: boolean }, ExecuteCommandError>> {
     return this.readExternalApi((client) => client.health(signal));
   }

--- a/src/desktop/externalApi/mockExternalApiServer.ts
+++ b/src/desktop/externalApi/mockExternalApiServer.ts
@@ -644,6 +644,22 @@ export async function startMockExternalApiServer(
       return;
     }
 
+    if (
+      method === 'POST' &&
+      (path === EXTERNAL_API_ROUTES.workbookUndo || path === EXTERNAL_API_ROUTES.workbookRedo)
+    ) {
+      const command = path === EXTERNAL_API_ROUTES.workbookUndo ? 'undo' : 'redo';
+      sendJson(res, 200, {
+        id: `op-${command}-1`,
+        kind: `tabdoc:${command}`,
+        state: 'succeeded',
+        createdAt: '2026-07-07T10:00:00Z',
+        completedAt: '2026-07-07T10:00:01Z',
+        result: {},
+      });
+      return;
+    }
+
     if (method === 'GET' && path === EXTERNAL_API_ROUTES.openapi) {
       sendJson(res, 200, {
         openapi: '3.1.0',

--- a/src/desktop/externalApi/types.ts
+++ b/src/desktop/externalApi/types.ts
@@ -22,6 +22,8 @@ export const EXTERNAL_API_ROUTES = {
   workbookDocumentValidate: '/v0/workbook/document:validate',
   workbookStoryboards: '/v0/workbook/storyboards',
   workbookWorksheets: '/v0/workbook/worksheets',
+  workbookUndo: '/v0/workbook:undo',
+  workbookRedo: '/v0/workbook:redo',
   dashboardById: '/v0/workbook/dashboards/{id}',
   dashboardDocument: '/v0/workbook/dashboards/{id}/document',
   dashboardImage: '/v0/workbook/dashboards/{id}/image',

--- a/src/server.desktop.test.ts
+++ b/src/server.desktop.test.ts
@@ -210,12 +210,12 @@ describe('desktop tools/list serialized surface', () => {
     // guards that invariant). The full desktop surface is opt-in (TOOL_PROFILE=full), not
     // what clients see by default; its looser cap only catches runaway growth without
     // forcing valuable full-profile tools to be trimmed.
-    // Honest wire measurements are 29,693 bytes dynamic and 47,102 bytes full: the dynamic
-    // surface carries this PR's compact insight candidate tuples (replacing list-available-fields'
-    // old slim schema), and the full surface additionally carries the full-profile-only
-    // get-storyboard-xml and apply-storyboard tools. Keep only a few bytes of ratchet headroom.
-    expect(dynamicAuthoringTotal).toBeLessThanOrEqual(29_709);
-    expect(fullSurfaceTotal).toBeLessThanOrEqual(47_118);
+    // Honest wire measurements are 30,480 bytes dynamic and 47,889 bytes full: both surfaces
+    // carry the undo-workbook / redo-workbook command tools, and the full surface additionally
+    // carries the full-profile-only get-storyboard-xml and apply-storyboard tools. The dynamic
+    // surface stays well under the 46k tools/list cliff. Keep only a few bytes of ratchet headroom.
+    expect(dynamicAuthoringTotal).toBeLessThanOrEqual(30_480);
+    expect(fullSurfaceTotal).toBeLessThanOrEqual(47_889);
   });
 });
 
@@ -447,10 +447,10 @@ describe('selectToolsForProfile (TOOL_PROFILE, W60 spike lever 1 / preamble P1)'
     expect(selected.map((t) => t.name)).toContain('execute-tableau-command');
   });
 
-  it('TOOL_PROFILE=dynamic-authoring registers exactly the 33-tool data-first singable surface — native authoring + workbook reads + atomic sheet activation + the manual path read/edit legs, no workbook round-trip/validation XML tools', () => {
+  it('TOOL_PROFILE=dynamic-authoring registers exactly the 35-tool data-first singable surface — native authoring + workbook reads + atomic sheet activation + undo/redo + the manual path read/edit legs, no workbook round-trip/validation XML tools', () => {
     const selected = selectToolsForProfile(allTools(), 'dynamic-authoring');
     expect(new Set(selected.map((t) => t.name))).toEqual(DYNAMIC_AUTHORING_TOOL_PROFILE);
-    expect(selected).toHaveLength(33);
+    expect(selected).toHaveLength(35);
     // The full dynamic dialect, semantically named — every author-* verb present,
     // plus the ask-for-help, command-discovery, deterministic fast-path, and the two
     // knowledge doors the system prompt's "consult the expertise library" law routes to.
@@ -480,6 +480,8 @@ describe('selectToolsForProfile (TOOL_PROFILE, W60 spike lever 1 / preamble P1)'
       'list-workbook-datasources',
       'list-site-datasources',
       'activate-sheet',
+      'undo-workbook',
+      'redo-workbook',
       // The manual field-edit path's read leg — mints the worksheetFile add-field/
       // remove-field/apply-worksheet consume.
       'get-worksheet-xml',
@@ -527,7 +529,7 @@ describe('selectToolsForProfile (TOOL_PROFILE, W60 spike lever 1 / preamble P1)'
     // A lean surface must have generous headroom — this is a structural win, not a
     // describe-stub squeeze. If this ever approaches 46k something is very wrong.
     // list-available-fields serves both full exploration and slim headless field selection.
-    expect(total).toBeLessThanOrEqual(29_710);
+    expect(total).toBeLessThanOrEqual(30_481);
   });
 
   it('unset ("") profile returns the lean dynamic-authoring native surface — the singer sings native by default', () => {

--- a/src/server.desktop.ts
+++ b/src/server.desktop.ts
@@ -139,6 +139,9 @@ export const DYNAMIC_AUTHORING_TOOL_PROFILE: ReadonlySet<DesktopToolName> =
     // Atomic navigation fallback: switch the workbook active window without exposing the
     // whole-document read/apply authoring escape hatch.
     'activate-sheet',
+    // Workbook-level undo/redo — recover from a bad edit without hand-reverting XML.
+    'undo-workbook',
+    'redo-workbook',
     'ask-user',
     'list-instances',
     'list-available-fields',

--- a/src/tools/desktop/external-api/redoWorkbook.ts
+++ b/src/tools/desktop/external-api/redoWorkbook.ts
@@ -1,0 +1,60 @@
+import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { Ok } from 'ts-results-es';
+import { z } from 'zod';
+
+import { resolveSession } from '../../../desktop/sessionResolution.js';
+import { DesktopCommandExecutionError } from '../../../errors/mcpToolError.js';
+import { DesktopMcpServer } from '../../../server.desktop.js';
+import { DesktopTool } from '../tool.js';
+import { endpointNotInThisBuild, isRouteMissing } from './externalApiToolUtils.js';
+
+const paramsSchema = {
+  session: z.string().optional().describe('Session ID; optional if pinned or unique.'),
+};
+const title = 'Redo';
+
+export const getRedoWorkbookTool = (server: DesktopMcpServer): DesktopTool<typeof paramsSchema> => {
+  const redoWorkbookTool = new DesktopTool({
+    server,
+    name: 'redo-workbook',
+    title,
+    description: 'Reapply the change most recently undone on the open workbook (Edit > Redo).',
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: false,
+      openWorldHint: false,
+    },
+    paramsSchema,
+    callback: async ({ session }, extra): Promise<CallToolResult> => {
+      return await redoWorkbookTool.logAndExecute({
+        extra,
+        args: { session },
+        callback: async () => {
+          const sessionResult = resolveSession(session);
+          if (sessionResult.isErr()) {
+            return sessionResult.error.toErr();
+          }
+          const executor = await extra.getExecutor(sessionResult.value);
+
+          const result = await executor.redo(extra.signal);
+          if (result.isErr()) {
+            if (isRouteMissing(result.error)) {
+              return endpointNotInThisBuild('redo').toErr();
+            }
+            return new DesktopCommandExecutionError(result.error).toErr();
+          }
+
+          return new Ok({
+            message:
+              result.value.status === 'completed'
+                ? 'Reapplied the most recently undone change to the open workbook.'
+                : 'Requested redo; Desktop is still applying it.',
+          });
+        },
+      });
+    },
+  });
+
+  return redoWorkbookTool;
+};

--- a/src/tools/desktop/external-api/undoRedoWorkbook.test.ts
+++ b/src/tools/desktop/external-api/undoRedoWorkbook.test.ts
@@ -1,0 +1,84 @@
+import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { Ok } from 'ts-results-es';
+
+import { ExternalApiToolExecutor } from '../../../desktop/externalApi/externalApiToolExecutor.js';
+import {
+  MockExternalApiServer,
+  startMockExternalApiServer,
+} from '../../../desktop/externalApi/mockExternalApiServer.js';
+import { ExternalApiInstance } from '../../../desktop/externalApi/types.js';
+import * as sessionResolution from '../../../desktop/sessionResolution.js';
+import { DesktopMcpServer } from '../../../server.desktop.js';
+import invariant from '../../../utils/invariant.js';
+import { Provider } from '../../../utils/provider.js';
+import { DesktopTool } from '../tool.js';
+import { getMockRequestHandlerExtra } from '../toolContext.mock.js';
+import { getRedoWorkbookTool } from './redoWorkbook.js';
+import { getUndoWorkbookTool } from './undoWorkbook.js';
+
+vi.mock('../../../desktop/sessionResolution.js');
+
+describe('undo-workbook / redo-workbook tools', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(sessionResolution.resolveSession).mockReturnValue(Ok('999'));
+  });
+
+  it.each([
+    { makeTool: getUndoWorkbookTool, path: '/v0/workbook:undo', message: 'Undid the last change' },
+    { makeTool: getRedoWorkbookTool, path: '/v0/workbook:redo', message: 'Reapplied' },
+  ])('POSTs $path and reports success', async ({ makeTool, path, message }) => {
+    const harness = await startHarness(makeTool);
+    try {
+      const result = await harness.callTool({});
+      expect(result.isError).toBeFalsy();
+      invariant(result.content[0].type === 'text');
+      expect(result.content[0].text).toContain(message);
+
+      const posted = harness.server.requests.filter((r) => r.method === 'POST' && r.path === path);
+      expect(posted).toHaveLength(1);
+      // undo/redo carry no request body.
+      expect(posted[0].body).toBe('');
+    } finally {
+      await harness.close();
+    }
+  });
+});
+
+async function startHarness(makeTool: (server: DesktopMcpServer) => DesktopTool<any>): Promise<{
+  server: MockExternalApiServer;
+  callTool: (args: Record<string, unknown>) => Promise<CallToolResult>;
+  close: () => Promise<void>;
+}> {
+  const server = await startMockExternalApiServer();
+  const executor = new ExternalApiToolExecutor({ discover: () => [instanceFor(server)] });
+  await executor.start();
+  const tool = makeTool(new DesktopMcpServer());
+  const callback = (await Provider.from(tool.callback)) as (
+    args: Record<string, unknown>,
+    extra: ReturnType<typeof getMockRequestHandlerExtra>,
+  ) => Promise<CallToolResult>;
+  const extra = {
+    ...getMockRequestHandlerExtra(),
+    getExecutor: vi.fn().mockResolvedValue(executor),
+  };
+
+  return {
+    server,
+    callTool: async (args) => await callback(args, extra),
+    close: async () => {
+      executor.stop();
+      await server.close();
+    },
+  };
+}
+
+function instanceFor(server: MockExternalApiServer): ExternalApiInstance {
+  return {
+    baseUrl: server.baseUrl,
+    token: 'valid-token',
+    pid: 999,
+    instanceId: 'inst-undo-redo',
+    apiVersion: '1.0',
+  };
+}

--- a/src/tools/desktop/external-api/undoWorkbook.ts
+++ b/src/tools/desktop/external-api/undoWorkbook.ts
@@ -1,0 +1,60 @@
+import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { Ok } from 'ts-results-es';
+import { z } from 'zod';
+
+import { resolveSession } from '../../../desktop/sessionResolution.js';
+import { DesktopCommandExecutionError } from '../../../errors/mcpToolError.js';
+import { DesktopMcpServer } from '../../../server.desktop.js';
+import { DesktopTool } from '../tool.js';
+import { endpointNotInThisBuild, isRouteMissing } from './externalApiToolUtils.js';
+
+const paramsSchema = {
+  session: z.string().optional().describe('Session ID; optional if pinned or unique.'),
+};
+const title = 'Undo';
+
+export const getUndoWorkbookTool = (server: DesktopMcpServer): DesktopTool<typeof paramsSchema> => {
+  const undoWorkbookTool = new DesktopTool({
+    server,
+    name: 'undo-workbook',
+    title,
+    description: 'Reverse the most recent change to the open workbook (Edit > Undo).',
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: false,
+      openWorldHint: false,
+    },
+    paramsSchema,
+    callback: async ({ session }, extra): Promise<CallToolResult> => {
+      return await undoWorkbookTool.logAndExecute({
+        extra,
+        args: { session },
+        callback: async () => {
+          const sessionResult = resolveSession(session);
+          if (sessionResult.isErr()) {
+            return sessionResult.error.toErr();
+          }
+          const executor = await extra.getExecutor(sessionResult.value);
+
+          const result = await executor.undo(extra.signal);
+          if (result.isErr()) {
+            if (isRouteMissing(result.error)) {
+              return endpointNotInThisBuild('undo').toErr();
+            }
+            return new DesktopCommandExecutionError(result.error).toErr();
+          }
+
+          return new Ok({
+            message:
+              result.value.status === 'completed'
+                ? 'Undid the last change to the open workbook.'
+                : 'Requested undo; Desktop is still applying it.',
+          });
+        },
+      });
+    },
+  });
+
+  return undoWorkbookTool;
+};

--- a/src/tools/desktop/toolName.ts
+++ b/src/tools/desktop/toolName.ts
@@ -4,6 +4,8 @@ export const desktopToolNames = [
   'get-workbook-xml',
   'apply-workbook',
   'activate-sheet',
+  'undo-workbook',
+  'redo-workbook',
   'list-worksheets',
   'list-dashboards',
   'get-worksheet-xml',

--- a/src/tools/desktop/tools.ts
+++ b/src/tools/desktop/tools.ts
@@ -39,6 +39,8 @@ import { getStoryboardInfoTool } from './external-api/getStoryboardInfo.js';
 import { getStoryboardXmlTool } from './external-api/getStoryboardXml.js';
 import { getWorksheetInfoTool } from './external-api/getWorksheetInfo.js';
 import { getListStoryboardsTool } from './external-api/listStoryboards.js';
+import { getRedoWorkbookTool } from './external-api/redoWorkbook.js';
+import { getUndoWorkbookTool } from './external-api/undoWorkbook.js';
 import { getAddFieldTool } from './fields/addField.js';
 import { getListAvailableFieldsTool } from './fields/listAvailableFields.js';
 import { getListFieldsTool } from './fields/listFields.js';
@@ -73,6 +75,8 @@ export const desktopToolFactories = [
   getGetWorkbookXmlTool,
   getApplyWorkbookTool,
   getActivateSheetTool,
+  getUndoWorkbookTool,
+  getRedoWorkbookTool,
   getListWorksheetsTool,
   getListDashboardsTool,
   getGetWorksheetXmlTool,


### PR DESCRIPTION
## What

Add two desktop tools — `undo-workbook` and `redo-workbook` — that drive the External Client API's `POST /v0/workbook:undo` and `POST /v0/workbook:redo` routes. Both are in the served **dynamic-authoring** profile so the pinned downstream client reaches them.

This is **Slice C** of the External Client API refactor plan: the first typed `:action` command routes surfaced as tools rather than through the generic `invokeCommand` backdoor. The `:undo`/`:redo` routes have landed on the live 0.2.0 build (present in the captured `/openapi.json` fixture), so this is no longer wire-ahead.

## How

- **Routes**: add `workbookUndo` / `workbookRedo` to `EXTERNAL_API_ROUTES`.
- **Client**: `ExternalApiClient.undo()` / `redo()` — POST with no body, through the existing `parseEnvelope` (so a 202 polls to terminal for free; colon-kinds carry `result`).
- **Executor**: `ExternalApiToolExecutor.undo()` / `redo()` reuse the `applyDocument` pipeline — a FAILED/CANCELLED envelope becomes `command-failed`, a non-terminal state never reports `completed`.
- **Tools**: `undoWorkbook.ts` / `redoWorkbook.ts`, registered in `tools.ts` + `toolName.ts`, added to `DYNAMIC_AUTHORING_TOOL_PROFILE`.
- **Tests**: contract route-parity `it.each`, mock-server POST handlers, a new tool unit test, and the byte-budget ratchets moved to the measured totals.

## Byte budget

The served (dynamic-authoring) surface is the real tools/list auto-deferral gate (~46k). It moves 29,693 → **30,480** — well clear of the cliff. The tight author-set ratchets in `server.desktop.test.ts` (and the full-profile runaway guard, 47,102 → 47,889) are stepped to the honest measurements.

## Test

- New + touched suites green: contract, client, executor, async-dispatch, `server.desktop`, the new tool test.
- The 9 pre-existing Windows-local desktop failures (byte-identical on base and this branch; green on CI) are unaffected — this change adds zero new violations.

Draft: pairs with the async-dispatch work (#691) and the External Client API refactor.
