### PR TITLE
fix(validation): allow relative-date filter references

### DIFF
--- a/src/desktop/validation/rules/invalidColumnInstancePivot.test.ts
+++ b/src/desktop/validation/rules/invalidColumnInstancePivot.test.ts
@@ -30,6 +30,30 @@ describe('invalid-column-instance-pivot rule', () => {
     expect(rule.validate(xml)).toHaveLength(0);
   });
 
+  it('accepts a relative-date filter and its matching slice without a column-instance declaration', () => {
+    const xml = `<worksheet name="Relative Date">
+      <table><view>
+        <filter class="relative-date" column="[DS].[none:Close Date:qk]" first-period="-30" last-period="0" period-type-v2="day" />
+        <slices><column>[DS].[none:Close Date:qk]</column></slices>
+      </view></table>
+    </worksheet>`;
+
+    expect(rule.validate(xml)).toHaveLength(0);
+  });
+
+  it('does not let a relative-date filter exempt the same none:qk reference on a shelf', () => {
+    const xml = `<worksheet name="Relative Date">
+      <table><view>
+        <filter class="relative-date" column="[DS].[none:Close Date:qk]" first-period="-30" last-period="0" period-type-v2="day" />
+        <slices><column>[DS].[none:Close Date:qk]</column></slices>
+      </view><rows>[DS].[none:Close Date:qk]</rows></table>
+    </worksheet>`;
+
+    const issues = rule.validate(xml);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].message).toMatch(/\[none:Close Date:qk\]/);
+  });
+
   it('accepts a Desktop-declared quantitative None instance in the same datasource scope', () => {
     const xml = `<worksheet><table><view>
       <datasource-dependencies datasource="DS">

--- a/src/desktop/validation/rules/invalidColumnInstancePivot.ts
+++ b/src/desktop/validation/rules/invalidColumnInstancePivot.ts
@@ -4,10 +4,13 @@ const INVALID_NONE_QK = /\[none:([^:\]]+):qk\]/gi;
 const NAME_ATTR = /\bname=(?:'([^']*)'|"([^"]*)")/;
 const COLUMN_ATTR = /\bcolumn=(?:'([^']*)'|"([^"]*)")/;
 const DATASOURCE_ATTR = /\bdatasource=(?:'([^']*)'|"([^"]*)")/;
+const CLASS_ATTR = /\bclass=(?:'([^']*)'|"([^"]*)")/;
 const DERIVATION_ATTR = /\bderivation=(?:'([^']*)'|"([^"]*)")/;
 const TYPE_ATTR = /\btype=(?:'([^']*)'|"([^"]*)")/;
 const NONE_QK_NAME = /^\[none:([^:\]]+):qk\]$/i;
 const COLUMN_INSTANCE_TAG = /<column-instance\b[^>]*>/gi;
+const FILTER_TAG = /<filter\b[^>]*>/gi;
+const RELATIVE_NONE_QK_COLUMN = /^(?:\[(.*)\]\.)?\[none:([^:\]]+):qk\]$/i;
 
 interface ScopeBlock {
   start: number;
@@ -22,7 +25,7 @@ function stripOuterBrackets(name: string): string {
 
 function findBlocks(
   xml: string,
-  tag: 'datasource-dependencies' | 'datasource' | 'worksheet',
+  tag: 'datasource-dependencies' | 'datasource' | 'worksheet' | 'slices',
 ): ScopeBlock[] {
   const blocks: ScopeBlock[] = [];
   const openNeedle = `<${tag}`;
@@ -74,6 +77,7 @@ export const invalidColumnInstancePivotRule: ValidationRule = {
     const worksheetBlocks = findBlocks(source, 'worksheet');
     const dependencyBlocks = findBlocks(source, 'datasource-dependencies');
     const datasourceBlocks = findBlocks(source, 'datasource');
+    const sliceBlocks = findBlocks(source, 'slices');
     const topLevelDeclarations = new Set<string>();
 
     for (const match of source.matchAll(COLUMN_INSTANCE_TAG)) {
@@ -121,6 +125,43 @@ export const invalidColumnInstancePivotRule: ValidationRule = {
         : undefined;
     };
 
+    const relativeDateKeysByWorksheet = new Map<ScopeBlock | undefined, Set<string>>();
+    const relativeDateFilterRanges: Array<{ start: number; end: number }> = [];
+    const instanceKey = (field: string, datasource: string | undefined): string =>
+      JSON.stringify([datasource ?? null, field]);
+
+    for (const match of source.matchAll(FILTER_TAG)) {
+      const tag = match[0];
+      const classAttribute = CLASS_ATTR.exec(tag);
+      const filterClass = classAttribute ? (classAttribute[1] ?? classAttribute[2]) : '';
+      if (filterClass.toLowerCase() !== 'relative-date') continue;
+      const columnAttribute = COLUMN_ATTR.exec(tag);
+      const column = columnAttribute ? (columnAttribute[1] ?? columnAttribute[2]) : '';
+      const relativeColumn = RELATIVE_NONE_QK_COLUMN.exec(column);
+      if (!relativeColumn) continue;
+
+      const index = match.index ?? 0;
+      const worksheet = blockAt(worksheetBlocks, index);
+      const keys = relativeDateKeysByWorksheet.get(worksheet) ?? new Set<string>();
+      keys.add(instanceKey(relativeColumn[2].trim(), relativeColumn[1]));
+      relativeDateKeysByWorksheet.set(worksheet, keys);
+      relativeDateFilterRanges.push({ start: index, end: index + tag.length });
+    }
+
+    const isAllowedRelativeDateReference = (
+      field: string,
+      datasource: string | undefined,
+      index: number,
+    ): boolean => {
+      const worksheet = blockAt(worksheetBlocks, index);
+      const keys = relativeDateKeysByWorksheet.get(worksheet);
+      if (!keys?.has(instanceKey(field, datasource))) return false;
+      if (relativeDateFilterRanges.some((range) => index >= range.start && index < range.end)) {
+        return true;
+      }
+      return blockAt(sliceBlocks, index) !== undefined;
+    };
+
     const declarationExists = (
       field: string,
       datasource: string | undefined,
@@ -147,10 +188,12 @@ export const invalidColumnInstancePivotRule: ValidationRule = {
       const field = match[1].trim();
       if (issued.has(field)) continue;
       const index = match.index ?? 0;
+      const datasource = datasourceForRef(index);
+      if (isAllowedRelativeDateReference(field, datasource, index)) continue;
       const owner = blockAt(dependencyBlocks, index) ?? blockAt(datasourceBlocks, index);
       const declared = owner
         ? owner.declaredQuantitativeInstances.has(field)
-        : declarationExists(field, datasourceForRef(index), index);
+        : declarationExists(field, datasource, index);
       if (declared) continue;
 
       issued.add(field);


### PR DESCRIPTION
## Decision

The `invalid-column-instance-pivot` rule now accepts `[none:<date>:qk]` only when a relative-date filter uses it, including that filter's matching `<slices>` entry.

**This is a rule we now keep:** relative-date filter references are valid Tableau XML even without a general-purpose quantitative column-instance declaration. The same reference on a shelf or in another context still fails validation.

## Scope

- Recognizes relative-date filter references within the same worksheet.
- Allows the matching slice entry Tableau writes for that filter.
- Does not normalize or rewrite the template XML.
- Does not exempt other `none:...:qk` references.

## Why

PR #723's artifact path assembles a whole workbook and runs the full workbook validator before apply. That exposed an old validator assumption: every undeclared `none:...:qk` reference was treated as fabricated. Desktop accepts this shape for relative-date filters, and Nawar's repro applied and verified after disabling only this rule.

## What future work must preserve

Keep this exception tied to the relative-date filter and its slice. Do not turn it into a broad date-field exemption.

## Evidence

- Added a regression for an undeclared relative-date filter plus its matching slice.
- Added a negative regression proving the same reference still fails on a shelf.
- Red before the fix: the relative-date case failed with `invalid-column-instance-pivot`.
- `scripts/agent-check`: all six checks passed.
  - 5,609 general tests.
  - 3,309 desktop tests.
  - Lint, typecheck, desktop build, and lockstep checks passed.

## Reviewer decision

Approving this means relative-date template filters can pass preflight without weakening the guard for fabricated column-instance references.

Posted by MattGPT on Matt Filbert's behalf.