### PR TITLE
fix(desktop): fix list-available-fields message header and long-name alignment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "2.63.3",
+  "version": "2.63.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "2.63.3",
+      "version": "2.63.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.7.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "2.63.3",
+  "version": "2.63.4",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/src/tools/desktop/authoring/fields/listAvailableFields.test.ts
+++ b/src/tools/desktop/authoring/fields/listAvailableFields.test.ts
@@ -184,20 +184,29 @@ describe('listAvailableFieldsTool', () => {
     expect(body.message).not.toContain('Found 2 fields in "DS One"');
   });
 
-  it('truncates a name longer than the column width so the table stays aligned', async () => {
-    const longName = 'Calculation_1368249927221915648'; // 31 chars, exceeds the 30-wide column
+  it('middle-truncates over-width names, keeping the tail so similar ids stay distinct', async () => {
+    // 31 chars, exceeds the 30-wide column; the two differ only in the final digit.
+    const a = 'Calculation_1368249927221915648';
+    const b = 'Calculation_1368249927221915649';
+    const HEAD = 15;
+    const TAIL = 14; // 30-wide column: 15 head + ellipsis + 14 tail
     vi.mocked(existsSync).mockReturnValue(true);
     vi.mocked(readFileSync).mockReturnValue('<workbook/>');
     vi.mocked(metadataModule.listAvailableFields).mockReturnValue([
-      { ...mockFields[0], columnName: `[${longName}]`, caption: undefined },
+      { ...mockFields[0], columnName: `[${a}]`, caption: undefined },
+      { ...mockFields[0], columnName: `[${b}]`, caption: undefined },
     ] as any);
 
     const result = await getResult({ workbookFile: '/workbook.xml' });
 
     invariant(result.content[0].type === 'text');
     const body = resultSchema.parse(JSON.parse(result.content[0].text));
-    expect(body.message).toContain(longName.slice(0, 29) + '…');
-    expect(body.message).not.toContain(longName);
+    const rendered = (s: string): string => s.slice(0, HEAD) + '…' + s.slice(s.length - TAIL);
+    expect(body.message).toContain(rendered(a));
+    expect(body.message).toContain(rendered(b));
+    expect(rendered(a)).not.toBe(rendered(b));
+    expect(body.message).not.toContain(a);
+    expect(body.message).not.toContain(b);
   });
 
   it('with session re-snapshots live workbook, rewrites cache and sidecar, and lists new fields', async () => {

--- a/src/tools/desktop/authoring/fields/listAvailableFields.test.ts
+++ b/src/tools/desktop/authoring/fields/listAvailableFields.test.ts
@@ -166,6 +166,40 @@ describe('listAvailableFieldsTool', () => {
     expect(body.fields[0].column_ref).toBe('[Sample - Superstore].[sum:Profit:qk]');
   });
 
+  it('groups the message by datasource when fields span multiple datasources', async () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue('<workbook/>');
+    vi.mocked(metadataModule.listAvailableFields).mockReturnValue([
+      { ...mockFields[0], datasource: 'DS One' },
+      { ...mockFields[1], datasource: 'DS Two' },
+    ] as any);
+
+    const result = await getResult({ workbookFile: '/workbook.xml' });
+
+    invariant(result.content[0].type === 'text');
+    const body = resultSchema.parse(JSON.parse(result.content[0].text));
+    expect(body.message).toContain('Found 2 fields across 2 datasources:');
+    expect(body.message).toContain('Datasource "DS One" (1):');
+    expect(body.message).toContain('Datasource "DS Two" (1):');
+    expect(body.message).not.toContain('Found 2 fields in "DS One"');
+  });
+
+  it('truncates a name longer than the column width so the table stays aligned', async () => {
+    const longName = 'Calculation_1368249927221915648'; // 31 chars, exceeds the 30-wide column
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue('<workbook/>');
+    vi.mocked(metadataModule.listAvailableFields).mockReturnValue([
+      { ...mockFields[0], columnName: `[${longName}]`, caption: undefined },
+    ] as any);
+
+    const result = await getResult({ workbookFile: '/workbook.xml' });
+
+    invariant(result.content[0].type === 'text');
+    const body = resultSchema.parse(JSON.parse(result.content[0].text));
+    expect(body.message).toContain(longName.slice(0, 29) + '…');
+    expect(body.message).not.toContain(longName);
+  });
+
   it('with session re-snapshots live workbook, rewrites cache and sidecar, and lists new fields', async () => {
     vi.mocked(existsSync).mockReturnValue(true);
     vi.mocked(readFileSync).mockReturnValue(STALE_XML);

--- a/src/tools/desktop/authoring/fields/listAvailableFields.ts
+++ b/src/tools/desktop/authoring/fields/listAvailableFields.ts
@@ -50,7 +50,8 @@ class WorkbookFileNotFoundError extends McpToolError {
   }
 }
 
-const pad = (str: string, len: number): string => str + ' '.repeat(Math.max(0, len - str.length));
+const pad = (str: string, len: number): string =>
+  str.length > len ? str.slice(0, len - 1) + '…' : str + ' '.repeat(len - str.length);
 
 const typeAbbrev = (type: string): string => {
   if (type === 'quantitative') return 'Q';
@@ -77,6 +78,42 @@ const tableauDatatypeLabel = (datatype?: string): string => {
       return datatype || 'unknown';
   }
 };
+
+type AvailableField = ReturnType<typeof listAvailableFields>[number];
+
+function renderFieldRows(fields: AvailableField[]): string {
+  let output = pad('Name', 30) + ' | ' + pad('Local Name', 30) + ' | Type\n';
+  output += '-'.repeat(30) + '-+-' + '-'.repeat(30) + '-+-' + '-'.repeat(15) + '\n';
+  for (const field of fields) {
+    const displayName = field.caption || field.columnName.replace(/^\[|\]$/g, '');
+    const cleanName = field.columnName.replace(/^\[|\]$/g, '');
+    const localNameDisplay = displayName === cleanName ? '(same)' : cleanName;
+    const typeInfo = `${typeAbbrev(field.type)} (${tableauDatatypeLabel(field.datatype)})`;
+    const aggregated = field.isAggregated ? ' [AGG]' : '';
+    output +=
+      pad(displayName, 30) +
+      ' | ' +
+      pad(localNameDisplay, 30) +
+      ' | ' +
+      typeInfo +
+      aggregated +
+      '\n';
+  }
+  return output;
+}
+
+function renderFieldTable(fields: AvailableField[]): string {
+  const dimensions = fields.filter((f) => f.role === 'dimension');
+  const measures = fields.filter((f) => f.role === 'measure');
+  let output = '';
+  if (dimensions.length > 0) {
+    output += `DIMENSIONS (${dimensions.length}):\n` + renderFieldRows(dimensions) + '\n';
+  }
+  if (measures.length > 0) {
+    output += `MEASURES (${measures.length}):\n` + renderFieldRows(measures) + '\n';
+  }
+  return output;
+}
 
 type ListAvailableFieldsResult =
   | { message: string; fields: ReturnType<typeof listAvailableFields> }
@@ -210,54 +247,19 @@ export const getListAvailableFieldsTool = (
             });
           }
 
-          const dimensions = fields.filter((f) => f.role === 'dimension');
-          const measures = fields.filter((f) => f.role === 'measure');
-          const datasourceName = fields[0].datasource;
+          const datasources = [...new Set(fields.map((f) => f.datasource))];
 
-          let output = `Found ${fields.length} fields in "${datasourceName}":\n\n`;
-
-          if (dimensions.length > 0) {
-            output += `DIMENSIONS (${dimensions.length}):\n`;
-            output += pad('Name', 30) + ' | ' + pad('Local Name', 30) + ' | Type\n';
-            output += '-'.repeat(30) + '-+-' + '-'.repeat(30) + '-+-' + '-'.repeat(15) + '\n';
-            for (const field of dimensions) {
-              const displayName = field.caption || field.columnName.replace(/^\[|\]$/g, '');
-              const cleanName = field.columnName.replace(/^\[|\]$/g, '');
-              const localNameDisplay = displayName === cleanName ? '(same)' : cleanName;
-              const typeInfo = `${typeAbbrev(field.type)} (${tableauDatatypeLabel(field.datatype)})`;
-              const aggregated = field.isAggregated ? ' [AGG]' : '';
-              output +=
-                pad(displayName, 30) +
-                ' | ' +
-                pad(localNameDisplay, 30) +
-                ' | ' +
-                typeInfo +
-                aggregated +
-                '\n';
+          let output: string;
+          if (datasources.length === 1) {
+            output =
+              `Found ${fields.length} fields in "${datasources[0]}":\n\n` +
+              renderFieldTable(fields);
+          } else {
+            output = `Found ${fields.length} fields across ${datasources.length} datasources:\n\n`;
+            for (const ds of datasources) {
+              const dsFields = fields.filter((f) => f.datasource === ds);
+              output += `Datasource "${ds}" (${dsFields.length}):\n\n` + renderFieldTable(dsFields);
             }
-            output += '\n';
-          }
-
-          if (measures.length > 0) {
-            output += `MEASURES (${measures.length}):\n`;
-            output += pad('Name', 30) + ' | ' + pad('Local Name', 30) + ' | Type\n';
-            output += '-'.repeat(30) + '-+-' + '-'.repeat(30) + '-+-' + '-'.repeat(15) + '\n';
-            for (const field of measures) {
-              const displayName = field.caption || field.columnName.replace(/^\[|\]$/g, '');
-              const cleanName = field.columnName.replace(/^\[|\]$/g, '');
-              const localNameDisplay = displayName === cleanName ? '(same)' : cleanName;
-              const typeInfo = `${typeAbbrev(field.type)} (${tableauDatatypeLabel(field.datatype)})`;
-              const aggregated = field.isAggregated ? ' [AGG]' : '';
-              output +=
-                pad(displayName, 30) +
-                ' | ' +
-                pad(localNameDisplay, 30) +
-                ' | ' +
-                typeInfo +
-                aggregated +
-                '\n';
-            }
-            output += '\n';
           }
 
           return new Ok({ message: output, fields });

--- a/src/tools/desktop/authoring/fields/listAvailableFields.ts
+++ b/src/tools/desktop/authoring/fields/listAvailableFields.ts
@@ -50,8 +50,17 @@ class WorkbookFileNotFoundError extends McpToolError {
   }
 }
 
-const pad = (str: string, len: number): string =>
-  str.length > len ? str.slice(0, len - 1) + '…' : str + ' '.repeat(len - str.length);
+const pad = (str: string, len: number): string => {
+  if (str.length <= len) {
+    return str + ' '.repeat(len - str.length);
+  }
+  // Truncate in the middle, not the tail: auto-generated names like
+  // Calculation_<id> often differ only in their final digits, so keeping the
+  // tail as well as the head keeps otherwise-identical rows distinguishable.
+  const keep = len - 1;
+  const head = Math.ceil(keep / 2);
+  return str.slice(0, head) + '…' + str.slice(str.length - (keep - head));
+};
 
 const typeAbbrev = (type: string): string => {
   if (type === 'quantitative') return 'Q';


### PR DESCRIPTION
## What this fixes

Two defects in the `list-available-fields` **`verbosity=full`** `message` (the human-readable table; the structured `fields[]` array is unchanged). The tool is registered identically in the `dynamic-authoring` (default) and `full` tool profiles, so both are affected. Both verified live against Tableau Desktop (Superstore + a second datasource).

### 1. Multi-datasource header was wrong
The header read `Found N fields in "<first datasource>"` while it listed fields from **every** datasource. Now a single-datasource workbook is byte-for-byte unchanged; a multi-datasource workbook reads `Found N fields across M datasources:` and groups the table under a `Datasource "<name>" (k):` subheader.

### 2. Long names broke the table layout
`pad()` only padded up, never truncated, so any name > 30 chars (e.g. a 31-char `Calculation_<id>`) overflowed and shifted that row's ` | ` columns. It now truncates to the column width with `…`; the full name still lives in `fields[]`.

## Investigated, deliberately not here
- **`isAggregated` substring heuristic** (matches `SUM(` etc. anywhere in the formula). Real workbooks rarely put an aggregation-name-plus-paren inside a string literal or comment, and a token-scanner rework regressed the common table-calc case (`RUNNING_SUM([calc])` / `WINDOW_SUM([calc])` flipped to not-aggregated). Left as-is here; tracked in W-23836866.
- **Fields whose name contains `]`** (e.g. `Sales [USD]`) are silently dropped — a correct fix means teaching the `column_ref` grammar (`COLUMN_REF_REGEX`, `parseColumnInstanceRef`, and ~8 consumers) to carry a `]]`-escaped `]`, which belongs in its own PR.

## Testing
- New `list-available-fields` tests for multi-datasource grouping and long-name truncation; the existing byte-for-byte single-datasource test still passes.
- Verified live against Tableau Desktop: the multi-datasource header/grouping and the truncated-and-aligned `Calculation_…` row both render correctly through the built server.
- `npm run lint` clean, `tsc --noEmit` clean, `npm run build:desktop` succeeds, touched suites green. (`lockstepSelfContained.test.ts` fails identically with and without this change — a pre-existing Windows-only path-normalization issue.)
