### PR TITLE
fix(desktop): treat blockingWindows on a non-terminal poll as awaiting-user

### DIFF
--- a/src/desktop/externalApi/externalApiHttp.ts
+++ b/src/desktop/externalApi/externalApiHttp.ts
@@ -256,7 +256,7 @@ export class ExternalApiHttp {
     return this.parseJson(response, operationEnvelopeSchema);
   }
 
-  /** Blocks on the 202's `Location` until a terminal Operation; AWAITING_USER returns `awaiting-user`. */
+  /** Blocks on the 202's `Location` until a terminal Operation; a blocking dialog returns `awaiting-user`. */
   private async pollOperation(
     accepted: Response,
     signal?: AbortSignal,
@@ -296,16 +296,19 @@ export class ExternalApiHttp {
       }
 
       const envelope = parsed.value;
-      const state = envelope.state?.toUpperCase();
-      if (state === 'AWAITING_USER') {
+      if (isTerminalState(envelope.state)) {
+        return Ok(envelope);
+      }
+
+      // The server signals a blocking Desktop dialog with `blockingWindows` on a non-terminal
+      // operation. A person must dismiss it; polling can never clear it, so fail fast.
+      const blockingWindows = envelope.blockingWindows;
+      if (blockingWindows !== undefined && blockingWindows.length > 0) {
         return Err({
           type: 'awaiting-user',
           operationId: envelope.id ?? operationId,
-          blockingWindows: envelope.blockingWindows,
+          blockingWindows,
         });
-      }
-      if (isTerminalState(envelope.state)) {
-        return Ok(envelope);
       }
 
       retryAfterMs = parseRetryAfterMs(res.headers.get(HEADER_RETRY_AFTER));

--- a/src/desktop/externalApi/externalApiHttpAsyncDispatch.test.ts
+++ b/src/desktop/externalApi/externalApiHttpAsyncDispatch.test.ts
@@ -146,6 +146,35 @@ describe('ExternalApiHttp async dispatch (0.2.0)', () => {
       }
     });
 
+    it('returns awaiting-user when a RUNNING poll carries blockingWindows (server never sets AWAITING_USER)', async () => {
+      server.setOverride('POST /v0/app:invokeCommand', accepted202('op-user-2'));
+      server.setOperation('op-user-2', {
+        poll: [
+          {
+            id: 'op-user-2',
+            kind: 'tabui:open-bookmark',
+            state: 'RUNNING',
+            blockingWindows: [
+              { objectName: 'msgbox', title: 'Discard changes?', className: 'QMessageBox' },
+            ],
+          },
+        ],
+      });
+
+      const result = await http.postJsonEnvelope(
+        EXTERNAL_API_ROUTES.invokeCommand,
+        invokeBody('tabui', 'open-bookmark'),
+      );
+      expect(result.isErr()).toBe(true);
+      const error = result.unwrapErr();
+      expect(error.type).toBe('awaiting-user');
+      if (error.type === 'awaiting-user') {
+        expect(error.blockingWindows).toEqual([
+          { objectName: 'msgbox', title: 'Discard changes?', className: 'QMessageBox' },
+        ]);
+      }
+    });
+
     it('returns operation-expired when the polled operation 404s', async () => {
       server.setOverride('POST /v0/app:invokeCommand', accepted202('op-gone-1'));
       // No setOperation → the poll route 404s operation-not-found.


### PR DESCRIPTION
## What
`pollOperation` now returns `awaiting-user` when a **non-terminal** poll envelope carries a non-empty `blockingWindows`, in addition to the (never-emitted) `AWAITING_USER` state. The terminal check runs first, so a completed operation still returns its result.

## Why
The External Client API host never transitions an operation to `AWAITING_USER` — the enum + wire mapping exist but nothing assigns them; the real lifecycle is only `Queued → Running → Succeeded/Failed/Cancelled`. A blocking modal is reported as `blockingWindows` attached to a still-`RUNNING` operation (via the host's `BlockingWindowProbe`).

Our poll keyed **only** off `state === 'AWAITING_USER'`, so that branch was dead against the real server: every dialog fell through to the 60s call deadline instead of failing fast with the named-dialog "dismiss it" message.

This is the client-side half. The server is the correct owner of the state — tracked by **W-23824913** (host should set `AWAITING_USER` whenever `blockingWindows` is non-empty).

## Test
`externalApiHttpAsyncDispatch.test.ts`: a `RUNNING` poll carrying `blockingWindows` now surfaces `awaiting-user` with the window list. Full async-dispatch suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
