### PR TITLE
Add validateUploadedWorkbook SDK support

### DIFF
--- a/src/sdks/tableau/apis/workbooksApi.ts
+++ b/src/sdks/tableau/apis/workbooksApi.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 import { paginationSchema } from '../types/pagination.js';
 import { tagsSchema } from '../types/tags.js';
 import { workbookSchema } from '../types/workbook.js';
+import { workbookValidationResultSchema } from '../types/workbookValidation.js';
 import { paginationParameters } from './paginationParameters.js';
 
 const getWorkbookEndpoint = makeEndpoint({
@@ -89,11 +90,33 @@ const addTagsToWorkbookEndpoint = makeEndpoint({
   response: z.object({ tags: tagsSchema }),
 });
 
+const validateUploadedWorkbookEndpoint = makeEndpoint({
+  method: 'post',
+  path: '/sites/:siteId/workbooks/validateUploadedWorkbook',
+  alias: 'validateUploadedWorkbook',
+  description: 'Validates a workbook that has been uploaded to the site via a file upload session.',
+  parameters: [
+    {
+      name: 'siteId',
+      type: 'Path',
+      schema: z.string(),
+    },
+    {
+      name: 'uploadSessionId',
+      type: 'Query',
+      schema: z.string(),
+      description: 'The ID of the file upload session containing the workbook to validate.',
+    },
+  ],
+  response: workbookValidationResultSchema,
+});
+
 const workbooksApi = makeApi([
   queryWorkbooksForSiteEndpoint,
   getWorkbookEndpoint,
   deleteWorkbookEndpoint,
   addTagsToWorkbookEndpoint,
+  validateUploadedWorkbookEndpoint,
 ]);
 
 export const workbooksApis = [...workbooksApi] as const satisfies ZodiosEndpointDefinitions;

--- a/src/sdks/tableau/methods/workbooksMethods.test.ts
+++ b/src/sdks/tableau/methods/workbooksMethods.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import WorkbooksMethods from './workbooksMethods.js';
+
+describe('WorkbooksMethods', () => {
+  describe('validateUploadedWorkbook', () => {
+    it('should pass siteId as a path param, uploadSessionId as a query, and an undefined body', async () => {
+      const mockApiClient = {
+        validateUploadedWorkbook: vi.fn().mockResolvedValue({
+          timestamp: '2026-06-10T14:32:18.456Z',
+          uploadId: '12345:abc',
+        }),
+      };
+
+      const workbooksMethods = new WorkbooksMethods(
+        'http://test',
+        { type: 'Bearer', token: 'test' },
+        {},
+      );
+      // @ts-expect-error - Mocking private property
+      workbooksMethods._apiClient = mockApiClient;
+
+      await workbooksMethods.validateUploadedWorkbook({
+        siteId: 'site-1',
+        uploadSessionId: 'session-42',
+      });
+
+      expect(mockApiClient.validateUploadedWorkbook).toHaveBeenCalledWith(
+        undefined,
+        expect.objectContaining({
+          params: { siteId: 'site-1' },
+          queries: { uploadSessionId: 'session-42' },
+        }),
+      );
+    });
+
+    it('should return a successful validation result including warnings', async () => {
+      const result = {
+        timestamp: '2026-06-10T14:32:18.456Z',
+        uploadId: '12345:abc',
+        warnings: [
+          {
+            severity: 'WARNING',
+            message: 'Unknown map source is used',
+            line: 245,
+            column: 18,
+            elementName: 'map',
+          },
+        ],
+      };
+      const mockApiClient = {
+        validateUploadedWorkbook: vi.fn().mockResolvedValue(result),
+      };
+
+      const workbooksMethods = new WorkbooksMethods(
+        'http://test',
+        { type: 'Bearer', token: 'test' },
+        {},
+      );
+      // @ts-expect-error - Mocking private property
+      workbooksMethods._apiClient = mockApiClient;
+
+      const validation = await workbooksMethods.validateUploadedWorkbook({
+        siteId: 'site-1',
+        uploadSessionId: 'session-42',
+      });
+
+      expect(validation).toEqual(result);
+    });
+
+    it('should return a validation result carrying structured errors and warnings', async () => {
+      const result = {
+        timestamp: '2026-06-10T14:32:18.456Z',
+        errors: [
+          {
+            severity: 'ERROR',
+            message: 'Missing required closing tag for element',
+            line: 127,
+            column: 5,
+            elementName: 'preferences',
+          },
+        ],
+        warnings: [
+          {
+            severity: 'WARNING',
+            message: 'Unknown map source is used',
+            line: 245,
+            column: 18,
+            elementName: 'map',
+          },
+        ],
+      };
+      const mockApiClient = {
+        validateUploadedWorkbook: vi.fn().mockResolvedValue(result),
+      };
+
+      const workbooksMethods = new WorkbooksMethods(
+        'http://test',
+        { type: 'Bearer', token: 'test' },
+        {},
+      );
+      // @ts-expect-error - Mocking private property
+      workbooksMethods._apiClient = mockApiClient;
+
+      const validation = await workbooksMethods.validateUploadedWorkbook({
+        siteId: 'site-1',
+        uploadSessionId: 'session-42',
+      });
+
+      expect(validation.errors).toEqual(result.errors);
+      expect(validation.warnings).toEqual(result.warnings);
+      expect(validation.uploadId).toBeUndefined();
+    });
+  });
+});

--- a/src/sdks/tableau/methods/workbooksMethods.ts
+++ b/src/sdks/tableau/methods/workbooksMethods.ts
@@ -5,6 +5,7 @@ import { workbooksApis } from '../apis/workbooksApi.js';
 import { RestApiCredentials } from '../restApi.js';
 import { Pagination } from '../types/pagination.js';
 import { Workbook } from '../types/workbook.js';
+import { WorkbookValidationResult } from '../types/workbookValidation.js';
 import AuthenticatedMethods from './authenticatedMethods.js';
 
 /**
@@ -127,5 +128,28 @@ export default class WorkbooksMethods extends AuthenticatedMethods<typeof workbo
         ...this.authHeader,
       },
     );
+  };
+
+  /**
+   * Validates a workbook that has been uploaded to the site via a file upload session.
+   *
+   * Required scopes: `tableau:workbooks:create`
+   *
+   * @param siteId - The Tableau site ID
+   * @param uploadSessionId - The ID of the file upload session containing the workbook to validate.
+   * @link https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref_workbooks_and_views.htm#validate_uploaded_workbook
+   */
+  validateUploadedWorkbook = async ({
+    siteId,
+    uploadSessionId,
+  }: {
+    siteId: string;
+    uploadSessionId: string;
+  }): Promise<WorkbookValidationResult> => {
+    return await this._apiClient.validateUploadedWorkbook(undefined, {
+      params: { siteId },
+      queries: { uploadSessionId },
+      ...this.authHeader,
+    });
   };
 }

--- a/src/sdks/tableau/restApi.ts
+++ b/src/sdks/tableau/restApi.ts
@@ -43,7 +43,7 @@ export type RestApiCredentials =
  */
 export class RestApi {
   private static _host: string;
-  private static _version = '3.24';
+  private static _version = '3.29';
 
   private _creds?: RestApiCredentials;
   private _maxRequestTimeoutMs: number;

--- a/src/sdks/tableau/types/workbookValidation.test.ts
+++ b/src/sdks/tableau/types/workbookValidation.test.ts
@@ -1,0 +1,73 @@
+import { validationIssueSchema, workbookValidationResultSchema } from './workbookValidation.js';
+
+describe('validationIssueSchema', () => {
+  it('accepts a valid validation issue', () => {
+    const issue = {
+      severity: 'ERROR',
+      message: 'Missing required closing tag for element',
+      line: 127,
+      column: 5,
+      elementName: 'preferences',
+    };
+    expect(() => validationIssueSchema.parse(issue)).not.toThrow();
+  });
+
+  it('rejects an issue with a non-numeric line', () => {
+    const issue = {
+      severity: 'ERROR',
+      message: 'bad',
+      line: 'x',
+      column: 5,
+      elementName: 'preferences',
+    };
+    expect(() => validationIssueSchema.parse(issue)).toThrow();
+  });
+});
+
+describe('workbookValidationResultSchema', () => {
+  it('accepts a 200 success body with only a timestamp, uploadId, and warnings', () => {
+    const body = {
+      timestamp: '2026-06-10T14:32:18.456Z',
+      uploadId: '12345:abc',
+      warnings: [
+        {
+          severity: 'WARNING',
+          message: 'Unknown map source is used',
+          line: 245,
+          column: 18,
+          elementName: 'map',
+        },
+      ],
+    };
+    expect(() => workbookValidationResultSchema.parse(body)).not.toThrow();
+  });
+
+  it('accepts a 422 failure body with errors and no uploadId', () => {
+    const body = {
+      timestamp: '2026-06-10T14:32:18.456Z',
+      errors: [
+        {
+          severity: 'ERROR',
+          message: 'Missing required closing tag for element',
+          line: 127,
+          column: 5,
+          elementName: 'preferences',
+        },
+      ],
+      warnings: [],
+    };
+    const parsed = workbookValidationResultSchema.parse(body);
+    expect(parsed.uploadId).toBeUndefined();
+    expect(parsed.errors).toHaveLength(1);
+  });
+
+  it('accepts a minimal body with just a timestamp', () => {
+    expect(() =>
+      workbookValidationResultSchema.parse({ timestamp: '2026-06-10T14:32:18.456Z' }),
+    ).not.toThrow();
+  });
+
+  it('rejects a body missing the required timestamp', () => {
+    expect(() => workbookValidationResultSchema.parse({ uploadId: '12345:abc' })).toThrow();
+  });
+});

--- a/src/sdks/tableau/types/workbookValidation.ts
+++ b/src/sdks/tableau/types/workbookValidation.ts
@@ -1,0 +1,20 @@
+import { z } from 'zod';
+
+export const validationIssueSchema = z.object({
+  severity: z.string(),
+  message: z.string(),
+  line: z.number(),
+  column: z.number(),
+  elementName: z.string(),
+});
+
+export type ValidationIssue = z.infer<typeof validationIssueSchema>;
+
+export const workbookValidationResultSchema = z.object({
+  timestamp: z.string(),
+  uploadId: z.string().optional(),
+  errors: z.array(validationIssueSchema).optional(),
+  warnings: z.array(validationIssueSchema).optional(),
+});
+
+export type WorkbookValidationResult = z.infer<typeof workbookValidationResultSchema>;


### PR DESCRIPTION
## Description
- Adds the Zodios endpoint + method for Tableau's Validate Uploaded Workbook REST API (SDK layer only, no MCP tool).
- New `WorkbookValidationResult` type covering both the 200-success (warnings) and 422-failure (errors + warnings) response shapes.
- Bumps SDK API version 3.24 → 3.29 (required by this endpoint).

## Motivation and Context
Enables validating a TWB already staged via the file-upload API, ahead of a future MCP tool.

## Type of Change
- [x] New feature

## How Has This Been Tested?
Full suite (`npx vitest run`), `tsc --noEmit`, and lint all pass. New tests cover the schema (both response shapes) and the method (correct params/queries/body-less POST).

## Related Issues
None

## Checklist
- [x] New and existing unit tests pass locally with my changes