### PR TITLE
Expose upload session ID from web authoring tool

### DIFF
--- a/src/tools/web/workbooks/publishWorkbook.test.ts
+++ b/src/tools/web/workbooks/publishWorkbook.test.ts
@@ -54,10 +54,11 @@ describe('publishWorkbookTool', () => {
     });
   });
 
-  it('should state in its description that it does not validate the workbook', () => {
+  it('should direct callers to use the validated upload session from the start tool', () => {
     const publishWorkbookTool = getPublishWorkbookTool(new WebMcpServer());
-    expect(publishWorkbookTool.description).toContain('does NOT validate');
-    expect(publishWorkbookTool.description).toContain('validate-uploaded-workbook');
+    expect(publishWorkbookTool.description).toContain('does NOT validate the workbook again');
+    expect(publishWorkbookTool.description).toContain('start-web-authoring-session');
+    expect(publishWorkbookTool.description).not.toContain('validate-uploaded-workbook');
   });
 
   it('should be annotated as a non-read-only, non-destructive create operation', () => {
@@ -104,6 +105,25 @@ describe('publishWorkbookTool', () => {
     expect(mocks.mockPublishWorkbook).toHaveBeenCalledWith(
       expect.objectContaining({ overwrite: true }),
     );
+  });
+
+  it('should redact the upload session ID passed to shared logging', async () => {
+    const tool = getPublishWorkbookTool(new WebMcpServer());
+    const callback = await Provider.from(tool.callback);
+    const logAndExecute = vi
+      .spyOn(tool, 'logAndExecute')
+      .mockResolvedValue({ isError: false, content: [] } as CallToolResult);
+
+    await callback(validArgs, getMockRequestHandlerExtra());
+
+    const loggedArgs = logAndExecute.mock.calls[0][0].args;
+    expect(loggedArgs).toEqual({
+      uploadSessionId: '<redacted>',
+      name: validArgs.name,
+      projectId: validArgs.projectId,
+      overwrite: undefined,
+    });
+    expect(JSON.stringify(loggedArgs)).not.toContain(validArgs.uploadSessionId);
   });
 
   it('should fall back to webpageUrl when the workbook has no views', async () => {

--- a/src/tools/web/workbooks/publishWorkbook.ts
+++ b/src/tools/web/workbooks/publishWorkbook.ts
@@ -12,7 +12,7 @@ const paramsSchema = {
   uploadSessionId: z
     .string()
     .describe(
-      'The upload session ID returned by a prior Initiate File Upload / Append to File Upload sequence. The workbook file must already be fully staged into this session.',
+      'The validated upload session ID returned by start-web-authoring-session. The workbook file must already be fully staged into this session.',
     ),
   name: z.string().describe('The name to give the published workbook.'),
   projectId: z.string().describe('The LUID of the project to publish the workbook into.'),
@@ -29,9 +29,9 @@ export const getPublishWorkbookTool = (server: WebMcpServer): WebTool<typeof par
     server,
     name: 'publish-workbook',
     description: `
-Publishes a workbook to a Tableau site by committing a file that was already staged into an upload session via a prior Initiate File Upload / Append to File Upload sequence. This tool publishes \`.twb\` (unpackaged workbook XML) uploads specifically.
+Publishes a workbook to a Tableau site by committing the validated staged file associated with an \`uploadSessionId\` returned by \`start-web-authoring-session\`. This tool publishes \`.twb\` (unpackaged workbook XML) uploads specifically.
 
-**This tool does NOT validate the workbook before publishing.** It commits the upload session as-is. Tableau's Publish Workbook REST endpoint does not itself check the TWB's structural or semantic correctness — it only enforces things like file size limits, that not all views are hidden, and that connections are reachable. If you want a safety check before publishing, call the \`validate-uploaded-workbook\` tool (or the equivalent SDK method) against the same \`uploadSessionId\` first, then call this tool only if validation passes.
+**This tool does NOT validate the workbook again before publishing.** Use the \`uploadSessionId\` from a successful \`start-web-authoring-session\` result, which is returned only after validation has no blocking errors. This publishes the staged TWB associated with that upload session; it does not capture later edits made in the browser's live Web Authoring session.
 
 Returns the published workbook's metadata (including its new LUID) and a URL to view it.`,
     paramsSchema,
@@ -50,7 +50,7 @@ Returns the published workbook's metadata (including its new LUID) and a URL to 
     ): Promise<CallToolResult> => {
       return await publishWorkbookTool.logAndExecute<{ data: Workbook; url: string }>({
         extra,
-        args: { uploadSessionId, name, projectId, overwrite },
+        args: { uploadSessionId: '<redacted>', name, projectId, overwrite },
         callback: async () => {
           const workbook = await useRestApi({
             ...extra,

--- a/src/tools/web/workbooks/stageWorkbookForWebAuthoring.test.ts
+++ b/src/tools/web/workbooks/stageWorkbookForWebAuthoring.test.ts
@@ -47,6 +47,7 @@ describe('stageWorkbookForWebAuthoring', () => {
       uploadSessionId: 'upload-session-id',
     });
     expect(result).toEqual({
+      uploadSessionId: 'upload-session-id',
       validation,
       authoringUrl:
         'https://tableau.example.com/vizql/show/t/blackbear/authoring/newWorkbook/new-workbook-id/fromFileUpload/upload-session-id',

--- a/src/tools/web/workbooks/stageWorkbookForWebAuthoring.ts
+++ b/src/tools/web/workbooks/stageWorkbookForWebAuthoring.ts
@@ -25,6 +25,7 @@ export type StageWorkbookForWebAuthoringArgs = {
 };
 
 export type StagedWebAuthoringWorkbook = {
+  uploadSessionId: string;
   validation: WorkbookValidationResult;
   authoringUrl: string;
 };
@@ -61,6 +62,7 @@ export async function stageWorkbookForWebAuthoring({
   );
 
   return {
+    uploadSessionId,
     validation,
     authoringUrl: await runStage('handoff', async () =>
       constructWebAuthoringUrl({

--- a/src/tools/web/workbooks/startWebAuthoringSession.test.ts
+++ b/src/tools/web/workbooks/startWebAuthoringSession.test.ts
@@ -54,12 +54,13 @@ describe('getStartWebAuthoringSessionTool', () => {
     expect(schema.safeParse({ workbookFilePath, extra: true }).success).toBe(false);
   });
 
-  it('stages a local workbook and returns a ready URL without exposing the upload ID separately', async () => {
+  it('stages a local workbook and returns its ready URL and validated upload session ID', async () => {
     vi.mocked(resolveLocalWorkbook).mockResolvedValue({
       fileName: 'generated-workbook.twb',
       bytes: Buffer.from('<workbook />'),
     });
     vi.mocked(stageWorkbookForWebAuthoring).mockResolvedValue({
+      uploadSessionId: 'upload-session-id',
       validation: {
         uploadId: 'secret-upload-id',
         timestamp: '2026-08-09T12:00:00Z',
@@ -76,6 +77,7 @@ describe('getStartWebAuthoringSessionTool', () => {
     expect(result.structuredContent).toEqual({
       status: 'ready',
       url: 'https://tableau.example.com/vizql/show/authoring/newWorkbook/id/fromFileUpload/token',
+      uploadSessionId: 'upload-session-id',
       warnings: [],
     });
     expect(result.structuredContent).not.toHaveProperty('uploadId');
@@ -102,6 +104,7 @@ describe('getStartWebAuthoringSessionTool', () => {
         bytes: Buffer.from('<workbook />'),
       });
       vi.mocked(stageWorkbookForWebAuthoring).mockResolvedValue({
+        uploadSessionId: 'upload-session-id',
         validation: { timestamp: '2026-08-09T12:00:00Z', errors: [], warnings: [] },
         authoringUrl: 'https://tableau.example.com/authoring-url',
       });
@@ -143,6 +146,7 @@ describe('getStartWebAuthoringSessionTool', () => {
 describe('toStartWebAuthoringSessionResult', () => {
   it('returns validation errors and warnings without an authoring URL', () => {
     const result = toStartWebAuthoringSessionResult({
+      uploadSessionId: 'upload-session-id',
       validation: {
         uploadId: 'secret-upload-id',
         timestamp: '2026-08-09T12:00:00Z',
@@ -158,11 +162,13 @@ describe('toStartWebAuthoringSessionResult', () => {
       warnings: [finding('warning', 'Deprecated element')],
     });
     expect(result).not.toHaveProperty('url');
+    expect(result).not.toHaveProperty('uploadSessionId');
     expect(result).not.toHaveProperty('uploadId');
   });
 
   it('removes control characters and bounds finding text', () => {
     const result = toStartWebAuthoringSessionResult({
+      uploadSessionId: 'upload-session-id',
       validation: {
         timestamp: '2026-08-09T12:00:00Z',
         errors: [],
@@ -173,6 +179,7 @@ describe('toStartWebAuthoringSessionResult', () => {
 
     expect(result.status).toBe('ready');
     if (result.status === 'ready') {
+      expect(result.uploadSessionId).toBe('upload-session-id');
       expect(result.warnings[0].severity).toBe('warning ');
       expect(result.warnings[0].message).not.toContain('\u0000');
       expect(result.warnings[0].message).toHaveLength(2_000);

--- a/src/tools/web/workbooks/startWebAuthoringSession.ts
+++ b/src/tools/web/workbooks/startWebAuthoringSession.ts
@@ -30,6 +30,7 @@ export type StartWebAuthoringSessionResult =
   | {
       status: 'ready';
       url: string;
+      uploadSessionId: string;
       warnings: ValidationFinding[];
     }
   | {
@@ -45,7 +46,7 @@ export const getStartWebAuthoringSessionTool = (
     server,
     name: 'start-web-authoring-session',
     description:
-      'Starts a live, unsaved Tableau Web Authoring session from a local TWB file. The tool reads the bounded local file, stages and validates it through Tableau temporary upload APIs, and returns an authoring URL only when validation has no blocking errors. It never publishes or saves the workbook.',
+      'Starts a live, unsaved Tableau Web Authoring session from a local TWB file. The tool reads the bounded local file, stages and validates it through Tableau temporary upload APIs, and returns an authoring URL and uploadSessionId only when validation has no blocking errors. Pass that uploadSessionId to publish-workbook to publish the validated staged TWB. This tool never publishes or saves the workbook.',
     paramsSchema,
     annotations: {
       title: 'Start Web Authoring Session',
@@ -96,6 +97,7 @@ export const getStartWebAuthoringSessionTool = (
 };
 
 export function toStartWebAuthoringSessionResult({
+  uploadSessionId,
   validation,
   authoringUrl,
 }: Awaited<ReturnType<typeof stageWorkbookForWebAuthoring>>): StartWebAuthoringSessionResult {
@@ -106,7 +108,7 @@ export function toStartWebAuthoringSessionResult({
     return { status: 'invalid', errors, warnings };
   }
 
-  return { status: 'ready', url: authoringUrl, warnings };
+  return { status: 'ready', url: authoringUrl, uploadSessionId, warnings };
 }
 
 function isSupportedWebAuthoringAuth(


### PR DESCRIPTION
## Summary
- return `uploadSessionId` with successful `start-web-authoring-session` results
- omit the ID when workbook validation fails
- direct `publish-workbook` callers to the validated session ID and redact it from shared logs

## Verification
- `npm run build`
- `npm exec eslint -- src`
- 23 focused web-authoring tests
- full suite: 177 files, 2,776 tests