### PR TITLE
feat(desktop): add export-storyboard-image tool

### DIFF
--- a/src/desktop/externalApi/executor.mock.ts
+++ b/src/desktop/externalApi/executor.mock.ts
@@ -44,6 +44,7 @@ export function makeExecutorMock(
     getWorksheetUnderlyingData: vi.fn(),
     exportWorksheetImage: vi.fn(),
     exportDashboardImage: vi.fn(),
+    exportStoryboardImage: vi.fn(),
     validateWorkbookDocument: vi.fn(),
     applyWorkbookDocument: vi.fn(),
     applyWorksheetDocument: vi.fn(),

--- a/src/desktop/externalApi/externalApiToolExecutor.ts
+++ b/src/desktop/externalApi/externalApiToolExecutor.ts
@@ -53,6 +53,7 @@ import {
   SiteWorkbookList,
   siteWorkbookListSchema,
   storyboardDocumentRoute,
+  storyboardImageRoute,
   StoryboardItem,
   storyboardItemSchema,
   StoryboardList,
@@ -451,6 +452,16 @@ export class ExternalApiToolExecutor {
   ): Promise<Result<ImageResult, ExecuteCommandError>> {
     return this.readExternalApi((http) =>
       http.getJson(dashboardImageRoute(dashboardId, query), imageResultSchema, signal),
+    );
+  }
+
+  async exportStoryboardImage(
+    storyboardId: string,
+    query: ImageExportQuery,
+    signal: AbortSignal,
+  ): Promise<Result<ImageResult, ExecuteCommandError>> {
+    return this.readExternalApi((http) =>
+      http.getJson(storyboardImageRoute(storyboardId, query), imageResultSchema, signal),
     );
   }
 

--- a/src/desktop/externalApi/mockExternalApiServer.ts
+++ b/src/desktop/externalApi/mockExternalApiServer.ts
@@ -611,6 +611,17 @@ export async function startMockExternalApiServer(
       return;
     }
 
+    const storyboardImageMatch = path.match(/^\/v0\/workbook\/storyboards\/([^/]+)\/image$/);
+    if (method === 'GET' && storyboardImageMatch) {
+      const storyboardId = decodeURIComponent(storyboardImageMatch[1]);
+      if (!DEFAULT_STORYBOARDS.some((storyboard) => storyboard.id === storyboardId)) {
+        sendProblem(res, 404, 'sheet-not-found', `Storyboard not found: ${storyboardId}`);
+        return;
+      }
+      sendImageExport(res, searchParams, 1600, 900);
+      return;
+    }
+
     if (method === 'GET' && path === EXTERNAL_API_ROUTES.site) {
       sendJson(res, 200, {
         siteId: 'site-sales',

--- a/src/desktop/externalApi/types.ts
+++ b/src/desktop/externalApi/types.ts
@@ -39,6 +39,7 @@ export const EXTERNAL_API_ROUTES = {
   dashboardResumeAutoUpdates: '/v0/workbook/dashboards/{id}:resumeAutoUpdates',
   storyboardById: '/v0/workbook/storyboards/{id}',
   storyboardDocument: '/v0/workbook/storyboards/{id}/document',
+  storyboardImage: '/v0/workbook/storyboards/{id}/image',
   storyboardDelete: '/v0/workbook/storyboards/{id}:delete',
   storyboardRename: '/v0/workbook/storyboards/{id}:rename',
   worksheetById: '/v0/workbook/worksheets/{id}',
@@ -114,7 +115,7 @@ export type SaveWorkbookRequest = {
   filePath?: string;
 };
 
-/** Query accepted by {@link worksheetImageRoute} and {@link dashboardImageRoute}. */
+/** Query accepted by {@link worksheetImageRoute}, {@link dashboardImageRoute}, and {@link storyboardImageRoute}. */
 export type ImageExportQuery = {
   /**
    * Absolute path the Desktop host should persist the image to. When set, the response
@@ -275,6 +276,10 @@ export function worksheetImageRoute(worksheetId: string, query: ImageExportQuery
 
 export function dashboardImageRoute(dashboardId: string, query: ImageExportQuery): string {
   return `${dashboardRoute(dashboardId)}/image${imageQuerySuffix(query)}`;
+}
+
+export function storyboardImageRoute(storyboardId: string, query: ImageExportQuery): string {
+  return `${storyboardRoute(storyboardId)}/image${imageQuerySuffix(query)}`;
 }
 
 /**

--- a/src/server.desktop.test.ts
+++ b/src/server.desktop.test.ts
@@ -210,8 +210,13 @@ async function serializeDesktopToolSurface(tool: DesktopTool<any>): Promise<stri
 // descriptions carrying the new-window/session-binding and blocking-Save-As caveats the 0.2.6
 // descriptions spell out. All five join the dynamic-authoring profile: served moves
 // 31_485 -> 34_581 (still well under the 46k cliff), full moves 51_101 -> 54_197.
+// Re-pinned 2026-08-14: added export-storyboard-image over the External Client API storyboard
+// image route, mirroring export-worksheet-image and export-dashboard-image. Like those two it
+// stays out of DYNAMIC_AUTHORING_TOOL_PROFILE, so that ratchet is unchanged; full moves
+// 54_197 -> 55_076. Its description states the deliberate V0 scope — only the active story point
+// renders; other points are not included and cannot be selected.
 const DYNAMIC_AUTHORING_SURFACE_BUDGET = 34_581;
-const FULL_TOOL_SURFACE_BUDGET = 54_197;
+const FULL_TOOL_SURFACE_BUDGET = 55_076;
 
 describe('desktop tools/list serialized surface', () => {
   it('keeps the served dynamic authoring profile under the tool-search auto-deferral threshold budget', async () => {

--- a/src/tools/desktop/api/exportSheetImage.test.ts
+++ b/src/tools/desktop/api/exportSheetImage.test.ts
@@ -15,6 +15,7 @@ import { Provider } from '../../../utils/provider.js';
 import { DesktopTool } from '../tool.js';
 import { getMockRequestHandlerExtra } from '../toolContext.mock.js';
 import { exportDashboardImageTool } from './exportDashboardImage.js';
+import { exportStoryboardImageTool } from './exportStoryboardImage.js';
 import { exportWorksheetImageTool } from './exportWorksheetImage.js';
 
 vi.mock('../../../desktop/session/sessionResolution.js');
@@ -78,6 +79,23 @@ describe('export-image tools', () => {
       expect(harness.server.requests.map((request) => request.path)).toEqual([
         '/v0/workbook/dashboards',
         '/v0/workbook/dashboards/dash-exec/image',
+      ]);
+    } finally {
+      await harness.close();
+    }
+  });
+
+  it('returns a storyboard image inline as a base64 PNG block after resolving by name', async () => {
+    const harness = await startHarness(exportStoryboardImageTool);
+    try {
+      const result = await harness.callTool({ storyboardName: 'QBR Story' });
+
+      expect(result.isError).toBe(false);
+      invariant(result.content[0].type === 'image');
+      expect(result.content[0].mimeType).toBe('image/png');
+      expect(harness.server.requests.map((request) => request.path)).toEqual([
+        '/v0/workbook/storyboards',
+        '/v0/workbook/storyboards/story-qbr/image',
       ]);
     } finally {
       await harness.close();
@@ -414,6 +432,13 @@ describe('export-image tools', () => {
       value: 'dash-exec',
       imagePath: '/v0/workbook/dashboards/dash-exec/image',
     },
+    {
+      makeTool: exportStoryboardImageTool,
+      nameKey: 'storyboardName',
+      aliasKey: 'storyboard',
+      value: 'story-qbr',
+      imagePath: '/v0/workbook/storyboards/story-qbr/image',
+    },
   ])(
     'accepts the deprecated $aliasKey alias key and rejects missing or conflicting keys',
     async ({ makeTool, nameKey, aliasKey, value, imagePath }) => {
@@ -471,6 +496,12 @@ describe('export-image tools', () => {
       overrideKey: 'GET /v0/workbook/dashboards/dash-exec/image',
       expectedMessage: 'does not serve the dashboard image endpoint',
     },
+    {
+      makeTool: exportStoryboardImageTool,
+      args: { storyboardName: 'story-qbr' },
+      overrideKey: 'GET /v0/workbook/storyboards/story-qbr/image',
+      expectedMessage: 'does not serve the storyboard image endpoint',
+    },
   ])(
     'reports an honest too-new endpoint 404 for $expectedMessage',
     async ({ makeTool, args, overrideKey, expectedMessage }) => {
@@ -517,6 +548,12 @@ describe('export-image tools', () => {
       makeTool: exportDashboardImageTool,
       args: { dashboardName: 'dash-exec', filePath: 'relative/dash.png' },
       imagePath: '/v0/workbook/dashboards/dash-exec/image',
+    },
+    {
+      label: 'a relative storyboard filePath',
+      makeTool: exportStoryboardImageTool,
+      args: { storyboardName: 'story-qbr', filePath: 'relative/story.png' },
+      imagePath: '/v0/workbook/storyboards/story-qbr/image',
     },
   ])(
     'forwards the raw path and surfaces the Desktop 400 for $label (no client-side refine)',

--- a/src/tools/desktop/api/exportStoryboardImage.ts
+++ b/src/tools/desktop/api/exportStoryboardImage.ts
@@ -1,0 +1,110 @@
+import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { z } from 'zod';
+
+import { resolveItemByNameOrId } from '../../../desktop/externalApi/toolUtils.js';
+import { ImageResult } from '../../../desktop/externalApi/types.js';
+import { runExternalApiReadTool } from '../../../desktop/wrappers/readHarness.js';
+import { DesktopMcpServer } from '../../../server.desktop.js';
+import {
+  artifactNameParam,
+  deprecatedArtifactAliasParam,
+  resolveArtifactNameArg,
+} from '../params.js';
+import { DesktopTool } from '../tool.js';
+import {
+  buildSheetImageToolResult,
+  exportSheetImageWithDeadline,
+  resolveImageExportQuery,
+} from './exportSheetImageResult.js';
+
+const paramsSchema = {
+  session: z.string().optional().describe('Session ID; optional if pinned or unique.'),
+  storyboardName: artifactNameParam('storyboard').optional(),
+  storyboard: deprecatedArtifactAliasParam('storyboard'),
+  filePath: z
+    .string()
+    .optional()
+    .describe('Absolute path to save the image to. Omit to get the image inline.'),
+  mimeType: z
+    .enum(['image/png', 'image/svg+xml'])
+    .optional()
+    .describe('Image MIME type to render. Defaults to image/png.'),
+};
+const title = 'Export Storyboard Image';
+
+export const exportStoryboardImageTool = (
+  server: DesktopMcpServer,
+): DesktopTool<typeof paramsSchema> => {
+  const exportStoryboardImage = new DesktopTool({
+    server,
+    name: 'export-storyboard-image',
+    title,
+    description: "Render one storyboard's active story point as an image.",
+    paramsSchema,
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: true, // a caller-supplied filePath can overwrite an existing file at that path
+      idempotentHint: false,
+      openWorldHint: false,
+    },
+    callback: async (
+      { session, storyboardName, storyboard, filePath, mimeType },
+      extra,
+    ): Promise<CallToolResult> => {
+      const { query } = resolveImageExportQuery({ filePath, mimeType });
+      return await exportStoryboardImage.logAndExecute<ImageResult>({
+        extra,
+        args: { session, storyboardName, storyboard, filePath, mimeType },
+        callback: async () => {
+          const nameResult = resolveArtifactNameArg('storyboard', storyboardName, storyboard);
+          if (nameResult.isErr()) {
+            return nameResult;
+          }
+          const resolvedStoryboardName = nameResult.value;
+          return await runExternalApiReadTool<ImageResult>({
+            session,
+            extra,
+            callback: async (_executor, _signal, read) => {
+              const listResult = await read(
+                'storyboard list',
+                async (executor, signal) => await executor.listStoryboards(signal),
+              );
+              if (listResult.isErr()) {
+                return listResult;
+              }
+
+              const storyboardResult = resolveItemByNameOrId(
+                'Storyboard',
+                resolvedStoryboardName,
+                listResult.value.storyboards ?? [],
+              );
+              if (storyboardResult.isErr()) {
+                return storyboardResult.error.toErr();
+              }
+
+              return await exportSheetImageWithDeadline({
+                label: 'Storyboard',
+                endpoint: 'storyboard image',
+                timeoutMs: extra.config.imageExportTimeoutMs,
+                signal: _signal,
+                read,
+                doExport: (executor, combined) =>
+                  executor.exportStoryboardImage(storyboardResult.value.id, query, combined),
+              });
+            },
+          });
+        },
+        getSuccessResult: (image) =>
+          buildSheetImageToolResult({
+            tool: 'export-storyboard-image',
+            label: 'Storyboard',
+            cachePrefix: 'storyboard-image',
+            image,
+            config: extra.config,
+          }),
+      });
+    },
+  });
+
+  return exportStoryboardImage;
+};

--- a/src/tools/desktop/api/exportStoryboardImage.ts
+++ b/src/tools/desktop/api/exportStoryboardImage.ts
@@ -39,7 +39,8 @@ export const exportStoryboardImageTool = (
     server,
     name: 'export-storyboard-image',
     title,
-    description: "Render one storyboard's active story point as an image.",
+    description:
+      "Render a storyboard's active story point as an image. Only the active point is rendered; other story points are not included and cannot be selected.",
     paramsSchema,
     annotations: {
       readOnlyHint: false,

--- a/src/tools/desktop/emittedToolReferences.test.ts
+++ b/src/tools/desktop/emittedToolReferences.test.ts
@@ -166,6 +166,7 @@ const NON_TOOL_VOCABULARY = [
   'sizing-mode',
   'slot-to-field',
   'source-field',
+  'storyboard-image',
   'style-rule',
   'success-already-present',
   'summary-data',

--- a/src/tools/desktop/toolName.ts
+++ b/src/tools/desktop/toolName.ts
@@ -60,6 +60,7 @@ export const desktopToolNames = [
   'get-worksheet-underlying-data',
   'export-worksheet-image',
   'export-dashboard-image',
+  'export-storyboard-image',
   'get-workbook-inventory',
   'list-workbook-datasources',
   'list-site-datasources',

--- a/src/tools/desktop/tools.ts
+++ b/src/tools/desktop/tools.ts
@@ -9,6 +9,7 @@ import { getApplyWorksheetTool } from './api/applyWorksheet.js';
 import { getDeleteSheetTool } from './api/deleteSheet.js';
 import { getExecuteTableauCommandTool } from './api/executeTableauCommand.js';
 import { exportDashboardImageTool } from './api/exportDashboardImage.js';
+import { exportStoryboardImageTool } from './api/exportStoryboardImage.js';
 import { exportWorksheetImageTool } from './api/exportWorksheetImage.js';
 import { getApiRootTool } from './api/getApiRoot.js';
 import { getAppInfoTool } from './api/getAppInfo.js';
@@ -143,6 +144,7 @@ export const desktopToolFactories = [
   getWorksheetUnderlyingDataTool,
   exportWorksheetImageTool,
   exportDashboardImageTool,
+  exportStoryboardImageTool,
   getWorkbookInventoryTool,
   getListWorkbookDatasourcesTool,
   getListSiteDatasourcesTool,


### PR DESCRIPTION
## Summary

Adds `export-storyboard-image`, a desktop MCP tool that renders a storyboard as an image. It mirrors the existing `export-worksheet-image` and `export-dashboard-image` tools exactly: same route shape (`GET /v0/workbook/storyboards/{id}/image`), same optional `filePath`/`mimeType` query params, same response schema, and the same inline-vs-file-cache result handling. The storyboard endpoint has no story-point selector — it always renders the storyboard's currently active story point.

## Changes

- `src/desktop/externalApi/types.ts` — new `storyboardImage` route and `storyboardImageRoute()` helper
- `src/desktop/externalApi/externalApiToolExecutor.ts` — new `exportStoryboardImage()` method
- `src/desktop/externalApi/mockExternalApiServer.ts` / `executor.mock.ts` — mock support for tests
- `src/tools/desktop/api/exportStoryboardImage.ts` — new tool, structured like `exportDashboardImage.ts`
- `src/tools/desktop/toolName.ts` / `tools.ts` — tool registration
- `src/tools/desktop/api/exportSheetImage.test.ts` — storyboard coverage added to the shared test suite

`externalApiContract.test.ts` is intentionally left untouched — its captured fixture predates this endpoint.

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npx vitest run src/tools/desktop/api/exportSheetImage.test.ts src/desktop/externalApi/externalApiContract.test.ts` (116/116 passing)