### PR TITLE
fix(desktop): rank calculated measures correctly in bottom-N filters

### DIFF
--- a/src/desktop/refine/refineWorksheet.test.ts
+++ b/src/desktop/refine/refineWorksheet.test.ts
@@ -98,12 +98,29 @@ describe('planTopN — happy path', () => {
     expect(filterIdx).toBeGreaterThan(r.xml.indexOf('</datasource-dependencies>'));
   });
 
-  it('emits end=bottom direction=ASC for a bottom-N ask', () => {
+  it('keeps the ordered-list head with direction=ASC for a bottom-N ask', () => {
     const r = planTopN(BASE, { n: 3, end: 'bottom' });
     expect(r.ok).toBe(true);
     if (!r.ok) return;
-    expect(r.xml).toMatch(/function='end'\s+end='bottom'\s+count='3'/);
+    expect(r.xml).toMatch(/function='end'\s+end='top'\s+count='3'/);
     expect(r.xml).toContain("function='order' direction='ASC'");
+  });
+
+  it('ranks a regular calculated measure used on the worksheet', () => {
+    const xml = withDeps(
+      REGION_COL +
+        "<column caption='Attrition Value' datatype='real' name='[Calculation_1]' role='measure' type='quantitative'>" +
+        "<calculation class='tableau' formula='FLOAT([Attrition Text])' />" +
+        '</column>' +
+        REGION_CI +
+        "<column-instance column='[Calculation_1]' derivation='Sum' name='[sum:Calculation_1:qk]' pivot='key' type='quantitative' />",
+    );
+
+    const r = planTopN(xml, { n: 10, end: 'bottom' });
+
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.xml).toContain("direction='ASC' expression='SUM([Calculation_1])'");
   });
 
   it('emits the minimum count of 1', () => {

--- a/src/desktop/refine/refineWorksheet.ts
+++ b/src/desktop/refine/refineWorksheet.ts
@@ -19,7 +19,7 @@
  *     node at :24). Any richer shape keeps the no-sort refusal.
  *
  * Refusal, not repair: anything outside this tiny envelope (ambiguous dims/measures, n
- * outside 1..50, sets/params/rollups/calcs, an existing Top-N, a nested/multiple
+ * outside 1..50, sets/params/rollups/user-derived column instances, an existing Top-N, a nested/multiple
  * computed-sort, or an absent computed-sort on a shape richer than a simple bar) returns
  * `{ ok: false, reason }` so the caller can hand back to the standard authoring path
  * instead of entering whole-workbook XML surgery.
@@ -242,7 +242,7 @@ function resolveCiByCaption(
  * ("calc"|"set"|"param") or null. Order matters only for the message; all three refuse.
  */
 function unsupportedConstruct(xml: string, cis: ColumnInstance[]): 'calc' | 'set' | 'param' | null {
-  if (cis.some((c) => c.derivation === 'User') || /<calculation\b/.test(xml)) return 'calc';
+  if (cis.some((c) => c.derivation === 'User')) return 'calc';
   // `<group ` / `<group>` is a set/group; `<groupfilter` (no boundary) is NOT matched.
   if (/<group(\s|>)/.test(xml)) return 'set';
   if (/\[Parameters\]/.test(xml) || /\bparam-domain-type=/.test(xml)) return 'param';
@@ -372,7 +372,8 @@ export function planTopN(
   const filterXml = buildTopNFilter({
     filterColumn: escapeXml(filterColumn),
     count: n,
-    end,
+    // Desktop keeps the ordered-list head; ASC vs DESC selects bottom vs top members.
+    end: 'top',
     direction,
     expression: escapeXml(expression),
     level: escapeXml(dim.name),


### PR DESCRIPTION
## Decision

Worksheet Bottom-N filters now keep the first members of an ascending ranking, which is the XML shape Desktop applies correctly. Standard aggregated calculated measures can be ranking fields; user-derived column instances, sets, parameters, and ambiguous sheets still stop before apply.

## Scope

This changes the shared `planTopN` path used by worksheet refinement and template binding. It does not change set/group serialization or add a general categorical-filter operation.

Future changes must preserve the nested `end -> order -> level-members` filter, its matching slice, and row-level verification. An XML apply receipt alone is not enough: the returned members must match the requested ranking.

## Evidence

- Before the fix, Desktop accepted `end='bottom'` with ascending order but returned ten zero-value accounts. Recovery took 27 calls and 208 seconds.
- With `end='top'` and ascending order, the live Book2 probe returned the independently calculated ten most-negative accounts.
- The patched flow used one `refine-worksheet` call for the filter and verified all ten rows with `get-summary-data`.
- TDD regressions cover Bottom-N ordering and a normal calculated ranking measure.
- `scripts/agent-check`: lint, typecheck, 375 test files / 5,768 tests, desktop build, and lockstep all green.
- Grok 4.5 review: clean.

Approving this PR means accepting Desktop's observed worksheet Bottom-N serialization and allowing ordinary calculated measures through the existing safe refinement path.

Posted by MattGPT.
