### PR TITLE
feat(telemetry): measure Desktop authoring work

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "2.60.5",
+  "version": "2.60.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "2.60.5",
+      "version": "2.60.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.7.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "2.60.5",
+  "version": "2.60.7",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/src/desktop/episode-events.test.ts
+++ b/src/desktop/episode-events.test.ts
@@ -77,6 +77,61 @@ describe('episode event writer', () => {
     expect(events[0].ts).toEqual(expect.any(String));
     expect(readdirSync(dir)[0]).toMatch(/^episodes-.*\.jsonl$/);
   });
+
+  it('writes only bounded metadata for startup, Desktop RPC, and batch events', async () => {
+    const dir = tmpDir();
+    const cfg = config({ episodeEventsEnabled: true, episodeEventsDirectory: dir });
+
+    await emitEpisodeEvent(cfg, {
+      type: 'tool_schemas_registered',
+      profile: 'dynamic-authoring',
+      tool_count: 32,
+      schemas_json_chars: 27_000,
+      instructions_chars: 3_000,
+    });
+    await emitEpisodeEvent(cfg, {
+      type: 'desktop_rpc',
+      session_id: 'S1',
+      operation: 'document_apply',
+      duration_ms: 12,
+      transport_success: true,
+      rescan_count: 0,
+    });
+    await emitEpisodeEvent(cfg, {
+      type: 'batch_apply',
+      session_id: 'S1',
+      artifact_count: 2,
+      existing_worksheet_count: 1,
+      duration_ms: 25,
+      outcome: 'succeeded',
+    });
+
+    expect(readEvents(dir)).toMatchObject([
+      {
+        type: 'tool_schemas_registered',
+        profile: 'dynamic-authoring',
+        tool_count: 32,
+        schemas_json_chars: 27_000,
+        instructions_chars: 3_000,
+      },
+      {
+        type: 'desktop_rpc',
+        session_id: 'S1',
+        operation: 'document_apply',
+        duration_ms: 12,
+        transport_success: true,
+        rescan_count: 0,
+      },
+      {
+        type: 'batch_apply',
+        session_id: 'S1',
+        artifact_count: 2,
+        existing_worksheet_count: 1,
+        duration_ms: 25,
+        outcome: 'succeeded',
+      },
+    ]);
+  });
 });
 
 describe('episode lifecycle events', () => {

--- a/src/desktop/episode-events.test.ts
+++ b/src/desktop/episode-events.test.ts
@@ -84,6 +84,7 @@ describe('episode event writer', () => {
 
     await emitEpisodeEvent(cfg, {
       type: 'tool_schemas_registered',
+      surface: 'desktop',
       profile: 'dynamic-authoring',
       tool_count: 32,
       schemas_json_chars: 27_000,
@@ -109,6 +110,7 @@ describe('episode event writer', () => {
     expect(readEvents(dir)).toMatchObject([
       {
         type: 'tool_schemas_registered',
+        surface: 'desktop',
         profile: 'dynamic-authoring',
         tool_count: 32,
         schemas_json_chars: 27_000,

--- a/src/desktop/episode-events.ts
+++ b/src/desktop/episode-events.ts
@@ -109,6 +109,7 @@ export type EpisodeEventInput =
     })
   | (EventBase & {
       type: 'tool_schemas_registered';
+      surface: 'desktop';
       profile: ToolSchemaProfile;
       tool_count: number;
       schemas_json_chars: number;

--- a/src/desktop/episode-events.ts
+++ b/src/desktop/episode-events.ts
@@ -24,12 +24,31 @@ export type EpisodeStatus = 'succeeded' | 'failed' | 'abandoned';
 export type ToolInvocationOutcome = 'succeeded' | 'failed' | 'refused_by_gate';
 
 type EventBase = {
-  session_id: string;
   episode_id?: string;
 };
 
+type SessionEventBase = EventBase & {
+  session_id: string;
+};
+
+export type DesktopRpcOperation = 'read' | 'command' | 'document_apply';
+export type ToolSchemaProfile =
+  | 'dynamic-authoring'
+  | 'demo'
+  | 'spec-loop'
+  | 'full'
+  | 'combined-lean'
+  | 'unknown';
+export type BatchApplyOutcome =
+  | 'succeeded'
+  | 'partial'
+  | 'unknown'
+  | 'refused'
+  | 'failed'
+  | 'aborted';
+
 export type EpisodeEventInput =
-  | (EventBase & {
+  | (SessionEventBase & {
       type: 'episode_begin';
       intent?: string;
       source: 'agent' | 'client' | 'auto';
@@ -40,36 +59,38 @@ export type EpisodeEventInput =
       tableau_desktop_session_id?: string;
       langsmith_run_id?: string;
     })
-  | (EventBase & {
+  | (SessionEventBase & {
       type: 'episode_end';
       status: EpisodeStatus;
       route_receipt?: RouteReceipt;
       notes?: string;
       langsmith_run_id?: string;
     })
-  | (EventBase & {
+  | (SessionEventBase & {
       type: 'tool_start';
       tool: string;
     })
-  | (EventBase & {
+  | (SessionEventBase & {
       type: 'tool_end';
       tool: string;
       duration_ms: number;
       success: boolean;
       outcome: ToolInvocationOutcome;
+      request_id_hash: string;
+      result_size_chars: number;
     })
-  | (EventBase & {
+  | (SessionEventBase & {
       type: 'tool_error';
       tool: string;
       error?: string;
     })
-  | (EventBase & {
+  | (SessionEventBase & {
       type: 'apply_succeeded';
       tool: string;
       operation: string;
       promise_outcome: PromiseOutcome;
     })
-  | (EventBase & {
+  | (SessionEventBase & {
       type: 'readback_verification';
       tool: string;
       operation: string;
@@ -78,6 +99,27 @@ export type EpisodeEventInput =
       warnings?: number;
       findings?: ReadbackFinding[];
       message?: string;
+    })
+  | (SessionEventBase & {
+      type: 'desktop_rpc';
+      operation: DesktopRpcOperation;
+      duration_ms: number;
+      transport_success: boolean;
+      rescan_count: number;
+    })
+  | (EventBase & {
+      type: 'tool_schemas_registered';
+      profile: ToolSchemaProfile;
+      tool_count: number;
+      schemas_json_chars: number;
+      instructions_chars: number;
+    })
+  | (SessionEventBase & {
+      type: 'batch_apply';
+      artifact_count: number;
+      existing_worksheet_count: number;
+      duration_ms: number;
+      outcome: BatchApplyOutcome;
     });
 
 export type EpisodeEvent = EpisodeEventInput & {

--- a/src/desktop/externalApi/externalApiToolExecutor.test.ts
+++ b/src/desktop/externalApi/externalApiToolExecutor.test.ts
@@ -554,6 +554,75 @@ describe('ExternalApiToolExecutor', () => {
   });
 
   describe('401 rescan-once', () => {
+    it('emits one logical RPC event across a successful read', async () => {
+      const onRpc = vi.fn();
+      const executor = new ExternalApiToolExecutor({
+        discover: () => [instanceFor(server, 'valid-token')],
+        onRpc,
+      });
+      await executor.start();
+
+      const result = await executor.getWorkbookDocument(signal);
+
+      expect(result.isOk()).toBe(true);
+      expect(onRpc).toHaveBeenCalledOnce();
+      expect(onRpc).toHaveBeenCalledWith({
+        operation: 'read',
+        durationMs: expect.any(Number),
+        transportSuccess: true,
+        rescanCount: 0,
+      });
+    });
+
+    it('emits one logical RPC event when a read rescans after a 401', async () => {
+      const onRpc = vi.fn();
+      const discover = vi
+        .fn()
+        .mockReturnValueOnce([instanceFor(server, 'stale-token')])
+        .mockReturnValue([instanceFor(server, 'valid-token')]);
+      const executor = new ExternalApiToolExecutor({ discover, onRpc });
+      await executor.start();
+
+      const result = await executor.getWorkbookDocument(signal);
+
+      expect(result.isOk()).toBe(true);
+      expect(onRpc).toHaveBeenCalledOnce();
+      expect(onRpc).toHaveBeenCalledWith(
+        expect.objectContaining({ operation: 'read', transportSuccess: true, rescanCount: 1 }),
+      );
+    });
+
+    it('does not let a telemetry callback failure change the RPC result', async () => {
+      const executor = new ExternalApiToolExecutor({
+        discover: () => [instanceFor(server, 'valid-token')],
+        onRpc: () => {
+          throw new Error('telemetry sink failed');
+        },
+      });
+      await executor.start();
+
+      const result = await executor.getWorkbookDocument(signal);
+
+      expect(result.isOk()).toBe(true);
+    });
+
+    it('does not wait for a telemetry callback that never settles', async () => {
+      const executor = new ExternalApiToolExecutor({
+        discover: () => [instanceFor(server, 'valid-token')],
+        onRpc: () => new Promise(() => undefined),
+      });
+      await executor.start();
+
+      const result = await Promise.race([
+        executor.getWorkbookDocument(signal),
+        new Promise<never>((_, reject) =>
+          setTimeout(() => reject(new Error('RPC waited for telemetry')), 100),
+        ),
+      ]);
+
+      expect(result.isOk()).toBe(true);
+    });
+
     it('rediscovers once on a 401 and retries with the fresh token', async () => {
       const discover = vi
         .fn()
@@ -662,7 +731,11 @@ describe('ExternalApiToolExecutor', () => {
           { id: 'op-x', kind: 'tabdoc:sort', state: 'SUCCEEDED', result: { sorted: true } },
         ],
       });
-      const executor = new ExternalApiToolExecutor({ discover: () => [instanceFor(server)] });
+      const onRpc = vi.fn();
+      const executor = new ExternalApiToolExecutor({
+        discover: () => [instanceFor(server)],
+        onRpc,
+      });
       await executor.start();
 
       const result = await executor.executeCommand({
@@ -674,6 +747,14 @@ describe('ExternalApiToolExecutor', () => {
       expect(result.isOk()).toBe(true);
       expect(result.unwrap().status).toBe('completed');
       expect(result.unwrap().result).toEqual({ sorted: true });
+      expect(onRpc).toHaveBeenCalledOnce();
+      expect(onRpc).toHaveBeenCalledWith(
+        expect.objectContaining({
+          operation: 'command',
+          transportSuccess: true,
+          rescanCount: 0,
+        }),
+      );
     });
 
     it('reports a still-running operation as running, never completed', async () => {

--- a/src/desktop/externalApi/externalApiToolExecutor.ts
+++ b/src/desktop/externalApi/externalApiToolExecutor.ts
@@ -87,6 +87,15 @@ export type ExternalApiToolExecutorDeps = {
     instance: ExternalApiInstance,
     options?: ExternalApiHttpOptions,
   ) => ExternalApiHttp;
+  /** Optional fail-soft observer for one logical Desktop operation, including a 401 rescan. */
+  onRpc?: (event: DesktopRpcTelemetryEvent) => void | Promise<void>;
+};
+
+export type DesktopRpcTelemetryEvent = {
+  operation: 'read' | 'command' | 'document_apply';
+  durationMs: number;
+  transportSuccess: boolean;
+  rescanCount: number;
 };
 
 type NoInstance = { type: 'no-instance'; pinnedPid?: number };
@@ -185,7 +194,7 @@ export class ExternalApiToolExecutor {
   > {
     const resolvedArgs = args ?? {};
 
-    const outcomeResult = await this.withRescan(async (http) => {
+    const outcomeResult = await this.withRescan('command', async (http) => {
       const result = await http.postJsonEnvelope(
         EXTERNAL_API_ROUTES.invokeCommand,
         { namespace, command, parameters: resolvedArgs },
@@ -492,7 +501,7 @@ export class ExternalApiToolExecutor {
     command: string,
     options?: ApplyWorkbookDocumentOptions,
   ): Promise<Result<ExecuteCommandResult<undefined>, ExecuteCommandError>> {
-    const outcomeResult = await this.withRescan(async (http) => {
+    const outcomeResult = await this.withRescan('document_apply', async (http) => {
       if (
         options?.expectedInstanceId !== undefined &&
         http.instanceId !== options.expectedInstanceId
@@ -571,35 +580,57 @@ export class ExternalApiToolExecutor {
   }
 
   private async withRescan<T>(
+    operation: DesktopRpcTelemetryEvent['operation'],
     op: (http: ExternalApiHttp) => Promise<Result<T, ExternalApiError | InstanceMismatch>>,
   ): Promise<Result<T, ExternalApiError | NoInstance | InstanceMismatch>> {
-    const first = await this.ensureHttp();
-    if (first.isErr()) {
-      return Err(first.error);
-    }
-
-    let result = await op(first.value);
-    if (result.isErr() && result.error.type === 'unauthorized') {
-      log({
-        message: 'External Client API returned 401 — rescanning discovery once',
-        level: 'warning',
-        logger: LOGGER,
-      });
-      this.http = undefined;
-      const rescanned = await this.resolveHttp();
-      if (rescanned.isErr()) {
-        return Err(rescanned.error);
+    const startedAt = performance.now();
+    let rescanCount = 0;
+    let finalResult: Result<T, ExternalApiError | NoInstance | InstanceMismatch> | undefined;
+    try {
+      const first = await this.ensureHttp();
+      if (first.isErr()) {
+        finalResult = Err(first.error);
+        return finalResult;
       }
-      result = await op(rescanned.value);
-    }
 
-    return result;
+      let result = await op(first.value);
+      if (result.isErr() && result.error.type === 'unauthorized') {
+        rescanCount = 1;
+        log({
+          message: 'External Client API returned 401 — rescanning discovery once',
+          level: 'warning',
+          logger: LOGGER,
+        });
+        this.http = undefined;
+        const rescanned = await this.resolveHttp();
+        if (rescanned.isErr()) {
+          finalResult = Err(rescanned.error);
+          return finalResult;
+        }
+        result = await op(rescanned.value);
+      }
+
+      finalResult = result;
+      return finalResult;
+    } finally {
+      try {
+        const delivery = this.deps.onRpc?.({
+          operation,
+          durationMs: performance.now() - startedAt,
+          transportSuccess: finalResult?.isOk() ?? false,
+          rescanCount,
+        });
+        void delivery?.catch(() => undefined);
+      } catch {
+        // Telemetry is observational and must never alter a Desktop operation.
+      }
+    }
   }
 
   private async readExternalApi<T>(
     op: (http: ExternalApiHttp) => Promise<Result<T, ExternalApiError>>,
   ): Promise<Result<T, ExecuteCommandError>> {
-    const result = await this.withRescan(op);
+    const result = await this.withRescan('read', op);
     if (result.isErr()) {
       return Err(mapClientError(result.error, this.deps.pid));
     }

--- a/src/desktop/session/sessionManager.ts
+++ b/src/desktop/session/sessionManager.ts
@@ -2,6 +2,7 @@ import { Err, Ok, Result } from 'ts-results-es';
 
 import { getDesktopConfig } from '../../config.desktop.js';
 import { log } from '../../logging/logger.js';
+import { currentEpisodeId, emitEpisodeEvent } from '../episode-events.js';
 import { discoverInstances } from '../externalApi/discovery.js';
 import { ExternalApiToolExecutor } from '../externalApi/externalApiToolExecutor.js';
 import { parseSessionPid } from './parseSessionPid.js';
@@ -63,6 +64,17 @@ export class SessionManager {
         pid,
         discover,
         clientOptions: { timeoutMs: config.desktopCallTimeoutMs },
+        onRpc: async (event) => {
+          await emitEpisodeEvent(config, {
+            type: 'desktop_rpc',
+            session_id: sessionId,
+            episode_id: currentEpisodeId(sessionId),
+            operation: event.operation,
+            duration_ms: event.durationMs,
+            transport_success: event.transportSuccess,
+            rescan_count: event.rescanCount,
+          });
+        },
       });
       await executor.start();
       if (!executor.isAvailable()) {

--- a/src/server.desktop.test.ts
+++ b/src/server.desktop.test.ts
@@ -146,6 +146,7 @@ describe('DesktopMcpServer', () => {
 
       expect(emitSpy).toHaveBeenCalledWith(expect.anything(), {
         type: 'tool_schemas_registered',
+        surface: 'desktop',
         profile: 'unknown',
         tool_count: listedTools.length,
         schemas_json_chars: JSON.stringify(listedTools).length,

--- a/src/server.desktop.test.ts
+++ b/src/server.desktop.test.ts
@@ -1,9 +1,14 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { normalizeObjectSchema } from '@modelcontextprotocol/sdk/server/zod-compat.js';
 import { toJsonSchemaCompat } from '@modelcontextprotocol/sdk/server/zod-json-schema-compat.js';
-import { CallToolResult, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
+import {
+  CallToolResult,
+  ListToolsRequestSchema,
+  Tool as McpTool,
+} from '@modelcontextprotocol/sdk/types.js';
 
 import * as configModule from './config.desktop.js';
+import * as episodeEvents from './desktop/episode-events.js';
 import {
   buildDesktopInstructions,
   SESSION_RESOLUTION_TEXT_PINNED,
@@ -114,6 +119,44 @@ describe('DesktopMcpServer', () => {
       .mocked(sharedMcpServer.server.setRequestHandler)
       .mock.calls.find(([requestSchema]) => requestSchema === ListToolsRequestSchema);
     expect(listToolsCall).toBeUndefined();
+  });
+
+  it('records the bounded registered schema surface without recording schemas', async () => {
+    const base = configModule.getDesktopConfig();
+    const configSpy = vi.spyOn(configModule, 'getDesktopConfig').mockReturnValue({
+      ...base,
+      episodeEventsEnabled: false,
+      toolProfile: 'unexpected-profile',
+    });
+    const emitSpy = vi.spyOn(episodeEvents, 'emitEpisodeEvent').mockResolvedValue();
+
+    try {
+      const server = getServer();
+      const instructions = buildDesktopInstructions({
+        sessionPinned: base.desktopSessionId !== undefined,
+        profile: 'unexpected-profile',
+      });
+
+      await server.registerTools();
+      const listToolsCall = vi
+        .mocked(server.mcpServer.server.setRequestHandler)
+        .mock.calls.find(([requestSchema]) => requestSchema === ListToolsRequestSchema);
+      const listResult = await listToolsCall![1]({} as never, {} as never);
+      const listedTools = (listResult as { tools: McpTool[] }).tools;
+
+      expect(emitSpy).toHaveBeenCalledWith(expect.anything(), {
+        type: 'tool_schemas_registered',
+        profile: 'unknown',
+        tool_count: listedTools.length,
+        schemas_json_chars: JSON.stringify(listedTools).length,
+        instructions_chars: instructions.length,
+      });
+      const event = emitSpy.mock.calls.at(-1)?.[1];
+      expect(JSON.stringify(event)).not.toContain(String(listedTools[0]?.description));
+    } finally {
+      configSpy.mockRestore();
+      emitSpy.mockRestore();
+    }
   });
 });
 

--- a/src/server.desktop.ts
+++ b/src/server.desktop.ts
@@ -291,6 +291,7 @@ export class DesktopMcpServer extends Server {
     });
     await emitEpisodeEvent(config, {
       type: 'tool_schemas_registered',
+      surface: 'desktop',
       profile: normalizeToolSchemaProfile(config.toolProfile),
       tool_count: listedTools.length,
       schemas_json_chars: JSON.stringify(listedTools).length,

--- a/src/server.desktop.ts
+++ b/src/server.desktop.ts
@@ -15,6 +15,7 @@ import pkg from '../package.json';
 import { getDesktopConfig } from './config.desktop.js';
 import { DATA_ROOT, readResourceAsset, RESOURCES_ROOT } from './desktop/assets.js';
 import { createCallDeadline } from './desktop/callDeadline.js';
+import { emitEpisodeEvent, type ToolSchemaProfile } from './desktop/episode-events.js';
 import { buildDesktopInstructions } from './desktop/instructions.js';
 import {
   getKnowledgeCorpusEntryCount,
@@ -234,6 +235,7 @@ export class DesktopMcpServer extends Server {
   registerTools = async (): Promise<void> => {
     const config = getDesktopConfig();
     const tools = await this._getToolsToRegister();
+    const listedTools = await Promise.all(tools.map(getDesktopToolListEntry));
 
     log({
       message: 'Desktop transport ACTIVE: External Client API (Athena V0)',
@@ -283,11 +285,22 @@ export class DesktopMcpServer extends Server {
       );
     }
 
+    const instructions = buildDesktopInstructions({
+      sessionPinned: config.desktopSessionId !== undefined,
+      profile: config.toolProfile,
+    });
+    await emitEpisodeEvent(config, {
+      type: 'tool_schemas_registered',
+      profile: normalizeToolSchemaProfile(config.toolProfile),
+      tool_count: listedTools.length,
+      schemas_json_chars: JSON.stringify(listedTools).length,
+      instructions_chars: instructions.length,
+    });
+
     // Slim tools/list (no $schema dialect tags): only when this server owns the
     // McpServer. On the combined variant's shared server, overriding tools/list
     // would hide the web half's tools (including ones combined-lean registers late).
     if (this.ownsMcpServer) {
-      const listedTools = await Promise.all(tools.map(getDesktopToolListEntry));
       this.mcpServer.server.setRequestHandler(ListToolsRequestSchema, async () => ({
         tools: listedTools,
       }));
@@ -352,6 +365,19 @@ export class DesktopMcpServer extends Server {
       mimeType: 'text/markdown',
     });
   };
+}
+
+function normalizeToolSchemaProfile(profile: string): ToolSchemaProfile {
+  if (profile === '' || profile === 'dynamic-authoring') return 'dynamic-authoring';
+  if (
+    profile === 'demo' ||
+    profile === 'spec-loop' ||
+    profile === 'full' ||
+    profile === 'combined-lean'
+  ) {
+    return profile;
+  }
+  return 'unknown';
 }
 
 export async function getDesktopToolListEntry(tool: DesktopTool<any>): Promise<McpTool> {

--- a/src/tools/desktop/authoring/sheets/runDashboardBatch.test.ts
+++ b/src/tools/desktop/authoring/sheets/runDashboardBatch.test.ts
@@ -2,6 +2,7 @@ import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { Ok } from 'ts-results-es';
 import { z } from 'zod';
 
+import * as episodeEvents from '../../../../desktop/episode-events.js';
 import type { ExternalApiToolExecutor } from '../../../../desktop/externalApi/executorTypes.js';
 import { captureTargetWorksheetState } from '../../../../desktop/metadata/targetWorksheetState.js';
 import * as sessionResolution from '../../../../desktop/session/sessionResolution.js';
@@ -129,6 +130,86 @@ describe('runDashboardBatchTool', () => {
         { operation: 'dashboard', dashboardName: 'Executive Overview', state: 'applied' },
       ],
     });
+  });
+
+  it('records only bounded batch counts and the final outcome', async () => {
+    const emitSpy = vi.spyOn(episodeEvents, 'emitEpisodeEvent').mockResolvedValue();
+    vi.mocked(applyArtifactModule.applyWorksheetArtifact).mockResolvedValue(
+      appliedArtifact('a1', 'New A'),
+    );
+    vi.mocked(composeModule.composeDashboardCore).mockResolvedValue(composedDashboard());
+
+    await callBatch(['a1']);
+
+    expect(emitSpy).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        type: 'batch_apply',
+        session_id: '12345',
+        artifact_count: 1,
+        existing_worksheet_count: 1,
+        duration_ms: expect.any(Number),
+        outcome: 'succeeded',
+      }),
+    );
+    const event = emitSpy.mock.calls.find(([, value]) => value.type === 'batch_apply')?.[1];
+    expect(event).not.toHaveProperty('dashboardName');
+    expect(event).not.toHaveProperty('artifactIds');
+    expect(event).not.toHaveProperty('worksheetNames');
+  });
+
+  it('records preflight rejection as refused', async () => {
+    const emitSpy = vi.spyOn(episodeEvents, 'emitEpisodeEvent').mockResolvedValue();
+
+    await callBatch(['a1', 'a1'], { store: artifactStore(['a1']) });
+
+    expect(emitSpy).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ type: 'batch_apply', outcome: 'refused' }),
+    );
+  });
+
+  it('records an unavailable artifact as refused before execution starts', async () => {
+    const emitSpy = vi.spyOn(episodeEvents, 'emitEpisodeEvent').mockResolvedValue();
+
+    await callBatch(['a1', 'missing'], { store: artifactStore(['a1']) });
+
+    expect(emitSpy).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ type: 'batch_apply', outcome: 'refused' }),
+    );
+  });
+
+  it('records a runtime apply failure as failed', async () => {
+    const emitSpy = vi.spyOn(episodeEvents, 'emitEpisodeEvent').mockResolvedValue();
+    vi.mocked(applyArtifactModule.applyWorksheetArtifact).mockResolvedValue({
+      state: 'failed',
+      retrySafe: true,
+      error: toolError('artifact unavailable'),
+    });
+
+    await callBatch(['a1']);
+
+    expect(emitSpy).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ type: 'batch_apply', outcome: 'failed' }),
+    );
+  });
+
+  it('records an abort as aborted even after an earlier worksheet applied', async () => {
+    const emitSpy = vi.spyOn(episodeEvents, 'emitEpisodeEvent').mockResolvedValue();
+    const controller = new AbortController();
+    vi.mocked(applyArtifactModule.applyWorksheetArtifact).mockImplementationOnce(async () => {
+      controller.abort();
+      return appliedArtifact('a1', 'New A');
+    });
+
+    await callBatch(['a1', 'a2'], { signal: controller.signal });
+
+    expect(emitSpy).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ type: 'batch_apply', outcome: 'aborted' }),
+    );
   });
 
   it('reserves every artifact before writes and releases them when the second is invalid', async () => {

--- a/src/tools/desktop/authoring/sheets/runDashboardBatch.test.ts
+++ b/src/tools/desktop/authoring/sheets/runDashboardBatch.test.ts
@@ -158,6 +158,25 @@ describe('runDashboardBatchTool', () => {
     expect(event).not.toHaveProperty('worksheetNames');
   });
 
+  it('returns without waiting for the telemetry sink', async () => {
+    vi.spyOn(episodeEvents, 'emitEpisodeEvent').mockImplementation(
+      () => new Promise(() => undefined),
+    );
+    vi.mocked(applyArtifactModule.applyWorksheetArtifact).mockResolvedValue(
+      appliedArtifact('a1', 'New A'),
+    );
+    vi.mocked(composeModule.composeDashboardCore).mockResolvedValue(composedDashboard());
+
+    const result = await Promise.race([
+      callBatch(['a1']),
+      new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error('batch waited for telemetry')), 100),
+      ),
+    ]);
+
+    expect(result.isError).toBe(false);
+  });
+
   it('records preflight rejection as refused', async () => {
     const emitSpy = vi.spyOn(episodeEvents, 'emitEpisodeEvent').mockResolvedValue();
 

--- a/src/tools/desktop/authoring/sheets/runDashboardBatch.ts
+++ b/src/tools/desktop/authoring/sheets/runDashboardBatch.ts
@@ -2,6 +2,12 @@ import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { Ok, type Result } from 'ts-results-es';
 import { z } from 'zod';
 
+import {
+  type BatchApplyOutcome,
+  currentEpisodeId,
+  emitEpisodeEvent,
+  episodeSessionIdFromArgs,
+} from '../../../../desktop/episode-events.js';
 import { findAllWorksheets, parseXML } from '../../../../desktop/metadata/parser.js';
 import { compareTargetWorksheetState } from '../../../../desktop/metadata/targetWorksheetState.js';
 import { resolveSession } from '../../../../desktop/session/sessionResolution.js';
@@ -141,7 +147,10 @@ export const getRunDashboardBatchTool = (
       },
       extra,
     ): Promise<CallToolResult> => {
-      return await tool.logAndExecute<RunDashboardBatchResult>({
+      const startedAt = performance.now();
+      const sessionId = episodeSessionIdFromArgs(extra.config, { session });
+      let executionStarted = false;
+      const result = await tool.logAndExecute<RunDashboardBatchResult>({
         extra,
         args: {
           session,
@@ -329,6 +338,7 @@ export const getRunDashboardBatchTool = (
 
               let outcome: Awaited<ReturnType<typeof applyWorksheetArtifact>>;
               try {
+                executionStarted = true;
                 outcome = await applyWorksheetArtifact({
                   store: artifactStore,
                   artifactId,
@@ -433,6 +443,7 @@ export const getRunDashboardBatchTool = (
 
             let composeOutcome: Awaited<ReturnType<typeof composeDashboardCore>>;
             try {
+              executionStarted = true;
               composeOutcome = await composeDashboardCore({
                 dashboardName,
                 worksheetNames: [
@@ -500,11 +511,40 @@ export const getRunDashboardBatchTool = (
         },
         getSuccessResult: (result) => jsonToolResult(result, { isError: false }),
       });
+      await emitEpisodeEvent(extra.config, {
+        type: 'batch_apply',
+        session_id: sessionId,
+        episode_id: currentEpisodeId(sessionId),
+        artifact_count: artifactIds?.length ?? 0,
+        existing_worksheet_count: existingWorksheetNames?.length ?? 0,
+        duration_ms: performance.now() - startedAt,
+        outcome: batchApplyOutcome(result, executionStarted),
+      });
+      return result;
     },
   });
 
   return tool;
 };
+
+function batchApplyOutcome(result: CallToolResult, executionStarted: boolean): BatchApplyOutcome {
+  const content = result.content.find((item) => item.type === 'text');
+  if (!content || content.type !== 'text') return 'refused';
+  try {
+    const payload = JSON.parse(content.text) as {
+      applied?: AppliedState;
+      steps?: Array<{ state?: string }>;
+    };
+    if (payload.applied === true) return 'succeeded';
+    if (payload.applied === 'unknown') return 'unknown';
+    if (payload.steps?.some((step) => step.state === 'aborted')) return 'aborted';
+    if (payload.applied === 'partial') return 'partial';
+    if (payload.applied === false) return executionStarted ? 'failed' : 'refused';
+  } catch {
+    // Non-structured failures are refusals before a batch outcome exists.
+  }
+  return 'refused';
+}
 
 function incomplete(
   payload: RunDashboardBatchPayload,

--- a/src/tools/desktop/authoring/sheets/runDashboardBatch.ts
+++ b/src/tools/desktop/authoring/sheets/runDashboardBatch.ts
@@ -511,7 +511,7 @@ export const getRunDashboardBatchTool = (
         },
         getSuccessResult: (result) => jsonToolResult(result, { isError: false }),
       });
-      await emitEpisodeEvent(extra.config, {
+      void emitEpisodeEvent(extra.config, {
         type: 'batch_apply',
         session_id: sessionId,
         episode_id: currentEpisodeId(sessionId),

--- a/src/tools/desktop/local/episodeTools.test.ts
+++ b/src/tools/desktop/local/episodeTools.test.ts
@@ -84,6 +84,7 @@ describe('episode lifecycle tools', () => {
     expect(offNames).not.toContain('tableau-begin-episode');
     expect(offNames).not.toContain('tableau-end-episode');
 
+    vi.stubEnv('EPISODE_EVENTS_DIR', tmpDir());
     vi.stubEnv('EPISODE_EVENTS', 'on');
     const onServer = serverWithRegisterSpy();
     await onServer.registerTools();

--- a/src/tools/desktop/tool.test.ts
+++ b/src/tools/desktop/tool.test.ts
@@ -49,13 +49,14 @@ describe('DesktopTool episode telemetry', () => {
     };
     const begin = await beginEpisode(extra.config, { sessionId: 'S1' });
 
-    await tool.logAndExecute({
+    const result = await tool.logAndExecute({
       extra,
       args: { session: 'S1' },
       callback: async () => new Ok({ ok: true }),
     });
 
-    expect(readEvents(dir)).toMatchObject([
+    const events = readEvents(dir);
+    expect(events).toMatchObject([
       { type: 'episode_begin', episode_id: begin.episode_id },
       {
         type: 'tool_start',
@@ -69,9 +70,11 @@ describe('DesktopTool episode telemetry', () => {
         episode_id: begin.episode_id,
         tool: 'ask-user',
         success: true,
+        request_id_hash: expect.stringMatching(/^[a-f0-9]{16}$/),
+        result_size_chars: JSON.stringify(result).length,
       },
     ]);
-    expect(readEvents(dir)[2].duration_ms).toEqual(expect.any(Number));
+    expect(events[2].duration_ms).toEqual(expect.any(Number));
   });
 
   it('emits tool_error and unsuccessful tool_end when the callback throws', async () => {
@@ -86,7 +89,7 @@ describe('DesktopTool episode telemetry', () => {
       },
     };
 
-    await tool.logAndExecute({
+    const result = await tool.logAndExecute({
       extra,
       args: { session: 'S1' },
       callback: async () => {
@@ -97,7 +100,14 @@ describe('DesktopTool episode telemetry', () => {
     expect(readEvents(dir)).toMatchObject([
       { type: 'tool_start', session_id: 'S1', tool: 'ask-user' },
       { type: 'tool_error', session_id: 'S1', tool: 'ask-user' },
-      { type: 'tool_end', session_id: 'S1', tool: 'ask-user', success: false },
+      {
+        type: 'tool_end',
+        session_id: 'S1',
+        tool: 'ask-user',
+        success: false,
+        request_id_hash: expect.stringMatching(/^[a-f0-9]{16}$/),
+        result_size_chars: JSON.stringify(result).length,
+      },
     ]);
   });
 });

--- a/src/tools/desktop/tool.test.ts
+++ b/src/tools/desktop/tool.test.ts
@@ -2,6 +2,7 @@ import { mkdtempSync, readdirSync, readFileSync, rmSync } from 'fs';
 import { join } from 'path';
 import { Ok } from 'ts-results-es';
 
+import * as episodeEvents from '../../desktop/episode-events.js';
 import { beginEpisode, resetEpisodeEventsForTests } from '../../desktop/episode-events.js';
 import { sessionRouteState } from '../../desktop/route/route-state.js';
 import { DesktopMcpServer } from '../../server.desktop.js';
@@ -55,26 +56,51 @@ describe('DesktopTool episode telemetry', () => {
       callback: async () => new Ok({ ok: true }),
     });
 
+    await vi.waitFor(() => {
+      expect(readEvents(dir)).toMatchObject([
+        { type: 'episode_begin', episode_id: begin.episode_id },
+        {
+          type: 'tool_start',
+          session_id: 'S1',
+          episode_id: begin.episode_id,
+          tool: 'ask-user',
+        },
+        {
+          type: 'tool_end',
+          session_id: 'S1',
+          episode_id: begin.episode_id,
+          tool: 'ask-user',
+          success: true,
+          request_id_hash: expect.stringMatching(/^[a-f0-9]{16}$/),
+          result_size_chars: JSON.stringify(result).length,
+        },
+      ]);
+    });
     const events = readEvents(dir);
-    expect(events).toMatchObject([
-      { type: 'episode_begin', episode_id: begin.episode_id },
-      {
-        type: 'tool_start',
-        session_id: 'S1',
-        episode_id: begin.episode_id,
-        tool: 'ask-user',
-      },
-      {
-        type: 'tool_end',
-        session_id: 'S1',
-        episode_id: begin.episode_id,
-        tool: 'ask-user',
-        success: true,
-        request_id_hash: expect.stringMatching(/^[a-f0-9]{16}$/),
-        result_size_chars: JSON.stringify(result).length,
-      },
-    ]);
     expect(events[2].duration_ms).toEqual(expect.any(Number));
+  });
+
+  it('returns without waiting for the telemetry sink', async () => {
+    const emitSpy = vi
+      .spyOn(episodeEvents, 'emitEpisodeEvent')
+      .mockImplementation(() => new Promise(() => undefined));
+
+    try {
+      const result = await Promise.race([
+        makeTool().logAndExecute({
+          extra: getMockRequestHandlerExtra(),
+          args: { session: 'S1' },
+          callback: async () => new Ok({ ok: true }),
+        }),
+        new Promise<never>((_, reject) =>
+          setTimeout(() => reject(new Error('tool waited for telemetry')), 100),
+        ),
+      ]);
+
+      expect(result.isError).toBe(false);
+    } finally {
+      emitSpy.mockRestore();
+    }
   });
 
   it('emits tool_error and unsuccessful tool_end when the callback throws', async () => {
@@ -97,18 +123,20 @@ describe('DesktopTool episode telemetry', () => {
       },
     });
 
-    expect(readEvents(dir)).toMatchObject([
-      { type: 'tool_start', session_id: 'S1', tool: 'ask-user' },
-      { type: 'tool_error', session_id: 'S1', tool: 'ask-user' },
-      {
-        type: 'tool_end',
-        session_id: 'S1',
-        tool: 'ask-user',
-        success: false,
-        request_id_hash: expect.stringMatching(/^[a-f0-9]{16}$/),
-        result_size_chars: JSON.stringify(result).length,
-      },
-    ]);
+    await vi.waitFor(() => {
+      expect(readEvents(dir)).toMatchObject([
+        { type: 'tool_start', session_id: 'S1', tool: 'ask-user' },
+        { type: 'tool_error', session_id: 'S1', tool: 'ask-user' },
+        {
+          type: 'tool_end',
+          session_id: 'S1',
+          tool: 'ask-user',
+          success: false,
+          request_id_hash: expect.stringMatching(/^[a-f0-9]{16}$/),
+          result_size_chars: JSON.stringify(result).length,
+        },
+      ]);
+    });
   });
 });
 
@@ -134,23 +162,25 @@ describe('DesktopTool worksheet orientation', () => {
 
     expect(result.isError).toBe(false);
     expect(callback).toHaveBeenCalledOnce();
-    expect(readEvents(dir)).toMatchObject([
-      { type: 'episode_begin', episode_id: begin.episode_id },
-      {
-        type: 'tool_start',
-        session_id: 'S1',
-        episode_id: begin.episode_id,
-        tool: 'get-worksheet-xml',
-      },
-      {
-        type: 'tool_end',
-        session_id: 'S1',
-        episode_id: begin.episode_id,
-        tool: 'get-worksheet-xml',
-        success: true,
-        outcome: 'succeeded',
-      },
-    ]);
+    await vi.waitFor(() => {
+      expect(readEvents(dir)).toMatchObject([
+        { type: 'episode_begin', episode_id: begin.episode_id },
+        {
+          type: 'tool_start',
+          session_id: 'S1',
+          episode_id: begin.episode_id,
+          tool: 'get-worksheet-xml',
+        },
+        {
+          type: 'tool_end',
+          session_id: 'S1',
+          episode_id: begin.episode_id,
+          tool: 'get-worksheet-xml',
+          success: true,
+          outcome: 'succeeded',
+        },
+      ]);
+    });
   });
 });
 

--- a/src/tools/desktop/tool.ts
+++ b/src/tools/desktop/tool.ts
@@ -49,7 +49,7 @@ export class DesktopTool<Args extends ZodRawShape | undefined = undefined> exten
     const sessionId = episodeSessionIdFromArgs(extra.config, args);
     const episodeId = currentEpisodeId(sessionId);
 
-    await emitEpisodeEvent(extra.config, {
+    void emitEpisodeEvent(extra.config, {
       type: 'tool_start',
       session_id: sessionId,
       episode_id: episodeId,
@@ -66,7 +66,7 @@ export class DesktopTool<Args extends ZodRawShape | undefined = undefined> exten
               isError: false,
               content: [{ type: 'text', text: JSON.stringify(result.value) }],
             };
-        await emitEpisodeEvent(extra.config, {
+        void emitEpisodeEvent(extra.config, {
           type: 'tool_end',
           session_id: sessionId,
           episode_id: episodeId,
@@ -86,13 +86,13 @@ export class DesktopTool<Args extends ZodRawShape | undefined = undefined> exten
         content: [{ type: 'text', text: result.error.getErrorText() }],
         ...(structuredContent ? { structuredContent } : {}),
       };
-      await emitToolErrorEvent({
+      void emitToolErrorEvent({
         config: extra.config,
         sessionId,
         tool: this.name,
         error: result.error.getErrorText(),
       });
-      await emitEpisodeEvent(extra.config, {
+      void emitEpisodeEvent(extra.config, {
         type: 'tool_end',
         session_id: sessionId,
         episode_id: episodeId,
@@ -122,13 +122,13 @@ export class DesktopTool<Args extends ZodRawShape | undefined = undefined> exten
           tool: this.name,
           session: sessionId,
         });
-        await emitToolErrorEvent({ config: extra.config, sessionId, tool: this.name, error: text });
+        void emitToolErrorEvent({ config: extra.config, sessionId, tool: this.name, error: text });
         toolResult = { isError: true, content: [{ type: 'text', text }] };
       } else {
-        await emitToolErrorEvent({ config: extra.config, sessionId, tool: this.name, error });
+        void emitToolErrorEvent({ config: extra.config, sessionId, tool: this.name, error });
         toolResult = getErrorResult(requestId, error);
       }
-      await emitEpisodeEvent(extra.config, {
+      void emitEpisodeEvent(extra.config, {
         type: 'tool_end',
         session_id: sessionId,
         episode_id: episodeId,

--- a/src/tools/desktop/tool.ts
+++ b/src/tools/desktop/tool.ts
@@ -1,5 +1,6 @@
 import { AnySchema, ZodRawShapeCompat } from '@modelcontextprotocol/sdk/server/zod-compat.js';
 import { CallToolResult, RequestId } from '@modelcontextprotocol/sdk/types.js';
+import { createHash } from 'crypto';
 import { ZodRawShape } from 'zod';
 
 import { desktopCallTimeoutMessage, isDesktopCallTimeout } from '../../desktop/callDeadline.js';
@@ -45,7 +46,6 @@ export class DesktopTool<Args extends ZodRawShape | undefined = undefined> exten
     this.notifyInvocation({ requestId, args });
 
     let toolResult: CallToolResult;
-    const startedAt = Date.now();
     const sessionId = episodeSessionIdFromArgs(extra.config, args);
     const episodeId = currentEpisodeId(sessionId);
 
@@ -55,6 +55,7 @@ export class DesktopTool<Args extends ZodRawShape | undefined = undefined> exten
       episode_id: episodeId,
       tool: this.name,
     });
+    const startedAt = performance.now();
 
     try {
       const result = await raceDeadline(extra, callback);
@@ -70,9 +71,11 @@ export class DesktopTool<Args extends ZodRawShape | undefined = undefined> exten
           session_id: sessionId,
           episode_id: episodeId,
           tool: this.name,
-          duration_ms: Date.now() - startedAt,
+          duration_ms: performance.now() - startedAt,
           success: true,
           outcome: 'succeeded',
+          request_id_hash: hashRequestId(requestId),
+          result_size_chars: serializedResultSize(toolResult),
         });
         return toolResult;
       }
@@ -94,9 +97,11 @@ export class DesktopTool<Args extends ZodRawShape | undefined = undefined> exten
         session_id: sessionId,
         episode_id: episodeId,
         tool: this.name,
-        duration_ms: Date.now() - startedAt,
+        duration_ms: performance.now() - startedAt,
         success: false,
         outcome: 'failed',
+        request_id_hash: hashRequestId(requestId),
+        result_size_chars: serializedResultSize(toolResult),
       });
       return toolResult;
     } catch (error) {
@@ -128,13 +133,23 @@ export class DesktopTool<Args extends ZodRawShape | undefined = undefined> exten
         session_id: sessionId,
         episode_id: episodeId,
         tool: this.name,
-        duration_ms: Date.now() - startedAt,
+        duration_ms: performance.now() - startedAt,
         success: false,
         outcome: 'failed',
+        request_id_hash: hashRequestId(requestId),
+        result_size_chars: serializedResultSize(toolResult),
       });
       return toolResult;
     }
   }
+}
+
+function serializedResultSize(result: CallToolResult): number {
+  return JSON.stringify(result).length;
+}
+
+function hashRequestId(requestId: RequestId): string {
+  return createHash('sha256').update(String(requestId)).digest('hex').slice(0, 16);
 }
 
 /**

--- a/src/tools/desktop/toolDeadline.test.ts
+++ b/src/tools/desktop/toolDeadline.test.ts
@@ -155,13 +155,16 @@ describe('DesktopTool per-call deadline', () => {
     });
     await vi.advanceTimersByTimeAsync(60_000);
     await pending;
+    vi.useRealTimers();
 
-    expect(readEvents(dir)).toMatchObject([
-      { type: 'episode_begin' },
-      { type: 'tool_start', tool: 'apply-workbook' },
-      { type: 'tool_error', tool: 'apply-workbook' },
-      { type: 'tool_end', tool: 'apply-workbook', success: false },
-    ]);
+    await vi.waitFor(() => {
+      expect(readEvents(dir)).toMatchObject([
+        { type: 'episode_begin' },
+        { type: 'tool_start', tool: 'apply-workbook' },
+        { type: 'tool_error', tool: 'apply-workbook' },
+        { type: 'tool_end', tool: 'apply-workbook', success: false },
+      ]);
+    });
     const toolError = readEvents(dir)[2];
     expect(String(toolError.error)).toContain('did not respond within 60s');
 


### PR DESCRIPTION
## Decision

Desktop authoring telemetry stays opt-in. It records counts, timings, fixed outcomes, serialized sizes, and hashed request IDs. It does not record workbook content, tool payloads, names, paths, routes, errors, or schemas.

## Scope

This extends the existing episode event stream. It measures:

- each tool call and result size;
- each logical External Client API operation, including one event across polling or a discovery rescan;
- the tool schema size registered at startup;
- the final outcome of run-dashboard-batch.

It does not add a telemetry service, change the tool surface, or change authoring behavior. Future telemetry must keep the same bounded fields and must never delay a Desktop result.

## Evidence

- scripts/agent-check: all five checks green
- 369 test files and 5,644 tests passed
- Desktop build and lockstep check passed
- Regression coverage includes 202 polling, 401 rescan, a telemetry sink that never settles, safe request correlation, and every dashboard batch outcome class
- Independent adversarial review found no remaining blockers

Version: 2.60.7.

Approving this PR means we can measure real Desktop authoring cost and failure shape without widening the agent tool surface or collecting user content.

_Opened by MattGPT for Matt Filbert._
