### PR TITLE
fix(desktop): admit private-registry commands past the census gate

### DIFF
--- a/src/desktop/guards/commandGuard.test.ts
+++ b/src/desktop/guards/commandGuard.test.ts
@@ -65,27 +65,78 @@ describe('guardCommand', () => {
     }
   });
 
-  it('refuses an unknown command before consulting the External API registry', () => {
+  it('refuses a census-unknown command when the External API registry also lacks it', () => {
     enableExternalApiRegistry({
-      'tabdoc:not-a-command': {
-        ...SHOW_ME_REGISTRY_ENTRY,
-        agent_can_invoke: false,
-        opens_blocking_dialog: true,
-      },
+      'tabdoc:show-me': SHOW_ME_REGISTRY_ENTRY,
     });
 
     const result = guardCommand({
       namespace: 'tabdoc',
       cmd: 'not-a-command',
       command: 'tabdoc:not-a-command',
-      args: { WorksheetName: 'Sheet 1', ShowMeType: 'bars' },
+      args: {},
     });
 
     expect('refused' in result).toBe(true);
     if (!('refused' in result)) return;
     expect(result.message).toContain('Unknown Tableau command "tabdoc:not-a-command"');
-    expect(result.message).not.toContain('human-blocking dialog');
-    expect(result.message).not.toContain('agent_can_invoke=false');
+  });
+
+  it('admits a census-unknown command when the External API registry has an invocable entry', () => {
+    enableExternalApiRegistry({
+      'tabdoc:add-local-extension': {
+        agent_can_invoke: true,
+        opens_blocking_dialog: false,
+        modifies_state: 'true',
+        in_params: [
+          { local: 'SourceDir', type: 'DPI_SourceDir', required: true, wire: 'source-dir' },
+          {
+            local: 'LocalExtensionType',
+            type: 'DPI_LocalExtensionType',
+            required: true,
+            wire: 'local-extension-type',
+          },
+        ],
+      },
+    });
+
+    const result = guardCommand({
+      namespace: 'tabdoc',
+      cmd: 'add-local-extension',
+      command: 'tabdoc:add-local-extension',
+      args: { SourceDir: '/tmp/ext', LocalExtensionType: 'viz' },
+    });
+
+    expect('ok' in result).toBe(true);
+    if (!('ok' in result)) return;
+    expect(result.dispatchArgs).toEqual({
+      'source-dir': '/tmp/ext',
+      'local-extension-type': 'viz',
+    });
+  });
+
+  it('applies External API registry refusals for census-unknown commands after admission', () => {
+    enableExternalApiRegistry({
+      'tabdoc:add-local-extension': {
+        agent_can_invoke: false,
+        opens_blocking_dialog: true,
+        modifies_state: 'true',
+        in_params: [],
+      },
+    });
+
+    const result = guardCommand({
+      namespace: 'tabdoc',
+      cmd: 'add-local-extension',
+      command: 'tabdoc:add-local-extension',
+      args: {},
+    });
+
+    expect('refused' in result).toBe(true);
+    if (!('refused' in result)) return;
+    expect(result.message).toContain('human-blocking dialog');
+    expect(result.message).toContain('agent_can_invoke=false');
+    expect(result.message).not.toContain('Unknown Tableau command');
   });
 
   it('applies the unconditional dialog blocklist before registry-backed refusal reasons', () => {

--- a/src/desktop/guards/commandGuard.ts
+++ b/src/desktop/guards/commandGuard.ts
@@ -35,9 +35,14 @@ export function guardCommand({
   command,
   args,
 }: CommandGuardInput): CommandGuardResult {
+  const externalApiCommandRegistry = lookupExternalApiCommandRegistry(namespace, cmd);
   const commandValidation = validateKnownCommand(command);
   if (!commandValidation.ok) {
-    return { refused: true, message: commandValidation.message };
+    const admittedByPrivateRegistry =
+      isUnknownCommandRefusal(commandValidation.message) && externalApiCommandRegistry !== null;
+    if (!admittedByPrivateRegistry) {
+      return { refused: true, message: commandValidation.message };
+    }
   }
 
   const unvalidatedTargetPolicy = unvalidatedTargetPolicyFor(command);
@@ -65,7 +70,6 @@ export function guardCommand({
 
   let dispatchArgs = args ?? {};
   let warnings: string[] = [];
-  const externalApiCommandRegistry = lookupExternalApiCommandRegistry(namespace, cmd);
   if (externalApiCommandRegistry) {
     const externalApiGuard = validateCommandRegistry({
       command,
@@ -96,6 +100,10 @@ export function guardCommand({
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
+}
+
+function isUnknownCommandRefusal(message: string): boolean {
+  return message.startsWith('Unknown Tableau command "');
 }
 
 function validateCommandRegistry({


### PR DESCRIPTION
## Summary
- Census-unknown commands are admitted when `EXTERNAL_API_REGISTRY_DIR` has an invocable entry (e.g. `tabdoc:add-local-extension`).
- Registry refusals (`agent_can_invoke=false`, blocking dialog) still apply after admission.

## Test plan
- [ ] `npx vitest run src/desktop/guards/commandGuard.test.ts`
- [ ] Confirm private-registry command dispatch still works in Desktop