### PR TITLE
feat: add publish-workbook tool

### DIFF
--- a/src/overridableConfig.test.ts
+++ b/src/overridableConfig.test.ts
@@ -56,7 +56,12 @@ describe('OverridableConfig', () => {
       vi.stubEnv('INCLUDE_TOOLS', 'query-datasource,workbook');
 
       const config = new OverridableConfig({});
-      expect(config.includeTools).toEqual(['query-datasource', 'list-workbooks', 'get-workbook']);
+      expect(config.includeTools).toEqual([
+        'query-datasource',
+        'list-workbooks',
+        'get-workbook',
+        'publish-workbook',
+      ]);
     });
 
     it('should parse EXCLUDE_TOOLS into an array of valid tool names', () => {
@@ -70,7 +75,12 @@ describe('OverridableConfig', () => {
       vi.stubEnv('EXCLUDE_TOOLS', 'query-datasource,workbook');
 
       const config = new OverridableConfig({});
-      expect(config.excludeTools).toEqual(['query-datasource', 'list-workbooks', 'get-workbook']);
+      expect(config.excludeTools).toEqual([
+        'query-datasource',
+        'list-workbooks',
+        'get-workbook',
+        'publish-workbook',
+      ]);
     });
 
     it('should filter out invalid tool names from INCLUDE_TOOLS', () => {

--- a/src/restApiInstance.ts
+++ b/src/restApiInstance.ts
@@ -38,6 +38,7 @@ type JwtScopes =
   | 'tableau:tasks:write'
   | 'tableau:workbook_tags:update'
   | 'tableau:workbooks:delete'
+  | 'tableau:workbooks:create'
   | 'tableau:datasource_tags:update'
   | 'tableau:datasources:delete'
   | 'tableau:jobs:read'

--- a/src/server/oauth/scopes.ts
+++ b/src/server/oauth/scopes.ts
@@ -19,6 +19,7 @@ export type McpScope =
   | 'tableau:mcp:content:read'
   | 'tableau:mcp:datasource:read'
   | 'tableau:mcp:workbook:read'
+  | 'tableau:mcp:workbook:create'
   | 'tableau:mcp:view:read'
   | 'tableau:mcp:view:download'
   | 'tableau:mcp:flow:read'
@@ -50,6 +51,7 @@ export type TableauApiScope =
   | 'tableau:tasks:write'
   | 'tableau:workbook_tags:update'
   | 'tableau:workbooks:delete'
+  | 'tableau:workbooks:create'
   | 'tableau:datasource_tags:update'
   | 'tableau:datasources:delete'
   | 'tableau:jobs:read'
@@ -69,6 +71,7 @@ export const DEFAULT_SCOPES_SUPPORTED: ReadonlyArray<McpScope> = [
   'tableau:mcp:jobs:read',
   'tableau:mcp:users:read',
   'tableau:mcp:workbook:read',
+  'tableau:mcp:workbook:create',
   'tableau:mcp:content:read',
   'tableau:mcp:content:delete',
   'tableau:mcp:users:write',
@@ -237,6 +240,13 @@ const toolScopeMap: Record<
   'get-workbook': {
     mcp: ['tableau:mcp:workbook:read'],
     api: new Set(['tableau:content:read', ...RESOURCE_ACCESS_CHECKER_REQUIRED_API_SCOPES]),
+  },
+  // Commits an already-staged file upload session as a published workbook. Does NOT validate the
+  // workbook first (that is a separate, opt-in step). Publishing is the only Tableau REST call, so
+  // only the workbook-create scope is needed.
+  'publish-workbook': {
+    mcp: ['tableau:mcp:workbook:create'],
+    api: new Set(['tableau:workbooks:create']),
   },
   'get-view': {
     mcp: ['tableau:mcp:view:read'],

--- a/src/tools/web/toolName.ts
+++ b/src/tools/web/toolName.ts
@@ -15,6 +15,7 @@ export const webToolNames = [
   'get-embed-token',
   'record-event',
   'get-workbook',
+  'publish-workbook',
   'get-view',
   'get-flow',
   'list-flow-runs',
@@ -63,7 +64,7 @@ export type WebToolGroupName = (typeof webToolGroupNames)[number];
 
 export const webToolGroups = {
   datasource: ['list-datasources', 'get-datasource-metadata', 'query-datasource'],
-  workbook: ['list-workbooks', 'get-workbook'],
+  workbook: ['list-workbooks', 'get-workbook', 'publish-workbook'],
   project: ['list-projects'],
   view: [
     'list-views',

--- a/src/tools/web/tools.ts
+++ b/src/tools/web/tools.ts
@@ -38,6 +38,7 @@ import { getListCustomViewsTool } from './views/listCustomViews.js';
 import { getListViewsTool } from './views/listViews.js';
 import { getGetWorkbookTool } from './workbooks/getWorkbook.js';
 import { getListWorkbooksTool } from './workbooks/listWorkbooks.js';
+import { getPublishWorkbookTool } from './workbooks/publishWorkbook.js';
 
 export const webToolFactories = [
   getGetDatasourceMetadataTool,
@@ -65,6 +66,7 @@ export const webToolFactories = [
   getGeneratePulseInsightBriefTool,
   getGenerateInsightCardsTool,
   getGetWorkbookTool,
+  getPublishWorkbookTool,
   getGetViewTool,
   getGetViewDataTool,
   getGetViewImageTool,

--- a/src/tools/web/workbooks/publishWorkbook.test.ts
+++ b/src/tools/web/workbooks/publishWorkbook.test.ts
@@ -1,0 +1,164 @@
+import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+
+import { WebMcpServer } from '../../../server.web.js';
+import { stubDefaultEnvVars } from '../../../testShared.js';
+import invariant from '../../../utils/invariant.js';
+import { Provider } from '../../../utils/provider.js';
+import { getMockRequestHandlerExtra } from '../toolContext.mock.js';
+import { mockWorkbook } from './mockWorkbook.js';
+import { getPublishWorkbookTool } from './publishWorkbook.js';
+
+const mocks = vi.hoisted(() => ({
+  mockPublishWorkbook: vi.fn(),
+  mockValidateUploadedWorkbook: vi.fn(),
+}));
+
+vi.mock('../../../restApiInstance.js', () => ({
+  useRestApi: vi.fn().mockImplementation(async ({ callback }) =>
+    callback({
+      workbooksMethods: {
+        publishWorkbook: mocks.mockPublishWorkbook,
+        validateUploadedWorkbook: mocks.mockValidateUploadedWorkbook,
+      },
+      siteId: 'test-site-id',
+    }),
+  ),
+}));
+
+const validArgs = {
+  uploadSessionId: 'upload-session-123',
+  name: 'My New Workbook',
+  projectId: 'ae5e9374-2a58-40ab-93e4-a2fd1b07cf7d',
+};
+
+describe('publishWorkbookTool', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllEnvs();
+    stubDefaultEnvVars();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('should create a tool instance with correct properties', () => {
+    const publishWorkbookTool = getPublishWorkbookTool(new WebMcpServer());
+    expect(publishWorkbookTool.name).toBe('publish-workbook');
+    expect(publishWorkbookTool.description).toContain('Publishes a workbook');
+    expect(publishWorkbookTool.paramsSchema).toMatchObject({
+      uploadSessionId: expect.any(Object),
+      name: expect.any(Object),
+      projectId: expect.any(Object),
+      overwrite: expect.any(Object),
+    });
+  });
+
+  it('should state in its description that it does not validate the workbook', () => {
+    const publishWorkbookTool = getPublishWorkbookTool(new WebMcpServer());
+    expect(publishWorkbookTool.description).toContain('does NOT validate');
+    expect(publishWorkbookTool.description).toContain('validate-uploaded-workbook');
+  });
+
+  it('should be annotated as a non-read-only, non-destructive create operation', () => {
+    const publishWorkbookTool = getPublishWorkbookTool(new WebMcpServer());
+    expect(publishWorkbookTool.annotations).toMatchObject({
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: false,
+    });
+  });
+
+  it('should successfully publish a workbook and return its data and url', async () => {
+    mocks.mockPublishWorkbook.mockResolvedValue(mockWorkbook);
+
+    const result = await getToolResult(validArgs);
+
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+
+    const response = JSON.parse(result.content[0].text);
+    expect(response.data).toBeDefined();
+    expect(response.data.id).toBe(mockWorkbook.id);
+    expect(response.data.name).toBe('Superstore');
+    expect(response.url).toBe(
+      'https://my-tableau-server.com/#/site/tc25/views/Superstore/Overview',
+    );
+
+    expect(mocks.mockPublishWorkbook).toHaveBeenCalledWith({
+      siteId: 'test-site-id',
+      uploadSessionId: 'upload-session-123',
+      workbookType: 'twb',
+      name: 'My New Workbook',
+      projectId: 'ae5e9374-2a58-40ab-93e4-a2fd1b07cf7d',
+      overwrite: undefined,
+    });
+  });
+
+  it('should pass overwrite through to the SDK when provided', async () => {
+    mocks.mockPublishWorkbook.mockResolvedValue(mockWorkbook);
+
+    await getToolResult({ ...validArgs, overwrite: true });
+
+    expect(mocks.mockPublishWorkbook).toHaveBeenCalledWith(
+      expect.objectContaining({ overwrite: true }),
+    );
+  });
+
+  it('should fall back to webpageUrl when the workbook has no views', async () => {
+    const { views: _views, ...workbookWithoutViews } = mockWorkbook;
+    mocks.mockPublishWorkbook.mockResolvedValue({
+      ...workbookWithoutViews,
+      webpageUrl: 'https://my-tableau-server.com/#/workbooks/123/views',
+    });
+
+    const result = await getToolResult(validArgs);
+
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+    const response = JSON.parse(result.content[0].text);
+    expect(response.url).toBe('https://my-tableau-server.com/#/workbooks/123/views');
+  });
+
+  it('should NOT validate the uploaded workbook before publishing', async () => {
+    mocks.mockPublishWorkbook.mockResolvedValue(mockWorkbook);
+
+    await getToolResult(validArgs);
+
+    // The "we're not validating" design decision: publishing must never call the validation
+    // endpoint. This is a regression guard for that explicit choice.
+    expect(mocks.mockValidateUploadedWorkbook).not.toHaveBeenCalled();
+    expect(mocks.mockPublishWorkbook).toHaveBeenCalledTimes(1);
+  });
+
+  it('should handle API errors gracefully', async () => {
+    const errorMessage = 'API Error';
+    mocks.mockPublishWorkbook.mockRejectedValue(new Error(errorMessage));
+
+    const result = await getToolResult(validArgs);
+
+    expect(result.isError).toBe(true);
+    invariant(result.content[0].type === 'text');
+    expect(result.content[0].text).toContain(errorMessage);
+  });
+});
+
+async function getToolResult(params: {
+  uploadSessionId: string;
+  name: string;
+  projectId: string;
+  overwrite?: boolean;
+}): Promise<CallToolResult> {
+  const publishWorkbookTool = getPublishWorkbookTool(new WebMcpServer());
+  const callback = await Provider.from(publishWorkbookTool.callback);
+  return await callback(
+    {
+      uploadSessionId: params.uploadSessionId,
+      name: params.name,
+      projectId: params.projectId,
+      overwrite: params.overwrite,
+    },
+    getMockRequestHandlerExtra(),
+  );
+}

--- a/src/tools/web/workbooks/publishWorkbook.ts
+++ b/src/tools/web/workbooks/publishWorkbook.ts
@@ -1,0 +1,98 @@
+import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { Ok } from 'ts-results-es';
+import { z } from 'zod';
+
+import { useRestApi } from '../../../restApiInstance.js';
+import { Workbook } from '../../../sdks/tableau/types/workbook.js';
+import { WebMcpServer } from '../../../server.web.js';
+import { WebTool } from '../tool.js';
+import { getDefaultViewWebUrl } from '../utils/viewUrlUtils.js';
+
+const paramsSchema = {
+  uploadSessionId: z
+    .string()
+    .describe(
+      'The upload session ID returned by a prior Initiate File Upload / Append to File Upload sequence. The workbook file must already be fully staged into this session.',
+    ),
+  name: z.string().describe('The name to give the published workbook.'),
+  projectId: z.string().describe('The LUID of the project to publish the workbook into.'),
+  overwrite: z
+    .boolean()
+    .optional()
+    .describe(
+      'Whether to overwrite an existing workbook with the same name in the target project. Defaults to false.',
+    ),
+};
+
+export const getPublishWorkbookTool = (server: WebMcpServer): WebTool<typeof paramsSchema> => {
+  const publishWorkbookTool = new WebTool({
+    server,
+    name: 'publish-workbook',
+    description: `
+Publishes a workbook to a Tableau site by committing a file that was already staged into an upload session via a prior Initiate File Upload / Append to File Upload sequence. This tool publishes \`.twb\` (unpackaged workbook XML) uploads specifically.
+
+**This tool does NOT validate the workbook before publishing.** It commits the upload session as-is. Tableau's Publish Workbook REST endpoint does not itself check the TWB's structural or semantic correctness — it only enforces things like file size limits, that not all views are hidden, and that connections are reachable. If you want a safety check before publishing, call the \`validate-uploaded-workbook\` tool (or the equivalent SDK method) against the same \`uploadSessionId\` first, then call this tool only if validation passes.
+
+Returns the published workbook's metadata (including its new LUID) and a URL to view it.`,
+    paramsSchema,
+    annotations: {
+      title: 'Publish Workbook',
+      readOnlyHint: false,
+      // Publishing creates new content. It only overwrites an existing workbook when the caller
+      // explicitly passes `overwrite: true`, so it is not destructive by default.
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: false,
+    },
+    callback: async (
+      { uploadSessionId, name, projectId, overwrite },
+      extra,
+    ): Promise<CallToolResult> => {
+      return await publishWorkbookTool.logAndExecute<{ data: Workbook; url: string }>({
+        extra,
+        args: { uploadSessionId, name, projectId, overwrite },
+        callback: async () => {
+          const workbook = await useRestApi({
+            ...extra,
+            jwtScopes: publishWorkbookTool.requiredApiScopes,
+            callback: async (restApi) =>
+              await restApi.workbooksMethods.publishWorkbook({
+                siteId: restApi.siteId,
+                uploadSessionId,
+                // This tool only publishes unpackaged `.twb` workbook XML uploads; every
+                // upload-staging path in this codebase produces a `.twb`, so the file type is
+                // hardcoded rather than exposed as a caller-supplied param.
+                workbookType: 'twb',
+                name,
+                projectId,
+                overwrite,
+              }),
+          });
+
+          return new Ok({
+            data: workbook,
+            url: '', // Placeholder, will be computed in constrainSuccessResult
+          });
+        },
+        constrainSuccessResult: (result) => {
+          const { data: workbook } = result;
+
+          const url =
+            getDefaultViewWebUrl(workbook, extra.config.server, extra.getSiteName()) ??
+            workbook.webpageUrl ??
+            '';
+
+          return {
+            type: 'success',
+            result: {
+              data: workbook,
+              url,
+            },
+          };
+        },
+      });
+    },
+  });
+
+  return publishWorkbookTool;
+};


### PR DESCRIPTION
## Description

Adds a new MCP tool, `publish-workbook`, that thinly wraps the SDK's existing `workbooksMethods.publishWorkbook` method. It commits a `.twb` file that was already staged into an upload session via a prior `Initiate File Upload` / `Append to File Upload` sequence.

Params: `uploadSessionId`, `name`, `projectId`, `overwrite?`. `workbookType` is intentionally not exposed — every upload-staging path in this repo only ever produces `.twb` files, so it's hardcoded internally.

## Motivation and Context

This is the "commit" half of the upload → validate → publish flow for the web-authoring-from-file-upload work. `stageWorkbookForWebAuthoring` (already on this branch) covers upload + validate + authoring-URL construction; this tool adds the missing publish step.

By design, this tool does **not** validate before publishing. Tableau's Publish Workbook REST endpoint doesn't itself check TWB structural/semantic correctness (only things like file size, all-views-hidden, and reachable connections), so publishing an invalid TWB is genuinely possible. Callers who want a safety check should call `validate-uploaded-workbook` against the same `uploadSessionId` first — this tool's description says so explicitly.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## How Has This Been Tested?

- Unit tests in `src/tools/web/workbooks/publishWorkbook.test.ts` (8 cases): tool metadata/annotations, successful publish shape + URL, `overwrite` passthrough, `webpageUrl` fallback when there are no views yet, a regression guard asserting `validateUploadedWorkbook` is never called, and graceful API-error handling.
- Full suite: `npx tsc --noEmit`, `npx vitest run` (175 files / 2752 tests), `npm run lint` — all clean.
- Manually verified end-to-end against a live Tableau Cloud site via the MCP Inspector: uploaded a `.twb`, called `publish-workbook` with a real `uploadSessionId`/`projectId`, and confirmed the workbook published successfully.
- Independently reviewed twice (fresh reviewer agent, not the implementer) — both passed with no blocking issues.

## Related Issues

Builds on #738 (validateUploadedWorkbook SDK support) and #742 (validate-uploaded-workbook tool).

## Checklist

- [ ] I have updated the version in the package.json file by using `npm run version`.
- [x] I have made any necessary changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have documented any breaking changes in the PR description.

## Contributor Agreement

- [x] I have read the CONTRIBUTING guidelines for this project and followed its Contribution Checklist.