### PR TITLE
fix(author-calc): target the real published datasource

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "2.60.4",
+  "version": "2.60.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "2.60.4",
+      "version": "2.60.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.7.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "2.60.4",
+  "version": "2.60.5",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/src/tools/desktop/authoring/datasource/authorCalc.test.ts
+++ b/src/tools/desktop/authoring/datasource/authorCalc.test.ts
@@ -23,6 +23,18 @@ const BASE_XML = [
   '</workbook>',
 ].join('');
 
+const EMBEDDED_PUBLISHED_DATASOURCE =
+  "<datasource name='Published Metadata'><column name='[ARR]' /></datasource>";
+const PUBLISHED_BASE_XML = [
+  "<?xml version='1.0' encoding='utf-8'?>",
+  "<workbook version='18.1'><datasources><datasource name='Published'>",
+  "<connection class='sqlproxy'><metadata-records><metadata-record><attributes><attribute>",
+  `<![CDATA[${EMBEDDED_PUBLISHED_DATASOURCE}]]>`,
+  '</attribute></attributes></metadata-record></metadata-records></connection>',
+  "<column caption='ARR' datatype='integer' name='[ARR]' role='measure' type='quantitative' />",
+  "</datasource></datasources><worksheets><worksheet name='Sheet 1' /></worksheets></workbook>",
+].join('');
+
 describe('authorCalcTool', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -165,6 +177,48 @@ describe('authorCalcTool', () => {
     // the splice must land INSIDE the top-level <datasources> block, before its close
     const loaded = appliedDocumentXml(applyWorkbookDocument);
     expect(loaded.indexOf("caption='Margin'")).toBeLessThan(loaded.indexOf('</datasources>'));
+  });
+
+  it('splices a calc after a published datasource CDATA payload and before the outer close', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(1_700_000_000_000);
+    const calcXml =
+      "<column caption='ARR Plus Ten' datatype='real' name='[Calculation_1700000000000]' role='measure' type='quantitative'><calculation class='tableau' formula='[ARR] + 10' /></column>";
+    const readbackXml = PUBLISHED_BASE_XML.replace(
+      '</datasource></datasources>',
+      `${calcXml}</datasource></datasources>`,
+    );
+
+    const { result, applyWorkbookDocument } = await getToolResult({
+      args: { caption: 'ARR Plus Ten', formula: '[ARR] + 10' },
+      initialXml: PUBLISHED_BASE_XML,
+      readbackXml,
+    });
+
+    expect(result.isError).toBe(false);
+    const loaded = appliedDocumentXml(applyWorkbookDocument);
+    expect(loaded.slice(loaded.indexOf('<![CDATA[') + 9, loaded.indexOf(']]>'))).toBe(
+      EMBEDDED_PUBLISHED_DATASOURCE,
+    );
+    expect(loaded.indexOf("caption='ARR Plus Ten'")).toBeGreaterThan(loaded.indexOf(']]>'));
+    expect(loaded.indexOf("caption='ARR Plus Ten'")).toBeLessThan(
+      loaded.lastIndexOf('</datasource>'),
+    );
+  });
+
+  it('rejects a datasource name that exists only inside published metadata CDATA', async () => {
+    const { result, applyWorkbookDocument } = await getToolResult({
+      args: {
+        caption: 'ARR Plus Ten',
+        formula: '[ARR] + 10',
+        datasource: 'Published Metadata',
+      },
+      initialXml: PUBLISHED_BASE_XML,
+    });
+
+    expect(result.isError).toBe(true);
+    invariant(result.content[0].type === 'text');
+    expect(result.content[0].text).toContain('Datasource "Published Metadata" was not found');
+    expect(applyWorkbookDocument).not.toHaveBeenCalled();
   });
 
   it('rejects multiple candidate datasources without a selector and lists them', async () => {

--- a/src/tools/desktop/authoring/datasource/authorCalcCore.ts
+++ b/src/tools/desktop/authoring/datasource/authorCalcCore.ts
@@ -31,6 +31,11 @@ type DatasourceElement = {
   selfClosing: boolean;
 };
 
+type XmlRange = {
+  start: number;
+  end: number;
+};
+
 export type Role = z.infer<typeof roleSchema>;
 export type Datatype = z.infer<typeof datatypeSchema>;
 
@@ -329,15 +334,29 @@ function selectTargetDatasource(
 
 function findDatasourceElements(xml: string): DatasourceElement[] {
   const elements: DatasourceElement[] = [];
+  const opaqueRanges = findOpaqueXmlRanges(xml);
   // Worksheet <dependencies> blocks clone <datasource name='...'> elements.
   // Only the top-level <datasources> block holds the real datasource definitions.
-  const blockStart = xml.indexOf('<datasources>');
-  const blockEnd = xml.indexOf('</datasources>', blockStart);
+  const blockStart = findTokenOutsideOpaque(xml, '<datasources>', 0, xml.length, opaqueRanges);
+  const blockEnd =
+    blockStart === -1
+      ? -1
+      : findTokenOutsideOpaque(
+          xml,
+          '</datasources>',
+          blockStart + '<datasources>'.length,
+          xml.length,
+          opaqueRanges,
+        );
   const scanFrom = blockStart === -1 ? 0 : blockStart;
   const scanTo = blockEnd === -1 ? xml.length : blockEnd;
   const openTagRe = /<datasource\b[^>]*(?:\/>|>)/g;
   for (const match of xml.matchAll(openTagRe)) {
-    if (match.index < scanFrom || match.index >= scanTo) {
+    if (
+      match.index < scanFrom ||
+      match.index >= scanTo ||
+      containingRange(match.index, opaqueRanges) !== undefined
+    ) {
       continue;
     }
     const openTag = match[0];
@@ -360,7 +379,7 @@ function findDatasourceElements(xml: string): DatasourceElement[] {
       });
       continue;
     }
-    const closeStart = xml.indexOf('</datasource>', openEnd);
+    const closeStart = findDatasourceClose(xml, openEnd, scanTo, opaqueRanges);
     if (closeStart === -1) {
       continue;
     }
@@ -376,6 +395,62 @@ function findDatasourceElements(xml: string): DatasourceElement[] {
     });
   }
   return elements;
+}
+
+function findOpaqueXmlRanges(xml: string): XmlRange[] {
+  const opaqueSections = [
+    { open: '<![CDATA[', close: ']]>' },
+    { open: '<!--', close: '-->' },
+    { open: '<?', close: '?>' },
+  ];
+  const ranges: XmlRange[] = [];
+  let cursor = 0;
+
+  while (cursor < xml.length) {
+    const next = opaqueSections
+      .map((section) => ({ ...section, start: xml.indexOf(section.open, cursor) }))
+      .filter((section) => section.start !== -1)
+      .sort((left, right) => left.start - right.start)[0];
+    if (!next) break;
+
+    const closeStart = xml.indexOf(next.close, next.start + next.open.length);
+    const end = closeStart === -1 ? xml.length : closeStart + next.close.length;
+    ranges.push({ start: next.start, end });
+    cursor = end;
+  }
+
+  return ranges;
+}
+
+function containingRange(offset: number, ranges: XmlRange[]): XmlRange | undefined {
+  return ranges.find((range) => range.start <= offset && offset < range.end);
+}
+
+function findTokenOutsideOpaque(
+  xml: string,
+  token: string,
+  from: number,
+  scanTo: number,
+  opaqueRanges: XmlRange[],
+): number {
+  let cursor = from;
+  while (cursor < scanTo) {
+    const tokenStart = xml.indexOf(token, cursor);
+    if (tokenStart === -1 || tokenStart >= scanTo) return -1;
+    const opaqueRange = containingRange(tokenStart, opaqueRanges);
+    if (!opaqueRange) return tokenStart;
+    cursor = opaqueRange.end;
+  }
+  return -1;
+}
+
+function findDatasourceClose(
+  xml: string,
+  from: number,
+  scanTo: number,
+  opaqueRanges: XmlRange[],
+): number {
+  return findTokenOutsideOpaque(xml, '</datasource>', from, scanTo, opaqueRanges);
 }
 
 function hasColumnCaption(datasourceXml: string, caption: string): boolean {


### PR DESCRIPTION
## Decision

Rule we now keep: `author-calc` treats CDATA, comments, and processing instructions as opaque when it locates a datasource. It selects and changes only real datasource definitions.

## Description

Published datasource metadata can contain a second `<datasource>` document inside CDATA. `author-calc` mistook that embedded closing tag for the real datasource boundary, inserted the calculation into metadata, and reported that Desktop had dropped the field.

This change scans the whole datasource element outside opaque XML ranges. It leaves embedded metadata unchanged and inserts the calculation into the real published datasource.

## Motivation and Context

Calculations worked for local files but failed against published datasources even though Desktop accepted the workbook write. The write targeted the wrong XML location, so Desktop correctly discarded it during normalization.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## How Has This Been Tested?

- Regression tests cover embedded datasource-shaped XML in CDATA and reject an explicit selector that exists only inside that metadata.
- Live published-datasource proof: a calculation failed before this change and persisted after it.
- Live local-datasource control: the same operation still persisted.
- `scripts/agent-check`: lint, typecheck, 369 test files / 5,616 tests, desktop build, and lockstep checks all pass.
- Fresh-context adversarial review found no remaining actionable issues.

## Related Issues

None.

## Checklist

- [ ] I have updated the version in the package.json file by using `npm run version`. No version bump in this feature-branch fix.
- [x] I have made any necessary changes to the documentation. No documentation change is needed.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have documented any breaking changes in the PR description. There are no breaking changes.

## Contributor Agreement

By submitting this pull request, I confirm that:

- [x] I have read the [CONTRIBUTING guidelines](../../CONTRIBUTING.md) for this project and followed its Contribution Checklist.
