### PR TITLE
fix(desktop): reject fabricated fields before creating calculations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "2.62.3",
+  "version": "2.63.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "2.62.3",
+      "version": "2.63.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.7.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "2.63.1",
+  "version": "2.63.3",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/src/tools/desktop/authoring/datasource/authorCalc.test.ts
+++ b/src/tools/desktop/authoring/datasource/authorCalc.test.ts
@@ -17,6 +17,7 @@ const BASE_XML = [
   '<datasources>',
   "<datasource name='Superstore'>",
   "<column caption='Sales' datatype='real' name='[Sales]' role='measure' type='quantitative' />",
+  "<column caption='Region' datatype='string' name='[Region]' role='dimension' type='nominal' />",
   '</datasource>',
   '</datasources>',
   "<worksheets><worksheet name='Sheet 1' /></worksheets>",
@@ -129,6 +130,38 @@ describe('authorCalcTool', () => {
     expect(relStart === -1 || relEnd < at).toBe(true);
     expect(at).toBeLessThan(loaded.indexOf('</datasource>', at) + '</datasource>'.length);
     expect(at).toBeLessThan(loaded.indexOf('</datasources>'));
+  });
+
+  it('rejects a fabricated direct-calc field against a live-shaped workbook before dispatch', async () => {
+    const realXml = readFileSync(
+      join(
+        process.cwd(),
+        'src',
+        'tools',
+        'desktop',
+        'authoring',
+        'datasource',
+        '__fixtures__',
+        'real-superstore-document.twb.xml',
+      ),
+      'utf8',
+    );
+
+    const { result, applyWorkbookDocument } = await getToolResult({
+      args: { caption: 'Unsafe Calc', formula: '[Fabricated] + [Sales]' },
+      initialXml: realXml,
+    });
+
+    expect(result).toMatchObject({
+      isError: true,
+      content: [
+        {
+          type: 'text',
+          text: expect.stringContaining('field reference [Fabricated] was not found'),
+        },
+      ],
+    });
+    expect(applyWorkbookDocument).not.toHaveBeenCalled();
   });
 
   it('resolves sibling-calc caption references to internal names (live 2026-07-19: 5 of 6 layered calcs broken)', async () => {

--- a/src/tools/desktop/authoring/datasource/authorCalc.ts
+++ b/src/tools/desktop/authoring/datasource/authorCalc.ts
@@ -81,6 +81,7 @@ export const getAuthorCalcTool = (server: DesktopMcpServer): DesktopTool<typeof 
             executor,
             signal: extra.signal,
             labelErrors: false,
+            resolveLooseReferences: true,
           });
           if (authored.isErr()) {
             return authored.error.toErr();


### PR DESCRIPTION
## Description

`author-calc` now checks every unqualified field reference against the live datasource before it sends workbook XML to Desktop. This is the same resolver already used by template binding, so a made-up field returns a normal MCP validation error instead of reaching Tableau and risking a blocking dialog.

This sets the rule for calculation authoring: semantic references must resolve against live workbook state before mutation. It does not add a new validator or change qualified Tableau references.

## Motivation and Context

The audit following #757 found that direct `author-calc` skipped the shared loose-reference check. A formula such as `[Fabricated] + [Sales]` could reach `applyWorkbookDocument`; structural XML validation and readback do not prove the referenced field exists.

This PR is intentionally narrow. Similar set, action, parameter, and raw-command inputs need their own live-shaped tests before we choose a shared policy.

Merge after #766 so the package versions publish in order (`2.63.2`, then `2.63.3`).

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

- Live-shaped tool regression: fabricated field is rejected and `applyWorkbookDocument` is never called
- Existing direct calculation and shared core tests: 15/15 green
- ESLint and TypeScript green
- Full repository gate was attempted but did not terminate locally; CI is the remaining full-suite gate
- Grok 4.5 review was attempted twice and returned no output; no substitute reviewer was used

## Checklist

- [x] Version bumped to 2.63.3 with the package script
- [x] Tests added
- [x] No served tool-surface change

Authored by MattGPT.
