### PR TITLE
fix(apply-worksheet): add a second measure without invalid XML

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "2.60.5",
+  "version": "2.60.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "2.60.5",
+      "version": "2.60.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.7.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "2.60.5",
+  "version": "2.60.6",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/src/desktop/validation/readback-verify.test.ts
+++ b/src/desktop/validation/readback-verify.test.ts
@@ -115,6 +115,76 @@ describe('verifyWorksheetReadback', () => {
     );
   });
 
+  it('accepts Desktop canonicalizing two shelf measures from slash to plus syntax', () => {
+    const intended = worksheet(`<cols>${SALES_FIELD} / ${PROFIT_FIELD}</cols>`);
+    const readback = worksheet(`<cols>(${SALES_FIELD} + ${PROFIT_FIELD})</cols>`);
+
+    expect(verifyWorksheetReadback(intended, readback)).toEqual([]);
+  });
+
+  it('still flags a measure that Desktop drops from a canonicalized multi-measure shelf', () => {
+    const intended = worksheet(`<cols>${SALES_FIELD} / ${PROFIT_FIELD}</cols>`);
+    const readback = worksheet(`<cols>(${SALES_FIELD})</cols>`);
+
+    expect(verifyWorksheetReadback(intended, readback)).toContainEqual({
+      kind: 'shelf',
+      node: 'cols',
+      column: PROFIT_FIELD,
+      intended: PROFIT_FIELD,
+      readback: 'changed',
+      severity: 'error',
+    });
+  });
+
+  it('does not treat a changed shelf operator as Desktop multi-measure canonicalization', () => {
+    const intended = worksheet(`<cols>${SALES_FIELD} * ${PROFIT_FIELD}</cols>`);
+    const readback = worksheet(`<cols>(${SALES_FIELD} + ${PROFIT_FIELD})</cols>`);
+
+    expect(verifyWorksheetReadback(intended, readback)).toContainEqual(
+      expect.objectContaining({ kind: 'shelf', node: 'cols', readback: 'changed' }),
+    );
+  });
+
+  it('flags one occurrence when Desktop drops a duplicate shelf measure', () => {
+    const intended = worksheet(`<cols>${SALES_FIELD} / ${SALES_FIELD}</cols>`);
+    const readback = worksheet(`<cols>${SALES_FIELD}</cols>`);
+
+    expect(
+      verifyWorksheetReadback(intended, readback).filter(
+        (finding) => finding.kind === 'shelf' && finding.column === SALES_FIELD,
+      ),
+    ).toHaveLength(1);
+  });
+
+  it('recognizes canonicalized qualified refs with escaped closing brackets', () => {
+    const sales = '[D]]S].[sum:Sales]]Net:qk]';
+    const profit = '[D]]S].[sum:Profit]]Net:qk]';
+    const intended = worksheet(`<cols>${sales} / ${profit}</cols>`);
+    const readback = worksheet(`<cols>(${sales} + ${profit})</cols>`);
+
+    expect(verifyWorksheetReadback(intended, readback)).toEqual([]);
+  });
+
+  it('does not normalize slash to plus for dimension shelves', () => {
+    const category = '[DS].[none:Category:nk]';
+    const region = '[DS].[none:Region:nk]';
+    const intended = worksheet(`<cols>${category} / ${region}</cols>`);
+    const readback = worksheet(`<cols>(${category} + ${region})</cols>`);
+
+    expect(verifyWorksheetReadback(intended, readback)).toContainEqual(
+      expect.objectContaining({ kind: 'shelf', node: 'cols', readback: 'changed' }),
+    );
+  });
+
+  it('normalizes quantitative shelf refs with trailing instance suffixes', () => {
+    const sales = '[DS].[rank:sum:Sales:qk:3]';
+    const profit = '[DS].[usr:Profit Ratio:qk:14]';
+    const intended = worksheet(`<cols>${sales} / ${profit}</cols>`);
+    const readback = worksheet(`<cols>(${sales} + ${profit})</cols>`);
+
+    expect(verifyWorksheetReadback(intended, readback)).toEqual([]);
+  });
+
   it('does not flag an authored Automatic mark that Tableau resolved to a concrete class', () => {
     const intended = encodedWorksheet().replace(
       '<mark class="Shape"/>',

--- a/src/desktop/validation/readback-verify.ts
+++ b/src/desktop/validation/readback-verify.ts
@@ -112,7 +112,25 @@ function walkElements(node: unknown, visit: (tag: string, element: XmlRecord) =>
 
 function shelfValues(value: unknown): string[] {
   return normalizeArray(value)
-    .flatMap((item) => textValue(item).split('/'))
+    .flatMap((item) => {
+      const text = textValue(item);
+      const references = [...text.matchAll(/\[(?:[^\]]|\]\])+\](?:\.\[(?:[^\]]|\]\])+\])?/g)];
+      if (references.length > 0) {
+        const separators = references.map((match, index) => {
+          const start =
+            index === 0 ? 0 : references[index - 1]!.index! + references[index - 1]![0].length;
+          return text.slice(start, match.index);
+        });
+        const suffix = text.slice(references.at(-1)!.index! + references.at(-1)![0].length);
+        const isMultiMeasureExpression =
+          references.every((match) => /:qk(?::[^:\]]+)?\]$/.test(match[0])) &&
+          /^[\s(]*$/.test(separators[0] ?? '') &&
+          separators.slice(1).every((separator) => /^\s*[+/]\s*$/.test(separator)) &&
+          /^[\s)]*$/.test(suffix);
+        if (isMultiMeasureExpression) return references.map((match) => match[0]);
+      }
+      return text.split('/');
+    })
     .map((item) => item.trim())
     .filter(Boolean);
 }
@@ -295,8 +313,13 @@ export function verifyWorksheetReadback(
   }
 
   for (const shelf of ['rows', 'cols'] as const) {
+    const remainingReadback = [...readback.shelves[shelf]];
     for (const value of intended.shelves[shelf]) {
-      if (readback.shelves[shelf].includes(value)) continue;
+      const index = remainingReadback.indexOf(value);
+      if (index >= 0) {
+        remainingReadback.splice(index, 1);
+        continue;
+      }
       findings.push({
         kind: 'shelf',
         node: shelf,

--- a/src/desktop/wrappers/perSheetDocumentApply.test.ts
+++ b/src/desktop/wrappers/perSheetDocumentApply.test.ts
@@ -17,6 +17,25 @@ const routeMissing = {
   },
 };
 
+const COMPLETE_WORKBOOK_XML = `<?xml version='1.0'?>
+<workbook version='18.1'>
+  <datasources>
+    <datasource name='Sample - Superstore' />
+  </datasources>
+  <worksheets>
+    <worksheet name='Sheet 1'>
+      <table><cols>[Sample - Superstore].[sum:Sales:qk]</cols></table>
+    </worksheet>
+    <worksheet name='Other Sheet'><table /></worksheet>
+  </worksheets>
+  <dashboards />
+  <windows>
+    <window class='worksheet' name='Sheet 1' />
+    <window class='worksheet' name='Other Sheet' />
+  </windows>
+  <thumbnails />
+</workbook>`;
+
 type KindFixture = {
   kind: PerSheetKind;
   sheetName: string;
@@ -69,8 +88,54 @@ describe('tryApplyViaPerSheetRoute', () => {
     vi.restoreAllMocks();
   });
 
+  it('posts a complete workbook document when adding a second measure to an existing worksheet', async () => {
+    const editedWorksheet =
+      '<worksheet name="Sheet 1"><table><cols>[Sample - Superstore].[sum:Sales:qk] / [Sample - Superstore].[sum:Profit:qk]</cols></table></worksheet>';
+    const applyWorksheetDocument = vi
+      .fn()
+      .mockResolvedValue(Ok({ command_id: 'cmd-apply', status: 'completed', submitted_at: '' }));
+    const getWorkbookDocument = vi.fn().mockResolvedValue(
+      Ok({
+        xml: COMPLETE_WORKBOOK_XML,
+        instanceId: 'desktop-instance',
+        applicationVersion: '2026.1',
+        payloadVersion: '18.1',
+      }),
+    );
+    const executor = makeExecutorMock({
+      listWorksheets: vi
+        .fn()
+        .mockResolvedValue(Ok({ worksheets: [{ id: 'sheet-1', name: 'Sheet 1' }] })),
+      getWorkbookDocument,
+      applyWorksheetDocument,
+      executeCommand: vi
+        .fn()
+        .mockResolvedValue(Ok({ command_id: 'cmd-ok', status: 'completed', submitted_at: '' })),
+    });
+
+    const result = await tryApplyViaPerSheetRoute({
+      kind: 'worksheet',
+      sheetName: 'Sheet 1',
+      fragmentXml: editedWorksheet,
+      focus: NO_FOCUS,
+      executor,
+      signal: mockSignal,
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(getWorkbookDocument).toHaveBeenCalledTimes(1);
+    expect(applyWorksheetDocument).toHaveBeenCalledTimes(1);
+    const postedXml = applyWorksheetDocument.mock.calls[0]?.[1] as string;
+    expect(postedXml).toContain('<workbook');
+    expect(postedXml).toContain('<worksheets>');
+    expect(postedXml).toContain('[sum:Profit:qk]');
+    expect(postedXml).toContain('name="Other Sheet"');
+    expect(postedXml).toContain('<windows>');
+    expect(postedXml).toContain('<thumbnails');
+  });
+
   it.each(FIXTURES)(
-    'posts the $kind fragment as-is to its per-sheet route and reports applied',
+    'posts the current $kind payload shape to its per-sheet route and reports applied',
     async ({ kind, sheetName, fragmentXml, listMethod, listValue, applyMethod, id }) => {
       const apply = vi
         .fn()
@@ -81,6 +146,14 @@ describe('tryApplyViaPerSheetRoute', () => {
       const executor = makeExecutorMock({
         [listMethod]: vi.fn().mockResolvedValue(Ok(listValue)),
         [applyMethod]: apply,
+        getWorkbookDocument: vi.fn().mockResolvedValue(
+          Ok({
+            xml: COMPLETE_WORKBOOK_XML,
+            instanceId: 'desktop-instance',
+            applicationVersion: '2026.1',
+            payloadVersion: '18.1',
+          }),
+        ),
         executeCommand,
       });
 
@@ -97,13 +170,16 @@ describe('tryApplyViaPerSheetRoute', () => {
       if (result.isOk()) {
         expect(result.value).toBe('applied');
       }
-      // The route resolves by id, and the posted body is the sheet fragment as-is (Tableau Desktop
-      // wraps it into the live workbook server-side — the MCP does not build a <workbook> envelope).
       expect(apply).toHaveBeenCalledTimes(1);
       const [postedId, postedXml] = apply.mock.calls[0];
       expect(postedId).toBe(id);
-      expect(postedXml).toBe(fragmentXml);
-      expect(postedXml).not.toContain('<workbook>');
+      if (kind === 'worksheet') {
+        expect(postedXml).toContain('<workbook');
+        expect(postedXml).toContain('<worksheets>');
+        expect(postedXml).toContain('name="Other Sheet"');
+      } else {
+        expect(postedXml).toBe(fragmentXml);
+      }
     },
   );
 
@@ -167,6 +243,14 @@ describe('tryApplyViaPerSheetRoute', () => {
       const executor = makeExecutorMock({
         [listMethod]: vi.fn().mockResolvedValue(Ok(listValue)),
         [applyMethod]: apply,
+        getWorkbookDocument: vi.fn().mockResolvedValue(
+          Ok({
+            xml: COMPLETE_WORKBOOK_XML,
+            instanceId: 'desktop-instance',
+            applicationVersion: '2026.1',
+            payloadVersion: '18.1',
+          }),
+        ),
       });
 
       const result = await tryApplyViaPerSheetRoute({

--- a/src/desktop/wrappers/perSheetDocumentApply.ts
+++ b/src/desktop/wrappers/perSheetDocumentApply.ts
@@ -4,6 +4,7 @@ import { log } from '../../logging/logger.js';
 import { ExecuteCommandError, WithExecutorAndAbortSignal } from '../externalApi/executorTypes.js';
 import { ExternalApiToolExecutor } from '../externalApi/externalApiToolExecutor.js';
 import { isRouteMissing, resolveItemByNameOrId } from '../externalApi/toolUtils.js';
+import { upsertSheetIntoWorkbook } from '../metadata/sheets.js';
 import { type ApplyFocus, dispatchApplyFocus } from './applyFocus.js';
 
 export type PerSheetKind = 'worksheet' | 'dashboard' | 'storyboard';
@@ -65,12 +66,25 @@ export async function tryApplyViaPerSheetRoute({
     return Ok('sheet-absent');
   }
 
-  // POST the sheet fragment as-is: Tableau Desktop wraps it into the live workbook on the per-sheet
-  // `/document` route, so the MCP does not build a workbook envelope.
+  let documentXml = fragmentXml;
+  if (kind === 'worksheet') {
+    const workbookResult = await client.getWorkbookDocument(signal);
+    if (workbookResult.isErr()) {
+      return Err(workbookResult.error);
+    }
+    try {
+      documentXml = upsertSheetIntoWorkbook(workbookResult.value.xml, sheetName, fragmentXml);
+    } catch (error) {
+      return Err({ type: 'invalid-response', error });
+    }
+  }
+
+  // The worksheet endpoint replaces only the resolved sheet, but its POST contract still requires
+  // a complete workbook document. Preserve the live envelope so required metadata reaches Desktop.
   const applyResult = await applyDocumentForKind(
     kind,
     resolved.value.id,
-    fragmentXml,
+    documentXml,
     client,
     signal,
   );


### PR DESCRIPTION
## Decision

Existing-worksheet writes must send Desktop a complete live workbook document, not a standalone worksheet fragment. This is the rule for the worksheet document route; dashboard and storyboard routes are unchanged here.

## Description

`apply-worksheet` now reads the live workbook, replaces only the named worksheet in that document, and posts the complete workbook to Desktop. This preserves sibling sheets, dashboards, windows, thumbnails, and other required metadata.

The readback check also accepts Desktop's known rewrite of quantitative multi-measure shelves from `Sales / Profit` to `(Sales + Profit)`. It still rejects changed operators, missing or duplicate measures, dimension changes, and malformed references.

Future changes to this path must preserve the complete workbook envelope and keep readback checks strict outside that one quantitative shelf rewrite.

## Motivation and Context

Adding Profit to an existing Sales-by-Category chart consistently sent incomplete XML to Desktop. Desktop showed a blocking invalid-workbook modal and the agent stalled. The write now completes without a modal and verifies the second measure from Desktop's readback.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## How Has This Been Tested?

- Live Sample - Superstore smoke test in Desktop: create Sales by Category, add Profit to the existing sheet, apply once, then read summary data.
- Desktop reported `preflight clean · apply completed · readback clean`.
- Summary data returned 3 rows × 3 columns: Category, SUM(Profit), and SUM(Sales).
- `scripts/agent-check`: lint, typecheck, 371 test files / 5,667 tests, Desktop build, and lockstep all green.

## Related Issues

- GUS: `[P0] Design Council - Tableau Agent — apply-worksheet fails to add a 2nd measure to an existing sheet (invalid workbook XML)`

## Checklist

- [x] I updated the package version with `npm run version:patch` (2.60.6).
- [x] No documentation change is needed; this corrects an existing route contract.
- [x] I added tests that prove the fix and its failure boundaries.
- [x] New and existing unit tests pass locally.
- [x] This change does not break the served tool surface.

## Contributor Agreement

By submitting this pull request, I confirm that:

- [x] I have read the contributing guidelines and followed the contribution checklist.

_Opened by MattGPT on Matt Filbert's behalf._
