### PR TITLE
refactor(desktop): trust per-item /document bare fragments and route refine-worksheet through per-sheet apply

### DIFF
--- a/src/desktop/commands/workbook/getDashboardXml.test.ts
+++ b/src/desktop/commands/workbook/getDashboardXml.test.ts
@@ -2,7 +2,7 @@ import { Err, Ok } from 'ts-results-es';
 
 import { ExternalApiToolExecutor } from '../../externalApi/externalApiToolExecutor.js';
 import { ExecuteCommandError } from '../../toolExecutor/toolExecutor.js';
-import { getDashboardFragment, getDashboardXml } from './getDashboardXml.js';
+import { getDashboardXml } from './getDashboardXml.js';
 
 describe('getDashboardXml', () => {
   it('resolves dashboard name to id and fetches the per-item document', async () => {
@@ -118,63 +118,5 @@ describe('getDashboardXml', () => {
     expect(result.isOk()).toBe(true);
     expect(result.unwrap()).toContain('<dashboard name="Sales">');
     expect(executor.getWorkbookDocument).toHaveBeenCalledWith(signal);
-  });
-});
-
-describe('getDashboardFragment', () => {
-  it('slices the requested dashboard out of a whole-workbook /document response', async () => {
-    const signal = new AbortController().signal;
-    const executor = {
-      listDashboards: vi.fn().mockResolvedValue(
-        Ok({
-          dashboards: [
-            { id: 'dashboard-1', name: 'Executive Overview' },
-            { id: 'dashboard-2', name: 'Sales' },
-          ],
-        }),
-      ),
-      getDashboardDocument: vi.fn().mockResolvedValue(
-        Ok({
-          xml: `<workbook><dashboards>
-            <dashboard name="Executive Overview"><zone /></dashboard>
-            <dashboard name="Sales"><zone /></dashboard>
-          </dashboards></workbook>`,
-        }),
-      ),
-    } as unknown as ExternalApiToolExecutor;
-
-    const result = await getDashboardFragment({
-      executor,
-      signal,
-      dashboardName: 'Sales',
-    });
-
-    expect(result.isOk()).toBe(true);
-    if (result.isOk()) {
-      expect(result.value).toContain('<dashboard name="Sales"');
-      expect(result.value).not.toContain('<workbook');
-      expect(result.value).not.toContain('Executive Overview');
-    }
-  });
-
-  it('returns a bare dashboard fragment unchanged', async () => {
-    const signal = new AbortController().signal;
-    const executor = {
-      listDashboards: vi.fn().mockResolvedValue(
-        Ok({
-          dashboards: [{ id: 'dashboard-1', name: 'Sales' }],
-        }),
-      ),
-      getDashboardDocument: vi.fn().mockResolvedValue(Ok({ xml: '<dashboard name="Sales" />' })),
-    } as unknown as ExternalApiToolExecutor;
-
-    const result = await getDashboardFragment({
-      executor,
-      signal,
-      dashboardName: 'Sales',
-    });
-
-    expect(result.isOk()).toBe(true);
-    expect(result.unwrap()).toBe('<dashboard name="Sales" />');
   });
 });

--- a/src/desktop/commands/workbook/getDashboardXml.ts
+++ b/src/desktop/commands/workbook/getDashboardXml.ts
@@ -1,6 +1,3 @@
-import { Err, Ok } from 'ts-results-es';
-
-import { dashboardDocumentToFragment } from '../../metadata/dashboards.js';
 import { WithExecutorAndAbortSignal } from '../../toolExecutor/toolExecutor.js';
 import {
   type GetDashboardXmlError,
@@ -15,32 +12,4 @@ export async function getDashboardXml(
   args: { dashboardName: string } & WithExecutorAndAbortSignal,
 ): Promise<GetDashboardXmlResult> {
   return await new WorkbookReadGateway(args).getDashboardXml(args.dashboardName);
-}
-
-/**
- * Like {@link getDashboardXml}, but always resolves to a single `<dashboard>` fragment. The
- * External Client API per-dashboard `/document` route returns a whole `<workbook>` scoped to the
- * dashboard; callers that feed the XML to apply-dashboard need the fragment. The other transports
- * already return a fragment, so this is a no-op slice for them.
- */
-export async function getDashboardFragment(
-  args: { dashboardName: string } & WithExecutorAndAbortSignal,
-): Promise<GetDashboardXmlResult> {
-  const result = await getDashboardXml(args);
-  if (result.isErr()) {
-    return result;
-  }
-
-  const fragment = dashboardDocumentToFragment(result.value, args.dashboardName);
-  if (fragment === null) {
-    return Err({
-      type: 'get-dashboard-xml-error',
-      error: {
-        type: 'no-dashboard-found',
-        message: `No dashboard found for "${args.dashboardName}".`,
-      },
-    });
-  }
-
-  return Ok(fragment);
 }

--- a/src/desktop/commands/workbook/getWorksheetXml.test.ts
+++ b/src/desktop/commands/workbook/getWorksheetXml.test.ts
@@ -2,7 +2,7 @@ import { Err, Ok } from 'ts-results-es';
 
 import { ExternalApiToolExecutor } from '../../externalApi/externalApiToolExecutor.js';
 import { ExecuteCommandError } from '../../toolExecutor/toolExecutor.js';
-import { getWorksheetFragment, getWorksheetXml } from './getWorksheetXml.js';
+import { getWorksheetXml } from './getWorksheetXml.js';
 
 describe('getWorksheetXml', () => {
   it('resolves worksheet name to id and fetches the per-item document', async () => {
@@ -109,63 +109,5 @@ describe('getWorksheetXml', () => {
     expect(result.isOk()).toBe(true);
     expect(result.unwrap()).toContain('<worksheet name="Profit">');
     expect(executor.getWorkbookDocument).toHaveBeenCalledWith(signal);
-  });
-});
-
-describe('getWorksheetFragment', () => {
-  it('slices the requested sheet out of a whole-workbook /document response', async () => {
-    const signal = new AbortController().signal;
-    const executor = {
-      listWorksheets: vi.fn().mockResolvedValue(
-        Ok({
-          worksheets: [
-            { id: 'sheet-1', name: 'Sales by Region' },
-            { id: 'sheet-2', name: 'Profit by Category' },
-          ],
-        }),
-      ),
-      getWorksheetDocument: vi.fn().mockResolvedValue(
-        Ok({
-          xml: `<workbook><worksheets>
-            <worksheet name="Sales by Region"><table><view /></table></worksheet>
-            <worksheet name="Profit by Category"><table><view /></table></worksheet>
-          </worksheets></workbook>`,
-        }),
-      ),
-    } as unknown as ExternalApiToolExecutor;
-
-    const result = await getWorksheetFragment({
-      executor,
-      signal,
-      worksheetName: 'Sales by Region',
-    });
-
-    expect(result.isOk()).toBe(true);
-    if (result.isOk()) {
-      expect(result.value).toContain('<worksheet name="Sales by Region"');
-      expect(result.value).not.toContain('<workbook');
-      expect(result.value).not.toContain('Profit by Category');
-    }
-  });
-
-  it('returns a bare worksheet fragment unchanged', async () => {
-    const signal = new AbortController().signal;
-    const executor = {
-      listWorksheets: vi.fn().mockResolvedValue(
-        Ok({
-          worksheets: [{ id: 'sheet-1', name: 'Sales' }],
-        }),
-      ),
-      getWorksheetDocument: vi.fn().mockResolvedValue(Ok({ xml: '<worksheet name="Sales" />' })),
-    } as unknown as ExternalApiToolExecutor;
-
-    const result = await getWorksheetFragment({
-      executor,
-      signal,
-      worksheetName: 'Sales',
-    });
-
-    expect(result.isOk()).toBe(true);
-    expect(result.unwrap()).toBe('<worksheet name="Sales" />');
   });
 });

--- a/src/desktop/commands/workbook/getWorksheetXml.ts
+++ b/src/desktop/commands/workbook/getWorksheetXml.ts
@@ -1,6 +1,3 @@
-import { Err, Ok } from 'ts-results-es';
-
-import { worksheetDocumentToFragment } from '../../metadata/sheets.js';
 import { WithExecutorAndAbortSignal } from '../../toolExecutor/toolExecutor.js';
 import {
   type GetWorksheetXmlError,
@@ -15,32 +12,4 @@ export async function getWorksheetXml(
   args: { worksheetName: string } & WithExecutorAndAbortSignal,
 ): Promise<GetWorksheetXmlResult> {
   return await new WorkbookReadGateway(args).getWorksheetXml(args.worksheetName);
-}
-
-/**
- * Like {@link getWorksheetXml}, but always resolves to a single `<worksheet>` fragment. The
- * External Client API per-sheet `/document` route returns a whole `<workbook>` scoped to the
- * sheet; callers that feed the XML to apply-worksheet or a readback verifier need the fragment.
- * The other transports already return a fragment, so this is a no-op slice for them.
- */
-export async function getWorksheetFragment(
-  args: { worksheetName: string } & WithExecutorAndAbortSignal,
-): Promise<GetWorksheetXmlResult> {
-  const result = await getWorksheetXml(args);
-  if (result.isErr()) {
-    return result;
-  }
-
-  const fragment = worksheetDocumentToFragment(result.value, args.worksheetName);
-  if (fragment === null) {
-    return Err({
-      type: 'get-worksheet-xml-error',
-      error: {
-        type: 'no-worksheet-found',
-        message: `No worksheet found for ${args.worksheetName}.`,
-      },
-    });
-  }
-
-  return Ok(fragment);
 }

--- a/src/desktop/commands/workbook/loadWorksheetXml.ts
+++ b/src/desktop/commands/workbook/loadWorksheetXml.ts
@@ -21,7 +21,7 @@ import { xmlNamesEqual } from '../../xmlElement.js';
 import { type ApplyFocus } from './applyFocus.js';
 import { withApplyLock } from './applyMutex.js';
 import { getWorkbookXml } from './getWorkbookXml.js';
-import { getWorksheetFragment } from './getWorksheetXml.js';
+import { getWorksheetXml } from './getWorksheetXml.js';
 import { applyWorkbookText } from './loadWorkbookXml.js';
 import { tryApplyViaPerSheetRoute } from './perSheetDocumentApply.js';
 import { pollReadback } from './pollReadback.js';
@@ -93,7 +93,7 @@ export async function verifyPostApplyWorksheetReadback(
     // The apply lands asynchronously, so a re-read that looks like it dropped a node might just be
     // the pre-apply worksheet — poll rather than trust the first read.
     const polled = await pollReadback({
-      read: () => getWorksheetFragment({ worksheetName, executor, signal }),
+      read: () => getWorksheetXml({ worksheetName, executor, signal }),
       settled: (fragment) =>
         !verifyWorksheetReadback(intendedXml, fragment).some((f) => f.severity === 'error'),
       signal,

--- a/src/desktop/externalApi/externalApiClient.test.ts
+++ b/src/desktop/externalApi/externalApiClient.test.ts
@@ -401,7 +401,7 @@ describe('ExternalApiClient', () => {
     const result = await client.getStoryboardDocument('story-qbr');
 
     expect(result.isOk()).toBe(true);
-    // A storyboard serializes as a `<dashboard type="storyboard">` inside a whole <workbook>.
+    // A storyboard serializes as a bare `<dashboard type="storyboard">` fragment.
     expect(result.unwrap().xml).toContain('<dashboard name="QBR Story" type="storyboard"');
 
     const last = server.requests.at(-1);

--- a/src/desktop/externalApi/mockExternalApiServer.ts
+++ b/src/desktop/externalApi/mockExternalApiServer.ts
@@ -69,14 +69,11 @@ const DEFAULT_DASHBOARD_DOCUMENT_XML =
   '<?xml version="1.0"?><workbook><dashboards>' +
   '<dashboard name="Executive Dashboard"><zones><zone name="Sales by Region" /></zones></dashboard>' +
   '</dashboards></workbook>';
-// A storyboard serializes as a `<dashboard type='storyboard'>` under `<dashboards>` within a whole
-// `<workbook>` document — the same envelope shape as a dashboard, not a bare `<storyboard>` element.
-// The document carries a sibling dashboard the slice must exclude by name.
+// A storyboard serializes as a `<dashboard type='storyboard'>`, and its /document route returns
+// that bare fragment directly — not a `<storyboard>` element, and not wrapped in a `<workbook>`.
 const DEFAULT_STORYBOARD_DOCUMENT_XML =
-  '<?xml version="1.0"?><workbook><dashboards>' +
-  '<dashboard name="Executive Dashboard"><zones><zone name="Sales by Region" /></zones></dashboard>' +
-  '<dashboard name="QBR Story" type="storyboard"><zones><zone name="Sales by Region" /></zones></dashboard>' +
-  '</dashboards></workbook>';
+  '<?xml version="1.0"?>' +
+  '<dashboard name="QBR Story" type="storyboard"><zones><zone name="Sales by Region" /></zones></dashboard>';
 const DEFAULT_WORKSHEETS = [
   {
     id: 'sheet-sales',

--- a/src/desktop/externalApi/mockExternalApiServer.ts
+++ b/src/desktop/externalApi/mockExternalApiServer.ts
@@ -57,18 +57,14 @@ export type MockExternalApiServer = {
 
 const DEFAULT_TOKEN = 'valid-token';
 const DEFAULT_WORKBOOK_XML = '<?xml version="1.0"?><workbook><worksheets /></workbook>';
-// The live per-item /document routes return a whole <workbook> scoped to the requested item, NOT a
-// bare fragment (verified against Desktop 0.1.1). The mock mirrors that so the read paths' slice is
-// exercised: the worksheet document carries a sibling sheet the slice must exclude by name.
+// The per-item /document routes return the requested item's bare fragment directly — a
+// `<worksheet>` or `<dashboard>`, not wrapped in a `<workbook>`. The handler serves the same
+// fragment for any known id of that kind, standing in for the resolved item.
 const DEFAULT_WORKSHEET_DOCUMENT_XML =
-  '<?xml version="1.0"?><workbook><worksheets>' +
-  '<worksheet name="Sales by Region"><table><rows /></table></worksheet>' +
-  '<worksheet name="Profit by Category"><table><rows /></table></worksheet>' +
-  '</worksheets></workbook>';
+  '<?xml version="1.0"?>' + '<worksheet name="Sales by Region"><table><rows /></table></worksheet>';
 const DEFAULT_DASHBOARD_DOCUMENT_XML =
-  '<?xml version="1.0"?><workbook><dashboards>' +
-  '<dashboard name="Executive Dashboard"><zones><zone name="Sales by Region" /></zones></dashboard>' +
-  '</dashboards></workbook>';
+  '<?xml version="1.0"?>' +
+  '<dashboard name="Executive Dashboard"><zones><zone name="Sales by Region" /></zones></dashboard>';
 // A storyboard serializes as a `<dashboard type='storyboard'>`, and its /document route returns
 // that bare fragment directly — not a `<storyboard>` element, and not wrapped in a `<workbook>`.
 const DEFAULT_STORYBOARD_DOCUMENT_XML =

--- a/src/desktop/metadata/dashboards.test.ts
+++ b/src/desktop/metadata/dashboards.test.ts
@@ -1,6 +1,5 @@
 import { wellFormedXmlRule } from '../validation/rules/wellFormedXml.js';
 import {
-  dashboardDocumentToFragment,
   extractDashboardXml,
   listWorkbookDashboards,
   upsertDashboardIntoWorkbook,
@@ -58,34 +57,6 @@ describe('extractDashboardXml', () => {
     const xml = extractDashboardXml(workbookWithConflict, 'q');
     expect(xml).toContain('http://example.com/already-declared');
     expect(xml).not.toContain('http://www.tableausoftware.com/xml/user');
-  });
-});
-
-describe('dashboardDocumentToFragment', () => {
-  // The live per-dashboard /document route returns a whole <workbook>, not a bare fragment.
-  const WORKBOOK_WITH_DASHBOARD = `<?xml version='1.0' encoding='utf-8' ?>
-<workbook xmlns:user='http://www.tableausoftware.com/xml/user'>
-  <dashboards>
-    <dashboard name='Executive Dashboard'><zones /></dashboard>
-  </dashboards>
-</workbook>`;
-
-  it('slices the requested dashboard out of a whole-workbook document', () => {
-    const xml = dashboardDocumentToFragment(WORKBOOK_WITH_DASHBOARD, 'Executive Dashboard');
-    expect(xml).not.toBeNull();
-    expect(xml).toContain('name="Executive Dashboard"');
-    expect(xml).not.toContain('<workbook');
-  });
-
-  it('returns a document that is already a bare <dashboard> fragment unchanged', () => {
-    const fragment = '<dashboard name="Solo"><zones /></dashboard>';
-    expect(dashboardDocumentToFragment(fragment, 'Solo')).toBe(fragment);
-  });
-
-  it('returns null when the document contains no dashboard', () => {
-    expect(
-      dashboardDocumentToFragment('<workbook><dashboards /></workbook>', 'Missing'),
-    ).toBeNull();
   });
 });
 

--- a/src/desktop/metadata/dashboards.ts
+++ b/src/desktop/metadata/dashboards.ts
@@ -178,20 +178,6 @@ export function extractDashboardXml(workbookXml: string, dashboardName: string):
   return serializeXML({ dashboard });
 }
 
-// The External Client API per-dashboard `/document` route returns a whole `<workbook>` scoped to
-// the requested dashboard, but callers require a single `<dashboard>` fragment. Slice it out. A
-// document that is already a bare `<dashboard>` fragment is returned unchanged; null if absent.
-export function dashboardDocumentToFragment(
-  documentXml: string,
-  dashboardName: string,
-): string | null {
-  const fragment = extractDashboardXml(documentXml, dashboardName);
-  if (fragment !== null) {
-    return fragment;
-  }
-  return parseXML(documentXml).dashboard ? documentXml : null;
-}
-
 // The External Client API's whole-workbook POST route treats the posted document as authoritative
 // and replaces the open workbook with it. So the doc must carry the ENTIRE live workbook (worksheets
 // included — the dashboard's zones reference them by name) with only this dashboard swapped in;

--- a/src/desktop/metadata/sheets.test.ts
+++ b/src/desktop/metadata/sheets.test.ts
@@ -6,7 +6,6 @@ import {
   extractSheetXml,
   listSheets,
   upsertSheetIntoWorkbook,
-  worksheetDocumentToFragment,
 } from './sheets.js';
 
 // Real-world shape: the <workbook> root declares xmlns:user, and a worksheet's level-members
@@ -68,37 +67,6 @@ describe('extractSheetXml', () => {
     expect(xml).not.toContain('http://www.tableausoftware.com/xml/user');
   });
 });
-describe('worksheetDocumentToFragment', () => {
-  // The live per-sheet /document route returns a whole <workbook> carrying every sheet, not a bare
-  // fragment. The helper must slice out only the requested sheet.
-  const WORKBOOK_WITH_TWO_SHEETS = `<?xml version='1.0' encoding='utf-8' ?>
-<workbook xmlns:user='http://www.tableausoftware.com/xml/user'>
-  <worksheets>
-    <worksheet name='Sales by Region'><table /></worksheet>
-    <worksheet name='Profit by Category'><table /></worksheet>
-  </worksheets>
-</workbook>`;
-
-  it('slices the requested sheet out of a whole-workbook document, excluding siblings', () => {
-    const xml = worksheetDocumentToFragment(WORKBOOK_WITH_TWO_SHEETS, 'Sales by Region');
-    expect(xml).not.toBeNull();
-    expect(xml).toContain('name="Sales by Region"');
-    expect(xml).not.toContain('<workbook');
-    expect(xml).not.toContain('Profit by Category');
-  });
-
-  it('returns a document that is already a bare <worksheet> fragment unchanged', () => {
-    const fragment = '<worksheet name="Solo"><table /></worksheet>';
-    expect(worksheetDocumentToFragment(fragment, 'Solo')).toBe(fragment);
-  });
-
-  it('returns null when the document contains no worksheet', () => {
-    expect(
-      worksheetDocumentToFragment('<workbook><worksheets /></workbook>', 'Missing'),
-    ).toBeNull();
-  });
-});
-
 describe('upsertSheetIntoWorkbook', () => {
   // The External Client API POST replaces the open workbook wholesale, so the posted doc must carry
   // the entire live workbook with only the target sheet swapped in — siblings and dashboards intact.

--- a/src/desktop/metadata/sheets.ts
+++ b/src/desktop/metadata/sheets.ts
@@ -149,17 +149,6 @@ export function extractSheetXml(workbookXml: string, sheetName: string): string 
   return serializeXML({ worksheet });
 }
 
-// The External Client API per-sheet `/document` route returns a whole `<workbook>` scoped to the
-// requested sheet, but callers require a single `<worksheet>` fragment. Slice it out. A document
-// that is already a bare `<worksheet>` fragment is returned unchanged; null if no worksheet exists.
-export function worksheetDocumentToFragment(documentXml: string, sheetName: string): string | null {
-  const fragment = extractSheetXml(documentXml, sheetName);
-  if (fragment !== null) {
-    return fragment;
-  }
-  return parseXML(documentXml).worksheet ? documentXml : null;
-}
-
 // The External Client API's whole-workbook POST route treats the posted document as authoritative
 // and replaces the open workbook with it. So the doc must carry the ENTIRE live workbook with only
 // this sheet swapped in; anything omitted (sibling sheets, dashboards) would be pruned. Upsert by

--- a/src/tools/desktop/cache/noWholeDocumentParam.test.ts
+++ b/src/tools/desktop/cache/noWholeDocumentParam.test.ts
@@ -95,7 +95,7 @@ describe('the served profile still has a working edit path with no document para
   });
 
   it('runs the post-bind get -> slice-read -> splice-write -> apply(file) repair path', async () => {
-    vi.spyOn(getWorksheetXmlCmd, 'getWorksheetFragment').mockResolvedValue(Ok(SHEET));
+    vi.spyOn(getWorksheetXmlCmd, 'getWorksheetXml').mockResolvedValue(Ok(SHEET));
     const loadSpy = vi
       .spyOn(loadWorksheetXmlCmd, 'loadWorksheetXml')
       .mockResolvedValue(Ok({ validationWarnings: [], readbackWarnings: [] }));

--- a/src/tools/desktop/coordination/batchCreateAndCacheSheets.test.ts
+++ b/src/tools/desktop/coordination/batchCreateAndCacheSheets.test.ts
@@ -18,9 +18,9 @@ vi.mock('fs');
 import { writeFileSync } from 'fs';
 
 import { writeSidecar } from '../../../desktop/commands/workbook/cacheFingerprint.js';
-import { getDashboardFragment } from '../../../desktop/commands/workbook/getDashboardXml.js';
+import { getDashboardXml } from '../../../desktop/commands/workbook/getDashboardXml.js';
 import { getWorkbookXml } from '../../../desktop/commands/workbook/getWorkbookXml.js';
-import { getWorksheetFragment } from '../../../desktop/commands/workbook/getWorksheetXml.js';
+import { getWorksheetXml } from '../../../desktop/commands/workbook/getWorksheetXml.js';
 import { loadWorkbookXml } from '../../../desktop/commands/workbook/loadWorkbookXml.js';
 import { addDashboard, addSheet } from '../../../desktop/metadata/index.js';
 import { deflectionText } from '../../../desktop/route/route-gate.js';
@@ -42,8 +42,8 @@ function makeExtra(): TableauDesktopRequestHandlerExtra {
   vi.mocked(addSheet).mockReturnValue(WORKBOOK_XML);
   vi.mocked(addDashboard).mockReturnValue(WORKBOOK_XML);
   vi.mocked(loadWorkbookXml).mockResolvedValue(new Ok({ validationWarnings: [] }));
-  vi.mocked(getWorksheetFragment).mockResolvedValue(new Ok(WORKSHEET_XML));
-  vi.mocked(getDashboardFragment).mockResolvedValue(new Ok(DASHBOARD_XML));
+  vi.mocked(getWorksheetXml).mockResolvedValue(new Ok(WORKSHEET_XML));
+  vi.mocked(getDashboardXml).mockResolvedValue(new Ok(DASHBOARD_XML));
   vi.mocked(writeFileSync).mockImplementation(() => {});
   vi.mocked(writeSidecar).mockImplementation(() => {});
   return extra;
@@ -141,7 +141,7 @@ describe('batchCreateAndCacheSheetsTool', () => {
 
   it('should return an error naming a worksheet fetch failure', async () => {
     const extra = makeExtra();
-    vi.mocked(getWorksheetFragment).mockResolvedValue(
+    vi.mocked(getWorksheetXml).mockResolvedValue(
       new Err({
         type: 'get-worksheet-xml-error',
         error: { type: 'no-worksheet-found' as const, message: 'Not found' },
@@ -170,7 +170,7 @@ describe('batchCreateAndCacheSheetsTool', () => {
 
   it('should aggregate partial worksheet and dashboard cache failures', async () => {
     const extra = makeExtra();
-    vi.mocked(getWorksheetFragment)
+    vi.mocked(getWorksheetXml)
       .mockResolvedValueOnce(new Ok(WORKSHEET_XML))
       .mockResolvedValueOnce(
         new Err({
@@ -178,7 +178,7 @@ describe('batchCreateAndCacheSheetsTool', () => {
           error: { type: 'no-worksheet-found' as const, message: 'Missing worksheet' },
         }),
       );
-    vi.mocked(getDashboardFragment).mockResolvedValue(
+    vi.mocked(getDashboardXml).mockResolvedValue(
       new Err({
         type: 'get-dashboard-xml-error',
         error: { type: 'no-dashboard-found' as const, message: 'Missing dashboard' },

--- a/src/tools/desktop/coordination/batchCreateAndCacheSheets.ts
+++ b/src/tools/desktop/coordination/batchCreateAndCacheSheets.ts
@@ -5,9 +5,9 @@ import { z } from 'zod';
 
 import { DesktopCache } from '../../../desktop/cache.js';
 import { writeSidecar } from '../../../desktop/commands/workbook/cacheFingerprint.js';
-import { getDashboardFragment } from '../../../desktop/commands/workbook/getDashboardXml.js';
+import { getDashboardXml } from '../../../desktop/commands/workbook/getDashboardXml.js';
 import { getWorkbookXml } from '../../../desktop/commands/workbook/getWorkbookXml.js';
-import { getWorksheetFragment } from '../../../desktop/commands/workbook/getWorksheetXml.js';
+import { getWorksheetXml } from '../../../desktop/commands/workbook/getWorksheetXml.js';
 import { loadWorkbookXml } from '../../../desktop/commands/workbook/loadWorkbookXml.js';
 import { currentEpisodeId, emitEpisodeEvent } from '../../../desktop/episode-events.js';
 import { addDashboard, addSheet } from '../../../desktop/metadata/index.js';
@@ -155,7 +155,7 @@ export const getBatchCreateAndCacheSheetsTool = (
           const worksheetFiles: Record<string, string> = {};
           const worksheetFailures: ArtifactFailure[] = [];
           for (const name of worksheetNames) {
-            const wsResult = await getWorksheetFragment({ worksheetName: name, executor, signal });
+            const wsResult = await getWorksheetXml({ worksheetName: name, executor, signal });
             if (wsResult.isErr()) {
               worksheetFailures.push({
                 name,
@@ -181,7 +181,7 @@ export const getBatchCreateAndCacheSheetsTool = (
           // Fetch and cache the dashboard working copy.
           let dashboardFile: string | null = null;
           const dashboardFailures: ArtifactFailure[] = [];
-          const dashResult = await getDashboardFragment({ dashboardName, executor, signal });
+          const dashResult = await getDashboardXml({ dashboardName, executor, signal });
           if (dashResult.isErr()) {
             dashboardFailures.push({
               name: dashboardName,

--- a/src/tools/desktop/dashboard/getDashboardXml.test.ts
+++ b/src/tools/desktop/dashboard/getDashboardXml.test.ts
@@ -51,7 +51,7 @@ describe('getDashboardXmlTool', () => {
 
   it('should return dashboard XML inline when mode is inline', async () => {
     const mockXml = '<dashboard name="Sales Dashboard"><zones></zones></dashboard>';
-    vi.spyOn(getDashboardXmlModule, 'getDashboardFragment').mockResolvedValue(Ok(mockXml));
+    vi.spyOn(getDashboardXmlModule, 'getDashboardXml').mockResolvedValue(Ok(mockXml));
 
     const result = await getToolResult({ dashboardName: 'Sales Dashboard', mode: 'inline' });
 
@@ -66,7 +66,7 @@ describe('getDashboardXmlTool', () => {
 
   it('should write to file and return path when mode is file', async () => {
     const mockXml = '<dashboard name="Sales Dashboard"><zones></zones></dashboard>';
-    vi.spyOn(getDashboardXmlModule, 'getDashboardFragment').mockResolvedValue(Ok(mockXml));
+    vi.spyOn(getDashboardXmlModule, 'getDashboardXml').mockResolvedValue(Ok(mockXml));
 
     const result = await getToolResult({ dashboardName: 'Sales Dashboard', mode: 'file' });
 
@@ -87,7 +87,7 @@ describe('getDashboardXmlTool', () => {
         error: { code: 'ERROR', message: 'Network error', recoverable: false },
       },
     };
-    vi.spyOn(getDashboardXmlModule, 'getDashboardFragment').mockResolvedValue(Err(error));
+    vi.spyOn(getDashboardXmlModule, 'getDashboardXml').mockResolvedValue(Err(error));
 
     const result = await getToolResult({ dashboardName: 'Sales Dashboard', mode: 'inline' });
 
@@ -104,7 +104,7 @@ describe('getDashboardXmlTool', () => {
         message: 'No dashboard found for "Sales Dashboard".',
       },
     };
-    vi.spyOn(getDashboardXmlModule, 'getDashboardFragment').mockResolvedValue(Err(error));
+    vi.spyOn(getDashboardXmlModule, 'getDashboardXml').mockResolvedValue(Err(error));
 
     const result = await getToolResult({ dashboardName: 'Sales Dashboard', mode: 'inline' });
 
@@ -121,7 +121,7 @@ describe('getDashboardXmlTool', () => {
         message: '2 dashboards found instead of 1.',
       },
     };
-    vi.spyOn(getDashboardXmlModule, 'getDashboardFragment').mockResolvedValue(Err(error));
+    vi.spyOn(getDashboardXmlModule, 'getDashboardXml').mockResolvedValue(Err(error));
 
     const result = await getToolResult({ dashboardName: 'Sales Dashboard', mode: 'inline' });
 
@@ -130,9 +130,9 @@ describe('getDashboardXmlTool', () => {
     expect(result.content[0].text).toBe(new GetDashboardXmlFailedError(error.error).message);
   });
 
-  it('should pass the abort signal to getDashboardFragment', async () => {
+  it('should pass the abort signal to getDashboardXml', async () => {
     const mockGetDashboardXml = vi
-      .spyOn(getDashboardXmlModule, 'getDashboardFragment')
+      .spyOn(getDashboardXmlModule, 'getDashboardXml')
       .mockResolvedValue(Ok('<dashboard name="Sales Dashboard"/>'));
 
     const customSignal = new AbortController().signal;
@@ -146,7 +146,7 @@ describe('getDashboardXmlTool', () => {
   it('forces file mode when inline XML exceeds the cap, regardless of requested mode', async () => {
     const overCapXml =
       '<dashboard name="Sales Dashboard"><zones>' + 'x'.repeat(20000) + '</zones></dashboard>';
-    vi.spyOn(getDashboardXmlModule, 'getDashboardFragment').mockResolvedValue(Ok(overCapXml));
+    vi.spyOn(getDashboardXmlModule, 'getDashboardXml').mockResolvedValue(Ok(overCapXml));
 
     const result = await getToolResult({ dashboardName: 'Sales Dashboard', mode: 'inline' });
 
@@ -164,7 +164,7 @@ describe('getDashboardXmlTool', () => {
   it('logs a cap-hit receipt when the cap fires', async () => {
     const logSpy = vi.spyOn(loggerModule, 'log').mockImplementation(() => {});
     const overCapXml = '<dashboard name="D"><zones>' + 'x'.repeat(20000) + '</zones></dashboard>';
-    vi.spyOn(getDashboardXmlModule, 'getDashboardFragment').mockResolvedValue(Ok(overCapXml));
+    vi.spyOn(getDashboardXmlModule, 'getDashboardXml').mockResolvedValue(Ok(overCapXml));
 
     await getToolResult({ dashboardName: 'D', mode: 'inline' });
 
@@ -178,7 +178,7 @@ describe('getDashboardXmlTool', () => {
 
   it('respects a smaller cap overridden via config', async () => {
     const smallXml = '<dashboard name="D"><zones/></dashboard>';
-    vi.spyOn(getDashboardXmlModule, 'getDashboardFragment').mockResolvedValue(Ok(smallXml));
+    vi.spyOn(getDashboardXmlModule, 'getDashboardXml').mockResolvedValue(Ok(smallXml));
 
     const result = await getToolResult({ dashboardName: 'D', mode: 'inline', capBytes: 8 });
 

--- a/src/tools/desktop/dashboard/getDashboardXml.ts
+++ b/src/tools/desktop/dashboard/getDashboardXml.ts
@@ -7,7 +7,7 @@ import { formatArtifactSummary } from '../../../desktop/artifactSummary.js';
 import { DesktopCache } from '../../../desktop/cache.js';
 import { writeSidecar } from '../../../desktop/commands/workbook/cacheFingerprint.js';
 import {
-  getDashboardFragment,
+  getDashboardXml,
   isRouteMissing,
 } from '../../../desktop/commands/workbook/getDashboardXml.js';
 import {
@@ -64,7 +64,7 @@ export const getGetDashboardXmlTool = (
           }
           const resolvedSession = sessionResult.value;
           const executor = await extra.getExecutor(resolvedSession);
-          const result = await getDashboardFragment({
+          const result = await getDashboardXml({
             dashboardName,
             executor,
             signal: extra.signal,

--- a/src/tools/desktop/external-api/externalApiTools.test.ts
+++ b/src/tools/desktop/external-api/externalApiTools.test.ts
@@ -239,11 +239,11 @@ describe('External API coverage tools', () => {
     }
   });
 
-  it('gets a storyboard document by name, sliced to its <dashboard> fragment', async () => {
+  it('gets a storyboard document by name after resolving it to an id', async () => {
     const harness = await startHarness(getStoryboardXmlTool);
     try {
-      // A storyboard serializes as a `<dashboard type="storyboard">`; the whole-workbook document
-      // is sliced to that single fragment (the sibling dashboard is excluded by name).
+      // A storyboard serializes as a `<dashboard type="storyboard">`; its /document route returns
+      // that bare fragment directly, so the tool returns it as-is.
       const result = await harness.callTool({ storyboard: 'QBR Story', mode: 'inline' });
 
       expect(result.isError).toBe(false);
@@ -252,7 +252,6 @@ describe('External API coverage tools', () => {
         .parse(parseResult(result)).storyboardXml;
       expect(storyboardXml).toContain('name="QBR Story"');
       expect(storyboardXml).toContain('type="storyboard"');
-      expect(storyboardXml).not.toContain('Executive Dashboard');
       expect(harness.server.requests.map((request) => request.path)).toEqual([
         '/v0/workbook/storyboards',
         '/v0/workbook/storyboards/story-qbr/document',

--- a/src/tools/desktop/external-api/getStoryboardXml.test.ts
+++ b/src/tools/desktop/external-api/getStoryboardXml.test.ts
@@ -12,15 +12,10 @@ import { getStoryboardXmlTool } from './getStoryboardXml.js';
 
 vi.mock('fs');
 
-// A storyboard serializes as a `<dashboard type="storyboard">`, so its /document route returns a
-// whole <workbook>; the tool slices it to the single fragment by the resolved storyboard name.
+// A storyboard serializes as a `<dashboard type="storyboard">`, and its /document route returns
+// that bare fragment directly — no surrounding <workbook>, no sibling dashboards.
 function storyboardDocument(name: string, filler = ''): string {
-  return (
-    '<?xml version="1.0"?><workbook><dashboards>' +
-    '<dashboard name="Executive Dashboard"><zones><zone name="Sales by Region" /></zones></dashboard>' +
-    `<dashboard name="${name}" type="storyboard"><zones><zone name="Sales by Region" />${filler}</zones></dashboard>` +
-    '</dashboards></workbook>'
-  );
+  return `<dashboard name="${name}" type="storyboard"><zones><zone name="Sales by Region" />${filler}</zones></dashboard>`;
 }
 
 describe('getStoryboardXmlTool', () => {
@@ -48,7 +43,7 @@ describe('getStoryboardXmlTool', () => {
     expect(tool.annotations).toMatchObject({ readOnlyHint: false });
   });
 
-  it('writes the sliced fragment to a cache file and points at apply-storyboard (default mode)', async () => {
+  it('writes the fragment to a cache file and points at apply-storyboard (default mode)', async () => {
     const result = await getToolResult({ storyboard: 'QBR Story' });
 
     expect(result.isError).toBe(false);
@@ -60,7 +55,7 @@ describe('getStoryboardXmlTool', () => {
     expect(resultObj.instructions).toContain('apply-storyboard');
   });
 
-  it('returns the sliced fragment inline when mode is inline', async () => {
+  it('returns the fragment inline when mode is inline', async () => {
     const result = await getToolResult({ storyboard: 'QBR Story', mode: 'inline' });
 
     expect(result.isError).toBe(false);
@@ -71,8 +66,14 @@ describe('getStoryboardXmlTool', () => {
     expect(resultObj.message).toContain('inline');
     expect(resultObj.storyboardXml).toContain('name="QBR Story"');
     expect(resultObj.storyboardXml).toContain('type="storyboard"');
-    // The sibling dashboard is sliced out by name.
-    expect(resultObj.storyboardXml).not.toContain('Executive Dashboard');
+  });
+
+  it('errors when the document route returns no <dashboard> subtree', async () => {
+    const result = await getToolResult({ storyboard: 'QBR Story', emptyDocument: true });
+
+    expect(result.isError).toBe(true);
+    invariant(result.content[0].type === 'text');
+    expect(result.content[0].text).toContain('No storyboard document subtree found');
   });
 
   it('forces file mode when the inline fragment exceeds the cap, regardless of requested mode', async () => {
@@ -141,10 +142,12 @@ function makeExecutor({
   bigDocument,
   listRouteMissing,
   documentRouteMissing,
+  emptyDocument,
 }: {
   bigDocument?: string;
   listRouteMissing?: boolean;
   documentRouteMissing?: boolean;
+  emptyDocument?: boolean;
 }): {
   executor: {
     listStoryboards: ReturnType<typeof vi.fn>;
@@ -158,13 +161,12 @@ function makeExecutor({
         ? Err(routeMissing)
         : Ok({ storyboards: [{ id: 'story-qbr', name: 'QBR Story', hidden: false }] }),
     );
+  const documentXml = emptyDocument
+    ? '<empty />'
+    : (bigDocument ?? storyboardDocument('QBR Story'));
   const getStoryboardDocument = vi
     .fn()
-    .mockResolvedValue(
-      documentRouteMissing
-        ? Err(routeMissing)
-        : Ok({ xml: bigDocument ?? storyboardDocument('QBR Story') }),
-    );
+    .mockResolvedValue(documentRouteMissing ? Err(routeMissing) : Ok({ xml: documentXml }));
   return { executor: { listStoryboards, getStoryboardDocument } };
 }
 
@@ -176,6 +178,7 @@ async function getToolResult(opts: {
   bigDocument?: string;
   listRouteMissing?: boolean;
   documentRouteMissing?: boolean;
+  emptyDocument?: boolean;
   customSignal?: AbortSignal;
 }): Promise<CallToolResult> {
   const { session = '12345', storyboard, mode = 'file', capBytes, customSignal } = opts;

--- a/src/tools/desktop/external-api/getStoryboardXml.ts
+++ b/src/tools/desktop/external-api/getStoryboardXml.ts
@@ -12,7 +12,7 @@ import {
   logInlineXmlCapHit,
   xmlByteLength,
 } from '../../../desktop/inlineXmlCap.js';
-import { dashboardDocumentToFragment } from '../../../desktop/metadata/dashboards.js';
+import { parseXML } from '../../../desktop/metadata/parser.js';
 import { resolveSession } from '../../../desktop/sessionResolution.js';
 import { DesktopCommandExecutionError, UnknownError } from '../../../errors/mcpToolError.js';
 import { log } from '../../../logging/logger.js';
@@ -62,10 +62,8 @@ export const getStoryboardXmlTool = (
           const resolvedSession = sessionResult.value;
           const executor = await extra.getExecutor(resolvedSession);
 
-          // A storyboard serializes as a `<dashboard type='storyboard'>`, so its `/document` route
-          // returns a whole `<workbook>` scoped to it — the same shape as a dashboard. Resolve the
-          // name to an id, fetch the document, then slice out the single `<dashboard>` fragment by
-          // the resolved name so callers get exactly what apply-storyboard expects.
+          // A storyboard serializes as a `<dashboard type='storyboard'>`, and its `/document` route
+          // returns that bare fragment directly. Resolve the name to an id, then fetch the document.
           const listResult = await executor.listStoryboards(extra.signal);
           if (listResult.isErr()) {
             if (isRouteMissing(listResult.error)) {
@@ -92,11 +90,8 @@ export const getStoryboardXmlTool = (
             return new DesktopCommandExecutionError(documentResult.error).toErr();
           }
 
-          const storyboardXml = dashboardDocumentToFragment(
-            documentResult.value.xml,
-            resolved.name,
-          );
-          if (storyboardXml === null) {
+          const storyboardXml = documentResult.value.xml;
+          if (!parseXML(storyboardXml).dashboard) {
             return new UnknownError(
               `No storyboard document subtree found for "${storyboard}".`,
             ).toErr();

--- a/src/tools/desktop/fields/addField.test.ts
+++ b/src/tools/desktop/fields/addField.test.ts
@@ -233,7 +233,7 @@ describe('addFieldTool', () => {
   // --- name-based path (no prior get-worksheet-xml call) ---
   it('fetches + caches the sheet by name when no worksheetFile is given, then edits it', async () => {
     const FRAGMENT = '<worksheet name="Sheet 1"><table/></worksheet>';
-    vi.mocked(getWorksheetXmlModule.getWorksheetFragment).mockResolvedValue(Ok(FRAGMENT));
+    vi.mocked(getWorksheetXmlModule.getWorksheetXml).mockResolvedValue(Ok(FRAGMENT));
     // The minted cache file exists after the internal write; the edit reads it back.
     vi.mocked(existsSync).mockReturnValue(true);
     vi.mocked(readFileSync).mockReturnValue(FRAGMENT);
@@ -252,7 +252,7 @@ describe('addFieldTool', () => {
     expect(body.message).toContain('Rows shelf');
     // The fetch happened, and the minted cache path (worksheet-Sheet_1-*) is returned so
     // follow-up edits can pass it as worksheetFile.
-    expect(getWorksheetXmlModule.getWorksheetFragment).toHaveBeenCalledWith(
+    expect(getWorksheetXmlModule.getWorksheetXml).toHaveBeenCalledWith(
       expect.objectContaining({ worksheetName: 'Sheet 1' }),
     );
     expect(body.file).toMatch(/worksheet-Sheet_1-/);
@@ -267,7 +267,7 @@ describe('addFieldTool', () => {
       type: 'get-worksheet-xml-error' as const,
       error: { type: 'no-worksheet-found' as const, message: 'No worksheet found for Ghost.' },
     };
-    vi.mocked(getWorksheetXmlModule.getWorksheetFragment).mockResolvedValue(Err(fetchErr));
+    vi.mocked(getWorksheetXmlModule.getWorksheetXml).mockResolvedValue(Err(fetchErr));
 
     const result = await getResult({
       worksheetName: 'Ghost',
@@ -294,7 +294,7 @@ describe('addFieldTool', () => {
         },
       },
     };
-    vi.mocked(getWorksheetXmlModule.getWorksheetFragment).mockResolvedValue(Err(routeMissingErr));
+    vi.mocked(getWorksheetXmlModule.getWorksheetXml).mockResolvedValue(Err(routeMissingErr));
     vi.mocked(getWorksheetXmlModule.isRouteMissing).mockReturnValue(true);
 
     const result = await getResult({
@@ -321,7 +321,7 @@ describe('addFieldTool', () => {
         'Provide either worksheetName (to edit an existing sheet) or worksheetFile (a cached path).',
       ).message,
     );
-    expect(getWorksheetXmlModule.getWorksheetFragment).not.toHaveBeenCalled();
+    expect(getWorksheetXmlModule.getWorksheetXml).not.toHaveBeenCalled();
     expect(writeFileSync).not.toHaveBeenCalled();
   });
 
@@ -342,7 +342,7 @@ describe('addFieldTool', () => {
     invariant(result.content[0].type === 'text');
     expect(resultSchema.parse(JSON.parse(result.content[0].text)).file).toBe(WORKSHEET_FILE);
     // worksheetFile is authoritative — the name-based fetch must not run.
-    expect(getWorksheetXmlModule.getWorksheetFragment).not.toHaveBeenCalled();
+    expect(getWorksheetXmlModule.getWorksheetXml).not.toHaveBeenCalled();
   });
 
   it('should pass index and workbookFile to addFieldToRows (target=rows)', async () => {

--- a/src/tools/desktop/fields/removeField.test.ts
+++ b/src/tools/desktop/fields/removeField.test.ts
@@ -230,7 +230,7 @@ describe('removeFieldTool', () => {
 
   it('fetches and caches the sheet by name when no worksheetFile is given, then edits it', async () => {
     const fragment = '<worksheet name="Sheet 1"><table/></worksheet>';
-    vi.mocked(getWorksheetXmlModule.getWorksheetFragment).mockResolvedValue(Ok(fragment));
+    vi.mocked(getWorksheetXmlModule.getWorksheetXml).mockResolvedValue(Ok(fragment));
     vi.mocked(existsSync).mockReturnValue(true);
     vi.mocked(readFileSync).mockReturnValue(fragment);
     vi.mocked(metadataModule.removeFieldFromRows).mockReturnValue(MODIFIED_XML);
@@ -246,7 +246,7 @@ describe('removeFieldTool', () => {
     invariant(result.content[0].type === 'text');
     const body = resultSchema.parse(JSON.parse(result.content[0].text));
     expect(body.message).toContain('Rows shelf');
-    expect(getWorksheetXmlModule.getWorksheetFragment).toHaveBeenCalledWith(
+    expect(getWorksheetXmlModule.getWorksheetXml).toHaveBeenCalledWith(
       expect.objectContaining({ worksheetName: 'Sheet 1' }),
     );
     expect(body.file).toMatch(/worksheet-Sheet_1-/);
@@ -270,7 +270,7 @@ describe('removeFieldTool', () => {
     expect(result.isError).toBe(false);
     invariant(result.content[0].type === 'text');
     expect(resultSchema.parse(JSON.parse(result.content[0].text)).file).toBe(WORKSHEET_FILE);
-    expect(getWorksheetXmlModule.getWorksheetFragment).not.toHaveBeenCalled();
+    expect(getWorksheetXmlModule.getWorksheetXml).not.toHaveBeenCalled();
   });
 
   it('errors when neither worksheetName nor worksheetFile is provided', async () => {
@@ -283,7 +283,7 @@ describe('removeFieldTool', () => {
         'Provide either worksheetName (to edit an existing sheet) or worksheetFile (a cached path).',
       ).message,
     );
-    expect(getWorksheetXmlModule.getWorksheetFragment).not.toHaveBeenCalled();
+    expect(getWorksheetXmlModule.getWorksheetXml).not.toHaveBeenCalled();
     expect(writeFileSync).not.toHaveBeenCalled();
   });
 
@@ -292,7 +292,7 @@ describe('removeFieldTool', () => {
       type: 'get-worksheet-xml-error' as const,
       error: { type: 'no-worksheet-found' as const, message: 'No worksheet found for Ghost.' },
     };
-    vi.mocked(getWorksheetXmlModule.getWorksheetFragment).mockResolvedValue(Err(fetchErr));
+    vi.mocked(getWorksheetXmlModule.getWorksheetXml).mockResolvedValue(Err(fetchErr));
 
     const result = await getResult({
       worksheetName: 'Ghost',
@@ -319,7 +319,7 @@ describe('removeFieldTool', () => {
         },
       },
     };
-    vi.mocked(getWorksheetXmlModule.getWorksheetFragment).mockResolvedValue(Err(routeMissingErr));
+    vi.mocked(getWorksheetXmlModule.getWorksheetXml).mockResolvedValue(Err(routeMissingErr));
     vi.mocked(getWorksheetXmlModule.isRouteMissing).mockReturnValue(true);
 
     const result = await getResult({
@@ -341,7 +341,7 @@ describe('removeFieldTool', () => {
     const addedXml = '<worksheet name="Sheet 1"><table><rows>[Profit]</rows></table></worksheet>';
     const removedXml = '<worksheet name="Sheet 1"><table><rows/></table></worksheet>';
     const files = new Map<string, string>();
-    vi.mocked(getWorksheetXmlModule.getWorksheetFragment).mockResolvedValue(Ok(baseXml));
+    vi.mocked(getWorksheetXmlModule.getWorksheetXml).mockResolvedValue(Ok(baseXml));
     vi.mocked(existsSync).mockImplementation((path) => files.has(String(path)));
     vi.mocked(readFileSync).mockImplementation((path) => files.get(String(path)) ?? '');
     vi.mocked(writeFileSync).mockImplementation((path, data) => {
@@ -377,7 +377,7 @@ describe('removeFieldTool', () => {
     });
 
     expect(applyResult.isError).toBe(false);
-    expect(getWorksheetXmlModule.getWorksheetFragment).toHaveBeenCalledTimes(1);
+    expect(getWorksheetXmlModule.getWorksheetXml).toHaveBeenCalledTimes(1);
     expect(loadWorksheetXmlModule.loadWorksheetXml).toHaveBeenCalledWith(
       expect.objectContaining({ worksheetName: 'Sheet 1', xml: removedXml }),
     );

--- a/src/tools/desktop/fields/worksheetCache.ts
+++ b/src/tools/desktop/fields/worksheetCache.ts
@@ -4,7 +4,7 @@ import { Err, Ok, Result } from 'ts-results-es';
 import { DesktopCache } from '../../../desktop/cache.js';
 import { writeSidecar } from '../../../desktop/commands/workbook/cacheFingerprint.js';
 import {
-  getWorksheetFragment,
+  getWorksheetXml,
   isRouteMissing,
 } from '../../../desktop/commands/workbook/getWorksheetXml.js';
 import {
@@ -31,7 +31,7 @@ export async function fetchAndCacheWorksheet({
   extra: TableauDesktopRequestHandlerExtra;
 }): Promise<Result<string, McpToolError>> {
   const executor = await extra.getExecutor(resolvedSession);
-  const fetched = await getWorksheetFragment({ worksheetName, executor, signal: extra.signal });
+  const fetched = await getWorksheetXml({ worksheetName, executor, signal: extra.signal });
   if (fetched.isErr()) {
     const { type, error } = fetched.error;
     switch (type) {

--- a/src/tools/desktop/worksheet/getWorksheetXml.test.ts
+++ b/src/tools/desktop/worksheet/getWorksheetXml.test.ts
@@ -71,12 +71,12 @@ describe('getWorksheetXmlTool', () => {
       nextAction: { kind: 'prefill' },
     });
     expect(mockExecutor).not.toHaveBeenCalled();
-    expect(getWorksheetXmlModule.getWorksheetFragment).not.toHaveBeenCalled();
+    expect(getWorksheetXmlModule.getWorksheetXml).not.toHaveBeenCalled();
   });
 
   it('should return worksheet XML inline when mode is inline', async () => {
     const mockXml = '<worksheet name="Sheet 1"><table></table></worksheet>';
-    vi.spyOn(getWorksheetXmlModule, 'getWorksheetFragment').mockResolvedValue(Ok(mockXml));
+    vi.spyOn(getWorksheetXmlModule, 'getWorksheetXml').mockResolvedValue(Ok(mockXml));
 
     const result = await getToolResult({
       session: '12345',
@@ -95,7 +95,7 @@ describe('getWorksheetXmlTool', () => {
 
   it('should write to file and return path when mode is file', async () => {
     const mockXml = '<worksheet name="Sheet 1"><table></table></worksheet>';
-    vi.spyOn(getWorksheetXmlModule, 'getWorksheetFragment').mockResolvedValue(Ok(mockXml));
+    vi.spyOn(getWorksheetXmlModule, 'getWorksheetXml').mockResolvedValue(Ok(mockXml));
 
     const result = await getToolResult({
       session: '12345',
@@ -120,7 +120,7 @@ describe('getWorksheetXmlTool', () => {
         error: { code: 'ERROR', message: 'Network error', recoverable: false },
       },
     };
-    vi.spyOn(getWorksheetXmlModule, 'getWorksheetFragment').mockResolvedValue(Err(error));
+    vi.spyOn(getWorksheetXmlModule, 'getWorksheetXml').mockResolvedValue(Err(error));
 
     const result = await getToolResult({
       session: '12345',
@@ -138,7 +138,7 @@ describe('getWorksheetXmlTool', () => {
       type: 'get-worksheet-xml-error' as const,
       error: { type: 'no-worksheet-found' as const, message: 'No worksheet found for Sheet 1.' },
     };
-    vi.spyOn(getWorksheetXmlModule, 'getWorksheetFragment').mockResolvedValue(Err(error));
+    vi.spyOn(getWorksheetXmlModule, 'getWorksheetXml').mockResolvedValue(Err(error));
 
     const result = await getToolResult({
       session: '12345',
@@ -159,7 +159,7 @@ describe('getWorksheetXmlTool', () => {
         message: '3 worksheets found instead of 1.',
       },
     };
-    vi.spyOn(getWorksheetXmlModule, 'getWorksheetFragment').mockResolvedValue(Err(error));
+    vi.spyOn(getWorksheetXmlModule, 'getWorksheetXml').mockResolvedValue(Err(error));
 
     const result = await getToolResult({
       session: '12345',
@@ -172,9 +172,9 @@ describe('getWorksheetXmlTool', () => {
     expect(result.content[0].text).toBe(new GetWorksheetXmlFailedError(error.error).message);
   });
 
-  it('should pass the abort signal to getWorksheetFragment', async () => {
+  it('should pass the abort signal to getWorksheetXml', async () => {
     const mockGetWorksheetXml = vi
-      .spyOn(getWorksheetXmlModule, 'getWorksheetFragment')
+      .spyOn(getWorksheetXmlModule, 'getWorksheetXml')
       .mockResolvedValue(Ok('<worksheet name="Sheet 1"/>'));
 
     const customSignal = new AbortController().signal;
@@ -196,7 +196,7 @@ describe('getWorksheetXmlTool', () => {
 
   it('forces file mode when inline XML exceeds the cap, regardless of requested mode', async () => {
     const overCapXml = '<worksheet name="Sales">' + 'x'.repeat(20000) + '</worksheet>';
-    vi.spyOn(getWorksheetXmlModule, 'getWorksheetFragment').mockResolvedValue(Ok(overCapXml));
+    vi.spyOn(getWorksheetXmlModule, 'getWorksheetXml').mockResolvedValue(Ok(overCapXml));
 
     const result = await getToolResult({
       session: '12345',
@@ -218,7 +218,7 @@ describe('getWorksheetXmlTool', () => {
   it('logs a cap-hit receipt when the cap fires', async () => {
     const logSpy = vi.spyOn(loggerModule, 'log').mockImplementation(() => {});
     const overCapXml = '<worksheet name="Sales">' + 'x'.repeat(20000) + '</worksheet>';
-    vi.spyOn(getWorksheetXmlModule, 'getWorksheetFragment').mockResolvedValue(Ok(overCapXml));
+    vi.spyOn(getWorksheetXmlModule, 'getWorksheetXml').mockResolvedValue(Ok(overCapXml));
 
     await getToolResult({ session: '12345', worksheetName: 'Sales', mode: 'inline' });
 
@@ -232,7 +232,7 @@ describe('getWorksheetXmlTool', () => {
 
   it('respects a smaller cap overridden via config', async () => {
     const smallXml = '<worksheet name="Sales"><a/></worksheet>';
-    vi.spyOn(getWorksheetXmlModule, 'getWorksheetFragment').mockResolvedValue(Ok(smallXml));
+    vi.spyOn(getWorksheetXmlModule, 'getWorksheetXml').mockResolvedValue(Ok(smallXml));
 
     const result = await getToolResult({
       session: '12345',

--- a/src/tools/desktop/worksheet/getWorksheetXml.ts
+++ b/src/tools/desktop/worksheet/getWorksheetXml.ts
@@ -7,7 +7,7 @@ import { formatArtifactSummary } from '../../../desktop/artifactSummary.js';
 import { DesktopCache } from '../../../desktop/cache.js';
 import { writeSidecar } from '../../../desktop/commands/workbook/cacheFingerprint.js';
 import {
-  getWorksheetFragment,
+  getWorksheetXml,
   isRouteMissing,
 } from '../../../desktop/commands/workbook/getWorksheetXml.js';
 import {
@@ -71,7 +71,7 @@ export const getGetWorksheetXmlTool = (
           }
           const resolvedSession = sessionResult.value;
           const executor = await extra.getExecutor(resolvedSession);
-          const result = await getWorksheetFragment({
+          const result = await getWorksheetXml({
             worksheetName,
             executor,
             signal: extra.signal,

--- a/src/tools/desktop/worksheet/refineWorksheet.test.ts
+++ b/src/tools/desktop/worksheet/refineWorksheet.test.ts
@@ -190,6 +190,12 @@ describe('refineWorksheetTool — top_n happy path', () => {
     // Applied exactly once (never a second apply).
     expect(loadMock()).toHaveBeenCalledTimes(1);
 
+    // Refine edits a sheet it already fetched, so it applies via the per-sheet replace-by-id
+    // route (requireExistingSheet), never the whole-workbook upsert/create path.
+    expect(loadMock()).toHaveBeenCalledWith(
+      expect.objectContaining({ requireExistingSheet: true }),
+    );
+
     // The applied XML carries the native Top-N filter + a slices entry.
     const out = applied()!;
     expect(out).toMatch(/function='end'\s+end='top'\s+count='5'/);
@@ -268,6 +274,9 @@ describe('refineWorksheetTool — sort_direction happy path', () => {
     const parsed = successSchema.parse(JSON.parse(result.content[0].text));
     expect(parsed.message).toMatch(/Applied sort_direction/);
     expect(loadMock()).toHaveBeenCalledTimes(1);
+    expect(loadMock()).toHaveBeenCalledWith(
+      expect.objectContaining({ requireExistingSheet: true }),
+    );
     expect(applied()!).toContain("direction='ASC'");
     expect(applied()!).not.toContain("direction='DESC'");
   });
@@ -291,6 +300,9 @@ describe('refineWorksheetTool — sort_by_field happy path', () => {
     const parsed = successSchema.parse(JSON.parse(result.content[0].text));
     expect(parsed.message).toMatch(/Applied sort_by_field/);
     expect(loadMock()).toHaveBeenCalledTimes(1);
+    expect(loadMock()).toHaveBeenCalledWith(
+      expect.objectContaining({ requireExistingSheet: true }),
+    );
     expect(applied()!).toContain(
       "<computed-sort column='[Superstore].[none:line_item:nk]' direction='ASC' using='[Superstore].[sum:display_order:qk]' />",
     );
@@ -525,6 +537,33 @@ describe('refineWorksheetTool — refusals and errors', () => {
     expect(parsed.reason).toMatch(/preflight validation failed/);
     expect(parsed.reason).toMatch(/invalid-derivation-string/);
     expect(loadMock()).not.toHaveBeenCalled();
+  });
+
+  it('surfaces sheet-absent as an error when the per-sheet route cannot resolve the worksheet', async () => {
+    // The behavior this commit introduces: because refine now applies through the per-sheet
+    // replace-by-id route (requireExistingSheet:true), a worksheet that vanished between the
+    // initial fetch and the apply surfaces as a sheet-absent error — it is NOT silently
+    // re-created via the old whole-workbook upsert path.
+    const applyErr = {
+      type: 'load-worksheet-xml-error' as const,
+      error: {
+        type: 'sheet-absent' as const,
+        message: 'No worksheet named "Sales by Region" is open to update.',
+      },
+    };
+    setupMocks({ applyErr });
+    const result = await getToolResult({
+      worksheetName: 'Sales by Region',
+      operation: 'top_n',
+      topN: { n: 5 },
+    });
+    expect(result.isError).toBe(true);
+    invariant(result.content[0].type === 'text');
+    expect(result.content[0].text).toBe(new WorksheetXmlLoadFailedError(applyErr.error).message);
+    expect(loadMock()).toHaveBeenCalledTimes(1);
+    expect(loadMock()).toHaveBeenCalledWith(
+      expect.objectContaining({ requireExistingSheet: true }),
+    );
   });
 
   it('errors when the single apply fails, with no second apply', async () => {

--- a/src/tools/desktop/worksheet/refineWorksheet.test.ts
+++ b/src/tools/desktop/worksheet/refineWorksheet.test.ts
@@ -110,9 +110,8 @@ interface MockOpts {
   readbackXml?: string;
 }
 
-const getMock = (): ReturnType<
-  typeof vi.mocked<typeof getWorksheetXmlModule.getWorksheetFragment>
-> => vi.mocked(getWorksheetXmlModule.getWorksheetFragment);
+const getMock = (): ReturnType<typeof vi.mocked<typeof getWorksheetXmlModule.getWorksheetXml>> =>
+  vi.mocked(getWorksheetXmlModule.getWorksheetXml);
 const loadMock = (): ReturnType<typeof vi.mocked<typeof loadWorksheetXmlModule.loadWorksheetXml>> =>
   vi.mocked(loadWorksheetXmlModule.loadWorksheetXml);
 

--- a/src/tools/desktop/worksheet/refineWorksheet.ts
+++ b/src/tools/desktop/worksheet/refineWorksheet.ts
@@ -286,6 +286,11 @@ export const getRefineWorksheetTool = (
             focus: { navigate: 'artifact', sheetName: canonicalWorksheetName },
             executor,
             signal: extra.signal,
+            // refine-worksheet only ever edits a sheet it already fetched above, so it replaces an
+            // existing worksheet in place via the per-sheet `/document` route — the same route
+            // apply-worksheet uses. It never creates a sheet, so it must not take the whole-workbook
+            // upsert (create) path. A name that no longer resolves surfaces as an error, not a create.
+            requireExistingSheet: true,
           });
           if (applied.isErr()) {
             const { type, error } = applied.error;

--- a/src/tools/desktop/worksheet/refineWorksheet.ts
+++ b/src/tools/desktop/worksheet/refineWorksheet.ts
@@ -14,7 +14,7 @@ import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { Ok } from 'ts-results-es';
 import { z } from 'zod';
 
-import { getWorksheetFragment } from '../../../desktop/commands/workbook/getWorksheetXml.js';
+import { getWorksheetXml } from '../../../desktop/commands/workbook/getWorksheetXml.js';
 import { loadWorksheetXml } from '../../../desktop/commands/workbook/loadWorksheetXml.js';
 import {
   pollReadback,
@@ -169,7 +169,7 @@ export const getRefineWorksheetTool = (
           const executor = await extra.getExecutor(resolvedSession);
 
           // 1. ONE fetch of the target worksheet.
-          const fetched = await getWorksheetFragment({
+          const fetched = await getWorksheetXml({
             worksheetName,
             executor,
             signal: extra.signal,
@@ -311,7 +311,7 @@ export const getRefineWorksheetTool = (
           // first read can race the settle and still show pre-apply XML.
           const readback = await pollReadback({
             read: () =>
-              getWorksheetFragment({
+              getWorksheetXml({
                 worksheetName: canonicalWorksheetName,
                 executor,
                 signal: extra.signal,


### PR DESCRIPTION
## Decision

The External Client API's per-item `/document` routes now return a **bare** `<worksheet>`/`<dashboard>` fragment on GET and replace that item **in place** on POST. This PR aligns the desktop client with that contract: it trusts the per-item route's bare-fragment shape instead of slicing a single item out of a whole-`<workbook>` envelope, and it routes `refine-worksheet` through the same in-place per-sheet apply that `apply-worksheet` uses. This is a rule the codebase now keeps, not a one-off.

## What changed (four commits)

1. **`feat(desktop): route refine-worksheet through the per-sheet apply`** — `refine-worksheet` edits a worksheet it has already fetched, so it now replaces that sheet in place (`requireExistingSheet: true`) via the per-sheet `/document` route, instead of upserting it into the whole workbook. A worksheet that no longer resolves now surfaces an error rather than being silently re-created. (`refine-worksheet` is the only refine-family tool — there is no `refine-dashboard`/`refine-storyboard`.)

2. **`refactor(desktop): drop client-side read-path fragment slicing (revert #601)`** — the GET routes now return bare fragments, so the `getWorksheetFragment`/`getDashboardFragment` wrappers and the `worksheetDocumentToFragment` helper are removed and their six callers point back at `getWorksheetXml`/`getDashboardXml`. Behavior-preserving: the read path already returned a bare fragment on both transports, and the removed re-slice was a no-op whose null→error branch duplicated the gateway's own resolution error.

3. **`refactor(desktop): consume the bare storyboard document fragment directly`** — the same for the storyboard `/document` route: `get-storyboard-xml` returns the document as-is (guarding only that it parses to a `<dashboard>`), removing the last caller of `dashboardDocumentToFragment` and the helper itself. The mock server's storyboard fixture is corrected to the bare-fragment shape.

4. **`test(desktop): align worksheet and dashboard mock /document fixtures to bare fragments`** — flatten the mock server's remaining whole-`<workbook>` worksheet and dashboard document fixtures to bare fragments, matching the live shape and the read path that no longer slices. Test-only.

## Relationship to #601

#601 added client-side fragment extraction because, at the time, the per-item `/document` routes returned a whole `<workbook>` scoped to the requested item — the client had to slice out the single fragment. The backend now returns bare fragments directly, making that slicing a no-op. Commits 2–4 revert #601's **read-path** extraction accordingly (2–3 in the client, 4 in the test mock). The whole-workbook **upsert (create) path** that #601 also introduced is unrelated to the read-path slicing and is kept.

## Validation

`tsc --noEmit` clean · `eslint` clean · full unit suite green (6441 passed / 330 skipped).
