### PR TITLE
Add validate-uploaded-workbook MCP tool

### DIFF
--- a/src/overridableConfig.test.ts
+++ b/src/overridableConfig.test.ts
@@ -56,7 +56,12 @@ describe('OverridableConfig', () => {
       vi.stubEnv('INCLUDE_TOOLS', 'query-datasource,workbook');
 
       const config = new OverridableConfig({});
-      expect(config.includeTools).toEqual(['query-datasource', 'list-workbooks', 'get-workbook']);
+      expect(config.includeTools).toEqual([
+        'query-datasource',
+        'list-workbooks',
+        'get-workbook',
+        'validate-uploaded-workbook',
+      ]);
     });
 
     it('should parse EXCLUDE_TOOLS into an array of valid tool names', () => {
@@ -70,7 +75,12 @@ describe('OverridableConfig', () => {
       vi.stubEnv('EXCLUDE_TOOLS', 'query-datasource,workbook');
 
       const config = new OverridableConfig({});
-      expect(config.excludeTools).toEqual(['query-datasource', 'list-workbooks', 'get-workbook']);
+      expect(config.excludeTools).toEqual([
+        'query-datasource',
+        'list-workbooks',
+        'get-workbook',
+        'validate-uploaded-workbook',
+      ]);
     });
 
     it('should filter out invalid tool names from INCLUDE_TOOLS', () => {

--- a/src/restApiInstance.ts
+++ b/src/restApiInstance.ts
@@ -37,6 +37,7 @@ type JwtScopes =
   | 'tableau:tasks:delete'
   | 'tableau:tasks:write'
   | 'tableau:workbook_tags:update'
+  | 'tableau:workbooks:create'
   | 'tableau:workbooks:delete'
   | 'tableau:datasource_tags:update'
   | 'tableau:datasources:delete'

--- a/src/sdks/tableau/apis/workbooksApi.ts
+++ b/src/sdks/tableau/apis/workbooksApi.ts
@@ -140,6 +140,16 @@ const validateUploadedWorkbookEndpoint = makeEndpoint({
     },
   ],
   response: workbookValidationResultSchema,
+  // A 422 is not a request failure: it means validation ran and found structural
+  // errors. The body has the same shape as the 200 response (just with `errors`
+  // populated), so we reuse the schema. This lets `isErrorFromAlias` type-narrow the
+  // caught error so the method can return the structured payload instead of throwing.
+  errors: [
+    {
+      status: 422,
+      schema: workbookValidationResultSchema,
+    },
+  ],
 });
 
 const workbooksApi = makeApi([

--- a/src/sdks/tableau/methods/workbooksMethods.test.ts
+++ b/src/sdks/tableau/methods/workbooksMethods.test.ts
@@ -1,6 +1,7 @@
 import { AxiosInstance } from 'axios';
 import { describe, expect, it, vi } from 'vitest';
 
+import { workbooksApis } from '../apis/workbooksApi.js';
 import WorkbooksMethods from './workbooksMethods.js';
 
 describe('WorkbooksMethods', () => {
@@ -238,6 +239,78 @@ describe('WorkbooksMethods', () => {
       expect(validation.errors).toEqual(result.errors);
       expect(validation.warnings).toEqual(result.warnings);
       expect(validation.uploadId).toBeUndefined();
+    });
+
+    it('should return the structured body when the API responds 422 (validation errors) instead of throwing', async () => {
+      const data = {
+        timestamp: '2026-06-10T14:32:18.456Z',
+        errors: [
+          {
+            severity: 'ERROR',
+            message: 'Missing required closing tag for element',
+            line: 127,
+            column: 5,
+            elementName: 'preferences',
+          },
+        ],
+        warnings: [],
+      };
+      // Zodios/axios throws on a 422. isErrorFromAlias matches this shape via the
+      // endpoint's declared 422 error schema, so the method returns the body.
+      const axiosError = {
+        isAxiosError: true,
+        config: { method: 'post', url: '/sites/site-1/workbooks/validateUploadedWorkbook' },
+        response: { status: 422, data },
+      };
+      const mockApiClient = {
+        api: workbooksApis,
+        validateUploadedWorkbook: vi.fn().mockRejectedValue(axiosError),
+      };
+
+      const workbooksMethods = new WorkbooksMethods(
+        'http://test',
+        { type: 'Bearer', token: 'test' },
+        {},
+      );
+      // @ts-expect-error - Mocking private property
+      workbooksMethods._apiClient = mockApiClient;
+
+      const validation = await workbooksMethods.validateUploadedWorkbook({
+        siteId: 'site-1',
+        uploadSessionId: 'session-42',
+      });
+
+      expect(validation).toEqual(data);
+    });
+
+    it('should propagate a non-422 error (e.g. 404) instead of swallowing it', async () => {
+      const axiosError = {
+        isAxiosError: true,
+        config: { method: 'post', url: '/sites/site-1/workbooks/validateUploadedWorkbook' },
+        response: {
+          status: 404,
+          data: { error: { code: '404', summary: 'Not Found', detail: 'Unknown upload session' } },
+        },
+      };
+      const mockApiClient = {
+        api: workbooksApis,
+        validateUploadedWorkbook: vi.fn().mockRejectedValue(axiosError),
+      };
+
+      const workbooksMethods = new WorkbooksMethods(
+        'http://test',
+        { type: 'Bearer', token: 'test' },
+        {},
+      );
+      // @ts-expect-error - Mocking private property
+      workbooksMethods._apiClient = mockApiClient;
+
+      await expect(
+        workbooksMethods.validateUploadedWorkbook({
+          siteId: 'site-1',
+          uploadSessionId: 'unknown-session',
+        }),
+      ).rejects.toBe(axiosError);
     });
   });
 });

--- a/src/sdks/tableau/methods/workbooksMethods.ts
+++ b/src/sdks/tableau/methods/workbooksMethods.ts
@@ -1,4 +1,4 @@
-import { Zodios } from '@zodios/core';
+import { isErrorFromAlias, Zodios } from '@zodios/core';
 
 import { AxiosRequestConfig } from '../../../utils/axios.js';
 import { workbooksApis } from '../apis/workbooksApi.js';
@@ -196,11 +196,22 @@ export default class WorkbooksMethods extends AuthenticatedMethods<typeof workbo
     siteId: string;
     uploadSessionId: string;
   }): Promise<WorkbookValidationResult> => {
-    return await this._apiClient.validateUploadedWorkbook(undefined, {
-      params: { siteId },
-      queries: { uploadSessionId },
-      ...this.authHeader,
-    });
+    try {
+      return await this._apiClient.validateUploadedWorkbook(undefined, {
+        params: { siteId },
+        queries: { uploadSessionId },
+        ...this.authHeader,
+      });
+    } catch (error) {
+      // A 422 means validation ran and found structural errors. That is a normal,
+      // expected outcome (not a request failure), so return the structured body as-is
+      // instead of throwing. Genuine request problems (400/404/network) still propagate.
+      if (isErrorFromAlias(this._apiClient.api, 'validateUploadedWorkbook', error)) {
+        return error.response.data;
+      }
+
+      throw error;
+    }
   };
 }
 

--- a/src/server/oauth/scopes.ts
+++ b/src/server/oauth/scopes.ts
@@ -28,6 +28,7 @@ export type McpScope =
   | 'tableau:mcp:tasks:write'
   | 'tableau:mcp:jobs:read'
   | 'tableau:mcp:content:delete'
+  | 'tableau:mcp:workbook:create'
   | 'tableau:mcp:users:read'
   | 'tableau:mcp:users:write';
 
@@ -49,6 +50,7 @@ export type TableauApiScope =
   | 'tableau:tasks:delete'
   | 'tableau:tasks:write'
   | 'tableau:workbook_tags:update'
+  | 'tableau:workbooks:create'
   | 'tableau:workbooks:delete'
   | 'tableau:datasource_tags:update'
   | 'tableau:datasources:delete'
@@ -71,6 +73,7 @@ export const DEFAULT_SCOPES_SUPPORTED: ReadonlyArray<McpScope> = [
   'tableau:mcp:workbook:read',
   'tableau:mcp:content:read',
   'tableau:mcp:content:delete',
+  'tableau:mcp:workbook:create',
   'tableau:mcp:users:write',
   'tableau:mcp:view:read',
   'tableau:mcp:view:download',
@@ -237,6 +240,10 @@ const toolScopeMap: Record<
   'get-workbook': {
     mcp: ['tableau:mcp:workbook:read'],
     api: new Set(['tableau:content:read', ...RESOURCE_ACCESS_CHECKER_REQUIRED_API_SCOPES]),
+  },
+  'validate-uploaded-workbook': {
+    mcp: ['tableau:mcp:workbook:create'],
+    api: new Set<TableauApiScope>(['tableau:workbooks:create']),
   },
   'get-view': {
     mcp: ['tableau:mcp:view:read'],

--- a/src/tools/web/toolName.ts
+++ b/src/tools/web/toolName.ts
@@ -15,6 +15,7 @@ export const webToolNames = [
   'get-embed-token',
   'record-event',
   'get-workbook',
+  'validate-uploaded-workbook',
   'get-view',
   'get-flow',
   'list-flow-runs',
@@ -63,7 +64,7 @@ export type WebToolGroupName = (typeof webToolGroupNames)[number];
 
 export const webToolGroups = {
   datasource: ['list-datasources', 'get-datasource-metadata', 'query-datasource'],
-  workbook: ['list-workbooks', 'get-workbook'],
+  workbook: ['list-workbooks', 'get-workbook', 'validate-uploaded-workbook'],
   project: ['list-projects'],
   view: [
     'list-views',

--- a/src/tools/web/tools.ts
+++ b/src/tools/web/tools.ts
@@ -38,6 +38,7 @@ import { getListCustomViewsTool } from './views/listCustomViews.js';
 import { getListViewsTool } from './views/listViews.js';
 import { getGetWorkbookTool } from './workbooks/getWorkbook.js';
 import { getListWorkbooksTool } from './workbooks/listWorkbooks.js';
+import { getValidateUploadedWorkbookTool } from './workbooks/validateUploadedWorkbook.js';
 
 export const webToolFactories = [
   getGetDatasourceMetadataTool,
@@ -65,6 +66,7 @@ export const webToolFactories = [
   getGeneratePulseInsightBriefTool,
   getGenerateInsightCardsTool,
   getGetWorkbookTool,
+  getValidateUploadedWorkbookTool,
   getGetViewTool,
   getGetViewDataTool,
   getGetViewImageTool,

--- a/src/tools/web/workbooks/validateUploadedWorkbook.test.ts
+++ b/src/tools/web/workbooks/validateUploadedWorkbook.test.ts
@@ -1,0 +1,122 @@
+import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+
+import { WebMcpServer } from '../../../server.web.js';
+import { stubDefaultEnvVars } from '../../../testShared.js';
+import invariant from '../../../utils/invariant.js';
+import { Provider } from '../../../utils/provider.js';
+import { getMockRequestHandlerExtra } from '../toolContext.mock.js';
+import { getValidateUploadedWorkbookTool } from './validateUploadedWorkbook.js';
+
+const mocks = vi.hoisted(() => ({
+  mockValidateUploadedWorkbook: vi.fn(),
+}));
+
+vi.mock('../../../restApiInstance.js', () => ({
+  useRestApi: vi.fn().mockImplementation(async ({ callback }) =>
+    callback({
+      workbooksMethods: {
+        validateUploadedWorkbook: mocks.mockValidateUploadedWorkbook,
+      },
+      siteId: 'test-site-id',
+    }),
+  ),
+}));
+
+describe('validateUploadedWorkbookTool', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllEnvs();
+    stubDefaultEnvVars();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('should create a tool instance with correct properties', () => {
+    const tool = getValidateUploadedWorkbookTool(new WebMcpServer());
+    expect(tool.name).toBe('validate-uploaded-workbook');
+    expect(tool.description).toContain('Validates a workbook that has been uploaded');
+    expect(tool.paramsSchema).toMatchObject({ uploadSessionId: expect.any(Object) });
+  });
+
+  it('should return a successful validation result with warnings and no errors', async () => {
+    const validation = {
+      timestamp: '2026-06-10T14:32:18.456Z',
+      uploadId: '12345:abc',
+      warnings: [
+        {
+          severity: 'WARNING',
+          message: 'Unknown map source is used',
+          line: 245,
+          column: 18,
+          elementName: 'map',
+        },
+      ],
+    };
+    mocks.mockValidateUploadedWorkbook.mockResolvedValue(validation);
+
+    const result = await getToolResult({ uploadSessionId: 'session-42' });
+
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+
+    const response = JSON.parse(result.content[0].text);
+    expect(response.warnings).toEqual(validation.warnings);
+    expect(response.errors).toBeUndefined();
+
+    expect(mocks.mockValidateUploadedWorkbook).toHaveBeenCalledWith({
+      siteId: 'test-site-id',
+      uploadSessionId: 'session-42',
+    });
+  });
+
+  it('should report validation errors as structured success data (not a tool error)', async () => {
+    const validation = {
+      timestamp: '2026-06-10T14:32:18.456Z',
+      errors: [
+        {
+          severity: 'ERROR',
+          message: 'Missing required closing tag for element',
+          line: 1,
+          column: 1,
+          elementName: 'x',
+        },
+      ],
+      warnings: [],
+    };
+    mocks.mockValidateUploadedWorkbook.mockResolvedValue(validation);
+
+    const result = await getToolResult({ uploadSessionId: 'session-42' });
+
+    // A 422-style "validation found problems" result is a normal outcome, not a failure.
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+
+    const response = JSON.parse(result.content[0].text);
+    expect(response.errors).toEqual(validation.errors);
+    expect(response.warnings).toEqual([]);
+
+    expect(mocks.mockValidateUploadedWorkbook).toHaveBeenCalledWith({
+      siteId: 'test-site-id',
+      uploadSessionId: 'session-42',
+    });
+  });
+
+  it('should surface a genuine request error as a tool error', async () => {
+    const errorMessage = 'Request failed with status code 404';
+    mocks.mockValidateUploadedWorkbook.mockRejectedValue(new Error(errorMessage));
+
+    const result = await getToolResult({ uploadSessionId: 'unknown-session' });
+
+    expect(result.isError).toBe(true);
+    invariant(result.content[0].type === 'text');
+    expect(result.content[0].text).toContain(errorMessage);
+  });
+});
+
+async function getToolResult(params: { uploadSessionId: string }): Promise<CallToolResult> {
+  const tool = getValidateUploadedWorkbookTool(new WebMcpServer());
+  const callback = await Provider.from(tool.callback);
+  return await callback(params, getMockRequestHandlerExtra());
+}

--- a/src/tools/web/workbooks/validateUploadedWorkbook.ts
+++ b/src/tools/web/workbooks/validateUploadedWorkbook.ts
@@ -1,0 +1,62 @@
+import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { Ok } from 'ts-results-es';
+import { z } from 'zod';
+
+import { useRestApi } from '../../../restApiInstance.js';
+import { WorkbookValidationResult } from '../../../sdks/tableau/types/workbookValidation.js';
+import { WebMcpServer } from '../../../server.web.js';
+import { WebTool } from '../tool.js';
+
+const paramsSchema = {
+  uploadSessionId: z
+    .string()
+    .describe(
+      'The ID of the file upload session containing the workbook to validate. Obtained from a prior file-upload session (Initiate File Upload).',
+    ),
+};
+
+export const getValidateUploadedWorkbookTool = (
+  server: WebMcpServer,
+): WebTool<typeof paramsSchema> => {
+  const validateUploadedWorkbookTool = new WebTool({
+    server,
+    name: 'validate-uploaded-workbook',
+    description:
+      'Validates a workbook that has been uploaded to the site via a file upload session. Returns the structural errors and warnings found by validation. An empty (or absent) errors list means the workbook is valid; a populated errors list is a normal validation outcome, not a tool failure.',
+    paramsSchema,
+    annotations: {
+      title: 'Validate Uploaded Workbook',
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
+    callback: async ({ uploadSessionId }, extra): Promise<CallToolResult> => {
+      await extra.getConfigWithOverrides();
+
+      return await validateUploadedWorkbookTool.logAndExecute<WorkbookValidationResult>({
+        extra,
+        args: { uploadSessionId },
+        callback: async () => {
+          const result = await useRestApi({
+            ...extra,
+            jwtScopes: validateUploadedWorkbookTool.requiredApiScopes,
+            callback: async (restApi) =>
+              await restApi.workbooksMethods.validateUploadedWorkbook({
+                siteId: restApi.siteId,
+                uploadSessionId,
+              }),
+          });
+
+          return new Ok(result);
+        },
+        // Both an errors-present and an errors-absent result are legitimate validation
+        // outcomes, so this always resolves to success — a populated `errors` array is
+        // structured data for the model, not a tool failure.
+        constrainSuccessResult: (result) => ({ type: 'success', result }),
+      });
+    },
+  });
+
+  return validateUploadedWorkbookTool;
+};


### PR DESCRIPTION
## Description
- Adds MCP tool `validate-uploaded-workbook`, wrapping the SDK's `validateUploadedWorkbook` method (from #738).
- A 422 (validation found structural errors) is treated as a normal outcome, not a tool error — surfaced as `isError: false` with the errors/warnings as structured data, at both the SDK method and tool layers. Only genuine 400/404/network failures propagate as errors.
- Adds a dedicated `tableau:mcp:workbook:create` MCP scope (mirrors `delete-content`'s pattern of a dedicated mutating scope rather than reusing the read scope).

## Motivation and Context
Completes the SDK work in #738 with a usable MCP tool.

## Type of Change
- [x] New feature

## How Has This Been Tested?
Full suite (`npx vitest run`), `tsc --noEmit`, and lint all pass. New tests cover: tool shape, success-with-warnings, validation-errors-as-success-data (asserts `isError: false`), and genuine request errors (`isError: true`).

## Related Issues
Builds on #738

## Checklist
- [x] New and existing unit tests pass locally with my changes