### PR TITLE
fix(desktop): don't retry when Desktop is blocked on a modal dialog

### DIFF
--- a/src/desktop/callDeadline.ts
+++ b/src/desktop/callDeadline.ts
@@ -37,6 +37,11 @@ export function formatBudget(budgetMs: number): string {
   return budgetMs % 1000 === 0 ? `${budgetMs / 1000}s` : `${budgetMs}ms`;
 }
 
+export const BLOCKING_DIALOG_GUIDANCE =
+  'Desktop is most likely showing a blocking dialog that a person has to dismiss, or the instance is wedged. ' +
+  'Do not retry this call — it will hang against the same dialog. ' +
+  'Tell the user to dismiss any open Tableau dialog, then call list-instances to confirm the session is still reachable and re-target if the pid changed.';
+
 /**
  * The agent-facing text for an expired call. It names the budget, says what is most likely
  * wrong, and forbids a blind retry — retrying a call that raised a blocking Desktop dialog
@@ -59,9 +64,7 @@ export function desktopCallTimeoutMessage({
     `Tableau Desktop did not respond within ${formatBudget(budgetMs)} and the call was aborted${
       scope ? ` (${scope})` : ''
     }.`,
-    'Desktop is most likely showing a blocking dialog that a person has to dismiss, or the instance is wedged.',
-    'Do not retry this call — it will hang against the same dialog.',
-    'Tell the user to dismiss any open Tableau dialog, then call list-instances to confirm the session is still reachable and re-target if the pid changed.',
+    BLOCKING_DIALOG_GUIDANCE,
   ].join(' ');
 }
 

--- a/src/desktop/externalApi/externalApiToolExecutor.test.ts
+++ b/src/desktop/externalApi/externalApiToolExecutor.test.ts
@@ -826,7 +826,14 @@ describe('ExternalApiToolExecutor', () => {
       });
 
       expect(result.isErr()).toBe(true);
-      expect(result.unwrapErr().type).toBe('command-timed-out');
+      const error = result.unwrapErr();
+      expect(error.type).toBe('command-timed-out');
+      // A poll-timeout is a hang, most likely a modal Desktop can't clear — surface the same
+      // dismiss-the-dialog / do-not-retry / list-instances guidance the call-deadline path uses.
+      if (error.type === 'command-timed-out') {
+        expect(error.error).toContain('Do not retry');
+        expect(error.error).toContain('list-instances');
+      }
     });
 
     it('maps a CANCELLED terminal operation to a command-failed error', async () => {

--- a/src/desktop/externalApi/externalApiToolExecutor.ts
+++ b/src/desktop/externalApi/externalApiToolExecutor.ts
@@ -2,7 +2,11 @@ import { Err, Ok, Result } from 'ts-results-es';
 import { z } from 'zod';
 
 import { log } from '../../logging/logger.js';
-import { desktopCallTimeoutMessage, isDesktopCallTimeout } from '../callDeadline.js';
+import {
+  BLOCKING_DIALOG_GUIDANCE,
+  desktopCallTimeoutMessage,
+  isDesktopCallTimeout,
+} from '../callDeadline.js';
 import {
   noInstanceFoundMessage,
   unknownInstanceUnreachableMessage,
@@ -955,13 +959,12 @@ function mapClientError(
     case 'operation-expired':
       return {
         type: 'command-timed-out',
-        error:
-          'The async operation expired before it completed (polled past the Desktop retention window).',
+        error: `The async operation expired before it completed (polled past the Desktop retention window). ${BLOCKING_DIALOG_GUIDANCE}`,
       };
     case 'poll-timeout':
       return {
         type: 'command-timed-out',
-        error: 'The async operation did not reach a terminal state within the poll deadline.',
+        error: `The async operation did not reach a terminal state within the poll deadline. ${BLOCKING_DIALOG_GUIDANCE}`,
       };
     case 'no-instance':
       return {

--- a/src/errors/mcpToolError.test.ts
+++ b/src/errors/mcpToolError.test.ts
@@ -28,4 +28,35 @@ describe('DesktopCommandExecutionError', () => {
     expect(error.message).toContain('Access denied to workbook');
     expect(error.message).not.toContain('Do NOT name, guess, or imply a cause');
   });
+
+  it('flags an awaiting-user failure as blocked by a Desktop dialog', () => {
+    const error = new DesktopCommandExecutionError({
+      type: 'command-failed',
+      error: {
+        code: 'awaiting-user',
+        message: 'The operation is blocked on a Tableau Desktop dialog.',
+        recoverable: false,
+      },
+    });
+
+    expect(error.blockedByDesktopDialog).toBe(true);
+  });
+
+  it('flags a timed-out command as blocked by a Desktop dialog', () => {
+    const error = new DesktopCommandExecutionError({
+      type: 'command-timed-out',
+      error: 'Tableau Desktop did not respond within 60s.',
+    });
+
+    expect(error.blockedByDesktopDialog).toBe(true);
+  });
+
+  it('does not flag an ordinary command failure as blocked by a Desktop dialog', () => {
+    const error = new DesktopCommandExecutionError({
+      type: 'command-failed',
+      error: { code: '8F2A4D91', message: 'Unable to complete action', recoverable: false },
+    });
+
+    expect(error.blockedByDesktopDialog).toBe(false);
+  });
 });

--- a/src/errors/mcpToolError.ts
+++ b/src/errors/mcpToolError.ts
@@ -307,6 +307,10 @@ export class ImageExportTimeoutError extends McpToolError {
 }
 
 export class DesktopCommandExecutionError extends McpToolError {
+  // A timeout counts as dialog-blocked too: a hung Desktop call is almost always wedged behind a
+  // modal it cannot clear over the API, and a retry just hangs against the same dialog.
+  readonly blockedByDesktopDialog: boolean;
+
   constructor(error: ExecuteCommandError, fix?: string) {
     const message = formatDesktopCommandExecutionError(error);
     super({
@@ -314,6 +318,9 @@ export class DesktopCommandExecutionError extends McpToolError {
       message: fix ? `${message}\n${fix}` : message,
       statusCode: 500,
     });
+    this.blockedByDesktopDialog =
+      error.type === 'command-timed-out' ||
+      (error.type === 'command-failed' && error.error?.code === 'awaiting-user');
   }
 }
 

--- a/src/tools/desktop/api/getSummaryData.test.ts
+++ b/src/tools/desktop/api/getSummaryData.test.ts
@@ -472,6 +472,45 @@ describe('getSummaryDataTool', () => {
     }
   });
 
+  it('routes a blocking Desktop dialog to action-required instead of retryable', async () => {
+    const harness = await startHarness((server) => {
+      server.setOverride('GET /v0/workbook/worksheets/sheet-sales/summaryData', {
+        status: 202,
+        headers: { Location: '/v0/operations/op-blocked', 'Retry-After': '0' },
+      });
+      server.setOperation('op-blocked', {
+        retryAfterSeconds: 0,
+        poll: [
+          {
+            id: 'op-blocked',
+            kind: 'worksheet-summary-data',
+            state: 'RUNNING',
+            blockingWindows: [
+              {
+                objectName: 'signIn',
+                title: 'Sign In',
+                className: 'QDialog',
+                messageText: 'Enter your SQL Server password',
+              },
+            ],
+          },
+        ],
+      });
+    });
+
+    try {
+      const result = await harness.callTool({ worksheetName: 'Sales by Region', maxRows: 50 });
+      expect(result.isError).toBe(true);
+      expect(parseJsonResult(result)).toMatchObject({
+        status: 'action-required',
+        reason: 'desktop-blocked',
+        guidance: expect.stringContaining('list-instances'),
+      });
+    } finally {
+      await harness.close();
+    }
+  });
+
   it('does not replay a prior success payload for repeated calls', async () => {
     const harness = await startHarness();
     try {

--- a/src/tools/desktop/api/getSummaryData.ts
+++ b/src/tools/desktop/api/getSummaryData.ts
@@ -420,7 +420,7 @@ function nextActionForSummaryError(
     return prefillNextAction('Retry get-summary-data once');
   }
   if (reason === 'desktop-blocked') {
-    return prefillNextAction('Dismiss the Tableau dialog, then call list-instances');
+    return prefillNextAction('Dismiss any open Tableau dialog, then call list-instances');
   }
   if (reason === 'endpoint-unavailable') {
     return prefillNextAction('Update Desktop/API and retry');

--- a/src/tools/desktop/api/getSummaryData.ts
+++ b/src/tools/desktop/api/getSummaryData.ts
@@ -2,11 +2,17 @@ import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { Ok, Result } from 'ts-results-es';
 import { z } from 'zod';
 
+import { BLOCKING_DIALOG_GUIDANCE } from '../../../desktop/callDeadline.js';
 import { WorksheetItem } from '../../../desktop/externalApi/types.js';
 import { sessionRouteState } from '../../../desktop/route/route-state.js';
 import { resolveSession } from '../../../desktop/session/sessionResolution.js';
 import { runExternalApiReadTool } from '../../../desktop/wrappers/readHarness.js';
-import { ArgsValidationError, McpToolError, UnknownError } from '../../../errors/mcpToolError.js';
+import {
+  ArgsValidationError,
+  DesktopCommandExecutionError,
+  McpToolError,
+  UnknownError,
+} from '../../../errors/mcpToolError.js';
 import { DesktopMcpServer } from '../../../server.desktop.js';
 import { getExceptionMessage } from '../../../utils/getExceptionMessage.js';
 import { deprecatedArtifactAliasParam, resolveArtifactNameArg } from '../params.js';
@@ -252,7 +258,8 @@ type SummaryDataErrorReason =
   | 'columns-not-found'
   | 'session-resolution-failed'
   | 'request-failed'
-  | 'endpoint-unavailable';
+  | 'endpoint-unavailable'
+  | 'desktop-blocked';
 
 class SummaryDataResponseError extends McpToolError {
   readonly structuredContent: WireStructuredContent;
@@ -322,6 +329,11 @@ function summaryDataError(
 function requestError(error: McpToolError): SummaryDataResponseError {
   if (error instanceof SummaryDataResponseError) {
     return error;
+  }
+  // A blocking dialog (awaiting-user) or a hung call never clears on a retry, so keep it off the
+  // transient retry path — telling the agent to retry just wedges Desktop against the same dialog.
+  if (error instanceof DesktopCommandExecutionError && error.blockedByDesktopDialog) {
+    return summaryDataError(error, 'action-required', 'desktop-blocked', BLOCKING_DIALOG_GUIDANCE);
   }
   return error.statusCode >= 500
     ? summaryDataError(error, 'retryable', 'request-failed')
@@ -406,6 +418,9 @@ function nextActionForSummaryError(
   }
   if (status === 'retryable') {
     return prefillNextAction('Retry get-summary-data once');
+  }
+  if (reason === 'desktop-blocked') {
+    return prefillNextAction('Dismiss the Tableau dialog, then call list-instances');
   }
   if (reason === 'endpoint-unavailable') {
     return prefillNextAction('Update Desktop/API and retry');

--- a/src/tools/desktop/emittedToolReferences.test.ts
+++ b/src/tools/desktop/emittedToolReferences.test.ts
@@ -59,6 +59,7 @@ const NON_TOOL_VOCABULARY = [
   'datatype-customized',
   'default-format',
   'derivation-illegal',
+  'desktop-blocked',
   'diff-corpus',
   'do-nothing',
   'edit-group-action',


### PR DESCRIPTION
## Decision

A Tableau Desktop modal that only a person can dismiss (Sign In, connection/credential prompts, a hung call behind a dialog) is now surfaced **consistently as a non-retryable, action-required condition** across the desktop tool surface: the agent is told to dismiss the dialog and re-check with `list-instances`, never to retry — a retry just re-hangs against the same dialog. This is a rule the codebase now keeps, not a one-off.

## Why

Production cluster "Desktop blocked by modal dialogs" (~446 est. occurrences), where dialog-blocked failures surfaced through many tools as generic `other_error` and, worse, as **retryable**:

- `get-summary-data` classified every `statusCode >= 500` as `retryable` (`DesktopCommandExecutionError` is always 500). So an `awaiting-user` failure (`recoverable: false`) and a call timeout were handed back as "retry once" — telling the agent to retry a dialog a retry can never clear.
- The async **poll-timeout** mapping emitted a bare "did not reach a terminal state" string with none of the dismiss/`list-instances` guidance the call-deadline timeout already carried.

## What changed

1. **Unify the hang guidance.** Extract the existing call-deadline dialog guidance into a shared `BLOCKING_DIALOG_GUIDANCE` constant and reuse it on the async `poll-timeout` / `operation-expired` mappings, so every hang surface reads identically (dismiss the dialog, do not retry, `list-instances`).
2. **Don't retry a dialog.** Add `DesktopCommandExecutionError.blockedByDesktopDialog` (true for an `awaiting-user` command failure or a timeout) and route those in `get-summary-data` to `action-required` / `desktop-blocked` instead of `retryable`.
3. **Don't assert a dialog we can't see.** The `desktop-blocked` next-action reads "Dismiss **any open** Tableau dialog, then call `list-instances`" rather than "Dismiss the Tableau dialog" — a `command-timed-out` hang can't confirm a dialog from the client (only `awaiting-user` carries `blockingWindows`), so a genuine no-dialog timeout no longer tells the user to dismiss one that isn't there. (Matt's review.)

No version bump: rebased onto the current `feature/desktop` (already at 2.63.5, set by #768), so the PR's own duplicate 2.63.5 bump was dropped on rebase.

## Scope

Client-side only. The terminal-`FAILED`-with-a-cryptic-code case (e.g. `Unable to complete action` / `8F2A4D91`) **cannot** be recognized as dialog-related from the client: the Desktop server only probes for blocking windows on a *non-terminal* operation, so a terminal failure never carries `blockingWindows` (verified against the monolith `tabexternalapihost` handler — the probe is gated on `!IsTerminal`, and `AWAITING_USER` is never assigned). Closing that subset needs a server-side change, tracked in GUS **W-23855650**.

## Tests

- `DesktopCommandExecutionError.blockedByDesktopDialog` for awaiting-user / timeout / ordinary failure.
- Poll-timeout now carries the dismiss/`list-instances` guidance.
- `get-summary-data` integration test: a blocking dialog on a non-terminal poll → `action-required` / `desktop-blocked`, not `retryable`.

## Validation

Lint, `tsc --noEmit`, and the default + desktop bundle builds all pass; 101/101 unit tests on the touched files.

Live smoke test against Tableau Desktop (External Client API 0.2.6): with a modal ("Edit Title") blocking the command queue, `get-summary-data` returned `action-required` / `reason: desktop-blocked` (**not** `retryable`) carrying the dismiss/`list-instances` guidance and the surfaced dialog title; after dismissal, `list-instances` + a re-read recovered cleanly. Happy path (real rows) and the `worksheet-not-found` error path were also confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

