### PR TITLE
@W-12345678 modified metadata enhancement for getView tool to show upstream data …

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "4.3.1",
+  "version": "4.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "4.3.1",
+      "version": "4.3.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1095.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "4.3.0",
+  "version": "4.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "4.3.0",
+      "version": "4.3.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1095.0",
@@ -639,6 +639,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -687,6 +688,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -1752,6 +1754,7 @@
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
       "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@hono/node-server": "^1.19.9",
         "ajv": "^8.17.1",
@@ -2479,6 +2482,7 @@
       "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^5.0.0",
@@ -2657,6 +2661,7 @@
       "integrity": "sha512-A0M6ua6H252bVjPvvtSgl2QA4+ET9S5Mtkb2GDyTxIhH/C4qDItT7RQNO5PhMC6NXGYXOR9dIalcDDgBKT7oFA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.60.1",
         "@typescript-eslint/types": "8.60.1",
@@ -3081,6 +3086,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3103,7 +3109,6 @@
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "debug": "4"
       },
@@ -4157,6 +4162,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4217,6 +4223,7 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -4742,7 +4749,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=4.0"
       },
@@ -5214,6 +5220,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.27.tgz",
       "integrity": "sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -5270,7 +5277,6 @@
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
       "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "agent-base": "6",
         "debug": "4"
@@ -6872,6 +6878,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6998,6 +7005,7 @@
       "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -7052,7 +7060,6 @@
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
       "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -7212,6 +7219,7 @@
       "integrity": "sha512-I4KW6iuRpuu2uHBLraZ1wNZe0DP7lnRha+VJ9tNaYVaVgKhW0aI3h4RYnoRPeql0flHm/Co55b7snEDcOfOJrA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.9"
       },
@@ -8865,6 +8873,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9001,6 +9010,7 @@
       "integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -9620,6 +9630,7 @@
       "integrity": "sha512-xejya+bT/j/+R/AGa1XOfRxLmNUlLtlwjRsFUILF+xHfzElmGcmFydy2gqqIrd62ptIEfwVMofd19uNWD9L7Nw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.6",
@@ -10029,6 +10040,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "4.3.0",
+  "version": "4.3.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "4.3.1",
+  "version": "4.3.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/src/sdks/tableau/methods/lineageUtils.test.ts
+++ b/src/sdks/tableau/methods/lineageUtils.test.ts
@@ -1,5 +1,7 @@
 import {
+  getSearchContentLineageQuery,
   getViewLineageByLuid,
+  getViewLineageQuery,
   getWorkbookLineageByLuid,
   mergeViewLineage,
   mergeWorkbookLineage,
@@ -74,6 +76,100 @@ describe('lineageUtils', () => {
         owner: { id: 'owner-1', name: 'Workbook Owner' },
         project: { id: 'project-1', name: 'Executive Project' },
         upstreamDatasources: [{ luid: 'datasource-1', name: 'Sales' }],
+      },
+    ]);
+  });
+
+  it('queries both sheetsConnection and dashboardsConnection for view lineage', () => {
+    const query = getViewLineageQuery(['view-1', 'dashboard-1']);
+
+    expect(query).toContain('sheetsConnection(filter: { luidWithin: ["view-1", "dashboard-1"] })');
+    expect(query).toContain(
+      'dashboardsConnection(filter: { luidWithin: ["view-1", "dashboard-1"] })',
+    );
+  });
+
+  it('queries both sheetsConnection and dashboardsConnection in search content lineage', () => {
+    const query = getSearchContentLineageQuery({
+      workbookLuids: [],
+      viewLuids: ['view-1'],
+    });
+
+    expect(query).toContain('sheetsConnection(filter: { luidWithin: ["view-1"] })');
+    expect(query).toContain('dashboardsConnection(filter: { luidWithin: ["view-1"] })');
+  });
+
+  it('parses and merges dashboard view lineage from dashboardsConnection', () => {
+    const lineageByLuid = getViewLineageByLuid({
+      data: {
+        sheetsConnection: { nodes: [] },
+        dashboardsConnection: {
+          nodes: [
+            {
+              luid: 'dashboard-1',
+              upstreamDatasources: [
+                { luid: 'datasource-1', name: 'Data Depot' },
+                { name: 'Embedded Datasource' },
+              ],
+              workbook: {
+                luid: 'workbook-1',
+                name: 'Customer Support',
+                projectLuid: 'project-1',
+                projectName: 'Support Project',
+                owner: { luid: 'owner-1', name: 'Support Owner' },
+              },
+            },
+          ],
+        },
+      },
+    });
+
+    const result = mergeViewLineage(
+      [{ id: 'dashboard-1', workbook: { id: 'workbook-1' }, owner: {}, project: {} }],
+      lineageByLuid,
+    );
+
+    expect(result).toEqual([
+      {
+        id: 'dashboard-1',
+        workbook: { id: 'workbook-1', name: 'Customer Support' },
+        owner: { id: 'owner-1', name: 'Support Owner' },
+        project: { id: 'project-1', name: 'Support Project' },
+        upstreamDatasources: [{ luid: 'datasource-1', name: 'Data Depot' }],
+      },
+    ]);
+  });
+
+  it('merges sheet and dashboard lineage nodes from a combined response', () => {
+    const lineageByLuid = getViewLineageByLuid({
+      data: {
+        sheetsConnection: {
+          nodes: [
+            {
+              luid: 'sheet-1',
+              upstreamDatasources: [{ luid: 'ds-sheet', name: 'Sheet DS' }],
+            },
+          ],
+        },
+        dashboardsConnection: {
+          nodes: [
+            {
+              luid: 'dashboard-1',
+              upstreamDatasources: [{ luid: 'ds-dash', name: 'Dashboard DS' }],
+            },
+          ],
+        },
+      },
+    });
+
+    expect(mergeViewLineage([{ id: 'sheet-1' }, { id: 'dashboard-1' }], lineageByLuid)).toEqual([
+      {
+        id: 'sheet-1',
+        upstreamDatasources: [{ luid: 'ds-sheet', name: 'Sheet DS' }],
+      },
+      {
+        id: 'dashboard-1',
+        upstreamDatasources: [{ luid: 'ds-dash', name: 'Dashboard DS' }],
       },
     ]);
   });

--- a/src/sdks/tableau/methods/lineageUtils.ts
+++ b/src/sdks/tableau/methods/lineageUtils.ts
@@ -26,54 +26,42 @@ const workbookLineageResponseSchema = z.object({
   }),
 });
 
+const viewLineageNodeSchema = z.object({
+  luid: z.string(),
+  upstreamDatasources: z.array(lineageContentSchema).nullish(),
+  workbook: z
+    .object({
+      luid: z.string(),
+      name: z.string().nullable().optional(),
+      projectLuid: z.string().nullable().optional(),
+      projectName: z.string().nullable().optional(),
+      owner: z
+        .object({
+          luid: z.string().nullable().optional(),
+          name: z.string().nullable().optional(),
+          username: z.string().nullable().optional(),
+        })
+        .nullish(),
+    })
+    .nullish(),
+});
+
+const viewLineageConnectionSchema = z
+  .object({
+    nodes: z.array(viewLineageNodeSchema),
+  })
+  .nullish();
+
 const viewLineageResponseSchema = z.object({
   data: z.object({
-    sheetsConnection: z.object({
-      nodes: z.array(
-        z.object({
-          luid: z.string(),
-          upstreamDatasources: z.array(lineageContentSchema).nullish(),
-          workbook: z
-            .object({
-              luid: z.string(),
-              name: z.string().nullable().optional(),
-              projectLuid: z.string().nullable().optional(),
-              projectName: z.string().nullable().optional(),
-              owner: z
-                .object({
-                  luid: z.string().nullable().optional(),
-                  name: z.string().nullable().optional(),
-                  username: z.string().nullable().optional(),
-                })
-                .nullish(),
-            })
-            .nullish(),
-        }),
-      ),
-    }),
+    // REST "views" include worksheets and dashboards; Metadata API models them separately.
+    sheetsConnection: viewLineageConnectionSchema,
+    dashboardsConnection: viewLineageConnectionSchema,
   }),
 });
 
-export function getWorkbookLineageQuery(workbookLuids: Array<string>): string {
-  return `
-    query workbookLineage {
-      workbooksConnection(filter: { luidWithin: ${toGraphqlStringArray(workbookLuids)} }) {
-        nodes {
-          luid
-          upstreamDatasources {
-            luid
-            name
-          }
-        }
-      }
-    }
-  `;
-}
-
-export function getViewLineageQuery(viewLuids: Array<string>): string {
-  return `
-    query viewLineage {
-      sheetsConnection(filter: { luidWithin: ${toGraphqlStringArray(viewLuids)} }) {
+function getViewLineageConnectionQuery(connectionName: string, viewLuids: Array<string>): string {
+  return `${connectionName}(filter: { luidWithin: ${toGraphqlStringArray(viewLuids)} }) {
         nodes {
           luid
           upstreamDatasources {
@@ -94,7 +82,30 @@ export function getViewLineageQuery(viewLuids: Array<string>): string {
             }
           }
         }
+      }`;
+}
+
+export function getWorkbookLineageQuery(workbookLuids: Array<string>): string {
+  return `
+    query workbookLineage {
+      workbooksConnection(filter: { luidWithin: ${toGraphqlStringArray(workbookLuids)} }) {
+        nodes {
+          luid
+          upstreamDatasources {
+            luid
+            name
+          }
+        }
       }
+    }
+  `;
+}
+
+export function getViewLineageQuery(viewLuids: Array<string>): string {
+  return `
+    query viewLineage {
+      ${getViewLineageConnectionQuery('sheetsConnection', viewLuids)}
+      ${getViewLineageConnectionQuery('dashboardsConnection', viewLuids)}
     }
   `;
 }
@@ -123,28 +134,8 @@ export function getSearchContentLineageQuery({
       }
       ${
         viewLuids.length
-          ? `sheetsConnection(filter: { luidWithin: ${toGraphqlStringArray(viewLuids)} }) {
-        nodes {
-          luid
-          upstreamDatasources {
-            name
-            ... on PublishedDatasource {
-              luid
-            }
-          }
-          workbook {
-            luid
-            name
-            projectLuid
-            projectName
-            owner {
-              luid
-              name
-              username
-            }
-          }
-        }
-      }`
+          ? `${getViewLineageConnectionQuery('sheetsConnection', viewLuids)}
+      ${getViewLineageConnectionQuery('dashboardsConnection', viewLuids)}`
           : ''
       }
     }
@@ -163,8 +154,13 @@ export function getWorkbookLineageByLuid(response: unknown): Map<string, Array<L
 
 export function getViewLineageByLuid(response: unknown): Map<string, ViewLineage> {
   const parsed = viewLineageResponseSchema.parse(response);
+  const nodes = [
+    ...(parsed.data.sheetsConnection?.nodes ?? []),
+    ...(parsed.data.dashboardsConnection?.nodes ?? []),
+  ];
+
   return new Map(
-    parsed.data.sheetsConnection.nodes.map((node) => [
+    nodes.map((node) => [
       node.luid,
       {
         upstreamDatasources: normalizeLineageContents(node.upstreamDatasources),


### PR DESCRIPTION
View lineage enrichment missed dashboards (and stories).

get-view / list-views / search-content only queried Metadata API sheetsConnection. REST “views” also include dashboards and stories, which Metadata models under dashboardsConnection (stories are dashboards there — no separate story type).

Fix: query both connections with the same LUID filter and merge whichever nodes come back, so worksheet and dashboard/story views all get upstreamDatasources enrichment.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## How Has This Been Tested?

validated in mcp inspector

## Checklist

- [x] I have updated the version in the package.json file by using `npm run version`. For example,
      use `npm run version:patch` for a patch version bump.
- [ ] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have documented any breaking changes in the PR description. For example, renaming a config
      environment variable or changing its default value.

## Contributor Agreement

By submitting this pull request, I confirm that:

- [ ] I have read the [CONTRIBUTING guidelines](../../CONTRIBUTING.md) for this project and followed
      its Contribution Checklist.
