### PR TITLE
fix(desktop): validate line-separated field references

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "2.62.1",
+  "version": "2.62.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "2.62.1",
+      "version": "2.62.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.7.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "2.62.1",
+  "version": "2.62.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/src/desktop/validation/rules/qualifiedNameBrackets.test.ts
+++ b/src/desktop/validation/rules/qualifiedNameBrackets.test.ts
@@ -53,6 +53,93 @@ describe('qualified-name-brackets rule', () => {
     expect(qualifiedNameBracketsRule.validate(xml)).toHaveLength(0);
   });
 
+  it.each(['&#10;', '&amp;#10;', '&amp;#13;', '&amp;#010;', '&amp;#xA;', '&amp;#xD;'])(
+    'validates each reference in a line-separated list (%s)',
+    (separator) => {
+      const xml =
+        '<workbook><worksheet><encodings>' +
+        `<color column="[Orders].[none:Segment:nk]${separator}[Orders].[none:Forecast Indicator:nk]" />` +
+        '</encodings></worksheet></workbook>';
+
+      expect(qualifiedNameBracketsRule.validate(xml)).toHaveLength(0);
+    },
+  );
+
+  it('passes a valid list whose raw attribute newline was normalized to a space', () => {
+    const xml = `<workbook><worksheet><encodings><color column="[Orders].[none:Segment:nk]
+[Orders].[none:Forecast Indicator:nk]" /></encodings></worksheet></workbook>`;
+
+    expect(qualifiedNameBracketsRule.validate(xml)).toHaveLength(0);
+  });
+
+  it('does not split a valid escaped bracket followed by a literal opening bracket', () => {
+    const xml = '<workbook><column-instance column="[Orders].[none:a]] [b:nk]" /></workbook>';
+
+    expect(qualifiedNameBracketsRule.validate(xml)).toHaveLength(0);
+  });
+
+  it('does not split a decoded line break inside one escaped bracket identifier', () => {
+    const xml = '<workbook><column-instance column="[Orders].[none:a]]&#10;[b:nk]" /></workbook>';
+
+    expect(qualifiedNameBracketsRule.validate(xml)).toHaveLength(0);
+  });
+
+  it.each([
+    ['normalized space', ' '],
+    ['encoded newline', '&#10;'],
+  ])(
+    'ignores a nested-opener lookalike inside one escaped identifier (%s)',
+    (_label, separator) => {
+      const xml = `<workbook><column-instance column="[D].[a]]${separator}[.[[b]] [c]" /></workbook>`;
+
+      expect(qualifiedNameBracketsRule.validate(xml)).toHaveLength(0);
+    },
+  );
+
+  it.each(['&#10;', '&amp;#10;'])(
+    'still flags a malformed reference within a line-separated list (%s)',
+    (separator) => {
+      const xml =
+        '<workbook><worksheet><encodings>' +
+        `<color column="[Orders].[none:Segment:nk]${separator}[Orders].[[Forecast Indicator]]" />` +
+        '</encodings></worksheet></workbook>';
+
+      const errors = qualifiedNameBracketsRule.validate(xml).filter((i) => i.severity === 'error');
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0].message).toContain('[Orders].[[Forecast Indicator]]');
+    },
+  );
+
+  it.each([
+    ['encoded newline', '&#10;'],
+    ['raw newline normalized by the DOM', '\n'],
+  ])('flags the exact malformed first member across a %s', (_label, separator) => {
+    const malformed = '[Orders].[[Forecast Indicator]]';
+    const xml =
+      '<workbook><worksheet><encodings>' +
+      `<color column="${malformed}${separator}[Orders].[none:Segment:nk]" />` +
+      '</encodings></worksheet></workbook>';
+
+    const errors = qualifiedNameBracketsRule.validate(xml).filter((i) => i.severity === 'error');
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toContain(`Malformed qualified name ${JSON.stringify(malformed)}`);
+    expect(errors[0].xpath).toBe(`//*[contains(., ${JSON.stringify(malformed)})]`);
+  });
+
+  it.each(['&amp;#10;[Orders].[[Forecast Indicator]]', '[Orders].[[Forecast Indicator]]&amp;#10;'])(
+    'still flags a malformed sole reference beside an encoded separator (%s)',
+    (value) => {
+      const xml = `<workbook><column-instance column="${value}" /></workbook>`;
+
+      const errors = qualifiedNameBracketsRule.validate(xml).filter((i) => i.severity === 'error');
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0].message).toContain('[Orders].[[Forecast Indicator]]');
+    },
+  );
+
   it('passes a name that escapes a literal ] as ]] (valid Tableau escaping)', () => {
     // Field literally named `a]b` is written [a]]b]; qualified as [Orders].[none:a]]b:nk].
     const xml = '<workbook><column-instance column="[Orders].[none:a]]b:nk]" /></workbook>';

--- a/src/desktop/validation/rules/qualifiedNameBrackets.ts
+++ b/src/desktop/validation/rules/qualifiedNameBrackets.ts
@@ -17,9 +17,9 @@
  * Severity: ERROR. A mismatched-bracket qualified name is never intentional — it
  * always fails to load.
  *
- * Precision over recall: only values that are a SINGLE pure qualified-name
- * reference are validated (see isQualifiedNameCandidate). Formula bodies, captions
- * and multi-pill shelf expressions — which legitimately contain unbalanced
+ * Precision over recall: the rule validates one pure qualified name or an
+ * unambiguous line-separated list (see getQualifiedNameCandidates). Formula bodies,
+ * captions and multi-pill shelf expressions — which legitimately contain unbalanced
  * brackets inside string literals — are deliberately skipped so this rule never
  * false-rejects valid content (e.g. a bundled template).
  */
@@ -62,6 +62,66 @@ function isQualifiedNameCandidate(value: string): boolean {
   // never a single qualified name. (Chars valid INSIDE a name — spaces, '-', '.',
   // ':', '&', etc. — are intentionally allowed.)
   return !/["()\n\r\t/+*,=<>]/.test(value);
+}
+
+const LINE_SEPARATOR = /(?:\r\n|[\r\n]|&#(?:0*(?:10|13)|x0*[ad]);)/i;
+const NORMALIZED_LINE_SEPARATOR = /(?<=\]) +(?=\[)/;
+
+function hasNestedSegmentOpener(value: string): boolean {
+  let i = 0;
+  while (i < value.length) {
+    if (value[i] !== '[') return false;
+    if (value[i + 1] === '[') return true;
+    i += 1;
+
+    let closed = false;
+    while (i < value.length) {
+      if (value[i] !== ']') {
+        i += 1;
+        continue;
+      }
+      if (value[i + 1] === ']') {
+        i += 2;
+        continue;
+      }
+      i += 1;
+      closed = true;
+      break;
+    }
+
+    if (!closed || i === value.length) return false;
+    if (value[i] !== '.') return false;
+    i += 1;
+  }
+  return false;
+}
+
+/**
+ * Tableau can serialize a list of field references with either a real line
+ * break or a still-encoded numeric line break. Treat the list as compound only
+ * when every non-empty item is itself a qualified-name candidate; otherwise
+ * preserve the precision-first behavior for formulas and free text.
+ */
+function getQualifiedNameCandidates(value: string): string[] {
+  const trimmed = value.trim();
+  const parts = trimmed
+    .split(NORMALIZED_LINE_SEPARATOR)
+    .flatMap((part) => part.split(LINE_SEPARATOR))
+    .map((part) => part.trim())
+    .filter(Boolean);
+  const hasUnambiguousListSplit =
+    (parts.length > 1 || LINE_SEPARATOR.test(trimmed)) &&
+    parts.length > 0 &&
+    parts.every(isQualifiedNameCandidate);
+  const wholeIsWellFormed = isWellFormedQualifiedName(trimmed);
+
+  if (hasUnambiguousListSplit) {
+    if (!wholeIsWellFormed) return parts;
+    return parts.filter((part) => hasNestedSegmentOpener(part) && !isWellFormedQualifiedName(part));
+  }
+
+  if (wholeIsWellFormed) return [];
+  return isQualifiedNameCandidate(trimmed) ? [trimmed] : [];
 }
 
 /**
@@ -182,12 +242,12 @@ export const qualifiedNameBracketsRule: ValidationRule = {
       }
 
       if (!value) continue;
-      const trimmed = value.trim();
-      if (!isQualifiedNameCandidate(trimmed)) continue;
-      if (isWellFormedQualifiedName(trimmed)) continue;
-      if (seen.has(trimmed)) continue;
-      seen.add(trimmed);
-      issues.push(issueFor(trimmed));
+      for (const candidate of getQualifiedNameCandidates(value)) {
+        if (isWellFormedQualifiedName(candidate)) continue;
+        if (seen.has(candidate)) continue;
+        seen.add(candidate);
+        issues.push(issueFor(candidate));
+      }
     }
 
     return issues;


### PR DESCRIPTION
## Decision

Keep the qualified-name guard strict for malformed `[[Field]]` references, but validate each field separately when Tableau stores several references on separate lines. This is the rule for every template and workbook shape, not a map-specific exception.

## Description

- Splits real, encoded, and DOM-normalized line breaks before validating field references.
- Reports the exact malformed member instead of rejecting the full list.
- Preserves valid escaped brackets and avoids treating `.[[` text inside a field name as a new segment.
- Bumps the package to `2.62.2` for publication.

Future changes must keep both sides of the rule: malformed nested segment openers remain blocked, and a valid single qualified name must never be split just because its field name contains spaces, brackets, or a line break.

## Motivation and Context

Current Studio built a valid forecast map artifact, but MCP preflight blocked it before Desktop dispatch. An existing color encoding stored `Segment` and `Forecast Indicator` as a line-separated pair; the guard parsed the pair as one qualified name and reported `qualified-name-brackets`.

One syntax remains inherently ambiguous: an unmatched `]]` before a line break can also describe a valid field name containing that line break. This change stays precision-first and fixes the observed nested-opener defect without rejecting that valid name.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

- RED/green tests cover malformed members first and last, decimal and hex line entities, decoded and DOM-normalized line breaks, leading and trailing separators, and valid escaped-bracket lookalikes.
- `scripts/agent-check`: all five gates green; 373 test files / 5,722 tests.
- Independent Grok review and Sol adversarial review both found the segment-boundary false positive; the final parser-aware fix covers it.

## Related Issues

Live Studio repro from August 11; no public issue linked.

## Checklist

- [x] Version bumped with `npm run version:patch`
- [x] No documentation change required
- [x] Regression tests added
- [x] New and existing unit tests pass locally
- [x] No breaking changes

## Contributor Agreement

- [x] I have read the contributing guidelines and followed the contribution checklist.

Prepared by MattGPT.
