### PR TITLE
test(desktop): recapture External Client API openapi fixture from live 0.2.2 build

### DIFF
--- a/src/desktop/externalApi/__fixtures__/externalClientApi-openapi.json
+++ b/src/desktop/externalApi/__fixtures__/externalClientApi-openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Tableau External Client API",
-    "version": "0.2.3",
+    "version": "0.2.2",
     "description": "Loopback HTTP interface for reading and authoring the open Tableau Desktop document. Clients authenticate with the bearer token published in the per-user discovery file."
   },
   "servers": [


### PR DESCRIPTION
## What

Recapture the External Client API `/openapi.json` fixture from a live Tableau Desktop build. The only change is the spec version string:

```diff
-    "version": "0.2.3",
+    "version": "0.2.2",
```

## Why

Captured directly from the running instance's `GET /openapi.json`. A full normalized diff (keys sorted, whitespace neutralized) shows this version line is the **only** difference between the live build and the previously checked-in fixture — same 28 paths, same schema set, same `Problem.code` x-extensible-enum. So this is purely a version-label recapture; no route, schema, or code coverage changed.

## Heads-up for the reviewer

This moves the fixture version **backward** (0.2.3 → 0.2.2) to match the build it was captured from. If the 0.2.3 fixture was captured from a newer build on purpose, this reverts that — worth confirming before merge.

## Test

`externalApiContract.test.ts` green (60/60). The fixture is normalized-identical to the live capture (0 diffs).
