### PR TITLE
fix(validation): make qualified-name-brackets linear, not O(n²)

### DIFF
--- a/src/desktop/validation/rules/qualifiedNameBrackets.ts
+++ b/src/desktop/validation/rules/qualifiedNameBrackets.ts
@@ -24,12 +24,12 @@
  * false-rejects valid content (e.g. a bundled template).
  */
 import { DOMParser } from '@xmldom/xmldom';
-import * as xpath from 'xpath';
 
 import type { ValidationIssue, ValidationRule } from '../types.js';
 
 const TEXT_NODE = 3;
 const ATTRIBUTE_NODE = 2;
+const ELEMENT_NODE = 1;
 
 /**
  * Attributes / elements that carry FREE TEXT (calc formulas, captions, rich-text
@@ -135,7 +135,30 @@ export const qualifiedNameBracketsRule: ValidationRule = {
       return [];
     }
 
-    const nodes = xpath.select('//@* | //text()', doc as unknown as Node) as Node[];
+    // Collect every attribute + text node via a LINEAR iterative DOM walk.
+    // Previously this used xpath.select('//@* | //text()'), but the `xpath`
+    // package evaluates the '//@*' descendant global-attribute axis in O(n²) of
+    // total node count — on a large workbook (e.g. a live sqlproxy datasource
+    // with ~60k+ nodes) that call alone blocks the event loop for ~90s and hangs
+    // the apply preflight. The walk below visits the exact same node set in O(n).
+    const nodes: Node[] = [];
+    const stack: Node[] = doc.documentElement ? [doc.documentElement] : [];
+    while (stack.length > 0) {
+      const node = stack.pop() as Node;
+      if (node.nodeType === ELEMENT_NODE) {
+        const attrs = (node as unknown as Element).attributes;
+        for (let i = 0; i < attrs.length; i += 1) {
+          nodes.push(attrs.item(i) as unknown as Node);
+        }
+      }
+      for (let child = node.firstChild; child; child = child.nextSibling) {
+        if (child.nodeType === TEXT_NODE) {
+          nodes.push(child);
+        } else if (child.nodeType === ELEMENT_NODE) {
+          stack.push(child);
+        }
+      }
+    }
     const issues: ValidationIssue[] = [];
     const seen = new Set<string>();
 


### PR DESCRIPTION
## Decision

`qualified-name-brackets` collected nodes with `xpath.select('//@* | //text()')`. The `//@*` descendant global-attribute axis is evaluated **O(n²)** in node count by the `xpath` package, so on a large workbook the call spins a CPU core and never returns. It runs on every apply via `runValidation(_, 'workbook')`, so any apply against a large datasource hangs.

This PR swaps that select for a **linear iterative DOM walk** over the same node set (all attributes + all text nodes). No behavior change — same nodes visited, same issues reported.

## Repro / evidence

- Applying against a live sqlproxy datasource (a work-item extract: ~155 fields, ~63k attribute+text nodes, 1.5MB workbook) hangs the apply preflight.
- Timed all validation rules on that workbook: 33 finish under 220ms; `qualified-name-brackets` alone blocks past 90s and never returns.
- Confirmed clean O(n²) scaling on `//@*`: 400 / 800 / 1600 nodes = 51 / 210 / 938 ms.
- A small datasource (a few hundred nodes) stays sub-second, which is why this only surfaces on realistic/large datasources.
- After the fix: **~85ms** on the same workbook, same output (0 issues).

It's the only rule using that global-axis select.

## Tests

- The rule's 12 unit tests pass unchanged (behavior identical).
- Removed the now-unused `xpath` import.