### PR TITLE
@W-23710773 Display error cause in MCP app error card

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "4.2.0",
+      "version": "4.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1095.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/src/web/apps/src/shared/mcp-app.css
+++ b/src/web/apps/src/shared/mcp-app.css
@@ -170,3 +170,10 @@ tableau-viz {
   font-weight: 400;
   color: #5a6b7b;
 }
+
+.mcp-app-error-cause {
+  margin: 0;
+  font-size: 0.875rem;
+  font-weight: 400;
+  color: #8a97a3;
+}

--- a/src/web/apps/src/shared/recordEventClient.ts
+++ b/src/web/apps/src/shared/recordEventClient.ts
@@ -50,7 +50,7 @@ export function recordEvent(app: App, eventType: McpAppEventType, detail?: unkno
   }
 }
 
-function toMessage(detail: unknown): string | undefined {
+export function toMessage(detail: unknown): string | undefined {
   if (detail === undefined || detail === null) {
     return undefined;
   }

--- a/src/web/apps/src/shared/showError.test.ts
+++ b/src/web/apps/src/shared/showError.test.ts
@@ -4,7 +4,13 @@
 import type { App } from '@modelcontextprotocol/ext-apps';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-vi.mock('./recordEventClient.js');
+// Mock only recordEvent (telemetry side effect); keep the real toMessage so
+// showError's cause-rendering logic (which imports toMessage from this module)
+// is exercised as written.
+vi.mock('./recordEventClient.js', async (importOriginal) => ({
+  ...(await importOriginal()),
+  recordEvent: vi.fn(),
+}));
 import { recordEvent } from './recordEventClient.js';
 import { showError } from './showError.js';
 
@@ -49,7 +55,7 @@ describe('showError', () => {
     expect(errorElement?.querySelector('.mcp-app-error-icon')).toBeTruthy();
   });
 
-  it('should display PARSE_ERROR scenario with user-facing message', () => {
+  it('should display PARSE_ERROR scenario with user-facing message and cause line', () => {
     const cause = new Error('JSON parse failed');
 
     showError('PARSE_ERROR', cause);
@@ -58,6 +64,7 @@ describe('showError', () => {
     const errorElement = container?.querySelector('.mcp-app-error');
     const headingElement = errorElement?.querySelector('.mcp-app-error-heading');
     const messageElement = errorElement?.querySelector('.mcp-app-error-message');
+    const causeElement = errorElement?.querySelector('.mcp-app-error-cause');
 
     // tableau-viz removed, error UI displayed
     expect(container?.querySelector('tableau-viz')).toBeNull();
@@ -67,7 +74,38 @@ describe('showError', () => {
     expect(headingElement?.textContent).toBe('Unable to load this Tableau view');
     expect(messageElement?.textContent).toBe('The response was not in the expected format.');
 
+    // Cause (an Error) renders as a secondary line using its message
+    expect(causeElement?.textContent).toBe('JSON parse failed');
+
     expect(errorElement?.querySelector('.mcp-app-error-icon')).toBeTruthy();
+  });
+
+  it('should display the cause as a secondary line when cause is a plain string', () => {
+    showError('AUTH_ERROR', 'token expired at 12:00');
+
+    const container = document.getElementById('tableauVizContainer');
+    const errorElement = container?.querySelector('.mcp-app-error');
+    const causeElement = errorElement?.querySelector('.mcp-app-error-cause');
+
+    expect(causeElement?.textContent).toBe('token expired at 12:00');
+  });
+
+  it('should not display a cause line when cause is undefined', () => {
+    showError('AUTH_ERROR');
+
+    const container = document.getElementById('tableauVizContainer');
+    const errorElement = container?.querySelector('.mcp-app-error');
+
+    expect(errorElement?.querySelector('.mcp-app-error-cause')).toBeNull();
+  });
+
+  it('should not display a cause line when cause is an empty or whitespace-only string', () => {
+    showError('AUTH_ERROR', '   ');
+
+    const container = document.getElementById('tableauVizContainer');
+    const errorElement = container?.querySelector('.mcp-app-error');
+
+    expect(errorElement?.querySelector('.mcp-app-error-cause')).toBeNull();
   });
 
   it('should display AUTH_ERROR scenario with user-facing message', () => {

--- a/src/web/apps/src/shared/showError.ts
+++ b/src/web/apps/src/shared/showError.ts
@@ -1,7 +1,7 @@
 import type { App } from '@modelcontextprotocol/ext-apps';
 
 import DISCONNECTED_SVG from './assets/disconnected.svg?raw';
-import { type McpAppEventType, recordEvent } from './recordEventClient.js';
+import { type McpAppEventType, recordEvent, toMessage } from './recordEventClient.js';
 import { TABLEAU_VIZ_CONTAINER_ID } from './vizContainer.js';
 
 export type Scenario = Exclude<McpAppEventType, 'OPEN_IN_TABLEAU_CLICKED' | 'FULLSCREEN_CLICKED'>;
@@ -70,6 +70,20 @@ export function showError(scenario: Scenario, cause?: unknown, app?: App): void 
   messageElement.textContent = ERROR_UI[scenario].detail;
 
   textWrapper.append(headingElement, messageElement);
+
+  // Show the cause as an additional, secondary line when present. toMessage()
+  // safely stringifies unknown causes (Error -> .message, else String(cause));
+  // a blank/whitespace-only result is treated as "no cause" to keep the card clean.
+  const causeText = toMessage(cause)?.trim();
+  if (causeText) {
+    const causeElement = document.createElement('p');
+    causeElement.className = 'mcp-app-error-cause';
+    // Safe to use textContent here: cause may contain arbitrary/server-provided
+    // text and must never be interpreted as HTML.
+    causeElement.textContent = causeText;
+    textWrapper.append(causeElement);
+  }
+
   errorElement.append(iconWrapper, textWrapper);
   container.replaceChildren(errorElement);
 }


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

## Description
<img width="823" height="770" alt="Screenshot 2026-08-06 at 4 58 21 PM" src="https://github.com/user-attachments/assets/c6d878b7-1c0d-4095-a86b-208b7dc0bbac" />

Surfaces the underlying error `cause` as a secondary, muted line beneath the generic message in the MCP app error card. Previously, the `cause` was only sent to telemetry and never shown to the user in the UI.

- Exports `toMessage()` from `recordEventClient.ts` so it can be reused to safely stringify an unknown `cause` (uses `Error.message` when available, otherwise `String(cause)`).
- `showError()` now renders the cause as an additional `<p>` element (`.mcp-app-error-cause`) below the existing heading/message, using `textContent` (never `innerHTML`) since the cause may contain arbitrary/untrusted text.
- The cause line is suppressed when the stringified/trimmed result is empty or whitespace-only, keeping the error card clean when there's nothing useful to show.
- Adds a muted style (`color: #8a97a3`, `font-size: 0.875rem`) for the new `.mcp-app-error-cause` class in `mcp-app.css`.

## Motivation and Context

Users viewing an MCP app error card previously only saw a generic message with no indication of the underlying cause, even though that detail was already being captured for telemetry. Surfacing it in the UI gives users actionable context without requiring them to dig through logs/telemetry.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## How Has This Been Tested?

- Extended `showError.test.ts` with new cases covering: rendering the cause line when present, suppressing it when the cause is empty/whitespace, and stringifying `Error` vs. non-`Error` cause values.
- Ran `npx vitest run src/web/apps/src/shared/showError.test.ts` locally — all tests pass.

## Related Issues

N/A

## Checklist

- [ ] I have updated the version in the package.json file by using `npm run version`. For example,
      use `npm run version:patch` for a patch version bump.
- [ ] I have made any necessary changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have documented any breaking changes in the PR description. For example, renaming a config
      environment variable or changing its default value.

## Contributor Agreement

By submitting this pull request, I confirm that:

- [x] I have read the [CONTRIBUTING guidelines](../../CONTRIBUTING.md) for this project and followed
      its Contribution Checklist.