### PR TITLE
Add download-workbook tool

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1095.0",
+        "@aws-sdk/lib-storage": "^3.1095.0",
         "@aws-sdk/s3-request-presigner": "^3.1095.0",
         "@modelcontextprotocol/ext-apps": "^1.7.2",
         "@modelcontextprotocol/sdk": "^1.26.0",
@@ -23,6 +24,7 @@
         "jose": "^6.0.12",
         "ssrfcheck": "^1.2.0",
         "ts-results-es": "^7.1.0",
+        "unzipper": "^0.12.5",
         "uuid": "^14.0.1",
         "xpath": "^0.0.34",
         "zod": "^3.24.3",
@@ -44,6 +46,7 @@
         "@types/fast-levenshtein": "^0.0.1",
         "@types/node": "^22.15.3",
         "@types/supertest": "^6.0.3",
+        "@types/unzipper": "^0.10.11",
         "@typescript-eslint/eslint-plugin": "^8.31.1",
         "@typescript-eslint/parser": "^8.31.1",
         "@vitest/coverage-v8": "^3.1.3",
@@ -154,14 +157,14 @@
       "license": "MIT"
     },
     "node_modules/@aws-sdk/checksums": {
-      "version": "3.1000.20",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/checksums/-/checksums-3.1000.20.tgz",
-      "integrity": "sha512-uc5PMNcLcs+UBSLGsRjbMZKi3mgnPSalXpABw9Xjo0DMrv4gjIa/E4a02yJsuU4FF6Tmvis/JgGdKNIOoN4DQw==",
+      "version": "3.1000.26",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/checksums/-/checksums-3.1000.26.tgz",
+      "integrity": "sha512-CGznePoL+1oWCSzqmkvlYMpWQEZohPR3LntjKXXfVH+oh6Kd8d+yHLkjpiAGwPIHAxFe4OAq3aKfRnv/wqWIyA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.0",
+        "@aws-sdk/core": "^3.977.6",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.8",
+        "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -170,20 +173,20 @@
       }
     },
     "node_modules/@aws-sdk/client-s3": {
-      "version": "3.1095.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1095.0.tgz",
-      "integrity": "sha512-eeobm3TKci47CTTHIxc5s5UDjLL0gTKfjlcyzKU+NMoeIJ3flKPq51Fhi2nUDiMNbzsY5HAynM3bHAQFHxRTUw==",
+      "version": "3.1107.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1107.0.tgz",
+      "integrity": "sha512-95N3VATuqbyhEUO0YHQSsgKdkG872rZXm+O2ZkffsF8RJLRDQAsplVD8/OdWW3vX78vNDogK/zbfD1VG1OcSIA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/checksums": "^3.1000.20",
-        "@aws-sdk/core": "^3.977.0",
-        "@aws-sdk/credential-provider-node": "^3.972.72",
-        "@aws-sdk/middleware-sdk-s3": "^3.972.66",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.42",
+        "@aws-sdk/checksums": "^3.1000.26",
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/credential-provider-node": "^3.972.78",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.72",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.43",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.8",
-        "@smithy/fetch-http-handler": "^5.6.10",
-        "@smithy/node-http-handler": "^4.9.10",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -192,16 +195,16 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.977.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.0.tgz",
-      "integrity": "sha512-w+iANjPGOj4fHxWeyjfRt+xeRX8BIOVStqdTcMebfeIJicTiBTMAbQurQuVfAxHpUfsoV+fWaEQvGpO6IWifLQ==",
+      "version": "3.977.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.6.tgz",
+      "integrity": "sha512-QiaJV4/zDrB4ZY2mfeSXSzSTc36W16sZXcGz+SPFk0CJ26gziO0cS+4LjJUMAbdeeBOvS0k0Aq1cZpfGdUXxSw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.974.2",
         "@aws-sdk/xml-builder": "^3.972.37",
         "@aws/lambda-invoke-store": "^0.3.0",
-        "@smithy/core": "^3.29.8",
-        "@smithy/signature-v4": "^5.6.9",
+        "@smithy/core": "^3.31.1",
+        "@smithy/signature-v4": "^5.6.12",
         "@smithy/types": "^4.16.1",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
@@ -211,14 +214,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.61",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.61.tgz",
-      "integrity": "sha512-qihs2ekMb89Nxd2JenCgVFhjbkb3EIo7HEBCBzyZACKVJdrLUZBLOmAE3xr0Sayml8n/jZSzwO/IufIiIzO7PQ==",
+      "version": "3.972.67",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.67.tgz",
+      "integrity": "sha512-rcIpk5kxUqDaaNa6Xk23pQ6ViY7jlqzmfFWCahQcBT97ddXaXYYwzCen9Tz1Jvo6aJft6wDl5bN44/Jw5B4oLA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.0",
+        "@aws-sdk/core": "^3.977.6",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.8",
+        "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -227,16 +230,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.63",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.63.tgz",
-      "integrity": "sha512-yfozsS8wkWZEi/n6IsrodcFKBWZ0iNAezhJbTReMNc0z1Px17qdeAeuL1/wziCAmCZyXiW7QzP75ggJkBQv8jQ==",
+      "version": "3.972.69",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.69.tgz",
+      "integrity": "sha512-nggwJtZ4eeNsUw5IeWBMXsi1ryct5idi0K+/SCRF3kybLubOMaNTb3XCihXpWMiVpyzyPeIrl0zTkzhBH9porA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.0",
+        "@aws-sdk/core": "^3.977.6",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.8",
-        "@smithy/fetch-http-handler": "^5.6.10",
-        "@smithy/node-http-handler": "^4.9.10",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -245,22 +248,22 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.973.6",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.6.tgz",
-      "integrity": "sha512-jGLTW1bj148GL/6/IMlfY2fMYS9FtHOG+NahkFD4y0qkzYudNUahelxryY68/HGMslYuHClk1XaS/3b3eJzEkg==",
+      "version": "3.973.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.12.tgz",
+      "integrity": "sha512-pNEf/OeyN5X3VmLKlgSO6TqaWmW10CvI3TfwL1XhsuhYjSLT2VDaxFnCPHnOeQXSaFisMX4jNhpETriqN8DOmg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.0",
-        "@aws-sdk/credential-provider-env": "^3.972.61",
-        "@aws-sdk/credential-provider-http": "^3.972.63",
-        "@aws-sdk/credential-provider-login": "^3.972.68",
-        "@aws-sdk/credential-provider-process": "^3.972.61",
-        "@aws-sdk/credential-provider-sso": "^3.973.5",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.67",
-        "@aws-sdk/nested-clients": "^3.997.35",
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/credential-provider-env": "^3.972.67",
+        "@aws-sdk/credential-provider-http": "^3.972.69",
+        "@aws-sdk/credential-provider-login": "^3.972.74",
+        "@aws-sdk/credential-provider-process": "^3.972.67",
+        "@aws-sdk/credential-provider-sso": "^3.973.11",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.73",
+        "@aws-sdk/nested-clients": "^3.997.41",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.8",
-        "@smithy/credential-provider-imds": "^4.4.13",
+        "@smithy/core": "^3.31.1",
+        "@smithy/credential-provider-imds": "^4.4.16",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -269,15 +272,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.68",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.68.tgz",
-      "integrity": "sha512-w6tNci6g7RqFpLhj1f5xseBvaNojb4Pkgp5Jp5apl9hrJtaf2AA+rX9+qlhlWUK6kcyAFYPA7emO+55zj+S98Q==",
+      "version": "3.972.74",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.74.tgz",
+      "integrity": "sha512-0AQfDcf99TNmqVKv0owHrw/TQs6i4ZE5t9qmz6NvO53bE/sA/tpXhXL9AAcEP1qHc6Zzjd1UMb69+/9zdhvY3g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.0",
-        "@aws-sdk/nested-clients": "^3.997.35",
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/nested-clients": "^3.997.41",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.8",
+        "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -286,20 +289,20 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.72",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.72.tgz",
-      "integrity": "sha512-blQ7F5QGzylnzeh5549zQLoCAiMHkXFLjFovEMaVy4b2X8JhUu+u9NXro1hyK95YHdVFNmBHKs2hIHtZchxKlQ==",
+      "version": "3.972.78",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.78.tgz",
+      "integrity": "sha512-OgPAnfvbGAMWac6yvxJ1ihslrvDpPVwR68D2csospdNCCyPvHk9JLzYKwz48SNiS1T2znDwHauywRKRFfpyYng==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.61",
-        "@aws-sdk/credential-provider-http": "^3.972.63",
-        "@aws-sdk/credential-provider-ini": "^3.973.6",
-        "@aws-sdk/credential-provider-process": "^3.972.61",
-        "@aws-sdk/credential-provider-sso": "^3.973.5",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.67",
+        "@aws-sdk/credential-provider-env": "^3.972.67",
+        "@aws-sdk/credential-provider-http": "^3.972.69",
+        "@aws-sdk/credential-provider-ini": "^3.973.12",
+        "@aws-sdk/credential-provider-process": "^3.972.67",
+        "@aws-sdk/credential-provider-sso": "^3.973.11",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.73",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.8",
-        "@smithy/credential-provider-imds": "^4.4.13",
+        "@smithy/core": "^3.31.1",
+        "@smithy/credential-provider-imds": "^4.4.16",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -308,14 +311,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.61",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.61.tgz",
-      "integrity": "sha512-xzRuj+fUVO4nkafKQJVKAF97kGpeQbfjuwmRrtGZNf42/1dkmcz6o7dswBy7alY0htQn5sCL1GWQYEykviWZkA==",
+      "version": "3.972.67",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.67.tgz",
+      "integrity": "sha512-IlUEejorGTWKb4/Dm7K5Yw4QxUmXLThLhrvBmzVBqZFTbW72cv9LTcITmo1dsnYriALE4h68mOq4LB99x6sQ7Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.0",
+        "@aws-sdk/core": "^3.977.6",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.8",
+        "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -324,16 +327,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.973.5",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.5.tgz",
-      "integrity": "sha512-fZRjjWhLFelsDoOYjqShQTrIGYC3Pf9Mx9Czf+1ikfQDgktxjze33dVo1q1/ZQ+T0qbtejVoHNHrfD5aJVpv/w==",
+      "version": "3.973.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.11.tgz",
+      "integrity": "sha512-gAQBkBZxUB84d71+pPcI9L+jh2ujhuAVxc/4FgGiWFDjkPBlMKxzd5XDtkSXTFX8Ro7ansnT88+XadasxMeCRw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.0",
-        "@aws-sdk/nested-clients": "^3.997.35",
-        "@aws-sdk/token-providers": "3.1095.0",
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/nested-clients": "^3.997.41",
+        "@aws-sdk/token-providers": "3.1103.0",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.8",
+        "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -342,15 +345,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.67",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.67.tgz",
-      "integrity": "sha512-FTNZ05gkPBA6CKbU3N4zPgybV+stdazwMOya75CmGdcJL7p8Fw/BdHP8WVxJd0mvzyPK2cg/C3gli58Ir4HgCw==",
+      "version": "3.972.73",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.73.tgz",
+      "integrity": "sha512-SnlEmQa6SjOgs6iOPLUQl1Eyq4AKiAdPQlkOhFhqNfDtDCwibMGvL6QlkSmf3o6vAUSImzdPCxowT5dfQUZP1A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.0",
-        "@aws-sdk/nested-clients": "^3.997.35",
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/nested-clients": "^3.997.41",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.8",
+        "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -358,16 +361,36 @@
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-sdk/middleware-sdk-s3": {
-      "version": "3.972.66",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.66.tgz",
-      "integrity": "sha512-sTZKP1+SvyzWc/3alO8AM/PUiEzDCmn2P/KOcFFSk2UKzKZkB5ZxXdlHVtACE7DHaMFvx6DY0bognwHa1qTv4g==",
+    "node_modules/@aws-sdk/lib-storage": {
+      "version": "3.1107.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-storage/-/lib-storage-3.1107.0.tgz",
+      "integrity": "sha512-aQohoTGU0xYavudEZ+zEJejVfqH9Eu5Bk1yLi8soHyJO88qnSW+vF9qARjS8oLyo1ivXeesWvlGHfAuhCOw4Mg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.0",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.42",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "buffer": "5.6.0",
+        "events": "3.3.0",
+        "stream-browserify": "3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-s3": "^3.1107.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.972.72",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.72.tgz",
+      "integrity": "sha512-lSAoVPvQxX1d8TOM6waKDBQrvvZcm4w6pCldFAsRUffEaXq6lYY0pPyew3KlLu6Xqb74DXI42hGvSsbGBLljlw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.43",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.8",
+        "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -376,17 +399,17 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.997.35",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.35.tgz",
-      "integrity": "sha512-2MJfseVG/aXvIyOIBlYA/Oaf6qFDdsu4D8RKsEUdOQpVuLaor0BdxIBBtJLBNQQEe6Ku3YMvLljwb1MwVUpzRw==",
+      "version": "3.997.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.41.tgz",
+      "integrity": "sha512-RDHqPGQWlF6tatA/Tp3rg6oIwtgN9IVderxE+9av2Y93Dfyu+mO1hZ5Bu2jpfZg2rwdNbsssnwM+sLafIczMlQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.0",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.42",
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.43",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.8",
-        "@smithy/fetch-http-handler": "^5.6.10",
-        "@smithy/node-http-handler": "^4.9.10",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -412,13 +435,13 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.42",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.42.tgz",
-      "integrity": "sha512-DBV4naZP6HYBlAvPpoQzOP12Wvfou/5rN8yJPXjBTBylU5qwCbh/tXr2MddHoIjgoRkEl/eS+IljiUqvmwey1Q==",
+      "version": "3.996.43",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.43.tgz",
+      "integrity": "sha512-lKekx8bLBXSv4O+cslk9Zfnw2XKSkWBs3uWL5QGhH2ZAQfNS7FE0vcSSN2vD/AhxX54ZTywWxR4STThoeOXlBA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/signature-v4": "^5.6.9",
+        "@smithy/signature-v4": "^5.6.12",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -427,15 +450,15 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.1095.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1095.0.tgz",
-      "integrity": "sha512-65SudS6y4nzaYHybtqcpm3sHe5jLhdMn68HRKS1nUx690BtQeaAQOoujQ+dpOjBATIVGVgKKjEP8tR+U06QJQA==",
+      "version": "3.1103.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1103.0.tgz",
+      "integrity": "sha512-N4wy26MNn31ItGVHYHPrEuCIFY4MBBjC+C5v1lJKqIUSA7OZBdhleCY53zCCrXn27hsk7YNOaTuhQu807S4AfQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.0",
-        "@aws-sdk/nested-clients": "^3.997.35",
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/nested-clients": "^3.997.41",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.8",
+        "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -639,7 +662,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -688,7 +710,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -1754,7 +1775,6 @@
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
       "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@hono/node-server": "^1.19.9",
         "ajv": "^8.17.1",
@@ -2296,9 +2316,9 @@
       ]
     },
     "node_modules/@smithy/core": {
-      "version": "3.29.8",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.29.8.tgz",
-      "integrity": "sha512-rpCbCV+TimOBi3VLNBMmtTvgfOWcFIEAru3+TFlG87SL2F+te4jOnnNR+cf3uR4eJ5Qf4LnT80fqnBKgPRS6zA==",
+      "version": "3.31.1",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.31.1.tgz",
+      "integrity": "sha512-CyogUINxvi7C7LDsh8Syo6hVJOT9ckz4rG8dRZfTJ8r91HkMY59PnNooaj7WcHyxEkxPfBAmbgztZU+xTo76lg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.16.1",
@@ -2309,12 +2329,12 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.4.13",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.13.tgz",
-      "integrity": "sha512-X+2HNZhWi5i3rJsCas0LPf6fTQUaKyJ40zd8aTO/bwpRfpU3biYaqLr7C1WMibL7PVKJalpi1PyybjGPNoHC8Q==",
+      "version": "4.4.16",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.16.tgz",
+      "integrity": "sha512-QfuLWAkLzptffFW980AFeHZFdqds2B64rpEd3uJ6lgs3xVn9QegGMUgUcj+4d7dRrAsya3r58ZKpku97WcFb4w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.29.8",
+        "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -2323,12 +2343,12 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.6.10",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.10.tgz",
-      "integrity": "sha512-5/Yj9mS2JjTsB3B8ZX7euh77mrY9aXW23ag1yAmFykSRmA6vldqBrgqmSeQ50EjY+5SB8+aE4w14B6LKbBVEhQ==",
+      "version": "5.6.13",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.13.tgz",
+      "integrity": "sha512-4fW86pEUOMbrD5nkbyl/tTvPHHWJFbuB2odl6ps9lWfHoXf9HWh3Q/Smh59qH1g7+c/BSZghX6bbUk4gsiMs8A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.29.8",
+        "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -2337,12 +2357,12 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.9.10",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.10.tgz",
-      "integrity": "sha512-ETQz9v/Z+nTQc6fRWTXxUpxJqwpmzB3Tn3WKAdHwWkeT+m+HE5czs6GNG8vW+4vyxXSls65RVcvOZwk7Q/PS/Q==",
+      "version": "4.9.13",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.13.tgz",
+      "integrity": "sha512-Nmd/Nl35zfYrd+a6OO2cDJb3GPh9bgTjIUhcM+JFfjpp8/osCgboDV5nCT1I01Pv6R13eSKDKLSoVa5ZB6Zsfw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.29.8",
+        "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -2351,12 +2371,12 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.6.9",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.9.tgz",
-      "integrity": "sha512-g5rnEii/mkT0mjVJmlsaOfyNBtHNTecD9Lo4NP8D5HzMUEnZNpz7/FbvBCjNcV4vteHFAxOGiLUYNxPkDZZAPw==",
+      "version": "5.6.12",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.12.tgz",
+      "integrity": "sha512-I6KLtq3H0qqSuV9vLglfi8puHqzygzWHOnI4z/Rdoo+q50vvo18vBRdPAvvEtcaKROz7Zn6qnPa14kRfPH6PcQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.29.8",
+        "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -2482,7 +2502,6 @@
       "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^5.0.0",
@@ -2609,6 +2628,16 @@
         "@types/superagent": "^8.1.0"
       }
     },
+    "node_modules/@types/unzipper": {
+      "version": "0.10.11",
+      "resolved": "https://registry.npmjs.org/@types/unzipper/-/unzipper-0.10.11.tgz",
+      "integrity": "sha512-D25im2zjyMCcgL9ag6N46+wbtJBnXIr7SI4zHf9eJD2Dw2tEB5e+p5MYkrxKIVRscs5QV0EhtU9rgXSPx90oJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/wrap-ansi": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/wrap-ansi/-/wrap-ansi-3.0.0.tgz",
@@ -2661,7 +2690,6 @@
       "integrity": "sha512-A0M6ua6H252bVjPvvtSgl2QA4+ET9S5Mtkb2GDyTxIhH/C4qDItT7RQNO5PhMC6NXGYXOR9dIalcDDgBKT7oFA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.60.1",
         "@typescript-eslint/types": "8.60.1",
@@ -3086,7 +3114,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3109,6 +3136,7 @@
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "debug": "4"
       },
@@ -3341,6 +3369,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/bidi-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
@@ -3350,6 +3398,12 @@
       "dependencies": {
         "require-from-string": "^2.0.2"
       }
+    },
+    "node_modules/bluebird": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+      "license": "MIT"
     },
     "node_modules/body-parser": {
       "version": "2.2.2",
@@ -3403,6 +3457,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+      "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4"
       }
     },
     "node_modules/bytes": {
@@ -3659,6 +3723,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
+    },
     "node_modules/cors": {
       "version": "2.8.6",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
@@ -3902,6 +3972,51 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/duplexer2": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+      "integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "readable-stream": "^2.0.2"
+      }
+    },
+    "node_modules/duplexer2/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
+    "node_modules/duplexer2/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/duplexer2/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/duplexer2/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/eastasianwidth": {
@@ -4162,7 +4277,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4223,7 +4337,6 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -4422,6 +4535,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
       }
     },
     "node_modules/eventsource": {
@@ -4749,6 +4871,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=4.0"
       },
@@ -5121,7 +5244,6 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/has-bigints": {
@@ -5220,7 +5342,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.27.tgz",
       "integrity": "sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -5277,6 +5398,7 @@
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
       "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "agent-base": "6",
         "debug": "4"
@@ -5300,6 +5422,26 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/ignore": {
       "version": "7.0.5",
@@ -6010,7 +6152,6 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
       "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "universalify": "^2.0.0"
@@ -6345,6 +6486,12 @@
       "engines": {
         "node": ">= 6.13.0"
       }
+    },
+    "node_modules/node-int64": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+      "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
+      "license": "MIT"
     },
     "node_modules/normalize-package-data": {
       "version": "2.5.0",
@@ -6878,7 +7025,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7005,7 +7151,6 @@
       "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -7042,6 +7187,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -7060,6 +7211,7 @@
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
       "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -7126,6 +7278,20 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -7219,7 +7385,6 @@
       "integrity": "sha512-I4KW6iuRpuu2uHBLraZ1wNZe0DP7lnRha+VJ9tNaYVaVgKhW0aI3h4RYnoRPeql0flHm/Co55b7snEDcOfOJrA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.9"
       },
@@ -7294,6 +7459,26 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
@@ -7678,6 +7863,25 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/stream-browserify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-3.0.0.tgz",
+      "integrity": "sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "~2.0.4",
+        "readable-stream": "^3.5.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string-width": {
@@ -8873,7 +9077,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8946,7 +9149,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
@@ -8961,6 +9163,33 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/unzipper": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.12.5.tgz",
+      "integrity": "sha512-tXYOi9R57Uj/2Z25SOs5RRSzq886MBQj2gY8dPL+xl/kv6s6SvByoKfAtvfVeEuhntWDgjd2o9p2lb4TVPAz0A==",
+      "license": "MIT",
+      "dependencies": {
+        "bluebird": "~3.7.2",
+        "duplexer2": "~0.1.4",
+        "fs-extra": "11.3.1",
+        "graceful-fs": "^4.2.2",
+        "node-int64": "^0.4.0"
+      }
+    },
+    "node_modules/unzipper/node_modules/fs-extra": {
+      "version": "11.3.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.1.tgz",
+      "integrity": "sha512-eXvGGwZ5CL17ZSwHWd3bbgk7UUpF6IFHtP57NYYakPvHOs8GDgDe5KJI36jIJzDkJ6eJjuzRA8eBQb6SkKue0g==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -8970,6 +9199,12 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/uuid": {
       "version": "14.0.1",
@@ -9010,7 +9245,6 @@
       "integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -9630,7 +9864,6 @@
       "integrity": "sha512-xejya+bT/j/+R/AGa1XOfRxLmNUlLtlwjRsFUILF+xHfzElmGcmFydy2gqqIrd62ptIEfwVMofd19uNWD9L7Nw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.6",
@@ -10040,7 +10273,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1095.0",
+    "@aws-sdk/lib-storage": "^3.1095.0",
     "@aws-sdk/s3-request-presigner": "^3.1095.0",
     "@modelcontextprotocol/ext-apps": "^1.7.2",
     "@modelcontextprotocol/sdk": "^1.26.0",
@@ -77,6 +78,7 @@
     "jose": "^6.0.12",
     "ssrfcheck": "^1.2.0",
     "ts-results-es": "^7.1.0",
+    "unzipper": "^0.12.5",
     "uuid": "^14.0.1",
     "xpath": "^0.0.34",
     "zod": "^3.24.3",
@@ -95,6 +97,7 @@
     "@types/fast-levenshtein": "^0.0.1",
     "@types/node": "^22.15.3",
     "@types/supertest": "^6.0.3",
+    "@types/unzipper": "^0.10.11",
     "@typescript-eslint/eslint-plugin": "^8.31.1",
     "@typescript-eslint/parser": "^8.31.1",
     "@vitest/coverage-v8": "^3.1.3",

--- a/src/config.ts
+++ b/src/config.ts
@@ -322,17 +322,18 @@ export class Config extends BaseConfig {
     // INSIGHTS_TOOLS_ENABLED=true to register them.
     this.insightsToolsEnabled = insightsToolsEnabled === 'true';
 
-    // S3 offload: when MCP_S3_BUCKET is set, view-image and view-data tools
-    // upload the payload (rendered image or CSV) to S3 and return a short-lived
-    // presigned URL instead of inlining base64/text. AWS credentials are
+    // S3 offload: when MCP_S3_BUCKET is set, file-producing tools upload their
+    // payloads to S3 and return short-lived presigned URLs instead of inlining
+    // content or exposing a server-local path. AWS credentials are
     // resolved via the default AWS SDK credential chain (IAM role / instance
     // profile / standard AWS_* env vars), so no credentials are read here. When
     // unset, the tools fall back to returning the payload inline (unchanged
-    // behavior).
+    // behavior for tools that support an inline or local fallback).
     //
     // `keyPrefix` (MCP_IMAGE_PREFIX) is the shared base folder; each tool
-    // appends its own segment (e.g. `view-images/`, `view-data/`), so an unset
-    // base falls back to the per-tool default rather than a global one.
+    // appends its own segment (e.g. `view-images/`, `view-data/`,
+    // `workbook-downloads/`), so an unset base falls back to the per-tool
+    // default rather than a global one.
     const bucketS3BucketValue = bucketS3Bucket?.trim() ?? '';
     this.bucketS3 = {
       enabled: !!bucketS3BucketValue,

--- a/src/logging/secretMask.test.ts
+++ b/src/logging/secretMask.test.ts
@@ -107,6 +107,27 @@ describe('secretMask', () => {
     });
   });
 
+  it('should omit downloaded workbook bytes from debug response logs', () => {
+    const workbookBytes = (): string => 'non-cloneable workbook stream';
+
+    const maskedResponse = maskResponse({
+      status: 200,
+      baseUrl: 'https://example.com/api/3.29',
+      params: { includeExtract: false },
+      url: '/sites/site-id/workbooks/workbook-id/content',
+      headers: { 'content-type': 'application/xml' },
+      data: workbookBytes,
+    });
+
+    expect(maskedResponse).toEqual({
+      status: 200,
+      baseUrl: 'https://example.com/api/3.29',
+      params: { includeExtract: false },
+      url: '/sites/site-id/workbooks/workbook-id/content',
+      headers: { 'content-type': 'application/xml' },
+    });
+  });
+
   it('should remove multipart upload bodies and redact upload sessions in request paths', () => {
     const maskedRequest = maskRequest({
       method: 'PUT',

--- a/src/logging/secretMask.ts
+++ b/src/logging/secretMask.ts
@@ -70,6 +70,14 @@ export const maskRequest = (config: RequestInterceptorConfig): MaskedRequest => 
 };
 
 export const maskResponse = (response: ResponseInterceptorConfig): MaskedResponse => {
+  if (isWorkbookDownloadResponse(response.url)) {
+    const { data: _data, ...responseWithoutData } = response;
+    if (shouldNotifyWhenLevelIsAtLeast('debug')) return responseWithoutData;
+
+    const { headers: _headers, ...responseWithoutHeaders } = responseWithoutData;
+    return responseWithoutHeaders;
+  }
+
   const result = clone<MaskedResponse>(response);
   if (result.isErr()) {
     return response;
@@ -91,6 +99,10 @@ export const maskResponse = (response: ResponseInterceptorConfig): MaskedRespons
 
   return maskedData;
 };
+
+function isWorkbookDownloadResponse(url: string): boolean {
+  return /\/workbooks\/[^/]+\/content(?:\?|$)/i.test(url);
+}
 
 function redactUploadSessionIdFromUrl(url: string): string {
   return url.replace(/(\/fileUploads\/)[^/?]+/gi, '$1<redacted>');

--- a/src/overridableConfig.test.ts
+++ b/src/overridableConfig.test.ts
@@ -60,6 +60,7 @@ describe('OverridableConfig', () => {
         'query-datasource',
         'list-workbooks',
         'get-workbook',
+        'download-workbook',
         'start-web-authoring-session',
         'publish-workbook',
       ]);
@@ -80,6 +81,7 @@ describe('OverridableConfig', () => {
         'query-datasource',
         'list-workbooks',
         'get-workbook',
+        'download-workbook',
         'start-web-authoring-session',
         'publish-workbook',
       ]);

--- a/src/restApiInstance.ts
+++ b/src/restApiInstance.ts
@@ -39,6 +39,7 @@ type JwtScopes =
   | 'tableau:workbook_tags:update'
   | 'tableau:workbooks:delete'
   | 'tableau:workbooks:create'
+  | 'tableau:workbooks:download'
   | 'tableau:datasource_tags:update'
   | 'tableau:datasources:delete'
   | 'tableau:jobs:read'

--- a/src/sdks/tableau/apis/workbooksApi.ts
+++ b/src/sdks/tableau/apis/workbooksApi.ts
@@ -16,6 +16,32 @@ const getWorkbookEndpoint = makeEndpoint({
   response: z.object({ workbook: workbookSchema }),
 });
 
+const downloadWorkbookEndpoint = makeEndpoint({
+  method: 'get',
+  path: '/sites/:siteId/workbooks/:workbookId/content',
+  alias: 'downloadWorkbook',
+  description: 'Downloads a workbook in TWB or TWBX format.',
+  parameters: [
+    {
+      name: 'siteId',
+      type: 'Path',
+      schema: z.string(),
+    },
+    {
+      name: 'workbookId',
+      type: 'Path',
+      schema: z.string(),
+    },
+    {
+      name: 'includeExtract',
+      type: 'Query',
+      schema: z.boolean().optional(),
+      description: 'Whether to include workbook extracts in the downloaded file.',
+    },
+  ],
+  response: z.string(),
+});
+
 const queryWorkbooksForSiteEndpoint = makeEndpoint({
   method: 'get',
   path: '/sites/:siteId/workbooks',
@@ -145,6 +171,7 @@ const validateUploadedWorkbookEndpoint = makeEndpoint({
 const workbooksApi = makeApi([
   queryWorkbooksForSiteEndpoint,
   getWorkbookEndpoint,
+  downloadWorkbookEndpoint,
   deleteWorkbookEndpoint,
   addTagsToWorkbookEndpoint,
   publishWorkbookEndpoint,

--- a/src/sdks/tableau/methods/workbooksMethods.test.ts
+++ b/src/sdks/tableau/methods/workbooksMethods.test.ts
@@ -1,9 +1,56 @@
 import { AxiosInstance } from 'axios';
+import { Readable } from 'stream';
 import { describe, expect, it, vi } from 'vitest';
 
 import WorkbooksMethods from './workbooksMethods.js';
 
 describe('WorkbooksMethods', () => {
+  describe('downloadWorkbook', () => {
+    it('streams workbook content and returns response metadata', async () => {
+      const workbookBytes = Buffer.from('<workbook />');
+      const mockGet = vi.fn().mockResolvedValue({
+        data: Readable.from(workbookBytes),
+        headers: {
+          'content-disposition': 'name="tableau_workbook"; filename="Downloaded.twb"',
+          'content-type': 'application/xml',
+        },
+      });
+      const workbooksMethods = new WorkbooksMethods(
+        'http://test',
+        { type: 'Bearer', token: 'test' },
+        {},
+      );
+      // @ts-expect-error - Mocking private property
+      workbooksMethods._apiClient = {
+        axios: {
+          get: mockGet,
+          defaults: { baseURL: 'http://test' },
+        } as unknown as AxiosInstance,
+      };
+
+      const result = await workbooksMethods.downloadWorkbook({
+        siteId: 'site-1',
+        workbookId: 'workbook-1',
+        includeExtract: false,
+      });
+
+      expect(mockGet).toHaveBeenCalledWith(
+        'http://test/sites/site-1/workbooks/workbook-1/content',
+        {
+          params: { includeExtract: false },
+          headers: { Authorization: 'Bearer test' },
+          responseType: 'stream',
+        },
+      );
+      expect(result.contentDisposition).toBe('name="tableau_workbook"; filename="Downloaded.twb"');
+      expect(result.contentType).toBe('application/xml');
+
+      const chunks: Buffer[] = [];
+      for await (const chunk of result.content) chunks.push(Buffer.from(chunk));
+      expect(Buffer.concat(chunks)).toEqual(workbookBytes);
+    });
+  });
+
   describe('publishWorkbook', () => {
     it('POSTs a single-part multipart/mixed body containing the tsRequest XML', async () => {
       const mockPost = vi.fn().mockResolvedValue({

--- a/src/sdks/tableau/methods/workbooksMethods.ts
+++ b/src/sdks/tableau/methods/workbooksMethods.ts
@@ -1,4 +1,5 @@
 import { Zodios } from '@zodios/core';
+import { Readable } from 'stream';
 
 import { AxiosRequestConfig } from '../../../utils/axios.js';
 import { workbooksApis } from '../apis/workbooksApi.js';
@@ -8,6 +9,12 @@ import { Pagination } from '../types/pagination.js';
 import { Workbook, workbookSchema } from '../types/workbook.js';
 import { WorkbookValidationResult } from '../types/workbookValidation.js';
 import AuthenticatedMethods from './authenticatedMethods.js';
+
+export type DownloadedWorkbook = {
+  content: Readable;
+  contentDisposition?: string;
+  contentType?: string;
+};
 
 /**
  * Workbooks methods of the Tableau Server REST API
@@ -43,6 +50,42 @@ export default class WorkbooksMethods extends AuthenticatedMethods<typeof workbo
         ...this.authHeader,
       })
     ).workbook;
+  };
+
+  /**
+   * Downloads a workbook in TWB or TWBX format. The response is streamed so packaged
+   * workbooks and extracts do not need to be buffered in memory.
+   *
+   * Required scopes: `tableau:workbooks:download`
+   *
+   * @param workbookId - The ID of the workbook to download.
+   * @param siteId - The Tableau site ID.
+   * @param includeExtract - Whether to include workbook extracts in the download.
+   * @link https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref_workbooks_and_views.htm#download_workbook
+   */
+  downloadWorkbook = async ({
+    workbookId,
+    siteId,
+    includeExtract,
+  }: {
+    workbookId: string;
+    siteId: string;
+    includeExtract?: boolean;
+  }): Promise<DownloadedWorkbook> => {
+    const response = await this._apiClient.axios.get(
+      `${this._apiClient.axios.defaults.baseURL}/sites/${siteId}/workbooks/${workbookId}/content`,
+      {
+        params: { includeExtract },
+        headers: this.authHeader.headers,
+        responseType: 'stream',
+      },
+    );
+
+    return {
+      content: response.data as Readable,
+      contentDisposition: getHeader(response.headers, 'content-disposition'),
+      contentType: getHeader(response.headers, 'content-type'),
+    };
   };
 
   /**
@@ -210,4 +253,11 @@ function escapeXmlAttribute(value: string): string {
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;')
     .replace(/"/g, '&quot;');
+}
+
+function getHeader(headers: unknown, name: string): string | undefined {
+  if (!headers || typeof headers !== 'object') return undefined;
+
+  const value = (headers as Record<string, unknown>)[name];
+  return typeof value === 'string' ? value : undefined;
 }

--- a/src/server/oauth/scopes.ts
+++ b/src/server/oauth/scopes.ts
@@ -52,6 +52,7 @@ export type TableauApiScope =
   | 'tableau:workbook_tags:update'
   | 'tableau:workbooks:delete'
   | 'tableau:workbooks:create'
+  | 'tableau:workbooks:download'
   | 'tableau:datasource_tags:update'
   | 'tableau:datasources:delete'
   | 'tableau:jobs:read'
@@ -245,6 +246,10 @@ const toolScopeMap: Record<
   'get-workbook': {
     mcp: ['tableau:mcp:workbook:read'],
     api: new Set(['tableau:content:read', ...RESOURCE_ACCESS_CHECKER_REQUIRED_API_SCOPES]),
+  },
+  'download-workbook': {
+    mcp: ['tableau:mcp:workbook:read'],
+    api: new Set(['tableau:workbooks:download', ...RESOURCE_ACCESS_CHECKER_REQUIRED_API_SCOPES]),
   },
   // Commits an already-staged file upload session as a published workbook. Does NOT validate the
   // workbook first (that is a separate, opt-in step). Publishing is the only Tableau REST call, so

--- a/src/tools/web/s3Client.stream.test.ts
+++ b/src/tools/web/s3Client.stream.test.ts
@@ -1,0 +1,77 @@
+import { GetObjectCommand, S3Client } from '@aws-sdk/client-s3';
+import { Upload } from '@aws-sdk/lib-storage';
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+import { Readable } from 'stream';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { exportedForTesting, uploadStreamToS3 } from './s3Client.js';
+
+const mocks = vi.hoisted(() => ({
+  done: vi.fn(),
+  getSignedUrl: vi.fn(),
+}));
+
+vi.mock('@aws-sdk/client-s3', () => ({
+  S3Client: vi.fn().mockImplementation(() => ({ send: vi.fn() })),
+  PutObjectCommand: vi.fn(),
+  GetObjectCommand: vi.fn().mockImplementation((input) => ({ __command: 'get', input })),
+}));
+
+vi.mock('@aws-sdk/lib-storage', () => ({
+  Upload: vi.fn().mockImplementation((options) => ({ done: mocks.done, options })),
+}));
+
+vi.mock('@aws-sdk/s3-request-presigner', () => ({
+  getSignedUrl: mocks.getSignedUrl,
+}));
+
+describe('uploadStreamToS3', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    exportedForTesting.resetS3Bundle();
+    mocks.done.mockResolvedValue({});
+    mocks.getSignedUrl.mockResolvedValue('https://s3.example.com/signed-url');
+  });
+
+  it('uses managed multipart upload and presigns the uploaded object', async () => {
+    const body = Readable.from(Buffer.from('<workbook />'));
+    const url = await uploadStreamToS3(body, {
+      bucket: 'tableau-artifacts',
+      region: 'us-east-1',
+      key: 'workbook-downloads/workbook-id/file.twb',
+      contentType: 'application/xml',
+      contentDisposition: 'attachment; filename="Sales.twb"',
+      contentLength: 12,
+      presignTtlSeconds: 600,
+    });
+
+    expect(url).toBe('https://s3.example.com/signed-url');
+    expect(S3Client).toHaveBeenCalledWith(expect.objectContaining({ region: 'us-east-1' }));
+    expect(Upload).toHaveBeenCalledWith({
+      client: expect.anything(),
+      leavePartsOnError: false,
+      params: {
+        Bucket: 'tableau-artifacts',
+        Key: 'workbook-downloads/workbook-id/file.twb',
+        Body: body,
+        ContentType: 'application/xml',
+        ContentDisposition: 'attachment; filename="Sales.twb"',
+        ContentLength: 12,
+      },
+    });
+    expect(mocks.done).toHaveBeenCalledTimes(1);
+
+    const getInput = vi.mocked(GetObjectCommand).mock.calls[0][0];
+    expect(getInput).toEqual({
+      Bucket: 'tableau-artifacts',
+      Key: 'workbook-downloads/workbook-id/file.twb',
+      ResponseContentDisposition: 'attachment; filename="Sales.twb"',
+      ResponseContentType: 'application/xml',
+    });
+    expect(getSignedUrl).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ __command: 'get' }),
+      { expiresIn: 600 },
+    );
+  });
+});

--- a/src/tools/web/s3Client.ts
+++ b/src/tools/web/s3Client.ts
@@ -1,5 +1,7 @@
+import { Readable } from 'stream';
+
 /**
- * Shared S3 upload core.
+ * Shared S3 buffer/stream upload core.
  *
  * This module holds the format-agnostic pieces used by every S3-offload path
  * (rendered view images, view CSV data, ...): the lazily-created, cached S3
@@ -153,6 +155,59 @@ export async function uploadBufferToS3(
   return await getSignedUrl(client, new GetObjectCommand({ Bucket: bucket, Key: key }), {
     expiresIn: presignTtlSeconds,
   });
+}
+
+/**
+ * Streams a payload to S3 using the SDK's managed multipart uploader, then
+ * returns a short-lived presigned GET URL for the resulting object.
+ */
+export async function uploadStreamToS3(
+  body: Readable,
+  {
+    key,
+    contentType,
+    contentDisposition,
+    contentLength,
+    bucket,
+    region,
+    presignTtlSeconds,
+  }: {
+    key: string;
+    contentType: string;
+    contentDisposition?: string;
+    contentLength?: number;
+    bucket: string;
+    region: string;
+    presignTtlSeconds: number;
+  },
+): Promise<string> {
+  const { client, GetObjectCommand, getSignedUrl } = await getS3Bundle(region);
+  const { Upload } = await import('@aws-sdk/lib-storage');
+
+  const upload = new Upload({
+    client,
+    leavePartsOnError: false,
+    params: {
+      Bucket: bucket,
+      Key: key,
+      Body: body,
+      ContentType: contentType,
+      ...(contentDisposition ? { ContentDisposition: contentDisposition } : {}),
+      ...(contentLength !== undefined ? { ContentLength: contentLength } : {}),
+    },
+  });
+  await upload.done();
+
+  return await getSignedUrl(
+    client,
+    new GetObjectCommand({
+      Bucket: bucket,
+      Key: key,
+      ...(contentDisposition ? { ResponseContentDisposition: contentDisposition } : {}),
+      ResponseContentType: contentType,
+    }),
+    { expiresIn: presignTtlSeconds },
+  );
 }
 
 export const exportedForTesting = {

--- a/src/tools/web/toolName.ts
+++ b/src/tools/web/toolName.ts
@@ -16,6 +16,7 @@ export const webToolNames = [
   'get-embed-token',
   'record-event',
   'get-workbook',
+  'download-workbook',
   'publish-workbook',
   'get-view',
   'get-flow',
@@ -65,7 +66,13 @@ export type WebToolGroupName = (typeof webToolGroupNames)[number];
 
 export const webToolGroups = {
   datasource: ['list-datasources', 'get-datasource-metadata', 'query-datasource'],
-  workbook: ['list-workbooks', 'get-workbook', 'start-web-authoring-session', 'publish-workbook'],
+  workbook: [
+    'list-workbooks',
+    'get-workbook',
+    'download-workbook',
+    'start-web-authoring-session',
+    'publish-workbook',
+  ],
   project: ['list-projects'],
   view: [
     'list-views',

--- a/src/tools/web/tools.ts
+++ b/src/tools/web/tools.ts
@@ -36,6 +36,7 @@ import { getGetViewDataTool } from './views/getViewData.js';
 import { getGetViewImageTool } from './views/getViewImage.js';
 import { getListCustomViewsTool } from './views/listCustomViews.js';
 import { getListViewsTool } from './views/listViews.js';
+import { getDownloadWorkbookTool } from './workbooks/downloadWorkbook.js';
 import { getGetWorkbookTool } from './workbooks/getWorkbook.js';
 import { getListWorkbooksTool } from './workbooks/listWorkbooks.js';
 import { getPublishWorkbookTool } from './workbooks/publishWorkbook.js';
@@ -67,6 +68,7 @@ export const webToolFactories = [
   getGeneratePulseInsightBriefTool,
   getGenerateInsightCardsTool,
   getStartWebAuthoringSessionTool,
+  getDownloadWorkbookTool,
   getGetWorkbookTool,
   getPublishWorkbookTool,
   getGetViewTool,

--- a/src/tools/web/workbooks/downloadWorkbook.test.ts
+++ b/src/tools/web/workbooks/downloadWorkbook.test.ts
@@ -1,15 +1,17 @@
 import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { Readable } from 'stream';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';
 
 import { useRestApi } from '../../../restApiInstance.js';
 import { WebMcpServer } from '../../../server.web.js';
+import { stubDefaultEnvVars } from '../../../testShared.js';
 import { Provider } from '../../../utils/provider.js';
 import { resourceAccessChecker } from '../resourceAccessChecker.js';
 import { getMockRequestHandlerExtra } from '../toolContext.mock.js';
 import { persistDownloadedWorkbook } from './downloadedWorkbookFile.js';
 import { getDownloadWorkbookTool } from './downloadWorkbook.js';
+import { uploadWorkbookToS3 } from './uploadWorkbookToS3.js';
 
 const mocks = vi.hoisted(() => ({
   downloadWorkbook: vi.fn(),
@@ -28,8 +30,21 @@ vi.mock('./downloadedWorkbookFile.js', () => ({
   persistDownloadedWorkbook: vi.fn(),
 }));
 
+vi.mock('./uploadWorkbookToS3.js', () => ({
+  uploadWorkbookToS3: vi.fn(),
+}));
+
+beforeEach(() => {
+  vi.unstubAllEnvs();
+  stubDefaultEnvVars();
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
 describe('getDownloadWorkbookTool', () => {
-  it('declares the workbook download contract and required scopes', async () => {
+  it('declares a TWB-only download contract and required scopes', async () => {
     const tool = getDownloadWorkbookTool(new WebMcpServer());
     const schema = z.object(await Provider.from(tool.paramsSchema)).strict();
 
@@ -48,18 +63,20 @@ describe('getDownloadWorkbookTool', () => {
     ]);
     expect(schema.safeParse({ workbookId: 'workbook-id' }).success).toBe(true);
     expect(schema.safeParse({ workbookId: 'workbook-id', includeExtract: true }).success).toBe(
-      true,
+      false,
     );
     expect(schema.safeParse({}).success).toBe(false);
   });
 
-  it('downloads without extracts by default and returns the local artifact metadata', async () => {
+  it('excludes extracts and returns a local TWB artifact when S3 is not configured', async () => {
+    vi.stubEnv('MCP_S3_BUCKET', '');
     const downloadedWorkbook = { content: Readable.from(Buffer.from('<workbook />')) };
     mocks.downloadWorkbook.mockResolvedValue(downloadedWorkbook);
     vi.mocked(persistDownloadedWorkbook).mockResolvedValue({
       workbookFilePath: '/tmp/tableau-mcp-workbook-1/Sales.twb',
       fileName: 'Sales.twb',
       fileType: 'twb',
+      sourceFileType: 'twb',
       sizeBytes: 42,
     });
     vi.spyOn(resourceAccessChecker, 'isWorkbookAllowed').mockResolvedValue({ allowed: true });
@@ -68,11 +85,12 @@ describe('getDownloadWorkbookTool', () => {
 
     expect(result.isError).toBe(false);
     expect(result.structuredContent).toEqual({
+      delivery: 'local',
       workbookFilePath: '/tmp/tableau-mcp-workbook-1/Sales.twb',
       fileName: 'Sales.twb',
       fileType: 'twb',
+      sourceFileType: 'twb',
       sizeBytes: 42,
-      includeExtract: false,
     });
     expect(mocks.downloadWorkbook).toHaveBeenCalledWith({
       siteId: 'test-site-id',
@@ -80,6 +98,7 @@ describe('getDownloadWorkbookTool', () => {
       includeExtract: false,
     });
     expect(persistDownloadedWorkbook).toHaveBeenCalledWith(downloadedWorkbook);
+    expect(uploadWorkbookToS3).not.toHaveBeenCalled();
     expect(useRestApi).toHaveBeenCalledWith(
       expect.objectContaining({
         jwtScopes: [
@@ -91,22 +110,55 @@ describe('getDownloadWorkbookTool', () => {
     );
   });
 
-  it('passes includeExtract through when requested', async () => {
-    mocks.downloadWorkbook.mockResolvedValue({
-      content: Readable.from(Buffer.from('packaged workbook')),
-    });
+  it('uploads the normalized TWB to S3 and returns a resource link', async () => {
+    vi.stubEnv('MCP_S3_BUCKET', 'tableau-artifacts');
+    vi.stubEnv('MCP_IMAGE_PREFIX', 'tableau/');
+    const downloadedWorkbook = { content: Readable.from(Buffer.from('package')) };
+    mocks.downloadWorkbook.mockResolvedValue(downloadedWorkbook);
     vi.mocked(persistDownloadedWorkbook).mockResolvedValue({
-      workbookFilePath: '/tmp/tableau-mcp-workbook-1/Sales.twbx',
-      fileName: 'Sales.twbx',
-      fileType: 'twbx',
-      sizeBytes: 100,
+      workbookFilePath: '/tmp/tableau-mcp-workbook-1/Sales.twb',
+      fileName: 'Sales.twb',
+      fileType: 'twb',
+      sourceFileType: 'twbx',
+      sizeBytes: 42,
+    });
+    vi.mocked(uploadWorkbookToS3).mockResolvedValue({
+      url: 'https://s3.example.com/signed-url',
+      fileName: 'Sales.twb',
+      fileType: 'twb',
+      sourceFileType: 'twbx',
+      sizeBytes: 42,
     });
     vi.spyOn(resourceAccessChecker, 'isWorkbookAllowed').mockResolvedValue({ allowed: true });
 
-    await getToolResult({ workbookId: 'workbook-id', includeExtract: true });
+    const result = await getToolResult({ workbookId: 'workbook-id' });
 
-    expect(mocks.downloadWorkbook).toHaveBeenCalledWith(
-      expect.objectContaining({ includeExtract: true }),
+    expect(result.isError).toBe(false);
+    expect(result.content).toEqual([
+      expect.objectContaining({
+        type: 'resource_link',
+        uri: 'https://s3.example.com/signed-url',
+        name: 'Sales.twb',
+        mimeType: 'application/xml',
+      }),
+    ]);
+    expect(result.structuredContent).toEqual({
+      delivery: 'url',
+      url: 'https://s3.example.com/signed-url',
+      fileName: 'Sales.twb',
+      fileType: 'twb',
+      sourceFileType: 'twbx',
+      sizeBytes: 42,
+    });
+    expect(uploadWorkbookToS3).toHaveBeenCalledWith(
+      expect.objectContaining({ workbookFilePath: expect.any(String) }),
+      {
+        workbookId: 'workbook-id',
+        config: expect.objectContaining({
+          bucket: 'tableau-artifacts',
+          keyPrefix: 'tableau/workbook-downloads/',
+        }),
+      },
     );
   });
 
@@ -127,15 +179,9 @@ describe('getDownloadWorkbookTool', () => {
   });
 });
 
-async function getToolResult({
-  workbookId,
-  includeExtract,
-}: {
-  workbookId: string;
-  includeExtract?: boolean;
-}): Promise<CallToolResult> {
+async function getToolResult({ workbookId }: { workbookId: string }): Promise<CallToolResult> {
   vi.clearAllMocks();
   const tool = getDownloadWorkbookTool(new WebMcpServer());
   const callback = await Provider.from(tool.callback);
-  return await callback({ workbookId, includeExtract }, getMockRequestHandlerExtra());
+  return await callback({ workbookId }, getMockRequestHandlerExtra());
 }

--- a/src/tools/web/workbooks/downloadWorkbook.test.ts
+++ b/src/tools/web/workbooks/downloadWorkbook.test.ts
@@ -1,0 +1,141 @@
+import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { Readable } from 'stream';
+import { describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+
+import { useRestApi } from '../../../restApiInstance.js';
+import { WebMcpServer } from '../../../server.web.js';
+import { Provider } from '../../../utils/provider.js';
+import { resourceAccessChecker } from '../resourceAccessChecker.js';
+import { getMockRequestHandlerExtra } from '../toolContext.mock.js';
+import { persistDownloadedWorkbook } from './downloadedWorkbookFile.js';
+import { getDownloadWorkbookTool } from './downloadWorkbook.js';
+
+const mocks = vi.hoisted(() => ({
+  downloadWorkbook: vi.fn(),
+}));
+
+vi.mock('../../../restApiInstance.js', () => ({
+  useRestApi: vi.fn().mockImplementation(async ({ callback }) =>
+    callback({
+      siteId: 'test-site-id',
+      workbooksMethods: { downloadWorkbook: mocks.downloadWorkbook },
+    }),
+  ),
+}));
+
+vi.mock('./downloadedWorkbookFile.js', () => ({
+  persistDownloadedWorkbook: vi.fn(),
+}));
+
+describe('getDownloadWorkbookTool', () => {
+  it('declares the workbook download contract and required scopes', async () => {
+    const tool = getDownloadWorkbookTool(new WebMcpServer());
+    const schema = z.object(await Provider.from(tool.paramsSchema)).strict();
+
+    expect(tool.name).toBe('download-workbook');
+    expect(tool.annotations).toEqual({
+      title: 'Download Workbook',
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    });
+    expect(tool.requiredApiScopes).toEqual([
+      'tableau:workbooks:download',
+      'tableau:content:read',
+      'tableau:mcp_site_settings:read',
+    ]);
+    expect(schema.safeParse({ workbookId: 'workbook-id' }).success).toBe(true);
+    expect(schema.safeParse({ workbookId: 'workbook-id', includeExtract: true }).success).toBe(
+      true,
+    );
+    expect(schema.safeParse({}).success).toBe(false);
+  });
+
+  it('downloads without extracts by default and returns the local artifact metadata', async () => {
+    const downloadedWorkbook = { content: Readable.from(Buffer.from('<workbook />')) };
+    mocks.downloadWorkbook.mockResolvedValue(downloadedWorkbook);
+    vi.mocked(persistDownloadedWorkbook).mockResolvedValue({
+      workbookFilePath: '/tmp/tableau-mcp-workbook-1/Sales.twb',
+      fileName: 'Sales.twb',
+      fileType: 'twb',
+      sizeBytes: 42,
+    });
+    vi.spyOn(resourceAccessChecker, 'isWorkbookAllowed').mockResolvedValue({ allowed: true });
+
+    const result = await getToolResult({ workbookId: 'workbook-id' });
+
+    expect(result.isError).toBe(false);
+    expect(result.structuredContent).toEqual({
+      workbookFilePath: '/tmp/tableau-mcp-workbook-1/Sales.twb',
+      fileName: 'Sales.twb',
+      fileType: 'twb',
+      sizeBytes: 42,
+      includeExtract: false,
+    });
+    expect(mocks.downloadWorkbook).toHaveBeenCalledWith({
+      siteId: 'test-site-id',
+      workbookId: 'workbook-id',
+      includeExtract: false,
+    });
+    expect(persistDownloadedWorkbook).toHaveBeenCalledWith(downloadedWorkbook);
+    expect(useRestApi).toHaveBeenCalledWith(
+      expect.objectContaining({
+        jwtScopes: [
+          'tableau:workbooks:download',
+          'tableau:content:read',
+          'tableau:mcp_site_settings:read',
+        ],
+      }),
+    );
+  });
+
+  it('passes includeExtract through when requested', async () => {
+    mocks.downloadWorkbook.mockResolvedValue({
+      content: Readable.from(Buffer.from('packaged workbook')),
+    });
+    vi.mocked(persistDownloadedWorkbook).mockResolvedValue({
+      workbookFilePath: '/tmp/tableau-mcp-workbook-1/Sales.twbx',
+      fileName: 'Sales.twbx',
+      fileType: 'twbx',
+      sizeBytes: 100,
+    });
+    vi.spyOn(resourceAccessChecker, 'isWorkbookAllowed').mockResolvedValue({ allowed: true });
+
+    await getToolResult({ workbookId: 'workbook-id', includeExtract: true });
+
+    expect(mocks.downloadWorkbook).toHaveBeenCalledWith(
+      expect.objectContaining({ includeExtract: true }),
+    );
+  });
+
+  it('does not download a workbook excluded by bounded context', async () => {
+    vi.spyOn(resourceAccessChecker, 'isWorkbookAllowed').mockResolvedValue({
+      allowed: false,
+      message: 'Workbook is outside the allowed context.',
+    });
+
+    const result = await getToolResult({ workbookId: 'workbook-id' });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0]).toEqual({
+      type: 'text',
+      text: 'Workbook is outside the allowed context.',
+    });
+    expect(useRestApi).not.toHaveBeenCalled();
+  });
+});
+
+async function getToolResult({
+  workbookId,
+  includeExtract,
+}: {
+  workbookId: string;
+  includeExtract?: boolean;
+}): Promise<CallToolResult> {
+  vi.clearAllMocks();
+  const tool = getDownloadWorkbookTool(new WebMcpServer());
+  const callback = await Provider.from(tool.callback);
+  return await callback({ workbookId, includeExtract }, getMockRequestHandlerExtra());
+}

--- a/src/tools/web/workbooks/downloadWorkbook.ts
+++ b/src/tools/web/workbooks/downloadWorkbook.ts
@@ -1,0 +1,87 @@
+import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { Ok } from 'ts-results-es';
+import { z } from 'zod';
+
+import { WorkbookNotAllowedError } from '../../../errors/mcpToolError.js';
+import { useRestApi } from '../../../restApiInstance.js';
+import { WebMcpServer } from '../../../server.web.js';
+import { resourceAccessChecker } from '../resourceAccessChecker.js';
+import { WebTool } from '../tool.js';
+import { DownloadedWorkbookFile, persistDownloadedWorkbook } from './downloadedWorkbookFile.js';
+
+const paramsSchema = {
+  workbookId: z.string().min(1).describe('The LUID of the published workbook to download.'),
+  includeExtract: z
+    .boolean()
+    .optional()
+    .describe(
+      'Whether to include workbook extracts. Defaults to false to reduce download size for authoring workflows.',
+    ),
+};
+
+export type DownloadWorkbookResult = DownloadedWorkbookFile & {
+  includeExtract: boolean;
+};
+
+export const getDownloadWorkbookTool = (server: WebMcpServer): WebTool<typeof paramsSchema> => {
+  const tool = new WebTool({
+    server,
+    name: 'download-workbook',
+    description:
+      'Downloads a published Tableau workbook to a private temporary file accessible to the MCP server. Returns the absolute local path, file type, and size without placing workbook bytes in model context. The result may be a TWB or TWBX; only a TWB path can be passed directly to start-web-authoring-session. The caller must have ExportXml permission for the workbook.',
+    paramsSchema,
+    annotations: {
+      title: 'Download Workbook',
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
+    callback: async ({ workbookId, includeExtract }, extra): Promise<CallToolResult> => {
+      const resolvedIncludeExtract = includeExtract ?? false;
+
+      return await tool.logAndExecute<DownloadWorkbookResult>({
+        extra,
+        args: { workbookId, includeExtract: resolvedIncludeExtract },
+        callback: async () => {
+          const isWorkbookAllowedResult = await resourceAccessChecker.isWorkbookAllowed({
+            workbookId,
+            extra,
+          });
+
+          if (!isWorkbookAllowedResult.allowed) {
+            return new WorkbookNotAllowedError(isWorkbookAllowedResult.message).toErr();
+          }
+
+          const downloadedFile = await useRestApi({
+            ...extra,
+            jwtScopes: tool.requiredApiScopes,
+            callback: async (restApi) => {
+              const downloadedWorkbook = await restApi.workbooksMethods.downloadWorkbook({
+                siteId: restApi.siteId,
+                workbookId,
+                includeExtract: resolvedIncludeExtract,
+              });
+
+              // Consume the stream before useRestApi releases its authentication context.
+              return await persistDownloadedWorkbook(downloadedWorkbook);
+            },
+          });
+
+          return new Ok({
+            ...downloadedFile,
+            includeExtract: resolvedIncludeExtract,
+          });
+        },
+        constrainSuccessResult: (result) => ({ type: 'success', result }),
+        getSuccessResult: (result) => ({
+          isError: false,
+          structuredContent: result,
+          content: [{ type: 'text', text: JSON.stringify(result) }],
+        }),
+      });
+    },
+  });
+
+  return tool;
+};

--- a/src/tools/web/workbooks/downloadWorkbook.ts
+++ b/src/tools/web/workbooks/downloadWorkbook.ts
@@ -1,4 +1,6 @@
 import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { rm } from 'fs/promises';
+import { dirname } from 'path';
 import { Ok } from 'ts-results-es';
 import { z } from 'zod';
 
@@ -6,29 +8,25 @@ import { WorkbookNotAllowedError } from '../../../errors/mcpToolError.js';
 import { useRestApi } from '../../../restApiInstance.js';
 import { WebMcpServer } from '../../../server.web.js';
 import { resourceAccessChecker } from '../resourceAccessChecker.js';
+import { joinS3Prefix } from '../s3Client.js';
 import { WebTool } from '../tool.js';
 import { DownloadedWorkbookFile, persistDownloadedWorkbook } from './downloadedWorkbookFile.js';
+import { UploadedWorkbookArtifact, uploadWorkbookToS3 } from './uploadWorkbookToS3.js';
 
 const paramsSchema = {
   workbookId: z.string().min(1).describe('The LUID of the published workbook to download.'),
-  includeExtract: z
-    .boolean()
-    .optional()
-    .describe(
-      'Whether to include workbook extracts. Defaults to false to reduce download size for authoring workflows.',
-    ),
 };
 
-export type DownloadWorkbookResult = DownloadedWorkbookFile & {
-  includeExtract: boolean;
-};
+export type DownloadWorkbookResult =
+  | ({ delivery: 'local' } & DownloadedWorkbookFile)
+  | ({ delivery: 'url' } & UploadedWorkbookArtifact);
 
 export const getDownloadWorkbookTool = (server: WebMcpServer): WebTool<typeof paramsSchema> => {
   const tool = new WebTool({
     server,
     name: 'download-workbook',
     description:
-      'Downloads a published Tableau workbook to a private temporary file accessible to the MCP server. Returns the absolute local path, file type, and size without placing workbook bytes in model context. The result may be a TWB or TWBX; only a TWB path can be passed directly to start-web-authoring-session. The caller must have ExportXml permission for the workbook.',
+      'Downloads a published Tableau workbook definition as an editable TWB without placing workbook bytes in model context. Tableau extracts and packaged local files are excluded, so this tool supports workbooks whose data remains available through published data sources, accessible live connections, or other server-resolvable connections. If Tableau returns a TWBX, the server extracts its single embedded TWB and omits other package contents. When S3 artifact storage is configured, returns a short-lived resource link; otherwise returns a private local path accessible to the MCP server. The caller must have ExportXml permission for the workbook.',
     paramsSchema,
     annotations: {
       title: 'Download Workbook',
@@ -37,12 +35,10 @@ export const getDownloadWorkbookTool = (server: WebMcpServer): WebTool<typeof pa
       idempotentHint: true,
       openWorldHint: false,
     },
-    callback: async ({ workbookId, includeExtract }, extra): Promise<CallToolResult> => {
-      const resolvedIncludeExtract = includeExtract ?? false;
-
+    callback: async ({ workbookId }, extra): Promise<CallToolResult> => {
       return await tool.logAndExecute<DownloadWorkbookResult>({
         extra,
-        args: { workbookId, includeExtract: resolvedIncludeExtract },
+        args: { workbookId },
         callback: async () => {
           const isWorkbookAllowedResult = await resourceAccessChecker.isWorkbookAllowed({
             workbookId,
@@ -53,32 +49,67 @@ export const getDownloadWorkbookTool = (server: WebMcpServer): WebTool<typeof pa
             return new WorkbookNotAllowedError(isWorkbookAllowedResult.message).toErr();
           }
 
-          const downloadedFile = await useRestApi({
+          const artifact = await useRestApi({
             ...extra,
             jwtScopes: tool.requiredApiScopes,
-            callback: async (restApi) => {
+            callback: async (restApi): Promise<DownloadWorkbookResult> => {
               const downloadedWorkbook = await restApi.workbooksMethods.downloadWorkbook({
                 siteId: restApi.siteId,
                 workbookId,
-                includeExtract: resolvedIncludeExtract,
+                includeExtract: false,
               });
 
-              // Consume the stream before useRestApi releases its authentication context.
-              return await persistDownloadedWorkbook(downloadedWorkbook);
+              // Consume and normalize the stream before useRestApi releases its auth context.
+              const downloadedFile = await persistDownloadedWorkbook(downloadedWorkbook);
+              if (!extra.config.bucketS3.enabled) {
+                return { delivery: 'local', ...downloadedFile };
+              }
+
+              try {
+                const uploadedWorkbook = await uploadWorkbookToS3(downloadedFile, {
+                  workbookId,
+                  config: {
+                    ...extra.config.bucketS3,
+                    keyPrefix: joinS3Prefix(extra.config.bucketS3.keyPrefix, 'workbook-downloads/'),
+                  },
+                });
+                return { delivery: 'url', ...uploadedWorkbook };
+              } finally {
+                await rm(dirname(downloadedFile.workbookFilePath), {
+                  recursive: true,
+                  force: true,
+                }).catch(() => undefined);
+              }
             },
           });
 
-          return new Ok({
-            ...downloadedFile,
-            includeExtract: resolvedIncludeExtract,
-          });
+          return new Ok(artifact);
         },
         constrainSuccessResult: (result) => ({ type: 'success', result }),
-        getSuccessResult: (result) => ({
-          isError: false,
-          structuredContent: result,
-          content: [{ type: 'text', text: JSON.stringify(result) }],
-        }),
+        getSuccessResult: (result) => {
+          if (result.delivery === 'url') {
+            return {
+              isError: false,
+              structuredContent: result,
+              content: [
+                {
+                  type: 'resource_link',
+                  uri: result.url,
+                  name: result.fileName,
+                  mimeType: 'application/xml',
+                  description:
+                    'Editable Tableau TWB stored in S3. This is a short-lived presigned URL.',
+                },
+              ],
+            };
+          }
+
+          return {
+            isError: false,
+            structuredContent: result,
+            content: [{ type: 'text', text: JSON.stringify(result) }],
+          };
+        },
       });
     },
   });

--- a/src/tools/web/workbooks/downloadedWorkbookFile.test.ts
+++ b/src/tools/web/workbooks/downloadedWorkbookFile.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, rm } from 'fs/promises';
+import { mkdtemp, readdir, readFile, rm } from 'fs/promises';
 import { tmpdir } from 'os';
 import { dirname, join } from 'path';
 import { Readable } from 'stream';
@@ -7,7 +7,8 @@ import { afterEach, describe, expect, it } from 'vitest';
 import { exportedForTesting, persistDownloadedWorkbook } from './downloadedWorkbookFile.js';
 
 const temporaryDirectories: string[] = [];
-const { getContentDispositionFileName, getWorkbookFileType, getSafeFileName } = exportedForTesting;
+const { getContentDispositionFileName, getWorkbookFileType, getSafeTwbFileName } =
+  exportedForTesting;
 
 afterEach(async () => {
   await Promise.all(
@@ -21,7 +22,7 @@ afterEach(async () => {
 });
 
 describe('persistDownloadedWorkbook', () => {
-  it('streams a TWB into a private temporary file and returns its metadata', async () => {
+  it('streams a native TWB into a private temporary file', async () => {
     const temporaryDirectory = await createTemporaryDirectory();
     const bytes = Buffer.from('<workbook />');
 
@@ -34,11 +35,34 @@ describe('persistDownloadedWorkbook', () => {
       { temporaryDirectory },
     );
 
-    expect(result.fileName).toBe('Sales Workbook.twb');
-    expect(result.fileType).toBe('twb');
-    expect(result.sizeBytes).toBe(bytes.byteLength);
+    expect(result).toMatchObject({
+      fileName: 'Sales Workbook.twb',
+      fileType: 'twb',
+      sourceFileType: 'twb',
+      sizeBytes: bytes.byteLength,
+    });
     expect(dirname(result.workbookFilePath)).toContain('tableau-mcp-workbook-');
     await expect(readFile(result.workbookFilePath)).resolves.toEqual(bytes);
+  });
+
+  it('streams a TWBX and retains only its embedded TWB', async () => {
+    const temporaryDirectory = await createTemporaryDirectory();
+
+    const result = await persistDownloadedWorkbook(
+      {
+        content: Readable.from(Buffer.from(TWBX_WITH_ONE_TWB_BASE64, 'base64')),
+        contentDisposition: 'name="tableau_workbook"; filename="Sales Workbook.twbx"',
+        contentType: 'application/octet-stream',
+      },
+      { temporaryDirectory },
+    );
+
+    expect(result).toMatchObject({
+      fileName: 'Sales.twb',
+      fileType: 'twb',
+      sourceFileType: 'twbx',
+    });
+    await expect(readFile(result.workbookFilePath, 'utf8')).resolves.toContain('<workbook />');
   });
 
   it('does not allow a response filename to escape the temporary directory', async () => {
@@ -46,31 +70,46 @@ describe('persistDownloadedWorkbook', () => {
 
     const result = await persistDownloadedWorkbook(
       {
-        content: Readable.from(Buffer.from('package')),
-        contentDisposition: 'filename="../../Private Workbook.twbx"',
-        contentType: 'application/octet-stream',
+        content: Readable.from(Buffer.from('<workbook />')),
+        contentDisposition: 'filename="../../Private Workbook.twb"',
+        contentType: 'application/xml',
       },
       { temporaryDirectory },
     );
 
-    expect(result.fileName).toBe('Private Workbook.twbx');
-    expect(result.fileType).toBe('twbx');
+    expect(result.fileName).toBe('Private Workbook.twb');
     expect(result.workbookFilePath.startsWith(temporaryDirectory)).toBe(true);
   });
 
-  it('uses the content type and a generated name when no filename is returned', async () => {
+  it('rejects a TWBX containing multiple workbook definitions', async () => {
     const temporaryDirectory = await createTemporaryDirectory();
 
-    const result = await persistDownloadedWorkbook(
-      {
-        content: Readable.from(Buffer.from('<workbook />')),
-        contentType: 'application/xml; charset=utf-8',
-      },
-      { temporaryDirectory, generateUuid: () => 'generated-id' },
-    );
+    await expect(
+      persistDownloadedWorkbook(
+        {
+          content: Readable.from(Buffer.from(TWBX_WITH_MULTIPLE_TWBS_BASE64, 'base64')),
+          contentDisposition: 'filename="Ambiguous.twbx"',
+          contentType: 'application/octet-stream',
+        },
+        { temporaryDirectory },
+      ),
+    ).rejects.toThrow('multiple TWB files');
+    await expect(readdir(temporaryDirectory)).resolves.toEqual([]);
+  });
 
-    expect(result.fileName).toBe('generated-id.twb');
-    expect(result.fileType).toBe('twb');
+  it('rejects a TWBX with no workbook definition', async () => {
+    const temporaryDirectory = await createTemporaryDirectory();
+
+    await expect(
+      persistDownloadedWorkbook(
+        {
+          content: Readable.from(Buffer.from(TWBX_WITHOUT_TWB_BASE64, 'base64')),
+          contentDisposition: 'filename="Missing.twbx"',
+          contentType: 'application/octet-stream',
+        },
+        { temporaryDirectory },
+      ),
+    ).rejects.toThrow('does not contain a TWB file');
   });
 });
 
@@ -81,12 +120,12 @@ describe('downloaded workbook filename handling', () => {
     );
   });
 
-  it('falls back to TWBX for an unknown binary response', () => {
+  it('detects TWBX for an unknown binary response', () => {
     expect(getWorkbookFileType(undefined, 'application/octet-stream')).toBe('twbx');
   });
 
-  it('replaces an unsafe filename with a generated filename', () => {
-    expect(getSafeFileName('..hidden.twb', 'twb', () => 'generated-id')).toBe('generated-id.twb');
+  it('replaces an unsafe filename with a generated TWB filename', () => {
+    expect(getSafeTwbFileName('..hidden.twb', () => 'generated-id')).toBe('generated-id.twb');
   });
 });
 
@@ -95,3 +134,12 @@ async function createTemporaryDirectory(): Promise<string> {
   temporaryDirectories.push(directory);
   return directory;
 }
+
+const TWBX_WITH_ONE_TWB_BASE64 =
+  'UEsDBAoAAAAAAGKvCl1I3YgJNQAAADUAAAAJABwAU2FsZXMudHdiVVQJAAPngXpq6IF6anV4CwABBPUBAAAEAAAAADw/eG1sIHZlcnNpb249JzEuMCcgZW5jb2Rpbmc9J3V0Zi04JyA/Pgo8d29ya2Jvb2sgLz4KUEsDBAoAAAAAAGKvCl0AAAAAAAAAAAAAAAAFABwARGF0YS9VVAkAA+eBemrugXpqdXgLAAEE9QEAAAQAAAAAUEsDBAoAAAAAAGKvCl2TZDaLEgAAABIAAAAPABwARGF0YS9yZWFkbWUudHh0VVQJAAPngXpq6IF6anV4CwABBPUBAAAEAAAAAHBhY2thZ2VkIHJlc291cmNlClBLAQIeAwoAAAAAAGKvCl1I3YgJNQAAADUAAAAJABgAAAAAAAEAAACkgQAAAABTYWxlcy50d2JVVAUAA+eBemp1eAsAAQT1AQAABAAAAABQSwECHgMKAAAAAABirwpdAAAAAAAAAAAAAAAABQAYAAAAAAAAABAA7UF4AAAARGF0YS9VVAUAA+eBemp1eAsAAQT1AQAABAAAAABQSwECHgMKAAAAAABirwpdk2Q2ixIAAAASAAAADwAYAAAAAAABAAAApIG3AAAARGF0YS9yZWFkbWUudHh0VVQFAAPngXpqdXgLAAEE9QEAAAQAAAAAUEsFBgAAAAADAAMA7wAAABIBAAAAAA==';
+
+const TWBX_WITH_MULTIPLE_TWBS_BASE64 =
+  'UEsDBAoAAAAAAGuvCl2WboDnDQAAAA0AAAAJABwARmlyc3QudHdiVVQJAAP5gXpq+oF6anV4CwABBPUBAAAEAAAAADx3b3JrYm9vayAvPgpQSwMECgAAAAAAa68KXQAAAAAAAAAAAAAAAAcAHABuZXN0ZWQvVVQJAAP5gXpq/4F6anV4CwABBPUBAAAEAAAAAFBLAwQKAAAAAABrrwpdlm6A5w0AAAANAAAAEQAcAG5lc3RlZC9TZWNvbmQudHdiVVQJAAP5gXpq+oF6anV4CwABBPUBAAAEAAAAADx3b3JrYm9vayAvPgpQSwECHgMKAAAAAABrrwpdlm6A5w0AAAANAAAACQAYAAAAAAABAAAApIEAAAAARmlyc3QudHdiVVQFAAP5gXpqdXgLAAEE9QEAAAQAAAAAUEsBAh4DCgAAAAAAa68KXQAAAAAAAAAAAAAAAAcAGAAAAAAAAAAQAO1BUAAAAG5lc3RlZC9VVAUAA/mBemp1eAsAAQT1AQAABAAAAABQSwECHgMKAAAAAABrrwpdlm6A5w0AAAANAAAAEQAYAAAAAAABAAAApIGRAAAAbmVzdGVkL1NlY29uZC50d2JVVAUAA/mBemp1eAsAAQT1AQAABAAAAABQSwUGAAAAAAMAAwDzAAAA6QAAAAAA';
+
+const TWBX_WITHOUT_TWB_BASE64 =
+  'UEsDBAoAAAAAAHOvCl2GVmsCEQAAABEAAAAKABwAcmVhZG1lLnR4dFVUCQADCYJ6agqCemp1eAsAAQT1AQAABAAAAABubyB3b3JrYm9vayBoZXJlClBLAQIeAwoAAAAAAHOvCl2GVmsCEQAAABEAAAAKABgAAAAAAAEAAACkgQAAAAByZWFkbWUudHh0VVQFAAMJgnpqdXgLAAEE9QEAAAQAAAAAUEsFBgAAAAABAAEAUAAAAFUAAAAAAA==';

--- a/src/tools/web/workbooks/downloadedWorkbookFile.test.ts
+++ b/src/tools/web/workbooks/downloadedWorkbookFile.test.ts
@@ -1,0 +1,97 @@
+import { mkdtemp, readFile, rm } from 'fs/promises';
+import { tmpdir } from 'os';
+import { dirname, join } from 'path';
+import { Readable } from 'stream';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { exportedForTesting, persistDownloadedWorkbook } from './downloadedWorkbookFile.js';
+
+const temporaryDirectories: string[] = [];
+const { getContentDispositionFileName, getWorkbookFileType, getSafeFileName } = exportedForTesting;
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories.splice(0).map((directory) =>
+      rm(directory, {
+        recursive: true,
+        force: true,
+      }),
+    ),
+  );
+});
+
+describe('persistDownloadedWorkbook', () => {
+  it('streams a TWB into a private temporary file and returns its metadata', async () => {
+    const temporaryDirectory = await createTemporaryDirectory();
+    const bytes = Buffer.from('<workbook />');
+
+    const result = await persistDownloadedWorkbook(
+      {
+        content: Readable.from(bytes),
+        contentDisposition: 'name="tableau_workbook"; filename="Sales Workbook.twb"',
+        contentType: 'application/xml',
+      },
+      { temporaryDirectory },
+    );
+
+    expect(result.fileName).toBe('Sales Workbook.twb');
+    expect(result.fileType).toBe('twb');
+    expect(result.sizeBytes).toBe(bytes.byteLength);
+    expect(dirname(result.workbookFilePath)).toContain('tableau-mcp-workbook-');
+    await expect(readFile(result.workbookFilePath)).resolves.toEqual(bytes);
+  });
+
+  it('does not allow a response filename to escape the temporary directory', async () => {
+    const temporaryDirectory = await createTemporaryDirectory();
+
+    const result = await persistDownloadedWorkbook(
+      {
+        content: Readable.from(Buffer.from('package')),
+        contentDisposition: 'filename="../../Private Workbook.twbx"',
+        contentType: 'application/octet-stream',
+      },
+      { temporaryDirectory },
+    );
+
+    expect(result.fileName).toBe('Private Workbook.twbx');
+    expect(result.fileType).toBe('twbx');
+    expect(result.workbookFilePath.startsWith(temporaryDirectory)).toBe(true);
+  });
+
+  it('uses the content type and a generated name when no filename is returned', async () => {
+    const temporaryDirectory = await createTemporaryDirectory();
+
+    const result = await persistDownloadedWorkbook(
+      {
+        content: Readable.from(Buffer.from('<workbook />')),
+        contentType: 'application/xml; charset=utf-8',
+      },
+      { temporaryDirectory, generateUuid: () => 'generated-id' },
+    );
+
+    expect(result.fileName).toBe('generated-id.twb');
+    expect(result.fileType).toBe('twb');
+  });
+});
+
+describe('downloaded workbook filename handling', () => {
+  it('parses RFC 5987 encoded filenames', () => {
+    expect(getContentDispositionFileName("attachment; filename*=UTF-8''Sales%20Workbook.twb")).toBe(
+      'Sales Workbook.twb',
+    );
+  });
+
+  it('falls back to TWBX for an unknown binary response', () => {
+    expect(getWorkbookFileType(undefined, 'application/octet-stream')).toBe('twbx');
+  });
+
+  it('replaces an unsafe filename with a generated filename', () => {
+    expect(getSafeFileName('..hidden.twb', 'twb', () => 'generated-id')).toBe('generated-id.twb');
+  });
+});
+
+async function createTemporaryDirectory(): Promise<string> {
+  const directory = await mkdtemp(join(tmpdir(), 'tableau-mcp-download-test-'));
+  temporaryDirectories.push(directory);
+  return directory;
+}

--- a/src/tools/web/workbooks/downloadedWorkbookFile.ts
+++ b/src/tools/web/workbooks/downloadedWorkbookFile.ts
@@ -1,0 +1,117 @@
+import { randomUUID } from 'crypto';
+import { createWriteStream } from 'fs';
+import { mkdtemp, rm, stat } from 'fs/promises';
+import { tmpdir } from 'os';
+import { basename, extname, join } from 'path';
+import { pipeline } from 'stream/promises';
+
+import { DownloadedWorkbook } from '../../../sdks/tableau/methods/workbooksMethods.js';
+
+export type DownloadedWorkbookFile = {
+  workbookFilePath: string;
+  fileName: string;
+  fileType: 'twb' | 'twbx';
+  sizeBytes: number;
+};
+
+type PersistDownloadedWorkbookOptions = {
+  temporaryDirectory?: string;
+  generateUuid?: () => string;
+};
+
+export async function persistDownloadedWorkbook(
+  workbook: DownloadedWorkbook,
+  options: PersistDownloadedWorkbookOptions = {},
+): Promise<DownloadedWorkbookFile> {
+  const generateUuid = options.generateUuid ?? randomUUID;
+  const fileNameFromHeader = getContentDispositionFileName(workbook.contentDisposition);
+  const fileType = getWorkbookFileType(fileNameFromHeader, workbook.contentType);
+  const fileName = getSafeFileName(fileNameFromHeader, fileType, generateUuid);
+  const directory = await mkdtemp(
+    join(options.temporaryDirectory ?? tmpdir(), 'tableau-mcp-workbook-'),
+  );
+  const workbookFilePath = join(directory, fileName);
+
+  try {
+    await pipeline(
+      workbook.content,
+      createWriteStream(workbookFilePath, { flags: 'wx', mode: 0o600 }),
+    );
+    const fileStats = await stat(workbookFilePath);
+
+    return {
+      workbookFilePath,
+      fileName,
+      fileType,
+      sizeBytes: fileStats.size,
+    };
+  } catch (error) {
+    await rm(directory, { recursive: true, force: true });
+    throw error;
+  }
+}
+
+function getContentDispositionFileName(contentDisposition?: string): string | undefined {
+  if (!contentDisposition) return undefined;
+
+  const encodedMatch = /(?:^|;)\s*filename\*\s*=\s*(?:UTF-8'')?([^;]+)/i.exec(contentDisposition);
+  if (encodedMatch) {
+    const encodedFileName = stripQuotes(encodedMatch[1].trim());
+    try {
+      return decodeURIComponent(encodedFileName);
+    } catch {
+      return encodedFileName;
+    }
+  }
+
+  const quotedMatch = /(?:^|;)\s*filename\s*=\s*"([^"]+)"/i.exec(contentDisposition);
+  if (quotedMatch) return quotedMatch[1];
+
+  const unquotedMatch = /(?:^|;)\s*filename\s*=\s*([^;]+)/i.exec(contentDisposition);
+  return unquotedMatch ? stripQuotes(unquotedMatch[1].trim()) : undefined;
+}
+
+function getWorkbookFileType(
+  fileName: string | undefined,
+  contentType: string | undefined,
+): 'twb' | 'twbx' {
+  const extension = fileName ? extname(fileName).toLowerCase() : '';
+  if (extension === '.twb') return 'twb';
+  if (extension === '.twbx') return 'twbx';
+
+  const normalizedContentType = contentType?.split(';', 1)[0].trim().toLowerCase();
+  return normalizedContentType === 'application/xml' || normalizedContentType === 'text/xml'
+    ? 'twb'
+    : 'twbx';
+}
+
+function getSafeFileName(
+  fileName: string | undefined,
+  fileType: 'twb' | 'twbx',
+  generateUuid: () => string,
+): string {
+  if (!fileName) return `${generateUuid()}.${fileType}`;
+
+  const localName = basename(fileName).replace(/[^A-Za-z0-9._ -]/g, '_');
+  if (
+    localName.length > 0 &&
+    localName.length <= 240 &&
+    /^[A-Za-z0-9]/.test(localName) &&
+    !localName.includes('..') &&
+    extname(localName).toLowerCase() === `.${fileType}`
+  ) {
+    return localName;
+  }
+
+  return `${generateUuid()}.${fileType}`;
+}
+
+function stripQuotes(value: string): string {
+  return value.startsWith('"') && value.endsWith('"') ? value.slice(1, -1) : value;
+}
+
+export const exportedForTesting = {
+  getContentDispositionFileName,
+  getWorkbookFileType,
+  getSafeFileName,
+};

--- a/src/tools/web/workbooks/downloadedWorkbookFile.ts
+++ b/src/tools/web/workbooks/downloadedWorkbookFile.ts
@@ -2,15 +2,18 @@ import { randomUUID } from 'crypto';
 import { createWriteStream } from 'fs';
 import { mkdtemp, rm, stat } from 'fs/promises';
 import { tmpdir } from 'os';
-import { basename, extname, join } from 'path';
+import { basename, extname, join, posix } from 'path';
+import { Readable } from 'stream';
 import { pipeline } from 'stream/promises';
+import { type Entry, Parse } from 'unzipper';
 
 import { DownloadedWorkbook } from '../../../sdks/tableau/methods/workbooksMethods.js';
 
 export type DownloadedWorkbookFile = {
   workbookFilePath: string;
   fileName: string;
-  fileType: 'twb' | 'twbx';
+  fileType: 'twb';
+  sourceFileType: 'twb' | 'twbx';
   sizeBytes: number;
 };
 
@@ -19,36 +22,116 @@ type PersistDownloadedWorkbookOptions = {
   generateUuid?: () => string;
 };
 
+/**
+ * Normalizes a Tableau workbook download into a local editable TWB. Native TWB
+ * responses are streamed directly to disk; TWBX responses are parsed as ZIP
+ * streams and only their single embedded TWB is retained.
+ */
 export async function persistDownloadedWorkbook(
   workbook: DownloadedWorkbook,
   options: PersistDownloadedWorkbookOptions = {},
 ): Promise<DownloadedWorkbookFile> {
   const generateUuid = options.generateUuid ?? randomUUID;
   const fileNameFromHeader = getContentDispositionFileName(workbook.contentDisposition);
-  const fileType = getWorkbookFileType(fileNameFromHeader, workbook.contentType);
-  const fileName = getSafeFileName(fileNameFromHeader, fileType, generateUuid);
+  const sourceFileType = getWorkbookFileType(fileNameFromHeader, workbook.contentType);
   const directory = await mkdtemp(
     join(options.temporaryDirectory ?? tmpdir(), 'tableau-mcp-workbook-'),
   );
-  const workbookFilePath = join(directory, fileName);
 
   try {
-    await pipeline(
-      workbook.content,
-      createWriteStream(workbookFilePath, { flags: 'wx', mode: 0o600 }),
-    );
-    const fileStats = await stat(workbookFilePath);
+    if (sourceFileType === 'twb') {
+      return await persistTwbStream({
+        content: workbook.content,
+        directory,
+        fileName: getSafeTwbFileName(fileNameFromHeader, generateUuid),
+        sourceFileType,
+      });
+    }
 
-    return {
-      workbookFilePath,
-      fileName,
-      fileType,
-      sizeBytes: fileStats.size,
-    };
+    return await extractTwbFromTwbx({
+      content: workbook.content,
+      directory,
+      generateUuid,
+    });
   } catch (error) {
+    workbook.content.destroy();
     await rm(directory, { recursive: true, force: true });
     throw error;
   }
+}
+
+async function persistTwbStream({
+  content,
+  directory,
+  fileName,
+  sourceFileType,
+}: {
+  content: Readable;
+  directory: string;
+  fileName: string;
+  sourceFileType: 'twb' | 'twbx';
+}): Promise<DownloadedWorkbookFile> {
+  const workbookFilePath = join(directory, fileName);
+  await pipeline(content, createWriteStream(workbookFilePath, { flags: 'wx', mode: 0o600 }));
+  const fileStats = await stat(workbookFilePath);
+
+  return {
+    workbookFilePath,
+    fileName,
+    fileType: 'twb',
+    sourceFileType,
+    sizeBytes: fileStats.size,
+  };
+}
+
+async function extractTwbFromTwbx({
+  content,
+  directory,
+  generateUuid,
+}: {
+  content: Readable;
+  directory: string;
+  generateUuid: () => string;
+}): Promise<DownloadedWorkbookFile> {
+  const parser = Parse({ forceStream: true });
+  const forwardSourceError = (error: Error): void => {
+    parser.destroy(error);
+  };
+  content.once('error', forwardSourceError);
+  content.pipe(parser);
+
+  let extractedWorkbook: DownloadedWorkbookFile | undefined;
+
+  try {
+    for await (const candidate of parser as AsyncIterable<Entry>) {
+      const entry = candidate as Entry;
+      if (entry.type !== 'File' || extname(entry.path).toLowerCase() !== '.twb') {
+        await entry.autodrain().promise();
+        continue;
+      }
+
+      if (extractedWorkbook) {
+        await entry.autodrain().promise();
+        throw new Error('Downloaded TWBX contains multiple TWB files.');
+      }
+
+      const fileName = getSafeTwbFileName(posix.basename(entry.path), generateUuid);
+      extractedWorkbook = await persistTwbStream({
+        content: entry,
+        directory,
+        fileName,
+        sourceFileType: 'twbx',
+      });
+    }
+  } finally {
+    content.off('error', forwardSourceError);
+  }
+
+  if (!extractedWorkbook) {
+    throw new Error('Downloaded TWBX does not contain a TWB file.');
+  }
+
+  return extractedWorkbook;
 }
 
 function getContentDispositionFileName(contentDisposition?: string): string | undefined {
@@ -85,12 +168,8 @@ function getWorkbookFileType(
     : 'twbx';
 }
 
-function getSafeFileName(
-  fileName: string | undefined,
-  fileType: 'twb' | 'twbx',
-  generateUuid: () => string,
-): string {
-  if (!fileName) return `${generateUuid()}.${fileType}`;
+function getSafeTwbFileName(fileName: string | undefined, generateUuid: () => string): string {
+  if (!fileName) return `${generateUuid()}.twb`;
 
   const localName = basename(fileName).replace(/[^A-Za-z0-9._ -]/g, '_');
   if (
@@ -98,12 +177,12 @@ function getSafeFileName(
     localName.length <= 240 &&
     /^[A-Za-z0-9]/.test(localName) &&
     !localName.includes('..') &&
-    extname(localName).toLowerCase() === `.${fileType}`
+    extname(localName).toLowerCase() === '.twb'
   ) {
     return localName;
   }
 
-  return `${generateUuid()}.${fileType}`;
+  return `${generateUuid()}.twb`;
 }
 
 function stripQuotes(value: string): string {
@@ -113,5 +192,5 @@ function stripQuotes(value: string): string {
 export const exportedForTesting = {
   getContentDispositionFileName,
   getWorkbookFileType,
-  getSafeFileName,
+  getSafeTwbFileName,
 };

--- a/src/tools/web/workbooks/uploadWorkbookToS3.test.ts
+++ b/src/tools/web/workbooks/uploadWorkbookToS3.test.ts
@@ -1,0 +1,82 @@
+import { mkdtemp, rm, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { uploadStreamToS3 } from '../s3Client.js';
+import { buildWorkbookS3Key, uploadWorkbookToS3 } from './uploadWorkbookToS3.js';
+
+vi.mock('../s3Client.js', async (importActual) => ({
+  ...(await importActual<typeof import('../s3Client.js')>()),
+  uploadStreamToS3: vi.fn().mockImplementation(async (stream) => {
+    for await (const _chunk of stream) {
+      // Consume the stream so the test exercises file-backed delivery.
+    }
+    return 'https://s3.example.com/signed-workbook';
+  }),
+}));
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  vi.clearAllMocks();
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((directory) => rm(directory, { recursive: true, force: true })),
+  );
+});
+
+describe('uploadWorkbookToS3', () => {
+  it('streams a normalized TWB with download metadata', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'tableau-mcp-s3-workbook-test-'));
+    temporaryDirectories.push(directory);
+    const workbookFilePath = join(directory, 'Sales.twb');
+    await writeFile(workbookFilePath, '<workbook />');
+
+    const result = await uploadWorkbookToS3(
+      {
+        workbookFilePath,
+        fileName: 'Sales.twb',
+        fileType: 'twb',
+        sourceFileType: 'twbx',
+        sizeBytes: 12,
+      },
+      {
+        workbookId: 'workbook-id',
+        config: {
+          bucket: 'tableau-artifacts',
+          region: 'us-east-1',
+          keyPrefix: 'workbook-downloads/',
+          presignTtlSeconds: 300,
+        },
+      },
+    );
+
+    expect(result).toEqual({
+      url: 'https://s3.example.com/signed-workbook',
+      fileName: 'Sales.twb',
+      fileType: 'twb',
+      sourceFileType: 'twbx',
+      sizeBytes: 12,
+    });
+    expect(uploadStreamToS3).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        bucket: 'tableau-artifacts',
+        key: expect.stringMatching(/^workbook-downloads\/workbook-id\/[0-9a-f-]+\.twb$/),
+        contentType: 'application/xml',
+        contentDisposition: 'attachment; filename="Sales.twb"',
+        contentLength: 12,
+      }),
+    );
+  });
+});
+
+describe('buildWorkbookS3Key', () => {
+  it('normalizes the prefix and workbook id', () => {
+    expect(buildWorkbookS3Key('/downloads', '../workbook/id', () => 'uuid')).toBe(
+      'downloads/___workbook_id/uuid.twb',
+    );
+  });
+});

--- a/src/tools/web/workbooks/uploadWorkbookToS3.ts
+++ b/src/tools/web/workbooks/uploadWorkbookToS3.ts
@@ -1,0 +1,50 @@
+import { randomUUID } from 'crypto';
+import { createReadStream } from 'fs';
+
+import { BucketS3Config, uploadStreamToS3 } from '../s3Client.js';
+import { DownloadedWorkbookFile } from './downloadedWorkbookFile.js';
+
+export type UploadedWorkbookArtifact = Omit<DownloadedWorkbookFile, 'workbookFilePath'> & {
+  url: string;
+};
+
+export async function uploadWorkbookToS3(
+  workbook: DownloadedWorkbookFile,
+  {
+    workbookId,
+    config,
+  }: {
+    workbookId: string;
+    config: BucketS3Config;
+  },
+): Promise<UploadedWorkbookArtifact> {
+  const key = buildWorkbookS3Key(config.keyPrefix, workbookId);
+  const contentDisposition = `attachment; filename="${workbook.fileName}"`;
+  const url = await uploadStreamToS3(createReadStream(workbook.workbookFilePath), {
+    key,
+    contentType: 'application/xml',
+    contentDisposition,
+    contentLength: workbook.sizeBytes,
+    bucket: config.bucket,
+    region: config.region,
+    presignTtlSeconds: config.presignTtlSeconds,
+  });
+
+  return {
+    url,
+    fileName: workbook.fileName,
+    fileType: 'twb',
+    sourceFileType: workbook.sourceFileType,
+    sizeBytes: workbook.sizeBytes,
+  };
+}
+
+export function buildWorkbookS3Key(
+  keyPrefix: string,
+  workbookId: string,
+  generateUuid: () => string = randomUUID,
+): string {
+  const normalizedPrefix = keyPrefix.replace(/^\/+/, '').replace(/\/*$/, '/');
+  const safeWorkbookId = workbookId.replace(/[^A-Za-z0-9_-]/g, '_') || 'workbook';
+  return `${normalizedPrefix}${safeWorkbookId}/${generateUuid()}.twb`;
+}


### PR DESCRIPTION
## Summary
- add SDK support for the Download Workbook REST API
- add a `download-workbook` MCP tool that streams TWB/TWBX content into a private temporary file and returns its absolute path
- default `includeExtract` to false for authoring workflows while allowing callers to opt in
- advertise `tableau:workbooks:download` and enforce workbook bounded context
- prevent downloaded workbook bytes from appearing in debug response logs

## Testing
- build and TypeScript provider check
- ESLint on all changed files
- full unit suite: 179 files, 2,788 tests passed