### PR TITLE
fix(desktop): preserve calculation newlines during worksheet edits

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "2.62.3",
+  "version": "2.63.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "2.62.3",
+      "version": "2.63.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.7.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "2.63.1",
+  "version": "2.63.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/src/desktop/metadata/fields.test.ts
+++ b/src/desktop/metadata/fields.test.ts
@@ -113,6 +113,22 @@ describe('parseShelfValue', () => {
 });
 
 describe('addFieldToRows / removeFieldFromRows', () => {
+  it('preserves an unrelated multiline calculation while adding a field', () => {
+    const worksheetWithMultilineCalc = WORKSHEET_XML.replace(
+      '</datasource-dependencies>',
+      `<column name="[Selected Measure]" datatype="real" role="measure" type="quantitative">
+        <calculation class="tableau" formula="CASE [Parameters].[Parameter 9]&#10;WHEN &apos;Total Values&apos; THEN&#10;MAX([Profit])&#10;END"/>
+      </column></datasource-dependencies>`,
+    );
+
+    const modified = addFieldToRows(worksheetWithMultilineCalc, '[Sample].[sum:Profit:qk]');
+
+    expect(modified).toContain(
+      'formula="CASE [Parameters].[Parameter 9]&#10;WHEN &apos;Total Values&apos; THEN&#10;MAX([Profit])&#10;END"',
+    );
+    expect(modified).not.toContain('&amp;#10;');
+  });
+
   it('should add a field to rows', () => {
     const modified = addFieldToRows(WORKSHEET_XML, '[Sample].[sum:Profit:qk]');
     const fields = listFields(modified);

--- a/src/desktop/metadata/fields.test.ts
+++ b/src/desktop/metadata/fields.test.ts
@@ -113,20 +113,24 @@ describe('parseShelfValue', () => {
 });
 
 describe('addFieldToRows / removeFieldFromRows', () => {
-  it('preserves an unrelated multiline calculation while adding a field', () => {
+  it('preserves an unrelated multiline calculation through two distinct field mutations', () => {
+    const formula =
+      'CASE [Parameters].[Parameter 9]&#10;WHEN &apos;Total Values&apos; THEN&#13;MAX([Profit])&#10;END';
     const worksheetWithMultilineCalc = WORKSHEET_XML.replace(
       '</datasource-dependencies>',
       `<column name="[Selected Measure]" datatype="real" role="measure" type="quantitative">
-        <calculation class="tableau" formula="CASE [Parameters].[Parameter 9]&#10;WHEN &apos;Total Values&apos; THEN&#10;MAX([Profit])&#10;END"/>
+        <calculation class="tableau" formula="${formula}"/>
       </column></datasource-dependencies>`,
     );
 
-    const modified = addFieldToRows(worksheetWithMultilineCalc, '[Sample].[sum:Profit:qk]');
+    const rowsModified = addFieldToRows(worksheetWithMultilineCalc, '[Sample].[sum:Profit:qk]');
+    const colsModified = addFieldToCols(rowsModified, '[Sample].[sum:Profit:qk]');
 
-    expect(modified).toContain(
-      'formula="CASE [Parameters].[Parameter 9]&#10;WHEN &apos;Total Values&apos; THEN&#10;MAX([Profit])&#10;END"',
-    );
-    expect(modified).not.toContain('&amp;#10;');
+    for (const modified of [rowsModified, colsModified]) {
+      expect(modified).toContain(`formula="${formula}"`);
+      expect(modified).not.toContain('&amp;#10;');
+      expect(modified).not.toContain('&amp;#13;');
+    }
   });
 
   it('should add a field to rows', () => {

--- a/src/desktop/metadata/parser.test.ts
+++ b/src/desktop/metadata/parser.test.ts
@@ -4,9 +4,7 @@ import {
   generateUUID,
   normalizeArray,
   parseXML,
-  parseXMLPreservingNumericEntities,
   serializeXML,
-  serializeXMLPreservingNumericEntities,
 } from './parser.js';
 
 const WORKBOOK_TWO_SHEETS = `<?xml version="1.0" encoding="UTF-8"?>
@@ -133,7 +131,7 @@ describe('serializeXML', () => {
     expect(output).not.toContain('&#10;');
   });
 
-  describe('numeric-entity-preserving template round-trip', () => {
+  describe('numeric-entity-preserving round-trip', () => {
     const calc = `<?xml version="1.0" encoding="UTF-8"?>
 <workbook><datasources><datasource name="DS">
   <column caption="Order Profitable?" name="[Order Profitable?]">
@@ -142,15 +140,15 @@ describe('serializeXML', () => {
 </datasource></datasources></workbook>`;
 
     it('preserves numeric newline entities instead of double-escaping them', () => {
-      const output = serializeXMLPreservingNumericEntities(parseXMLPreservingNumericEntities(calc));
+      const output = serializeXML(parseXML(calc));
       expect(output).toContain('&gt;0&#13;&#10;// calculates the profit at the order level');
       expect(output).not.toContain('&amp;#13;');
       expect(output).not.toContain('&amp;#10;');
     });
 
     it('does not progressively escape the formula on a second round-trip', () => {
-      const once = serializeXMLPreservingNumericEntities(parseXMLPreservingNumericEntities(calc));
-      const twice = serializeXMLPreservingNumericEntities(parseXMLPreservingNumericEntities(once));
+      const once = serializeXML(parseXML(calc));
+      const twice = serializeXML(parseXML(once));
       const formula = /formula="([^"]*)"/;
       expect(twice.match(formula)?.[1]).toBe(once.match(formula)?.[1]);
     });
@@ -158,8 +156,8 @@ describe('serializeXML', () => {
     it('keeps encoded literal numeric-entity text inert while preserving real newlines', () => {
       const source =
         '<column formula="literal &amp;#0; text, then a real newline: &#13;&#10;next" />';
-      const once = serializeXMLPreservingNumericEntities(parseXMLPreservingNumericEntities(source));
-      const twice = serializeXMLPreservingNumericEntities(parseXMLPreservingNumericEntities(once));
+      const once = serializeXML(parseXML(source));
+      const twice = serializeXML(parseXML(once));
 
       expect(once).toContain('literal &amp;#0; text, then a real newline: &#13;&#10;next');
       expect(once).not.toContain('literal &#0; text');
@@ -168,19 +166,15 @@ describe('serializeXML', () => {
 
     it('does not treat sentinel-shaped user text as protected parser state', () => {
       const sentinelText = '\uE000TABLEAU_NUMERIC_ENTITY_user_text_13\uE001';
-      const once = serializeXMLPreservingNumericEntities(
-        parseXMLPreservingNumericEntities(`<r>${sentinelText}</r>`),
-      );
+      const once = serializeXML(parseXML(`<r>${sentinelText}</r>`));
 
       expect(once).toBe(`<r>${sentinelText}</r>`);
       expect(once).not.toContain('&#13;');
     });
 
     it('does not reinterpret encoded entity text inside CDATA', () => {
-      const once = serializeXMLPreservingNumericEntities(
-        parseXMLPreservingNumericEntities('<r><![CDATA[&amp;#13;]]></r>'),
-      );
-      const twice = serializeXMLPreservingNumericEntities(parseXMLPreservingNumericEntities(once));
+      const once = serializeXML(parseXML('<r><![CDATA[&amp;#13;]]></r>'));
+      const twice = serializeXML(parseXML(once));
 
       expect(once).toBe('<r>&amp;amp;#13;</r>');
       expect(twice).toBe(once);
@@ -189,32 +183,24 @@ describe('serializeXML', () => {
     it('parses identical source into deeply equal values across calls', () => {
       const source = '<column formula="literal &amp;#13; text" />';
 
-      expect(parseXMLPreservingNumericEntities(source)).toEqual(
-        parseXMLPreservingNumericEntities(source),
-      );
+      expect(parseXML(source)).toEqual(parseXML(source));
     });
 
     it('returns semantic control characters and no parser sentinels', () => {
-      const parsed = parseXMLPreservingNumericEntities(
-        '<column formula="real:&#13;&#10;&#9; literal:&amp;#13;" />',
-      ) as any;
+      const parsed = parseXML('<column formula="real:&#13;&#10;&#9; literal:&amp;#13;" />') as any;
 
       expect(parsed.column[0]['@_formula']).toBe('real:\r\n\t literal:&#13;');
       expect(JSON.stringify(parsed)).not.toContain('TABLEAU_NUMERIC_ENTITY');
     });
 
     it('serializes semantic CR, LF, and tab separately from literal numeric-entity text', () => {
-      const parsed = parseXMLPreservingNumericEntities(
-        '<column formula="real:&#13;&#10;&#9; literal:&amp;#13;" />',
-      );
+      const parsed = parseXML('<column formula="real:&#13;&#10;&#9; literal:&amp;#13;" />');
 
-      expect(serializeXMLPreservingNumericEntities(parsed)).toContain(
-        'formula="real:&#13;&#10;&#9; literal:&amp;#13;"',
-      );
+      expect(serializeXML(parsed)).toContain('formula="real:&#13;&#10;&#9; literal:&amp;#13;"');
     });
 
     it('does not place numeric-entity sentinels inside CDATA', () => {
-      const parsed = parseXMLPreservingNumericEntities('<r><![CDATA[&#13;&amp;#13;]]></r>') as any;
+      const parsed = parseXML('<r><![CDATA[&#13;&amp;#13;]]></r>') as any;
 
       expect(parsed.r).toBe('&#13;&amp;#13;');
       expect(JSON.stringify(parsed)).not.toContain('TABLEAU_NUMERIC_ENTITY');

--- a/src/desktop/metadata/parser.test.ts
+++ b/src/desktop/metadata/parser.test.ts
@@ -120,11 +120,17 @@ describe('serializeXML', () => {
     expect(output).toContain('Sheet 2');
   });
 
-  it('keeps feature/desktop numeric-entity behavior in the default parser', () => {
+  it('preserves semantic numeric entities and encoded literal text in the default parser', () => {
     const parsed = parseXML('<column formula="real:&#13; literal:&amp;#13;" />') as any;
 
-    expect(parsed.column[0]['@_formula']).toBe('real:&#13; literal:&#13;');
-    expect(serializeXML(parsed)).toContain('formula="real:&amp;#13; literal:&amp;#13;"');
+    expect(parsed.column[0]['@_formula']).toBe('real:\r literal:&#13;');
+    expect(serializeXML(parsed)).toContain('formula="real:&#13; literal:&amp;#13;"');
+  });
+
+  it('keeps formatting whitespace literal instead of creating numeric entity churn', () => {
+    const output = serializeXML(parseXML('<root>\n  <child />\n</root>'));
+
+    expect(output).not.toContain('&#10;');
   });
 
   describe('numeric-entity-preserving template round-trip', () => {

--- a/src/desktop/metadata/parser.ts
+++ b/src/desktop/metadata/parser.ts
@@ -171,10 +171,6 @@ const parser = new XMLParser(parserOptions);
 const numericEntityPreservingBuilder = new XMLBuilder(numericEntityPreservingBuilderOptions);
 
 export function parseXML(xmlString: string): ParsedWorkbook {
-  return parseXMLPreservingNumericEntities(xmlString);
-}
-
-export function parseXMLPreservingNumericEntities(xmlString: string): ParsedWorkbook {
   try {
     const { protectedXml, sentinel } = protectNumericEntities(xmlString);
     const parsed = parser.parse(protectedXml) as ParsedWorkbook;
@@ -188,10 +184,6 @@ export function parseXMLPreservingNumericEntities(xmlString: string): ParsedWork
 }
 
 export function serializeXML(obj: any): string {
-  return serializeXMLPreservingNumericEntities(obj);
-}
-
-export function serializeXMLPreservingNumericEntities(obj: any): string {
   try {
     const result = numericEntityPreservingBuilder.build(obj);
     if (typeof result === 'string') {

--- a/src/desktop/metadata/parser.ts
+++ b/src/desktop/metadata/parser.ts
@@ -142,6 +142,13 @@ function escapeXmlValue(_name: string, value: unknown): string {
   return escapeXmlCore(value).replace(/"/g, '&quot;');
 }
 
+function escapeXmlText(_name: string, value: unknown): string {
+  const text = String(value);
+  // Formatting whitespace between XML elements is not Tableau content. Keeping it literal
+  // avoids turning every pretty-printed line break into a numeric character reference.
+  return /^\s+$/.test(text) ? text : escapeXmlCore(text).replace(/"/g, '&quot;');
+}
+
 const builderOptions = {
   ignoreAttributes: false,
   attributeNamePrefix: '@_',
@@ -157,21 +164,14 @@ const numericEntityPreservingBuilderOptions = {
   ...builderOptions,
   processEntities: false,
   attributeValueProcessor: escapeXmlValue,
-  tagValueProcessor: escapeXmlValue,
+  tagValueProcessor: escapeXmlText,
 };
 
 const parser = new XMLParser(parserOptions);
-const builder = new XMLBuilder(builderOptions);
 const numericEntityPreservingBuilder = new XMLBuilder(numericEntityPreservingBuilderOptions);
 
 export function parseXML(xmlString: string): ParsedWorkbook {
-  try {
-    return parser.parse(xmlString) as ParsedWorkbook;
-  } catch (error) {
-    throw new Error(
-      `Failed to parse XML: ${error instanceof Error ? error.message : String(error)}`,
-    );
-  }
+  return parseXMLPreservingNumericEntities(xmlString);
 }
 
 export function parseXMLPreservingNumericEntities(xmlString: string): ParsedWorkbook {
@@ -188,17 +188,7 @@ export function parseXMLPreservingNumericEntities(xmlString: string): ParsedWork
 }
 
 export function serializeXML(obj: any): string {
-  try {
-    const result = builder.build(obj);
-    if (typeof result === 'string') {
-      return result.trim();
-    }
-    throw new Error('XMLBuilder returned an object instead of a string');
-  } catch (error) {
-    throw new Error(
-      `Failed to serialize XML: ${error instanceof Error ? error.message : String(error)}`,
-    );
-  }
+  return serializeXMLPreservingNumericEntities(obj);
 }
 
 export function serializeXMLPreservingNumericEntities(obj: any): string {

--- a/src/desktop/templates/groupDefinitionSplice.ts
+++ b/src/desktop/templates/groupDefinitionSplice.ts
@@ -1,8 +1,4 @@
-import {
-  normalizeArray,
-  parseXMLPreservingNumericEntities,
-  serializeXMLPreservingNumericEntities,
-} from '../metadata/parser.js';
+import { normalizeArray, parseXML, serializeXML } from '../metadata/parser.js';
 
 const GROUP_CALC_CLASSES = new Set(['categorical-bin']);
 
@@ -36,14 +32,14 @@ function mappedFieldName(columnInstance: string): string | null {
 }
 
 function serializeElement(tag: string, node: unknown): string {
-  return serializeXMLPreservingNumericEntities({ [tag]: node });
+  return serializeXML({ [tag]: node });
 }
 
 function collectGroupDefinitions(workbookXml: string): Map<string, GroupDefinition> {
   const groups = new Map<string, GroupDefinition>();
   let workbook;
   try {
-    workbook = parseXMLPreservingNumericEntities(workbookXml);
+    workbook = parseXML(workbookXml);
   } catch {
     return groups; // a workbook we cannot parse defines no groups we can trust
   }
@@ -138,7 +134,7 @@ function collectCalcDefinitions(workbookXml: string): Map<string, CalcDefinition
   const calcs = new Map<string, CalcDefinition>();
   let workbook;
   try {
-    workbook = parseXMLPreservingNumericEntities(workbookXml);
+    workbook = parseXML(workbookXml);
   } catch {
     return calcs;
   }

--- a/src/desktop/templates/injectTemplate.ts
+++ b/src/desktop/templates/injectTemplate.ts
@@ -2,8 +2,8 @@ import {
   carryNamespaceDeclarations,
   generateUUID,
   normalizeArray,
-  parseXMLPreservingNumericEntities,
-  serializeXMLPreservingNumericEntities,
+  parseXML,
+  serializeXML,
 } from '../metadata/parser.js';
 
 export type SheetType = 'worksheet' | 'dashboard' | 'story';
@@ -54,8 +54,8 @@ export function injectTemplate(
 ): string {
   const { container, element, windowClass } = SHEET_CONFIG[sheetType];
 
-  const workbook = parseXMLPreservingNumericEntities(workbookXml);
-  const template = parseXMLPreservingNumericEntities(templateXml);
+  const workbook = parseXML(workbookXml);
+  const template = parseXML(templateXml);
 
   const wb = workbook.workbook;
   if (!wb) throw new Error('Workbook XML has no <workbook> root element');
@@ -116,5 +116,5 @@ export function injectTemplate(
 
   wb.windows.window = (existingWindows.length === 1 ? existingWindows[0] : existingWindows) as any;
 
-  return serializeXMLPreservingNumericEntities(workbook);
+  return serializeXML(workbook);
 }

--- a/src/desktop/templates/injectTemplateCore.ts
+++ b/src/desktop/templates/injectTemplateCore.ts
@@ -13,12 +13,7 @@
 // binder's args as-is (matching what the manual inject-template call would receive).
 
 import { listAvailableFields } from '../metadata/field-builder.js';
-import {
-  normalizeArray,
-  parseXML,
-  parseXMLPreservingNumericEntities,
-  serializeXMLPreservingNumericEntities,
-} from '../metadata/parser.js';
+import { normalizeArray, parseXML, serializeXML } from '../metadata/parser.js';
 import { ParsedWindow, ParsedWorkbook, ParsedWorksheet } from '../metadata/types.js';
 import { wellFormedXmlRule } from '../validation/rules/wellFormedXml.js';
 import { type DateparseAxisSpec, spliceDateparseTemporalAxis } from './dateparseTemporalAxis.js';
@@ -271,7 +266,7 @@ export function classifyWorksheetReplaceTarget(
 export function removeSameNamedWorksheet(workbookXml: string, title: string): string {
   let workbook: ParsedWorkbook;
   try {
-    workbook = parseXMLPreservingNumericEntities(workbookXml);
+    workbook = parseXML(workbookXml);
   } catch {
     return workbookXml;
   }
@@ -297,7 +292,7 @@ export function removeSameNamedWorksheet(workbookXml: string, title: string): st
   if (wb.windows && keptWindows.length !== windows.length) {
     wb.windows.window = keptWindows.length === 1 ? keptWindows[0] : keptWindows;
   }
-  return serializeXMLPreservingNumericEntities(workbook);
+  return serializeXML(workbook);
 }
 
 /**

--- a/src/tools/desktop/authoring/fields/addField.test.ts
+++ b/src/tools/desktop/authoring/fields/addField.test.ts
@@ -368,6 +368,7 @@ describe('addFieldTool', () => {
     // re-fetches a fresh (blank) sheet from the live workbook.
     expect(secondBody.file).toBe(firstBody.file);
     expect(getWorksheetXmlModule.getWorksheetXml).toHaveBeenCalledOnce();
+    expect(vi.mocked(metadataModule.addFieldToRows).mock.calls[1]?.[0]).toBe(MODIFIED_XML);
   });
 
   it('mints a fresh sheet when the sticky buffer fails its sidecar/session check', async () => {


### PR DESCRIPTION
## Description

Every shared workbook XML edit now preserves numeric character references. This is a parser rule for all metadata mutations, not a one-off fix for one calculation: a real `&#10;` remains a line break, while literal `&amp;#10;` text remains literal.

This prevents an unrelated worksheet edit from rewriting multiline calculations so Tableau displays `&#10;` inside the formula. Future metadata mutators should keep using the shared parser instead of adding tool-specific escaping.

## Motivation and Context

An authoring flow added a field to one sheet and corrupted an existing calculation elsewhere in the worksheet fragment. The shared parser decoded ordinary XML entities but serialized numeric references as escaped text. The safer parser already used by template injection is now the default path.

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

- Regression test: adding a shelf field preserves an unrelated multiline calculation
- Parser tests: semantic numeric references, encoded literal text, formatting whitespace, and repeat round trips
- Full gate: 376 test files / 5,772 tests, lint, typecheck, Desktop build, and lockstep
- Live Tableau Desktop 0.2.6: applied and read back a real Superstore worksheet with six numeric references preserved, zero double-escapes, semantic XML parity, and a successful PNG render
- Independent Grok 4.5 review: clean

## Checklist

- [x] Version bumped to 2.63.2
- [x] Tests added/updated
- [x] Unit tests pass locally
- [x] No served tool-surface changes

Authored by MattGPT.
