### PR TITLE
feat(desktop): pause/resume auto-updates — routes, inventory fields, and MCP tools (API 0.2.5)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "2.61.0",
+  "version": "2.62.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "2.61.0",
+      "version": "2.62.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.7.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "2.61.0",
+  "version": "2.62.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/src/desktop/externalApi/__fixtures__/externalClientApi-openapi.json
+++ b/src/desktop/externalApi/__fixtures__/externalClientApi-openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Tableau External Client API",
-    "version": "0.2.4",
+    "version": "0.2.5",
     "description": "Loopback HTTP interface for reading and authoring the open Tableau Desktop document. Clients authenticate with the bearer token published in the per-user discovery file."
   },
   "servers": [
@@ -816,6 +816,73 @@
         }
       }
     },
+    "/v0/workbook/dashboards/{id}:pauseAutoUpdates": {
+      "post": {
+        "summary": "Pause dashboard auto-updates",
+        "description": "Pauses automatic query execution for a dashboard so several edits can be batched before the next refresh.",
+        "operationId": "pauseDashboardAutoUpdates",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Pauses automatic query execution for a dashboard so several edits can be batched before the next refresh.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Operation"
+                }
+              }
+            },
+            "headers": {
+              "X-Tableau-Operation-Id": {
+                "description": "Id of the operation.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "X-Tableau-Application-Version": {
+                "description": "Running Tableau Desktop build.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "202": {
+            "$ref": "#/components/responses/Accepted"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "421": {
+            "$ref": "#/components/responses/MisdirectedRequest"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          },
+          "503": {
+            "$ref": "#/components/responses/ServiceUnavailable"
+          }
+        }
+      }
+    },
     "/v0/workbook/dashboards/{id}:rename": {
       "post": {
         "summary": "Rename a dashboard",
@@ -877,6 +944,73 @@
           },
           "403": {
             "$ref": "#/components/responses/Forbidden"
+          },
+          "421": {
+            "$ref": "#/components/responses/MisdirectedRequest"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          },
+          "503": {
+            "$ref": "#/components/responses/ServiceUnavailable"
+          }
+        }
+      }
+    },
+    "/v0/workbook/dashboards/{id}:resumeAutoUpdates": {
+      "post": {
+        "summary": "Resume dashboard auto-updates",
+        "description": "Resumes automatic query execution for a dashboard.",
+        "operationId": "resumeDashboardAutoUpdates",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resumes automatic query execution for a dashboard.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Operation"
+                }
+              }
+            },
+            "headers": {
+              "X-Tableau-Operation-Id": {
+                "description": "Id of the operation.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "X-Tableau-Application-Version": {
+                "description": "Running Tableau Desktop build.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "202": {
+            "$ref": "#/components/responses/Accepted"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
           },
           "421": {
             "$ref": "#/components/responses/MisdirectedRequest"
@@ -1985,7 +2119,7 @@
             "name": "columnsToIncludeByFieldName",
             "in": "query",
             "required": false,
-            "description": "Field name to restrict the returned columns; repeat the parameter to include several (values are not comma-split, so a field name may contain a comma).",
+            "description": "Restricts the returned columns. Each value is a base source-column name qualified by the datasource caption (e.g. \"[Sample - Superstore].[Sales]\"). A value that matches no column is silently ignored. Repeat the parameter to name several; values are not comma-split, so a name may contain a comma.",
             "schema": {
               "type": "string"
             }
@@ -2074,7 +2208,7 @@
             "name": "columnsToIncludeByFieldName",
             "in": "query",
             "required": false,
-            "description": "Field name to restrict the returned columns; repeat the parameter to include several (values are not comma-split, so a field name may contain a comma).",
+            "description": "Restricts the returned columns. Each value is a column-instance name qualified by the datasource caption, as it appears in the worksheet's <cols>/<rows> (e.g. \"[Sample - Superstore].[none:Ship Mode:nk]\"). A value that matches no column is silently ignored. Repeat the parameter to name several; values are not comma-split, so a name may contain a comma.",
             "schema": {
               "type": "string"
             }
@@ -2185,6 +2319,73 @@
         }
       }
     },
+    "/v0/workbook/worksheets/{id}:pauseAutoUpdates": {
+      "post": {
+        "summary": "Pause worksheet auto-updates",
+        "description": "Pauses automatic query execution for a worksheet so several edits can be batched before the next refresh.",
+        "operationId": "pauseWorksheetAutoUpdates",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Pauses automatic query execution for a worksheet so several edits can be batched before the next refresh.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Operation"
+                }
+              }
+            },
+            "headers": {
+              "X-Tableau-Operation-Id": {
+                "description": "Id of the operation.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "X-Tableau-Application-Version": {
+                "description": "Running Tableau Desktop build.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "202": {
+            "$ref": "#/components/responses/Accepted"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "421": {
+            "$ref": "#/components/responses/MisdirectedRequest"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          },
+          "503": {
+            "$ref": "#/components/responses/ServiceUnavailable"
+          }
+        }
+      }
+    },
     "/v0/workbook/worksheets/{id}:rename": {
       "post": {
         "summary": "Rename a worksheet",
@@ -2246,6 +2447,73 @@
           },
           "403": {
             "$ref": "#/components/responses/Forbidden"
+          },
+          "421": {
+            "$ref": "#/components/responses/MisdirectedRequest"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          },
+          "503": {
+            "$ref": "#/components/responses/ServiceUnavailable"
+          }
+        }
+      }
+    },
+    "/v0/workbook/worksheets/{id}:resumeAutoUpdates": {
+      "post": {
+        "summary": "Resume worksheet auto-updates",
+        "description": "Resumes automatic query execution for a worksheet.",
+        "operationId": "resumeWorksheetAutoUpdates",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resumes automatic query execution for a worksheet.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Operation"
+                }
+              }
+            },
+            "headers": {
+              "X-Tableau-Operation-Id": {
+                "description": "Id of the operation.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "X-Tableau-Application-Version": {
+                "description": "Running Tableau Desktop build.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "202": {
+            "$ref": "#/components/responses/Accepted"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
           },
           "421": {
             "$ref": "#/components/responses/MisdirectedRequest"
@@ -2698,7 +2966,8 @@
         "required": [
           "id",
           "name",
-          "hidden"
+          "hidden",
+          "isActiveSheet"
         ],
         "properties": {
           "id": {
@@ -2718,8 +2987,14 @@
           "hidden": {
             "type": "boolean"
           },
+          "isActiveSheet": {
+            "type": "boolean"
+          },
           "index": {
             "type": "integer"
+          },
+          "isAutoUpdatesPaused": {
+            "type": "boolean"
           },
           "datasources": {
             "type": "array",
@@ -2735,7 +3010,8 @@
         "required": [
           "id",
           "name",
-          "hidden"
+          "hidden",
+          "isActiveSheet"
         ],
         "properties": {
           "id": {
@@ -2755,8 +3031,14 @@
           "hidden": {
             "type": "boolean"
           },
+          "isActiveSheet": {
+            "type": "boolean"
+          },
           "index": {
             "type": "integer"
+          },
+          "isAutoUpdatesPaused": {
+            "type": "boolean"
           },
           "containedSheets": {
             "type": "array",
@@ -2772,7 +3054,8 @@
         "required": [
           "id",
           "name",
-          "hidden"
+          "hidden",
+          "isActiveSheet"
         ],
         "properties": {
           "id": {
@@ -2790,6 +3073,9 @@
             ]
           },
           "hidden": {
+            "type": "boolean"
+          },
+          "isActiveSheet": {
             "type": "boolean"
           },
           "index": {

--- a/src/desktop/externalApi/executor.mock.ts
+++ b/src/desktop/externalApi/executor.mock.ts
@@ -55,6 +55,10 @@ export function makeExecutorMock(
     renameSheet: vi.fn(),
     sortWorksheet: vi.fn(),
     goToSheet: vi.fn(),
+    pauseWorksheetAutoUpdates: vi.fn(),
+    resumeWorksheetAutoUpdates: vi.fn(),
+    pauseDashboardAutoUpdates: vi.fn(),
+    resumeDashboardAutoUpdates: vi.fn(),
   };
   return { ...defaults, ...overrides } as ExternalApiToolExecutor;
 }

--- a/src/desktop/externalApi/externalApiContract.test.ts
+++ b/src/desktop/externalApi/externalApiContract.test.ts
@@ -41,9 +41,10 @@ import {
  * fixture with it and rerun — every drift (new field, changed requiredness, enum
  * growth, route add/remove) surfaces as a red/green diff instead of a manual reread.
  *
- * Fixture provenance: live Desktop `/openapi.json`, `info.version` 0.2.4,
- * captured 2026-08-07 (a build serving worksheet logical-table reads, the
- * `:delete`, `:rename`, `:sort`, and `:goToSheet` routes, and Operation
+ * Fixture provenance: live Desktop `/openapi.json`, `info.version` 0.2.5 — a build
+ * adding the per-sheet `:pauseAutoUpdates`/`:resumeAutoUpdates` routes and the
+ * `isActiveSheet`/`isAutoUpdatesPaused` sheet-item fields, on top of the 0.2.4 surface
+ * (logical-table reads, `:delete`/`:rename`/`:sort`/`:goToSheet`, Operation
  * `blockingWindows`). No hand-edits.
  */
 
@@ -199,8 +200,12 @@ describe('external client API contract (captured openapi fixture)', () => {
       EXTERNAL_API_ROUTES.worksheetDelete,
       EXTERNAL_API_ROUTES.worksheetRename,
       EXTERNAL_API_ROUTES.worksheetSort,
+      EXTERNAL_API_ROUTES.worksheetPauseAutoUpdates,
+      EXTERNAL_API_ROUTES.worksheetResumeAutoUpdates,
       EXTERNAL_API_ROUTES.dashboardDelete,
       EXTERNAL_API_ROUTES.dashboardRename,
+      EXTERNAL_API_ROUTES.dashboardPauseAutoUpdates,
+      EXTERNAL_API_ROUTES.dashboardResumeAutoUpdates,
       EXTERNAL_API_ROUTES.storyboardDelete,
       EXTERNAL_API_ROUTES.storyboardRename,
       EXTERNAL_API_ROUTES.workbookGoToSheet,

--- a/src/desktop/externalApi/externalApiHttp.test.ts
+++ b/src/desktop/externalApi/externalApiHttp.test.ts
@@ -216,7 +216,11 @@ describe('ExternalApiHttp', () => {
           id: 'op-ws',
           kind: 'workbook.listWorksheets',
           state: 'SUCCEEDED',
-          result: { worksheets: [{ id: 'sheet-sales', name: 'Sales by Region', hidden: false }] },
+          result: {
+            worksheets: [
+              { id: 'sheet-sales', name: 'Sales by Region', hidden: false, isActiveSheet: true },
+            ],
+          },
         },
       ],
     });

--- a/src/desktop/externalApi/externalApiHttpAsyncDispatch.test.ts
+++ b/src/desktop/externalApi/externalApiHttpAsyncDispatch.test.ts
@@ -229,7 +229,11 @@ describe('ExternalApiHttp async dispatch (0.2.0)', () => {
             id: 'op-read-2',
             kind: 'workbook.listWorksheets',
             state: 'SUCCEEDED',
-            result: { worksheets: [{ id: 'sheet-sales', name: 'Sales by Region', hidden: false }] },
+            result: {
+              worksheets: [
+                { id: 'sheet-sales', name: 'Sales by Region', hidden: false, isActiveSheet: true },
+              ],
+            },
           },
         ],
       });

--- a/src/desktop/externalApi/externalApiToolExecutor.test.ts
+++ b/src/desktop/externalApi/externalApiToolExecutor.test.ts
@@ -431,6 +431,57 @@ describe('ExternalApiToolExecutor', () => {
       expect(server.requests.at(-1)?.path).toBe('/v0/workbook/storyboards/story-qbr');
     });
 
+    it.each([
+      {
+        label: 'pauses worksheet auto-updates',
+        call: (executor: ExternalApiToolExecutor) =>
+          executor.pauseWorksheetAutoUpdates('sheet-sales', signal),
+        path: '/v0/workbook/worksheets/sheet-sales:pauseAutoUpdates',
+      },
+      {
+        label: 'resumes worksheet auto-updates',
+        call: (executor: ExternalApiToolExecutor) =>
+          executor.resumeWorksheetAutoUpdates('sheet-sales', signal),
+        path: '/v0/workbook/worksheets/sheet-sales:resumeAutoUpdates',
+      },
+      {
+        label: 'pauses dashboard auto-updates',
+        call: (executor: ExternalApiToolExecutor) =>
+          executor.pauseDashboardAutoUpdates('dash-exec', signal),
+        path: '/v0/workbook/dashboards/dash-exec:pauseAutoUpdates',
+      },
+      {
+        label: 'resumes dashboard auto-updates',
+        call: (executor: ExternalApiToolExecutor) =>
+          executor.resumeDashboardAutoUpdates('dash-exec', signal),
+        path: '/v0/workbook/dashboards/dash-exec:resumeAutoUpdates',
+      },
+    ])('$label via a bodyless POST to the per-sheet action route', async ({ call, path }) => {
+      const executor = new ExternalApiToolExecutor({ discover: () => [instanceFor(server)] });
+      await executor.start();
+
+      const result = await call(executor);
+
+      expect(result.isOk()).toBe(true);
+      expect(result.unwrap().status).toBe('completed');
+      const last = server.requests.at(-1);
+      expect(last?.method).toBe('POST');
+      expect(last?.path).toBe(path);
+      expect(last?.body).toBe('');
+    });
+
+    it('dispatches auto-update pause without an id-existence guard (matches the live command)', async () => {
+      const executor = new ExternalApiToolExecutor({ discover: () => [instanceFor(server)] });
+      await executor.start();
+
+      const result = await executor.pauseWorksheetAutoUpdates('sheet-not-in-inventory', signal);
+
+      expect(result.isOk()).toBe(true);
+      expect(server.requests.at(-1)?.path).toBe(
+        '/v0/workbook/worksheets/sheet-not-in-inventory:pauseAutoUpdates',
+      );
+    });
+
     it('lists dashboards', async () => {
       const executor = new ExternalApiToolExecutor({ discover: () => [instanceFor(server)] });
       await executor.start();
@@ -725,7 +776,9 @@ describe('ExternalApiToolExecutor', () => {
             id: 'op-read',
             kind: 'workbook.listWorksheets',
             state: 'SUCCEEDED',
-            result: { worksheets: [{ id: 'ws-1', name: 'Sales', hidden: false }] },
+            result: {
+              worksheets: [{ id: 'ws-1', name: 'Sales', hidden: false, isActiveSheet: false }],
+            },
           },
         ],
       });

--- a/src/desktop/externalApi/externalApiToolExecutor.ts
+++ b/src/desktop/externalApi/externalApiToolExecutor.ts
@@ -28,6 +28,8 @@ import {
   dashboardItemSchema,
   DashboardList,
   dashboardListSchema,
+  dashboardPauseAutoUpdatesRoute,
+  dashboardResumeAutoUpdatesRoute,
   dashboardRoute,
   DatasourceList,
   datasourceListSchema,
@@ -71,6 +73,8 @@ import {
   worksheetListSchema,
   worksheetLogicalTableDataRoute,
   worksheetLogicalTablesRoute,
+  worksheetPauseAutoUpdatesRoute,
+  worksheetResumeAutoUpdatesRoute,
   worksheetRoute,
   WorksheetSort,
   worksheetSortRoute,
@@ -555,6 +559,46 @@ export class ExternalApiToolExecutor {
       (http) =>
         http.postJsonEnvelope(EXTERNAL_API_ROUTES.workbookGoToSheet, { id: sheetId }, signal),
       'go-to-sheet',
+    );
+  }
+
+  async pauseWorksheetAutoUpdates(
+    worksheetId: string,
+    signal: AbortSignal,
+  ): Promise<Result<ExecuteCommandResult<undefined>, ExecuteCommandError>> {
+    return this.applyDocument(
+      (http) => http.postEnvelope(worksheetPauseAutoUpdatesRoute(worksheetId), signal),
+      'pause-worksheet-auto-updates',
+    );
+  }
+
+  async resumeWorksheetAutoUpdates(
+    worksheetId: string,
+    signal: AbortSignal,
+  ): Promise<Result<ExecuteCommandResult<undefined>, ExecuteCommandError>> {
+    return this.applyDocument(
+      (http) => http.postEnvelope(worksheetResumeAutoUpdatesRoute(worksheetId), signal),
+      'resume-worksheet-auto-updates',
+    );
+  }
+
+  async pauseDashboardAutoUpdates(
+    dashboardId: string,
+    signal: AbortSignal,
+  ): Promise<Result<ExecuteCommandResult<undefined>, ExecuteCommandError>> {
+    return this.applyDocument(
+      (http) => http.postEnvelope(dashboardPauseAutoUpdatesRoute(dashboardId), signal),
+      'pause-dashboard-auto-updates',
+    );
+  }
+
+  async resumeDashboardAutoUpdates(
+    dashboardId: string,
+    signal: AbortSignal,
+  ): Promise<Result<ExecuteCommandResult<undefined>, ExecuteCommandError>> {
+    return this.applyDocument(
+      (http) => http.postEnvelope(dashboardResumeAutoUpdatesRoute(dashboardId), signal),
+      'resume-dashboard-auto-updates',
     );
   }
 

--- a/src/desktop/externalApi/mockExternalApiServer.ts
+++ b/src/desktop/externalApi/mockExternalApiServer.ts
@@ -81,6 +81,8 @@ const DEFAULT_WORKSHEETS = [
     name: 'Sales by Region',
     type: 'WORKSHEET',
     hidden: false,
+    isActiveSheet: true,
+    isAutoUpdatesPaused: false,
     index: 0,
     datasources: ['Sample - Superstore'],
   },
@@ -89,6 +91,8 @@ const DEFAULT_WORKSHEETS = [
     name: 'Profit by Category',
     type: 'WORKSHEET',
     hidden: false,
+    isActiveSheet: false,
+    isAutoUpdatesPaused: true,
     index: 1,
     datasources: ['Sample - Superstore'],
   },
@@ -99,6 +103,8 @@ const DEFAULT_DASHBOARDS = [
     name: 'Executive Dashboard',
     type: 'DASHBOARD',
     hidden: false,
+    isActiveSheet: false,
+    isAutoUpdatesPaused: false,
     index: 2,
     containedSheets: ['sheet-sales', 'sheet-profit'],
   },
@@ -109,6 +115,7 @@ const DEFAULT_STORYBOARDS = [
     name: 'QBR Story',
     type: 'STORYBOARD',
     hidden: false,
+    isActiveSheet: false,
     index: 3,
     storyPointCount: 4,
   },
@@ -780,6 +787,17 @@ export async function startMockExternalApiServer(
         return;
       }
       sendOperation(res, 'go-to-sheet');
+      return;
+    }
+
+    // Deliberately no id guard (unlike the sibling :sort/:document routes): AutoUpdates succeeds for
+    // any id, so this never 404s on an unknown sheet.
+    const autoUpdatesMatch = path.match(
+      /^\/v0\/workbook\/(worksheets|dashboards)\/([^/]+):(pause|resume)AutoUpdates$/,
+    );
+    if (method === 'POST' && autoUpdatesMatch) {
+      const [, , , action] = autoUpdatesMatch;
+      sendOperation(res, `${action}-auto-updates`);
       return;
     }
 

--- a/src/desktop/externalApi/types.ts
+++ b/src/desktop/externalApi/types.ts
@@ -30,6 +30,8 @@ export const EXTERNAL_API_ROUTES = {
   dashboardImage: '/v0/workbook/dashboards/{id}/image',
   dashboardDelete: '/v0/workbook/dashboards/{id}:delete',
   dashboardRename: '/v0/workbook/dashboards/{id}:rename',
+  dashboardPauseAutoUpdates: '/v0/workbook/dashboards/{id}:pauseAutoUpdates',
+  dashboardResumeAutoUpdates: '/v0/workbook/dashboards/{id}:resumeAutoUpdates',
   storyboardById: '/v0/workbook/storyboards/{id}',
   storyboardDocument: '/v0/workbook/storyboards/{id}/document',
   storyboardDelete: '/v0/workbook/storyboards/{id}:delete',
@@ -43,6 +45,8 @@ export const EXTERNAL_API_ROUTES = {
   worksheetDelete: '/v0/workbook/worksheets/{id}:delete',
   worksheetRename: '/v0/workbook/worksheets/{id}:rename',
   worksheetSort: '/v0/workbook/worksheets/{id}:sort',
+  worksheetPauseAutoUpdates: '/v0/workbook/worksheets/{id}:pauseAutoUpdates',
+  worksheetResumeAutoUpdates: '/v0/workbook/worksheets/{id}:resumeAutoUpdates',
   site: '/v0/site',
   siteDatasources: '/v0/site/datasources',
   siteWorkbooks: '/v0/site/workbooks',
@@ -165,6 +169,22 @@ export function sheetActionRoute(sheet: SheetRef, action: 'rename' | 'delete'): 
 
 export function worksheetSortRoute(worksheetId: string): string {
   return `${worksheetRoute(worksheetId)}:sort`;
+}
+
+export function worksheetPauseAutoUpdatesRoute(worksheetId: string): string {
+  return `${worksheetRoute(worksheetId)}:pauseAutoUpdates`;
+}
+
+export function worksheetResumeAutoUpdatesRoute(worksheetId: string): string {
+  return `${worksheetRoute(worksheetId)}:resumeAutoUpdates`;
+}
+
+export function dashboardPauseAutoUpdatesRoute(dashboardId: string): string {
+  return `${dashboardRoute(dashboardId)}:pauseAutoUpdates`;
+}
+
+export function dashboardResumeAutoUpdatesRoute(dashboardId: string): string {
+  return `${dashboardRoute(dashboardId)}:resumeAutoUpdates`;
 }
 
 export function worksheetLogicalTablesRoute(worksheetId: string): string {
@@ -393,6 +413,8 @@ export const worksheetItemSchema = z
     name: z.string(),
     type: z.string().optional(),
     hidden: z.boolean(),
+    isActiveSheet: z.boolean(),
+    isAutoUpdatesPaused: z.boolean().optional(),
     index: z.number().int().optional(),
     datasources: z.array(z.string()).optional(),
   })
@@ -414,6 +436,8 @@ export const dashboardItemSchema = z
     name: z.string(),
     type: z.string().optional(),
     hidden: z.boolean(),
+    isActiveSheet: z.boolean(),
+    isAutoUpdatesPaused: z.boolean().optional(),
     index: z.number().int().optional(),
     containedSheets: z.array(z.string()).optional(),
   })
@@ -435,6 +459,7 @@ export const storyboardItemSchema = z
     name: z.string(),
     type: z.string().optional(),
     hidden: z.boolean(),
+    isActiveSheet: z.boolean(),
     index: z.number().int().optional(),
     storyPointCount: z.number().int().optional(),
   })

--- a/src/server.desktop.test.ts
+++ b/src/server.desktop.test.ts
@@ -147,17 +147,19 @@ async function serializeDesktopToolSurface(tool: DesktopTool<any>): Promise<stri
   return JSON.stringify(await getDesktopToolListEntry(tool));
 }
 
-// Re-pinned 2026-08-07: added delete-sheet, rename-sheet, sort-worksheet,
-// list-worksheet-logical-tables, and get-worksheet-underlying-data over the External
-// Client API sheet-action and logical-table routes, and dropped delete-worksheet.
+// Re-pinned 2026-08-10: added pause-auto-updates and resume-auto-updates over the External
+// Client API per-sheet auto-update routes — both in DYNAMIC_AUTHORING_TOOL_PROFILE, so the
+// served surface moves 29_380 -> 30_627 and the full surface 49_076 -> 50_323.
 // Raised 2026-08-10 (#734 review fold) 48_958 -> 49_076: bind-template gained
 // skip_validation, the server-gated trust flag for the deterministic build_viz path.
 // It is a genuinely new param (name + boolean schema, description dropped since the
 // LLM must never set it), so shrinking prose could not fund it. bind-template is not
-// in DYNAMIC_AUTHORING_TOOL_PROFILE, so the served surface (29_380) is unchanged and
-// stays ~16K under the 46K auto-deferral cliff; only this full-surface ratchet moves.
-const DYNAMIC_AUTHORING_SURFACE_BUDGET = 29_380;
-const FULL_TOOL_SURFACE_BUDGET = 49_076;
+// in DYNAMIC_AUTHORING_TOOL_PROFILE, so that ratchet was unchanged by #734.
+// Re-pinned 2026-08-07: added delete-sheet, rename-sheet, sort-worksheet,
+// list-worksheet-logical-tables, and get-worksheet-underlying-data over the External
+// Client API sheet-action and logical-table routes, and dropped delete-worksheet.
+const DYNAMIC_AUTHORING_SURFACE_BUDGET = 30_627;
+const FULL_TOOL_SURFACE_BUDGET = 50_323;
 
 describe('desktop tools/list serialized surface', () => {
   it('keeps the served dynamic authoring profile under the tool-search auto-deferral threshold budget', async () => {
@@ -410,10 +412,10 @@ describe('selectToolsForProfile (TOOL_PROFILE, W60 spike lever 1 / preamble P1)'
     expect(selected.map((t) => t.name)).toContain('execute-tableau-command');
   });
 
-  it('TOOL_PROFILE=dynamic-authoring registers exactly the 37-tool modern surface with one dashboard mutation door', () => {
+  it('TOOL_PROFILE=dynamic-authoring registers exactly the 39-tool modern surface with one dashboard mutation door', () => {
     const selected = selectToolsForProfile(allTools(), 'dynamic-authoring');
     expect(new Set(selected.map((t) => t.name))).toEqual(DYNAMIC_AUTHORING_TOOL_PROFILE);
-    expect(selected).toHaveLength(37);
+    expect(selected).toHaveLength(39);
     expect(selected.map((tool) => tool.name)).not.toEqual(
       expect.arrayContaining(['bind-template', 'build-and-apply-worksheet']),
     );

--- a/src/server.desktop.ts
+++ b/src/server.desktop.ts
@@ -138,6 +138,8 @@ export const DYNAMIC_AUTHORING_TOOL_PROFILE: ReadonlySet<DesktopToolName> =
     'delete-sheet',
     'rename-sheet',
     'sort-worksheet',
+    'pause-auto-updates',
+    'resume-auto-updates',
     // Workbook-level undo/redo — recover from a bad edit without hand-reverting XML.
     'undo-workbook',
     'redo-workbook',

--- a/src/tools/desktop/api/externalApiTools.test.ts
+++ b/src/tools/desktop/api/externalApiTools.test.ts
@@ -241,13 +241,20 @@ describe('External API coverage tools', () => {
         status: 200,
         contentType: 'application/json',
         body: JSON.stringify({
-          dashboards: [{ id: 'dash-amp', name: 'Sales & Data', hidden: false }],
+          dashboards: [
+            { id: 'dash-amp', name: 'Sales & Data', hidden: false, isActiveSheet: false },
+          ],
         }),
       });
       server.setOverride('GET /v0/workbook/dashboards/dash-amp', {
         status: 200,
         contentType: 'application/json',
-        body: JSON.stringify({ id: 'dash-amp', name: 'Sales & Data', hidden: false }),
+        body: JSON.stringify({
+          id: 'dash-amp',
+          name: 'Sales & Data',
+          hidden: false,
+          isActiveSheet: false,
+        }),
       });
     });
     try {

--- a/src/tools/desktop/api/getSummaryData.test.ts
+++ b/src/tools/desktop/api/getSummaryData.test.ts
@@ -306,7 +306,15 @@ describe('getSummaryDataTool', () => {
         status: 200,
         contentType: 'application/json',
         body: JSON.stringify({
-          worksheets: [{ id: 'sheet-empty', name: 'Empty Sheet', hidden: false, datasources: [] }],
+          worksheets: [
+            {
+              id: 'sheet-empty',
+              name: 'Empty Sheet',
+              hidden: false,
+              isActiveSheet: false,
+              datasources: [],
+            },
+          ],
         }),
       });
     });
@@ -496,7 +504,15 @@ describe('getSummaryDataTool', () => {
         status: 200,
         contentType: 'application/json',
         body: JSON.stringify({
-          worksheets: [{ id: 'sheet-empty', name: 'Empty Sheet', hidden: false, datasources: [] }],
+          worksheets: [
+            {
+              id: 'sheet-empty',
+              name: 'Empty Sheet',
+              hidden: false,
+              isActiveSheet: false,
+              datasources: [],
+            },
+          ],
         }),
       });
     });
@@ -822,7 +838,9 @@ describe('getSummaryDataTool', () => {
         status: 200,
         contentType: 'application/json',
         body: JSON.stringify({
-          worksheets: [{ id: 'sheet-only', name: 'Only Sheet', hidden: false }],
+          worksheets: [
+            { id: 'sheet-only', name: 'Only Sheet', hidden: false, isActiveSheet: true },
+          ],
         }),
       });
       server.setOverride('GET /v0/workbook/worksheets/sheet-only/summaryData', {
@@ -876,8 +894,8 @@ describe('getSummaryDataTool', () => {
         contentType: 'application/json',
         body: JSON.stringify({
           worksheets: [
-            { id: 'sheet-a', name: 'Regional Sales', hidden: false },
-            { id: 'sheet-b', name: 'Regional Sales', hidden: false },
+            { id: 'sheet-a', name: 'Regional Sales', hidden: false, isActiveSheet: false },
+            { id: 'sheet-b', name: 'Regional Sales', hidden: false, isActiveSheet: false },
           ],
         }),
       });

--- a/src/tools/desktop/api/pauseAutoUpdates.ts
+++ b/src/tools/desktop/api/pauseAutoUpdates.ts
@@ -1,0 +1,85 @@
+import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { Ok } from 'ts-results-es';
+import { z } from 'zod';
+
+import { endpointNotInThisBuild, isRouteMissing } from '../../../desktop/externalApi/toolUtils.js';
+import { resolveSession } from '../../../desktop/session/sessionResolution.js';
+import { ArgsValidationError, DesktopCommandExecutionError } from '../../../errors/mcpToolError.js';
+import { DesktopMcpServer } from '../../../server.desktop.js';
+import { sessionParam } from '../params.js';
+import { DesktopTool } from '../tool.js';
+import { resolveSheetRef } from './resolveSheetRef.js';
+
+const paramsSchema = {
+  session: sessionParam(),
+  sheet: z
+    .string()
+    .describe('Worksheet or dashboard name/id to pause automatic query execution for.'),
+};
+const title = 'Pause Auto Updates';
+
+export const getPauseAutoUpdatesTool = (
+  server: DesktopMcpServer,
+): DesktopTool<typeof paramsSchema> => {
+  const pauseAutoUpdatesTool = new DesktopTool({
+    server,
+    name: 'pause-auto-updates',
+    title,
+    description:
+      'Pause automatic query execution for a worksheet or dashboard to batch edits before the next refresh. Resume with resume-auto-updates.',
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
+    paramsSchema,
+    callback: async ({ session, sheet }, extra): Promise<CallToolResult> => {
+      return await pauseAutoUpdatesTool.logAndExecute({
+        extra,
+        args: { session, sheet },
+        callback: async () => {
+          const sessionResult = resolveSession(session);
+          if (sessionResult.isErr()) {
+            return sessionResult.error.toErr();
+          }
+
+          const refResult = await resolveSheetRef({ session, sheet, extra });
+          if (refResult.isErr()) {
+            return refResult.error.toErr();
+          }
+          const { ref, previousName } = refResult.value;
+
+          if (ref.kind === 'storyboard') {
+            return new ArgsValidationError(
+              `"${previousName}" is a storyboard; auto-updates can only be paused on a worksheet or dashboard.`,
+            ).toErr();
+          }
+
+          const executor = await extra.getExecutor(sessionResult.value);
+          const result =
+            ref.kind === 'worksheet'
+              ? await executor.pauseWorksheetAutoUpdates(ref.id, extra.signal)
+              : await executor.pauseDashboardAutoUpdates(ref.id, extra.signal);
+          if (result.isErr()) {
+            if (isRouteMissing(result.error)) {
+              return endpointNotInThisBuild('pause-auto-updates').toErr();
+            }
+            return new DesktopCommandExecutionError(result.error).toErr();
+          }
+
+          return new Ok({
+            paused: result.value.status === 'completed',
+            sheet: { id: ref.id, kind: ref.kind, name: previousName },
+            message:
+              result.value.status === 'completed'
+                ? `Paused auto-updates for ${ref.kind} "${previousName}".`
+                : `Requested pausing auto-updates for ${ref.kind} "${previousName}"; Desktop is still applying it.`,
+          });
+        },
+      });
+    },
+  });
+
+  return pauseAutoUpdatesTool;
+};

--- a/src/tools/desktop/api/pauseResumeAutoUpdates.test.ts
+++ b/src/tools/desktop/api/pauseResumeAutoUpdates.test.ts
@@ -79,7 +79,30 @@ describe('pause-auto-updates / resume-auto-updates', () => {
       expect(posted).toHaveLength(1);
       expect(posted[0].body).toBe('');
       invariant(result.content[0].type === 'text');
-      expect(result.content[0].text).toContain('"resumed":true');
+      const body = JSON.parse(result.content[0].text);
+      expect(body.resumed).toBe(true);
+      // Worksheet resume affects only the named sheet — no dashboard blast-radius flag.
+      expect(body).not.toHaveProperty('alsoResumedContainedWorksheets');
+    } finally {
+      await harness.close();
+    }
+  });
+
+  it('resume-auto-updates on a dashboard surfaces the contained-worksheet blast radius in the result', async () => {
+    const harness = await startHarness(getResumeAutoUpdatesTool);
+    try {
+      const result = await harness.callTool({ sheet: DASHBOARD_NAME });
+      expect(result.isError).toBeFalsy();
+      const posted = harness.server.requests.filter(
+        (r) =>
+          r.method === 'POST' &&
+          r.path === `/v0/workbook/dashboards/${DASHBOARD_ID}:resumeAutoUpdates`,
+      );
+      expect(posted).toHaveLength(1);
+      invariant(result.content[0].type === 'text');
+      const body = JSON.parse(result.content[0].text);
+      expect(body.alsoResumedContainedWorksheets).toBe(true);
+      expect(body.message).toContain('every worksheet it contains');
     } finally {
       await harness.close();
     }

--- a/src/tools/desktop/api/pauseResumeAutoUpdates.test.ts
+++ b/src/tools/desktop/api/pauseResumeAutoUpdates.test.ts
@@ -1,0 +1,148 @@
+import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { Ok } from 'ts-results-es';
+
+import { ExternalApiToolExecutor } from '../../../desktop/externalApi/externalApiToolExecutor.js';
+import {
+  MockExternalApiServer,
+  startMockExternalApiServer,
+} from '../../../desktop/externalApi/mockExternalApiServer.js';
+import { ExternalApiInstance } from '../../../desktop/externalApi/types.js';
+import * as sessionResolution from '../../../desktop/session/sessionResolution.js';
+import { DesktopMcpServer } from '../../../server.desktop.js';
+import invariant from '../../../utils/invariant.js';
+import { Provider } from '../../../utils/provider.js';
+import { DesktopTool } from '../tool.js';
+import { getMockRequestHandlerExtra } from '../toolContext.mock.js';
+import { getPauseAutoUpdatesTool } from './pauseAutoUpdates.js';
+import { getResumeAutoUpdatesTool } from './resumeAutoUpdates.js';
+
+vi.mock('../../../desktop/session/sessionResolution.js');
+
+// Seeded by mockExternalApiServer.
+const WORKSHEET_ID = 'sheet-sales';
+const WORKSHEET_NAME = 'Sales by Region';
+const DASHBOARD_ID = 'dash-exec';
+const DASHBOARD_NAME = 'Executive Dashboard';
+const STORYBOARD_NAME = 'QBR Story';
+
+describe('pause-auto-updates / resume-auto-updates', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(sessionResolution.resolveSession).mockReturnValue(Ok('999'));
+  });
+
+  it('pause-auto-updates POSTs the worksheet :pauseAutoUpdates route body-less', async () => {
+    const harness = await startHarness(getPauseAutoUpdatesTool);
+    try {
+      const result = await harness.callTool({ sheet: WORKSHEET_NAME });
+      expect(result.isError).toBeFalsy();
+      const posted = harness.server.requests.filter(
+        (r) =>
+          r.method === 'POST' &&
+          r.path === `/v0/workbook/worksheets/${WORKSHEET_ID}:pauseAutoUpdates`,
+      );
+      expect(posted).toHaveLength(1);
+      expect(posted[0].body).toBe('');
+      invariant(result.content[0].type === 'text');
+      expect(result.content[0].text).toContain('"paused":true');
+    } finally {
+      await harness.close();
+    }
+  });
+
+  it('pause-auto-updates routes a dashboard target to the dashboards path', async () => {
+    const harness = await startHarness(getPauseAutoUpdatesTool);
+    try {
+      const result = await harness.callTool({ sheet: DASHBOARD_NAME });
+      expect(result.isError).toBeFalsy();
+      const posted = harness.server.requests.filter(
+        (r) =>
+          r.method === 'POST' &&
+          r.path === `/v0/workbook/dashboards/${DASHBOARD_ID}:pauseAutoUpdates`,
+      );
+      expect(posted).toHaveLength(1);
+    } finally {
+      await harness.close();
+    }
+  });
+
+  it('resume-auto-updates POSTs the worksheet :resumeAutoUpdates route body-less', async () => {
+    const harness = await startHarness(getResumeAutoUpdatesTool);
+    try {
+      const result = await harness.callTool({ sheet: WORKSHEET_ID });
+      expect(result.isError).toBeFalsy();
+      const posted = harness.server.requests.filter(
+        (r) =>
+          r.method === 'POST' &&
+          r.path === `/v0/workbook/worksheets/${WORKSHEET_ID}:resumeAutoUpdates`,
+      );
+      expect(posted).toHaveLength(1);
+      expect(posted[0].body).toBe('');
+      invariant(result.content[0].type === 'text');
+      expect(result.content[0].text).toContain('"resumed":true');
+    } finally {
+      await harness.close();
+    }
+  });
+
+  it.each([
+    ['pause-auto-updates', getPauseAutoUpdatesTool],
+    ['resume-auto-updates', getResumeAutoUpdatesTool],
+  ] as const)('%s rejects a storyboard target without dispatching', async (_name, makeTool) => {
+    const harness = await startHarness(makeTool);
+    try {
+      const result = await harness.callTool({ sheet: STORYBOARD_NAME });
+      expect(result.isError).toBe(true);
+      invariant(result.content[0].type === 'text');
+      expect(result.content[0].text).toContain('storyboard');
+      const posted = harness.server.requests.filter(
+        (r) => r.method === 'POST' && /AutoUpdates$/.test(r.path),
+      );
+      expect(posted).toHaveLength(0);
+    } finally {
+      await harness.close();
+    }
+  });
+});
+
+type Harness = {
+  server: MockExternalApiServer;
+  callTool: (args: Record<string, unknown>) => Promise<CallToolResult>;
+  close: () => Promise<void>;
+};
+
+async function startHarness(
+  makeTool: (server: DesktopMcpServer) => DesktopTool<any>,
+): Promise<Harness> {
+  const server = await startMockExternalApiServer();
+  const executor = new ExternalApiToolExecutor({ discover: () => [instanceFor(server)] });
+  await executor.start();
+  const tool = makeTool(new DesktopMcpServer());
+  const callback = (await Provider.from(tool.callback)) as (
+    args: Record<string, unknown>,
+    extra: ReturnType<typeof getMockRequestHandlerExtra>,
+  ) => Promise<CallToolResult>;
+  const extra = {
+    ...getMockRequestHandlerExtra(),
+    getExecutor: vi.fn().mockResolvedValue(executor),
+  };
+
+  return {
+    server,
+    callTool: async (args) => await callback(args, extra),
+    close: async () => {
+      executor.stop();
+      await server.close();
+    },
+  };
+}
+
+function instanceFor(server: MockExternalApiServer): ExternalApiInstance {
+  return {
+    baseUrl: server.baseUrl,
+    token: 'valid-token',
+    pid: 999,
+    instanceId: 'inst-auto-updates',
+    apiVersion: '0.2.5',
+  };
+}

--- a/src/tools/desktop/api/resumeAutoUpdates.ts
+++ b/src/tools/desktop/api/resumeAutoUpdates.ts
@@ -68,13 +68,18 @@ export const getResumeAutoUpdatesTool = (
             return new DesktopCommandExecutionError(result.error).toErr();
           }
 
+          const completed = result.value.status === 'completed';
+          const alsoResumedContainedWorksheets = ref.kind === 'dashboard';
+          const scopeSuffix = alsoResumedContainedWorksheets
+            ? ' and every worksheet it contains'
+            : '';
           return new Ok({
-            resumed: result.value.status === 'completed',
+            resumed: completed,
             sheet: { id: ref.id, kind: ref.kind, name: previousName },
-            message:
-              result.value.status === 'completed'
-                ? `Resumed auto-updates for ${ref.kind} "${previousName}".`
-                : `Requested resuming auto-updates for ${ref.kind} "${previousName}"; Desktop is still applying it.`,
+            ...(alsoResumedContainedWorksheets ? { alsoResumedContainedWorksheets: true } : {}),
+            message: completed
+              ? `Resumed auto-updates for ${ref.kind} "${previousName}"${scopeSuffix}.`
+              : `Requested resuming auto-updates for ${ref.kind} "${previousName}"${scopeSuffix}; Desktop is still applying it.`,
           });
         },
       });

--- a/src/tools/desktop/api/resumeAutoUpdates.ts
+++ b/src/tools/desktop/api/resumeAutoUpdates.ts
@@ -1,0 +1,85 @@
+import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { Ok } from 'ts-results-es';
+import { z } from 'zod';
+
+import { endpointNotInThisBuild, isRouteMissing } from '../../../desktop/externalApi/toolUtils.js';
+import { resolveSession } from '../../../desktop/session/sessionResolution.js';
+import { ArgsValidationError, DesktopCommandExecutionError } from '../../../errors/mcpToolError.js';
+import { DesktopMcpServer } from '../../../server.desktop.js';
+import { sessionParam } from '../params.js';
+import { DesktopTool } from '../tool.js';
+import { resolveSheetRef } from './resolveSheetRef.js';
+
+const paramsSchema = {
+  session: sessionParam(),
+  sheet: z
+    .string()
+    .describe('Worksheet or dashboard name/id to resume automatic query execution for.'),
+};
+const title = 'Resume Auto Updates';
+
+export const getResumeAutoUpdatesTool = (
+  server: DesktopMcpServer,
+): DesktopTool<typeof paramsSchema> => {
+  const resumeAutoUpdatesTool = new DesktopTool({
+    server,
+    name: 'resume-auto-updates',
+    title,
+    description:
+      'Resume automatic query execution paused with pause-auto-updates. Resuming a dashboard re-enables it and every worksheet it contains, not only ones this paused.',
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
+    paramsSchema,
+    callback: async ({ session, sheet }, extra): Promise<CallToolResult> => {
+      return await resumeAutoUpdatesTool.logAndExecute({
+        extra,
+        args: { session, sheet },
+        callback: async () => {
+          const sessionResult = resolveSession(session);
+          if (sessionResult.isErr()) {
+            return sessionResult.error.toErr();
+          }
+
+          const refResult = await resolveSheetRef({ session, sheet, extra });
+          if (refResult.isErr()) {
+            return refResult.error.toErr();
+          }
+          const { ref, previousName } = refResult.value;
+
+          if (ref.kind === 'storyboard') {
+            return new ArgsValidationError(
+              `"${previousName}" is a storyboard; auto-updates can only be resumed on a worksheet or dashboard.`,
+            ).toErr();
+          }
+
+          const executor = await extra.getExecutor(sessionResult.value);
+          const result =
+            ref.kind === 'worksheet'
+              ? await executor.resumeWorksheetAutoUpdates(ref.id, extra.signal)
+              : await executor.resumeDashboardAutoUpdates(ref.id, extra.signal);
+          if (result.isErr()) {
+            if (isRouteMissing(result.error)) {
+              return endpointNotInThisBuild('resume-auto-updates').toErr();
+            }
+            return new DesktopCommandExecutionError(result.error).toErr();
+          }
+
+          return new Ok({
+            resumed: result.value.status === 'completed',
+            sheet: { id: ref.id, kind: ref.kind, name: previousName },
+            message:
+              result.value.status === 'completed'
+                ? `Resumed auto-updates for ${ref.kind} "${previousName}".`
+                : `Requested resuming auto-updates for ${ref.kind} "${previousName}"; Desktop is still applying it.`,
+          });
+        },
+      });
+    },
+  });
+
+  return resumeAutoUpdatesTool;
+};

--- a/src/tools/desktop/toolName.ts
+++ b/src/tools/desktop/toolName.ts
@@ -12,6 +12,8 @@ export const desktopToolNames = [
   'delete-sheet',
   'rename-sheet',
   'sort-worksheet',
+  'pause-auto-updates',
+  'resume-auto-updates',
   'refine-worksheet',
   'get-dashboard-xml',
   'apply-dashboard',

--- a/src/tools/desktop/tools.ts
+++ b/src/tools/desktop/tools.ts
@@ -29,8 +29,10 @@ import { getListStoryboardsTool } from './api/listStoryboards.js';
 import { getListWorkbookDatasourcesTool } from './api/listWorkbookDatasources.js';
 import { getListWorksheetLogicalTablesTool } from './api/listWorksheetLogicalTables.js';
 import { getListWorksheetsTool } from './api/listWorksheets.js';
+import { getPauseAutoUpdatesTool } from './api/pauseAutoUpdates.js';
 import { getRedoWorkbookTool } from './api/redoWorkbook.js';
 import { getRenameSheetTool } from './api/renameSheet.js';
+import { getResumeAutoUpdatesTool } from './api/resumeAutoUpdates.js';
 import { getSortWorksheetTool } from './api/sortWorksheet.js';
 import { getUndoWorkbookTool } from './api/undoWorkbook.js';
 import { getValidateWorkbookXmlTool } from './api/validateWorkbookXml.js';
@@ -85,6 +87,8 @@ export const desktopToolFactories = [
   getDeleteSheetTool,
   getRenameSheetTool,
   getSortWorksheetTool,
+  getPauseAutoUpdatesTool,
+  getResumeAutoUpdatesTool,
   getRefineWorksheetTool,
   getGetDashboardXmlTool,
   getApplyDashboardTool,


### PR DESCRIPTION
## What this does

Full-wires monolith **PR #62299** (External Client API `0.2.4 → 0.2.5`) into the Desktop client — reads, transport, and agent-facing tools.

- **Inventory read fields** — `isActiveSheet` (required) on worksheet/dashboard/storyboard items, `isAutoUpdatesPaused` (optional) on worksheet + dashboard. Surface automatically through `get-workbook-inventory`.
- **Transport** — 4 executor methods for `worksheets|dashboards/{id}:pauseAutoUpdates` / `:resumeAutoUpdates`, on the undo/redo `applyDocument`+`postEnvelope` template.
- **MCP tools** — `pause-auto-updates` and `resume-auto-updates`: take a worksheet/dashboard name-or-id, resolve it against the live inventory, reject storyboards (no route), and dispatch to the right per-kind route. Both in the default dynamic-authoring profile.

## Decisions to accept

- `isActiveSheet` is a **required** sheet-item field (matches the host generator), so the contract test enforces requiredness parity and item literals that round-trip the real schema carry it. `isAutoUpdatesPaused` is optional, worksheet/dashboard-only.
- **Byte-budget ratchet raised with intent:** two default-profile tools move `DYNAMIC_AUTHORING_SURFACE_BUDGET` 29,380 → 30,627 and `FULL_TOOL_SURFACE_BUDGET` 48,958 → 50,205 (both pinned to exact measured totals), and the dynamic-authoring count 37 → 39.
- **Resume is a blanket re-enable on a dashboard** (re-enables it and every contained worksheet, not only ones this paused) — stated in the tool description so agents don't treat pause→edit→resume as state-preserving.

## Fixture

`__fixtures__/externalClientApi-openapi.json` is the live `0.2.5` `/openapi.json`, pretty-printed to match the repo convention.

## Version

Bumped `2.60.5 → 2.61.0` (minor, per the repo's new-feature tier) so clients incorporate the new tools by version.

## Base

Targets `feature/desktop`, stacked on #725 (which already landed `WindowInfo`/`blockingWindows`/`logical-table-not-found` and the aug5 routes — untouched here).

## Verification

- tsc clean, ESLint clean; contract, executor, tool, and byte-budget suites green (added executor + tool unit tests for pause/resume).
- **Smoke-tested end-to-end through the MCP tools against a running 0.2.6 Desktop:** `get-workbook-inventory` surfaces both fields (active sheet flagged); `pause-auto-updates "Sheet 1"` flips `isAutoUpdatesPaused` false→true for that sheet only, `resume-auto-updates` flips it back; dashboard target routes to the dashboard path; a storyboard target is rejected before dispatch.
- **Verified quirk:** the `AutoUpdates` command does **no id validation** — it returns `200 SUCCEEDED` for any id (unlike the id-guarded `:sort`/`:document` routes). The mock reflects this. Both MCP tools resolve name→id against live inventory first, so a mistyped sheet fails at resolution rather than dispatching a silent no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
