### PR TITLE
fix(apply): ignore unchanged workbook errors

### DIFF
--- a/src/desktop/commands/workbook/loadWorksheetXml.test.ts
+++ b/src/desktop/commands/workbook/loadWorksheetXml.test.ts
@@ -564,6 +564,150 @@ describe('loadWorksheetXml (External Client API transport)', () => {
     if (result.isOk()) expect(result.value.readbackVerification?.status).toBe('passed');
   });
 
+  it('does not let an unchanged pre-existing workbook error veto an artifact apply', async () => {
+    vi.mocked(validationRegistry.runValidation).mockRestore();
+    const baseline = liveWorkbook(['Sheet 1', 'Existing']).replace(
+      "<window class='worksheet' name='Existing' />",
+      '',
+    );
+    const dispatchState = { attempted: false };
+    let liveXml = baseline;
+    const applyWorkbookDocument = vi.fn(
+      async (
+        xml: string,
+        _signal: AbortSignal,
+        options?: { expectedInstanceId?: string; onDispatch?: () => void },
+      ) => {
+        options?.onDispatch?.();
+        liveXml = xml;
+        return Ok({ command_id: 'apply-artifact', status: 'completed', submitted_at: '' });
+      },
+    );
+    const executor = {
+      getWorkbookDocument: vi.fn(async () =>
+        Ok({ xml: liveXml, applicationVersion: undefined, xsdPayloadVersion: undefined }),
+      ),
+      applyWorkbookDocument,
+    } as unknown as ToolExecutor;
+
+    const result = await loadWorksheetXml({
+      worksheetName,
+      xml: validXml,
+      executor,
+      signal: mockSignal,
+      focus: NO_FOCUS,
+      artifactApply: {
+        windowXml: `<window class='worksheet' name='${worksheetName}' />`,
+        expectedTargetState: captureTargetWorksheetState(baseline, worksheetName, validXml),
+        expectedInstanceId: 'inst-build',
+        dispatchState,
+      },
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(dispatchState.attempted).toBe(true);
+    expect(applyWorkbookDocument).toHaveBeenCalledTimes(1);
+  });
+
+  it('still rejects a workbook-only error introduced by artifact assembly', async () => {
+    vi.mocked(validationRegistry.runValidation).mockRestore();
+    const baseline = liveWorkbook(['Sheet 1']);
+    const xmlWithMissingSet = `<worksheet name='${worksheetName}'><table>
+      <datasource-dependencies datasource='DS'>
+        <column name='[Calculation_1]'>
+          <calculation class='tableau' formula='IF [Missing Set] THEN &quot;yes&quot; ELSE &quot;no&quot; END'/>
+        </column>
+      </datasource-dependencies>
+    </table></worksheet>`;
+    const dispatchState = { attempted: false };
+    const applyWorkbookDocument = vi.fn();
+    const executor = {
+      getWorkbookDocument: vi.fn(async () =>
+        Ok({ xml: baseline, applicationVersion: undefined, xsdPayloadVersion: undefined }),
+      ),
+      applyWorkbookDocument,
+    } as unknown as ToolExecutor;
+
+    const result = await loadWorksheetXml({
+      worksheetName,
+      xml: xmlWithMissingSet,
+      executor,
+      signal: mockSignal,
+      focus: NO_FOCUS,
+      artifactApply: {
+        windowXml: `<window class='worksheet' name='${worksheetName}' />`,
+        expectedTargetState: captureTargetWorksheetState(
+          baseline,
+          worksheetName,
+          xmlWithMissingSet,
+        ),
+        expectedInstanceId: 'inst-build',
+        dispatchState,
+      },
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      invariant(result.error.type === 'load-worksheet-xml-error');
+      invariant(result.error.error.type === 'validation-failed');
+      expect(result.error.error.issues).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ ruleId: 'undeclared-set-reference', severity: 'error' }),
+        ]),
+      );
+    }
+    expect(dispatchState.attempted).toBe(false);
+    expect(applyWorkbookDocument).not.toHaveBeenCalled();
+  });
+
+  it('rejects a new copy of a workbook error already present on a sibling sheet', async () => {
+    vi.mocked(validationRegistry.runValidation).mockRestore();
+    const missingSetCalculation =
+      "<column name='[Calculation_1]'><calculation class='tableau' formula='IF [Missing Set] THEN &quot;yes&quot; ELSE &quot;no&quot; END'/></column>";
+    const baseline = liveWorkbook(['Sheet 1', 'Existing']).replace(
+      "<worksheet name='Existing'><table /></worksheet>",
+      `<worksheet name='Existing'><table><datasource-dependencies datasource='DS'>${missingSetCalculation}</datasource-dependencies></table></worksheet>`,
+    );
+    const targetXml = `<worksheet name='${worksheetName}'><table><datasource-dependencies datasource='DS'>${missingSetCalculation}</datasource-dependencies></table></worksheet>`;
+    const dispatchState = { attempted: false };
+    const applyWorkbookDocument = vi.fn(async () =>
+      Ok({ command_id: 'unexpected-apply', status: 'completed', submitted_at: '' }),
+    );
+    const executor = {
+      getWorkbookDocument: vi.fn(async () =>
+        Ok({ xml: baseline, applicationVersion: undefined, xsdPayloadVersion: undefined }),
+      ),
+      applyWorkbookDocument,
+    } as unknown as ToolExecutor;
+
+    const result = await loadWorksheetXml({
+      worksheetName,
+      xml: targetXml,
+      executor,
+      signal: mockSignal,
+      focus: NO_FOCUS,
+      artifactApply: {
+        windowXml: `<window class='worksheet' name='${worksheetName}' />`,
+        expectedTargetState: captureTargetWorksheetState(baseline, worksheetName, targetXml),
+        expectedInstanceId: 'inst-build',
+        dispatchState,
+      },
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      invariant(result.error.type === 'load-worksheet-xml-error');
+      invariant(result.error.error.type === 'validation-failed');
+      expect(result.error.error.issues).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ ruleId: 'undeclared-set-reference', severity: 'error' }),
+        ]),
+      );
+    }
+    expect(dispatchState.attempted).toBe(false);
+    expect(applyWorkbookDocument).not.toHaveBeenCalled();
+  });
+
   it('rejects scoped target drift before dispatch', async () => {
     const baseline = liveWorkbook(['Sheet 1', 'Other']);
     const latest = baseline.replace(

--- a/src/desktop/commands/workbook/loadWorksheetXml.ts
+++ b/src/desktop/commands/workbook/loadWorksheetXml.ts
@@ -23,7 +23,11 @@ import {
   type ReadbackVerificationResult,
   verifyWorksheetReadback,
 } from '../../validation/readback-verify.js';
-import { blockingValidationIssues, runValidation } from '../../validation/registry.js';
+import {
+  blockingValidationIssues,
+  introducedBlockingValidationIssues,
+  runValidation,
+} from '../../validation/registry.js';
 import { ValidationIssue } from '../../validation/types.js';
 import { xmlNamesEqual } from '../../xmlElement.js';
 import { type ApplyFocus } from './applyFocus.js';
@@ -395,6 +399,8 @@ export async function loadWorksheetXml({
         });
       }
 
+      const baselineValidation = runValidation(workbookResult.value, 'workbook');
+
       let workbookDoc: string;
       try {
         workbookDoc = upsertWorksheetAndWindowIntoWorkbook(
@@ -408,7 +414,10 @@ export async function loadWorksheetXml({
       }
 
       const workbookValidation = runValidation(workbookDoc, 'workbook');
-      const workbookBlockingIssues = blockingValidationIssues(workbookValidation.issues);
+      const workbookBlockingIssues = introducedBlockingValidationIssues(
+        baselineValidation.issues,
+        workbookValidation.issues,
+      );
       if (workbookBlockingIssues.length > 0) {
         return Err({
           type: 'load-worksheet-xml-error',

--- a/src/desktop/validation/registry.test.ts
+++ b/src/desktop/validation/registry.test.ts
@@ -1,7 +1,50 @@
-import { runValidation } from './registry.js';
-import type { ValidationRule } from './types.js';
+import { introducedBlockingValidationIssues, runValidation } from './registry.js';
+import type { ValidationIssue, ValidationRule } from './types.js';
 
 describe('validation framework', () => {
+  describe('introducedBlockingValidationIssues', () => {
+    const issue = (overrides: Partial<ValidationIssue> = {}): ValidationIssue => ({
+      ruleId: 'test-rule',
+      severity: 'error',
+      message: 'existing problem',
+      xpath: '//worksheet[@name="Existing"]',
+      ...overrides,
+    });
+
+    it('ignores an unchanged blocking issue from the baseline workbook', () => {
+      expect(introducedBlockingValidationIssues([issue()], [issue()])).toEqual([]);
+    });
+
+    it('returns a newly introduced blocking issue', () => {
+      const introduced = issue({ xpath: '//worksheet[@name="New"]' });
+
+      expect(introducedBlockingValidationIssues([issue()], [issue(), introduced])).toEqual([
+        introduced,
+      ]);
+    });
+
+    it('returns an extra duplicate of a baseline blocking issue', () => {
+      const duplicate = issue();
+
+      expect(introducedBlockingValidationIssues([issue()], [issue(), duplicate])).toEqual([
+        duplicate,
+      ]);
+    });
+
+    it('returns an aggregated issue whose occurrence count increased', () => {
+      const baseline = issue({ occurrenceCount: 1 });
+      const candidate = issue({ occurrenceCount: 2 });
+
+      expect(introducedBlockingValidationIssues([baseline], [candidate])).toEqual([candidate]);
+    });
+
+    it('ignores warning-only differences', () => {
+      const warning = issue({ severity: 'warning', message: 'new warning' });
+
+      expect(introducedBlockingValidationIssues([], [warning])).toEqual([]);
+    });
+  });
+
   it('returns valid=true when no issues are emitted', () => {
     const passRule: ValidationRule = {
       id: 'test-pass-rule',

--- a/src/desktop/validation/registry.ts
+++ b/src/desktop/validation/registry.ts
@@ -17,6 +17,30 @@ export function blockingValidationIssues(issues: ValidationIssue[]): ValidationI
   return issues.filter((issue) => issue.severity === 'error');
 }
 
+export function introducedBlockingValidationIssues(
+  baselineIssues: ValidationIssue[],
+  candidateIssues: ValidationIssue[],
+): ValidationIssue[] {
+  const baselineCounts = new Map<string, number>();
+  for (const issue of blockingValidationIssues(baselineIssues)) {
+    const key = validationIssueKey(issue);
+    baselineCounts.set(key, (baselineCounts.get(key) ?? 0) + (issue.occurrenceCount ?? 1));
+  }
+
+  return blockingValidationIssues(candidateIssues).filter((issue) => {
+    const key = validationIssueKey(issue);
+    const remaining = baselineCounts.get(key) ?? 0;
+    const candidateCount = issue.occurrenceCount ?? 1;
+    if (remaining < candidateCount) return true;
+    baselineCounts.set(key, remaining - candidateCount);
+    return false;
+  });
+}
+
+function validationIssueKey(issue: ValidationIssue): string {
+  return JSON.stringify([issue.ruleId, issue.message, issue.xpath ?? null]);
+}
+
 export function runValidation(
   xml: string,
   context: ValidationContext,

--- a/src/desktop/validation/rules/aggregateCalcDerivation.test.ts
+++ b/src/desktop/validation/rules/aggregateCalcDerivation.test.ts
@@ -48,6 +48,18 @@ describe('aggregate-calc-derivation rule', () => {
     expect(issues).toHaveLength(0);
   });
 
+  it('counts equivalent invalid instances so a new duplicate remains detectable', () => {
+    const xml = calcWithCi('SUM([Sales])', 'None', '[none:Calculation_1:qk]').replace(
+      '</datasource-dependencies>',
+      '<column-instance name="[none:Calculation_1:qk]" column="[Calculation_1]" derivation="None" pivot="key" type="quantitative" /></datasource-dependencies>',
+    );
+
+    const issues = aggregateCalcDerivationRule.validate(xml);
+
+    expect(issues).toHaveLength(1);
+    expect(issues[0].occurrenceCount).toBe(2);
+  });
+
   it('does not fire on a row-level calc used as none:', () => {
     const issues = aggregateCalcDerivationRule.validate(
       calcWithCi('[Sales] * 2', 'None', '[none:Calculation_1:qk]'),

--- a/src/desktop/validation/rules/aggregateCalcDerivation.ts
+++ b/src/desktop/validation/rules/aggregateCalcDerivation.ts
@@ -104,20 +104,23 @@ export const aggregateCalcDerivationRule: ValidationRule = {
     }
     if (aggregateCalcNames.size === 0) return [];
 
-    const issues: ValidationIssue[] = [];
-    const seen = new Set<string>();
+    const issuesByInstance = new Map<string, ValidationIssue>();
     const cis = xpath.select('//column-instance[@column]', doc as unknown as Node) as Element[];
     for (const ci of cis) {
       const colRef = ci.getAttribute('column') ?? '';
       if (!aggregateCalcNames.has(colRef) || !isNoneDerivation(ci)) continue;
 
       const ciName = ci.getAttribute('name') ?? '';
-      if (seen.has(ciName)) continue;
-      seen.add(ciName);
+      const existing = issuesByInstance.get(ciName);
+      if (existing) {
+        existing.occurrenceCount = (existing.occurrenceCount ?? 1) + 1;
+        continue;
+      }
 
-      issues.push({
+      issuesByInstance.set(ciName, {
         ruleId: 'aggregate-calc-derivation',
         severity: 'error',
+        occurrenceCount: 1,
         message:
           `Aggregate/table-calc calculated field ${colRef} is referenced by a none:/derivation="None" ` +
           `column-instance (${ciName || '(unnamed)'}). An aggregate or table-calc calc must use derivation="User" ` +
@@ -130,6 +133,6 @@ export const aggregateCalcDerivationRule: ValidationRule = {
       });
     }
 
-    return issues;
+    return [...issuesByInstance.values()];
   },
 };

--- a/src/desktop/validation/rules/dateFieldBoundAsString.test.ts
+++ b/src/desktop/validation/rules/dateFieldBoundAsString.test.ts
@@ -75,6 +75,18 @@ describe('date-field-bound-as-string rule', () => {
     expect(dateFieldBoundAsStringRule.validate(xml)).toHaveLength(0);
   });
 
+  it('counts equivalent invalid bindings so a new duplicate remains detectable', () => {
+    const issues = dateFieldBoundAsStringRule.validate(
+      workbook(`
+        <cols>[ds].[none:month:nk]</cols>
+        <cols>[ds].[none:month:nk]</cols>
+      `),
+    );
+
+    expect(issues).toHaveLength(1);
+    expect(issues[0].occurrenceCount).toBe(2);
+  });
+
   it('stays silent when a date field is used on filters or encodings instead of rows/cols', () => {
     const xml = workbook(`
       <cols>[ds].[sum:mau:qk]</cols>

--- a/src/desktop/validation/rules/dateFieldBoundAsString.ts
+++ b/src/desktop/validation/rules/dateFieldBoundAsString.ts
@@ -130,8 +130,7 @@ export const dateFieldBoundAsStringRule: ValidationRule = {
     }
     if (allDateFields.size === 0) return [];
 
-    const issues: ValidationIssue[] = [];
-    const issued = new Set<string>();
+    const issuesByBinding = new Map<string, ValidationIssue>();
     const shelves = xpath.select('//rows | //cols', doc as unknown as Node) as Element[];
 
     for (const shelf of shelves) {
@@ -140,15 +139,19 @@ export const dateFieldBoundAsStringRule: ValidationRule = {
         if (!isDatasourceDeclaredDate(ref, dateFieldsByDatasource, allDateFields)) continue;
 
         const key = `${shelf.nodeName}:${ref.datasource ?? ''}:${ref.field}:${ref.pivot}`;
-        if (issued.has(key)) continue;
-        issued.add(key);
+        const existing = issuesByBinding.get(key);
+        if (existing) {
+          existing.occurrenceCount = (existing.occurrenceCount ?? 1) + 1;
+          continue;
+        }
 
         const fieldLabel = ref.datasource
           ? `[${ref.datasource}].[${ref.instance}]`
           : `[${ref.instance}]`;
-        issues.push({
+        issuesByBinding.set(key, {
           ruleId: 'date-field-bound-as-string',
           severity: 'error',
+          occurrenceCount: 1,
           message:
             `Date field "${ref.field}" is bound on ${shelf.nodeName} as raw string pill ${fieldLabel}. ` +
             'It renders as a flat categorical axis, not a time axis, so a line or trend over time is analytically wrong.',
@@ -161,6 +164,6 @@ export const dateFieldBoundAsStringRule: ValidationRule = {
       }
     }
 
-    return issues;
+    return [...issuesByBinding.values()];
   },
 };

--- a/src/desktop/validation/rules/setCountMalformedParameter.test.ts
+++ b/src/desktop/validation/rules/setCountMalformedParameter.test.ts
@@ -38,6 +38,15 @@ describe('set-count-malformed-parameter rule', () => {
     );
   });
 
+  it('counts equivalent malformed references so a new duplicate remains detectable', () => {
+    const issues = setCountMalformedParameterRule.validate(
+      workbook(bareStub, `${set('HN')}${set('HN')}`),
+    );
+
+    expect(issues).toHaveLength(1);
+    expect(issues[0].occurrenceCount).toBe(2);
+  });
+
   it('errors when the count parameter is not declared in workbook context', () => {
     const issues = setCountMalformedParameterRule.validate(workbook('', set('Nonexistent')));
 

--- a/src/desktop/validation/rules/setCountMalformedParameter.ts
+++ b/src/desktop/validation/rules/setCountMalformedParameter.ts
@@ -17,11 +17,12 @@ export const setCountMalformedParameterRule = {
     const doc = parseXml(s);
     if (!doc?.documentElement) return [];
 
-    const countRefs = new Set<string>();
+    const countRefs = new Map<string, number>();
     for (const match of s.matchAll(
       /<groupfilter\b[^>]*\bcount=(['"])\[Parameters\]\.\[([^\]]+)\]\1/gi,
     )) {
-      countRefs.add(match[2]);
+      const paramName = match[2];
+      countRefs.set(paramName, (countRefs.get(paramName) ?? 0) + 1);
     }
     if (countRefs.size === 0) return [];
 
@@ -39,14 +40,16 @@ export const setCountMalformedParameterRule = {
       .filter(Boolean);
 
     const issues: ValidationIssue[] = [];
-    for (const paramName of countRefs) {
+    for (const [paramName, occurrenceCount] of countRefs) {
       const cols = xpath.select(
         `//column[@name="[${paramName}]"]`,
         doc as unknown as Node,
       ) as Element[];
       if (cols.length === 0) {
         if (suppressUndeclared) continue;
-        issues.push(malformedIssue(paramName, 'not declared anywhere', wellFormedParams));
+        issues.push(
+          malformedIssue(paramName, 'not declared anywhere', wellFormedParams, occurrenceCount),
+        );
         continue;
       }
 
@@ -56,6 +59,7 @@ export const setCountMalformedParameterRule = {
             paramName,
             'declared as a bare <column> (no param-domain-type / no value / no <calculation>)',
             wellFormedParams,
+            occurrenceCount,
           ),
         );
       }
@@ -76,6 +80,7 @@ function malformedIssue(
   paramName: string,
   why: string,
   wellFormedParams: string[] = [],
+  occurrenceCount = 1,
 ): ValidationIssue {
   const others = wellFormedParams.filter((name) => name !== `[${paramName}]`);
   const repointHint =
@@ -95,6 +100,7 @@ function malformedIssue(
   return {
     ruleId: 'set-count-malformed-parameter',
     severity: 'error',
+    occurrenceCount,
     message:
       `A set's <groupfilter count='[Parameters].[${paramName}]'> references a parameter that is ${why}. ` +
       'The set applies but CANNOT compute at query time — Tableau throws "The filter limit expression is invalid" ' +

--- a/src/desktop/validation/rules/undeclaredSetReference.test.ts
+++ b/src/desktop/validation/rules/undeclaredSetReference.test.ts
@@ -50,6 +50,18 @@ describe('undeclared-set-reference rule', () => {
     expect(issues[0].suggestion).toMatch(/groupfilter/);
   });
 
+  it('reports the number of references so a new duplicate remains detectable', () => {
+    const xml = `<workbook><datasources><datasource name="Sample - Superstore">
+      <column name="[C1]"><calculation class="tableau" formula="IF [Missing Set] THEN &quot;yes&quot; ELSE &quot;no&quot; END"/></column>
+      <column name="[C2]"><calculation class="tableau" formula="IF [Missing Set] THEN &quot;yes&quot; ELSE &quot;no&quot; END"/></column>
+    </datasource></datasources></workbook>`;
+
+    const issues = undeclaredSetReferenceRule.validate(xml);
+
+    expect(issues).toHaveLength(1);
+    expect(issues[0].occurrenceCount).toBe(2);
+  });
+
   it('does not flag sets declared as groups', () => {
     expect(undeclaredSetReferenceRule.validate(safeDefined)).toHaveLength(0);
   });

--- a/src/desktop/validation/rules/undeclaredSetReference.ts
+++ b/src/desktop/validation/rules/undeclaredSetReference.ts
@@ -12,16 +12,19 @@ export const undeclaredSetReferenceRule: ValidationRule = {
 
   validate(xml: string): ValidationIssue[] {
     const s = String(xml ?? '');
-    const referenced = new Set<string>();
+    const referenceCounts = new Map<string, number>();
 
     for (const calc of s.matchAll(/<calculation\b[^>]*\bformula=(['"])((?:(?!\1).)*)\1/gi)) {
       const formula = stripStringLiterals(calc[2] ?? '');
-      for (const match of formula.matchAll(SET_LIKE)) referenced.add(match[0]);
+      for (const match of formula.matchAll(SET_LIKE)) {
+        const token = match[0];
+        referenceCounts.set(token, (referenceCounts.get(token) ?? 0) + 1);
+      }
     }
-    if (referenced.size === 0) return [];
+    if (referenceCounts.size === 0) return [];
 
     const issues: ValidationIssue[] = [];
-    for (const token of referenced) {
+    for (const [token, referenceCount] of referenceCounts) {
       const name = token.slice(1, -1);
       const groupRe = new RegExp(`<group\\b[^>]*\\bname=(['"])\\[${escapeRe(name)}\\]\\1`, 'i');
       if (groupRe.test(s)) continue;
@@ -32,6 +35,7 @@ export const undeclaredSetReferenceRule: ValidationRule = {
       issues.push({
         ruleId: 'undeclared-set-reference',
         severity: 'error',
+        occurrenceCount: referenceCount,
         message:
           `The set "${token}" is referenced in a calc formula but never declared as a <group name='${token}'> with a ` +
           `<groupfilter>. The XML applies, but on reload Tableau reports "Error parsing set '${token}', deleting set" and ` +

--- a/src/desktop/validation/types.ts
+++ b/src/desktop/validation/types.ts
@@ -12,6 +12,8 @@ export interface ValidationIssue {
   ruleId: string;
   severity: ValidationSeverity;
   message: string;
+  /** Number of equivalent defects represented when a rule intentionally aggregates them. */
+  occurrenceCount?: number;
   /** XPath-like location hint within the XML, if available */
   xpath?: string;
   /** Suggested remediation shown in logs / error messages */


### PR DESCRIPTION
Artifact apply now blocks errors introduced by the artifact, not unrelated errors that were already present in the workbook.

This is the rule we keep: the incoming worksheet is still validated strictly, and non-artifact apply paths are unchanged. For artifact apply, TMCP validates the fetched workbook and the assembled candidate, then rejects only new blocking findings. Aggregating validators report occurrence counts so a second copy of an existing defect cannot hide behind the first.

The regressions prove all sides of the boundary:
- an unchanged missing-window error on another sheet no longer vetoes a valid apply;
- a new workbook-only undeclared-set error still blocks before dispatch;
- a duplicate of that same pre-existing error still blocks;
- the four reachable aggregating rules remain occurrence-aware.

Validation: scripts/agent-check passes all six checks: lint, typecheck, 5,619 general tests, desktop build, 3,319 desktop tests, and lockstep hashes. Independent re-review found no remaining reachable bypass in the current validator set.

Approving this makes artifact validation relative to the workbook state it actually read, while preserving strict checks on everything the artifact adds.

Posted by MattGPT on Matt Filbert's behalf.