### PR TITLE
@W-23865341 - consolidate the FFs for staging files in S3

### DIFF
--- a/docs/docs/configuration/mcp-config/env-vars.md
+++ b/docs/docs/configuration/mcp-config/env-vars.md
@@ -698,7 +698,7 @@ instead of inlining it:
 - `get-view-image` / `get-custom-view-image` — rendered image (otherwise inline base64)
 - `get-view-data` / `get-custom-view-data` — CSV data (otherwise inline text)
 - `download-workbook` — workbook file (otherwise a local temp-file path)
-- `request-workbook-upload` / `validate-upload-and-publish-workbook`- stage workbook in S3 before publishing,(otherwise a local file path)
+- `request-workbook-upload` / `validate-upload-and-publish-workbook`— stage workbook in S3 before publishing (otherwise a local file path)
 
 The client fetches the files directly from S3, so the payload never streams back through the MCP
 server on read.

--- a/docs/docs/configuration/mcp-config/env-vars.md
+++ b/docs/docs/configuration/mcp-config/env-vars.md
@@ -1,6 +1,6 @@
 ---
-sidebar_position: 1
----
+
+## sidebar_position: 1
 
 # Environment Variables
 
@@ -11,9 +11,9 @@ Values for the following environment variables can be provided to configure the 
 The URL of the Tableau server.
 
 - For Tableau Cloud, specify your site's specific pod e.g.
-  `https://prod-useast-c.online.tableau.com`
+`https://prod-useast-c.online.tableau.com`
 
-<hr />
+---
 
 ## `SITE_NAME`
 
@@ -22,9 +22,11 @@ Content URL `Internal` vs display name `[INTERNAL] My Company`).
 
 - For Tableau Cloud, specify your site's Content URL.
 - For Tableau Server, you may leave this value blank to use the default site.
-- Required unless [`AUTH`](#auth) is `oauth`.
+- Required unless `[AUTH](#auth)` is `oauth`.
 
-<hr />
+---
+
+
 
 ## `TRANSPORT`
 
@@ -33,9 +35,11 @@ The MCP transport type to use for the server.
 - Default: `stdio`
 - Possible values: `stdio` or `http`
 - For `http`, see [HTTP Server Configuration](http-server.md) for additional variables.
-- See [MCP Transports][mcp-transport] for details.
+- See [MCP Transports](https://modelcontextprotocol.io/docs/concepts/transports) for details.
 
-<hr />
+---
+
+
 
 ## `AUTH`
 
@@ -44,9 +48,11 @@ The method the MCP server uses to authenticate to the Tableau REST APIs.
 - Default: `pat`
 - Possible values: `pat`, `direct-trust`, or `oauth`
 - See [Authentication](authentication) for additional required variables depending on the desired
-  method.
+method.
 
-<hr />
+---
+
+
 
 ## `ENABLED_LOGGERS`
 
@@ -55,39 +61,42 @@ A comma-separated list of loggers to enable.
 - Default: `appLogger`
 - Possible values (may be combined): `fileLogger`, `appLogger`
   - `fileLogger` — writes log entries and MCP notifications normally only sent to clients to hourly
-    rotating files in the directory specified by[`FILE_LOGGER_DIRECTORY`](#file_logger_directory).
-    Notifications include tool calls and their arguments as well as HTTP traces for the requests and
-    responses to the Tableau REST APIs.
+  rotating files in the directory specified by`[FILE_LOGGER_DIRECTORY](#file_logger_directory)`.
+  Notifications include tool calls and their arguments as well as HTTP traces for the requests and
+  responses to the Tableau REST APIs.
   - `appLogger` — writes log entries to stdout as JSON. Enabled by default when transport is `http`.
 - The log file names are in the format `YYYY-MM-DDTHH-00-00-000Z.log` e.g.
-  `2025-10-15T22-00-00-000Z.log` meaning this log file contains all log messages for hour 22 of
-  2025-10-15 in UTC time. All log entries for a given hour of the day are appended to the same file.
+`2025-10-15T22-00-00-000Z.log` meaning this log file contains all log messages for hour 22 of
+2025-10-15 in UTC time. All log entries for a given hour of the day are appended to the same file.
 - Each line in the log file is a JSON object with a timestamp and additional properties:
   - `timestamp`: The timestamp of the log message in UTC time.
   - `level`: The logging level of the log message.
   - `logger`: The logger of the log message. This is typically `rest-api` for HTTP traces or
-    `tableau-mcp` for tool calls.
+  `tableau-mcp` for tool calls.
   - `message`: The log message itself. This may be a string or a JSON object.
-
 - All notifications are written to the local log files regardless of the notification level, since
-  [`DEFAULT_NOTIFICATION_LEVEL`](#default_notification_level) only applies to notifications sent to
-  MCP clients. Server log output (stderr/console) is controlled separately by
-  [`LOG_LEVEL`](#log_level).
+`[DEFAULT_NOTIFICATION_LEVEL](#default_notification_level)` only applies to notifications sent to
+MCP clients. Server log output (stderr/console) is controlled separately by
+`[LOG_LEVEL](#log_level)`.
 - Secrets are masked by default in the log files. To reveal them for debugging purposes, set the
-  [`DISABLE_LOG_MASKING`](#disable_log_masking) environment variable to `true`.
+`[DISABLE_LOG_MASKING](#disable_log_masking)` environment variable to `true`.
 
-<hr />
+---
+
+
 
 ## `FILE_LOGGER_DIRECTORY`
 
-The directory server logs are written to when [`ENABLED_LOGGERS`](#enabled_loggers) includes
+The directory server logs are written to when `[ENABLED_LOGGERS](#enabled_loggers)` includes
 `fileLogger`.
 
 - Default: `[build directory]/logs` i.e. `build/logs`.
 - The server will attempt to create the directory if it does not exist.
 - There is no cleanup of old log files. The server will continue to create log files indefinitely.
 
-<hr />
+---
+
+
 
 ## `DEFAULT_NOTIFICATION_LEVEL`
 
@@ -112,7 +121,9 @@ any time they want.
 
 Note: this variable was named DEFAULT_LOG_LEVEL until version 2.0.0
 
-<hr />
+---
+
+
 
 ## `LOG_LEVEL`
 
@@ -131,10 +142,12 @@ transport, and file logger).
   - `emergency`
 
 Log entries with a level below the configured value are silently dropped. This is independent of
-[`DEFAULT_NOTIFICATION_LEVEL`](#default_notification_level), which controls MCP client
+`[DEFAULT_NOTIFICATION_LEVEL](#default_notification_level)`, which controls MCP client
 notifications.
 
-<hr />
+---
+
+
 
 ## `DISABLE_LOG_MASKING`
 
@@ -142,7 +155,9 @@ Disable masking of credentials in MCP client notifications and server logs. For 
 
 - Default: `false`
 
-<hr />
+---
+
+
 
 ## `NOTIFICATION_PAYLOAD_MAX_BYTES`
 
@@ -155,7 +170,9 @@ are redacted or truncated.
 Binary payloads, large SVG/XML payloads, and large base64 image payloads are redacted. Other strings
 larger than this value are truncated.
 
-<hr />
+---
+
+
 
 ## `DATASOURCE_CREDENTIALS`
 
@@ -185,29 +202,35 @@ API][tab-ds-connections].
 Future work will include a tool to automate this process. For more information, see [Connect to your
 data source][tab-connect-ds].
 
-<hr />
+---
+
+
 
 ## `INCLUDE_TOOLS`
 
 A comma-separated list of tool or tool group names to include in the server. Only these tools will
 be available. This variable is site overridable, see [Site Settings](site-settings.md).
 
-- Default: Empty string (_all_ are included)
+- Default: Empty string (*all* are included)
 - For a list of available tools and groups, see
-  [toolName.ts](https://github.com/tableau/tableau-mcp/blob/main/src/tools/web/toolName.ts).
+[toolName.ts](https://github.com/tableau/tableau-mcp/blob/main/src/tools/web/toolName.ts).
 - Mixing tool names and group names is allowed.
 
-<hr />
+---
+
+
 
 ## `EXCLUDE_TOOLS`
 
 A comma-separated list of tool or tool group names to exclude from the server. All other tools will
 be available. This variable is site overridable, see [Site Settings](site-settings.md).
 
-- Default: Empty string (_none_ are excluded)
+- Default: Empty string (*none* are excluded)
 - Cannot be provided with `INCLUDE_TOOLS`.
 
-<hr />
+---
+
+
 
 ## `MAX_REQUEST_TIMEOUT_MS`
 
@@ -216,26 +239,30 @@ The maximum timeout for requests to the Tableau Server REST API.
 - Default: `600000` (10 minutes)
 - Must be a positive number between `5000` (5 seconds) and `3600000` (1 hour).
 
-<hr />
+---
+
+
 
 ## `MAX_RESULT_LIMIT`
 
 The maximum number of results that every tool with a `limit` parameter can return when no
-tool-specific max result limit is set in the [`MAX_RESULT_LIMITS`](#max_result_limits) variable.
+tool-specific max result limit is set in the `[MAX_RESULT_LIMITS](#max_result_limits)` variable.
 This variable is site and request overridable, see [Site Settings](site-settings.md) and
 [Request Overrides](request-overrides.md).
 
 :::warning
 
 Take care when setting this value and be sure to set appropriate tool-specific limits using the
-[`MAX_RESULT_LIMITS`](#max_result_limits) variable.
+`[MAX_RESULT_LIMITS](#max_result_limits)` variable.
 
 :::
 
-- Default: Empty string (_no limit_)
+- Default: Empty string (*no limit*)
 - Must be a positive number.
 
-<hr />
+---
+
+
 
 ## `MAX_RESULT_LIMITS`
 
@@ -260,32 +287,35 @@ This means that:
 
 :::
 
-- Default: Empty string (_no limits_)
+- Default: Empty string (*no limits*)
 - For a list of available tools and groups, see
-  [toolName.ts](https://github.com/tableau/tableau-mcp/blob/main/src/tools/web/toolName.ts).
+[toolName.ts](https://github.com/tableau/tableau-mcp/blob/main/src/tools/web/toolName.ts).
 - Only applies to tools that have a `limit` parameter and return an array of items.
 - Tool names take precedence over tool group names. That is, `datasource:1000,list-datasources:20`
-  means that the `list-datasources` tool can return up to 20 data sources but the `query-datasource`
-  tool can only return up to 1000 results.
+means that the `list-datasources` tool can return up to 20 data sources but the `query-datasource`
+tool can only return up to 1000 results.
 - If a tool is not included in the comma-separated list, the global limit specified by the
-  [`MAX_RESULT_LIMIT`](#max_result_limit) variable will be used instead.
+`[MAX_RESULT_LIMIT](#max_result_limit)` variable will be used instead.
 - Each limit must be a positive number, or `*` to indicate unbounded results.
 
+---
 
-<hr />
+
 
 ## `DISABLE_QUERY_DATASOURCE_VALIDATION_REQUESTS`
 
 Disables requests that are made to the VizQl Data Service for validating queries in the
-[`query-datasource`](../../tools/data-qna/query-datasource.md) tool. Does not disable the ability to
+`[query-datasource](../../tools/data-qna/query-datasource.md)` tool. Does not disable the ability to
 query the datasource. This variable is site and request overridable, see
 [Site Settings](site-settings.md) and [Request Overrides](request-overrides.md).
 
 - Default: `false`
 - When `true`, skips validation of queries against metadata results and validation of SET and MATCH
-  filters.
+filters.
 
-<hr />
+---
+
+
 
 ## `DISABLE_QUERY_DATASOURCE_FILTER_VALIDATION`
 
@@ -293,28 +323,32 @@ Note: This environment variable was deprecated in Tableau MCP `v1.13.0` and repl
 `DISABLE_QUERY_DATASOURCE_VALIDATION_REQUESTS`.
 
 Disable validation of SET and MATCH filter values in the
-[`query-datasource`](../../tools/data-qna/query-datasource.md) tool.
+`[query-datasource](../../tools/data-qna/query-datasource.md)` tool.
 
 - Default: `false`
 - When `true`, skips the validation that checks if filter values exist in the target field.
 
-<hr />
+---
+
+
 
 ## `DISABLE_METADATA_API_REQUESTS`
 
 Disables `graphql` requests to the Tableau Metadata API in the
-[`get-datasource-metadata`](../../tools/data-qna/get-datasource-metadata.md) tool. This variable is
+`[get-datasource-metadata](../../tools/data-qna/get-datasource-metadata.md)` tool. This variable is
 site and request overridable, see [Site Settings](site-settings.md) and
 [Request Overrides](request-overrides.md).
 
 - Default: `false`
 - When `true`, skips requests to the `graphql` endpoint that provides additional context to field
-  metadata.
+metadata.
 - Set this to `true` if you are using the
-  [`get-datasource-metadata`](../../tools/data-qna/get-datasource-metadata.md) tool and the Tableau
-  Metadata API is not enabled on your Tableau Server.
+`[get-datasource-metadata](../../tools/data-qna/get-datasource-metadata.md)` tool and the Tableau
+Metadata API is not enabled on your Tableau Server.
 
-<hr />
+---
+
+
 
 ## `DISABLE_SESSION_MANAGEMENT`
 
@@ -327,11 +361,13 @@ information about the client's identity, capabilities, and protocol version comp
 - Default: `false`
 - Does not apply to the stdio transport.
 - When `true`, the MCP server will no longer assign a session ID at initialization time nor require
-  clients to provide that session ID in the `mcp-session-id` header for subsequent requests.
+clients to provide that session ID in the `mcp-session-id` header for subsequent requests.
 - Set this to `true` if you are using the HTTP transport and your client does not support or need
-  session management.
+session management.
 
-<hr />
+---
+
+
 
 ## `TABLEAU_SERVER_VERSION_CHECK_INTERVAL_IN_HOURS`
 
@@ -343,7 +379,9 @@ variable.
 - Default: `1` hour
 - Must be a positive number between `1` and `168` (7 days).
 
-<hr />
+---
+
+
 
 ## `TELEMETRY_PROVIDER`
 
@@ -353,18 +391,20 @@ The telemetry provider to use for metrics collection.
 - Possible values:
   - `noop` - No telemetry (default)
   - `custom` - Use a custom telemetry provider (requires
-    [`TELEMETRY_PROVIDER_CONFIG`](#telemetry_provider_config))
+  `[TELEMETRY_PROVIDER_CONFIG](#telemetry_provider_config)`)
 
-<hr />
+---
+
+
 
 ## `TELEMETRY_PROVIDER_CONFIG`
 
 Configuration for the custom telemetry provider. Required when
-[`TELEMETRY_PROVIDER`](#telemetry_provider) is `custom`.
+`[TELEMETRY_PROVIDER](#telemetry_provider)` is `custom`.
 
 - Format: JSON string with at least a `module` field
 - The `module` field should be a path to a JavaScript file or npm package that exports a class
-  implementing the `TelemetryProvider` interface.
+implementing the `TelemetryProvider` interface.
 
 **Example:**
 
@@ -373,9 +413,11 @@ TELEMETRY_PROVIDER_CONFIG='{"module": "./my-telemetry-provider.js"}'
 ```
 
 The custom provider module should export a default class (or named export `TelemetryProvider`) that
-implements the [`TelemetryProvider`](https://github.com/tableau/tableau-mcp/blob/main/src/telemetry/types.ts) interface.
+implements the `[TelemetryProvider](https://github.com/tableau/tableau-mcp/blob/main/src/telemetry/types.ts)` interface.
 
-<hr />
+---
+
+
 
 ## `FEATURE_GATE_PROVIDER`
 
@@ -399,7 +441,9 @@ The custom provider module should export a default class or named export `Featur
 
 :::
 
-<hr />
+---
+
+
 
 ## `FEATURE_GATE_PROVIDER_CONFIG`
 
@@ -409,16 +453,20 @@ Configuration for custom feature gate providers (JSON string).
 - Format: `{"module": "<path-to-module>", ...additional-config}`
 
 The `module` field can be:
+
 - A relative file path (e.g., `./my-provider.js`) - resolved from process working directory
 - An absolute file path (e.g., `/path/to/provider.js`)
 - An npm package name (e.g., `@company/feature-gate-provider`)
 
 **Example:**
+
 ```bash
 FEATURE_GATE_PROVIDER_CONFIG='{"module":"./providers/cloud-feature-gate.js"}'
 ```
 
-<hr />
+---
+
+
 
 ## `LATENCY_METRIC_NAME`
 
@@ -426,7 +474,7 @@ The name of the histogram metric used to record HTTP request latency for tool ca
 
 - Default: `http_server_1agg1_request_duration`
 - Only recorded for requests that contain a tool call (non-tool requests such as `initialize` are
-  not tracked).
+not tracked).
 
 **Example:**
 
@@ -434,7 +482,9 @@ The name of the histogram metric used to record HTTP request latency for tool ca
 LATENCY_METRIC_NAME=http_server_1agg1_request_duration
 ```
 
-<hr />
+---
+
+
 
 ## `PRODUCT_TELEMETRY_ENABLED`
 
@@ -442,18 +492,14 @@ Enables product telemetry for tool usage tracking.
 
 - Default: `true`
 - When `true`, the server will send telemetry events to Tableau's telemetry endpoint for each tool
-  call, including tool name, request ID, session ID, and site name.
+call, including tool name, request ID, session ID, and site name.
 - Set to `false` to disable product telemetry. Read
-  https://help.tableau.com/current/server/en-us/usage_data_basic_product_data.htm for more
-  information
+[https://help.tableau.com/current/server/en-us/usage_data_basic_product_data.htm](https://help.tableau.com/current/server/en-us/usage_data_basic_product_data.htm) for more
+information
 
-[mcp-transport]: https://modelcontextprotocol.io/docs/concepts/transports
-[tab-ds-connections]:
-  https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref_data_sources.htm#query_data_source_connections
-[tab-connect-ds]:
-  https://help.tableau.com/current/api/vizql-data-service/en-us/docs/vds_create_queries.html#connect-to-your-data-source
+---
 
-<hr />
+
 
 ## `FLOW_TOOLS_ENABLED`
 
@@ -461,14 +507,16 @@ Controls whether the Tableau Prep flow tools are registered.
 
 - Default: `false`
 - Set to `true` to enable the Tableau Prep flow tools:
-  - [`list-flows`](../../tools/flows/list-flows.md)
-  - [`get-flow`](../../tools/flows/get-flow.md)
+  - `[list-flows](../../tools/flows/list-flows.md)`
+  - `[get-flow](../../tools/flows/get-flow.md)`
 - Only the exact value `true` enables them; any other value (or leaving it unset) keeps them
-  disabled.
+disabled.
 - When enabled, individual flow tools can still be excluded via
-  [`EXCLUDE_TOOLS`](#exclude_tools) (e.g. `EXCLUDE_TOOLS=flow`).
+`[EXCLUDE_TOOLS](#exclude_tools)` (e.g. `EXCLUDE_TOOLS=flow`).
 
-<hr />
+---
+
+
 
 ## `ADMIN_TOOLS_ENABLED`
 
@@ -476,20 +524,22 @@ Enables admin-only tools that require site administrator permissions.
 
 - Default: `false`
 - When `true`, enables tools that are restricted to Tableau site administrators:
-  - [`list-extract-refresh-tasks`](../../tools/tasks/list-extract-refresh-tasks.md)
-  - [`update-cloud-extract-refresh-task`](../../tools/tasks/update-cloud-extract-refresh-task.md)
-  - [`list-jobs`](../../tools/jobs/list-jobs.md)
-  - [`list-users`](../../tools/users/list-users.md)
-  - [`delete-content`](../../tools/content/delete-content.md)
-  - [`query-admin-insights`](../../tools/admin-insights/query-admin-insights.md)
+  - `[list-extract-refresh-tasks](../../tools/tasks/list-extract-refresh-tasks.md)`
+  - `[update-cloud-extract-refresh-task](../../tools/tasks/update-cloud-extract-refresh-task.md)`
+  - `[list-jobs](../../tools/jobs/list-jobs.md)`
+  - `[list-users](../../tools/users/list-users.md)`
+  - `[delete-content](../../tools/content/delete-content.md)`
+  - `[query-admin-insights](../../tools/admin-insights/query-admin-insights.md)`
 - These tools require the user to have one of the following site roles:
   - SiteAdministratorCreator
   - SiteAdministratorExplorer
   - ServerAdministrator
 - Admin tools perform runtime role verification and will return a 403 error if the user does not
-  have the required permissions.
+have the required permissions.
 
-<hr />
+---
+
+
 
 ## `ADMIN_GATE_CACHE_TTL_MINUTES`
 
@@ -498,7 +548,6 @@ TTL (in minutes) for caches used by admin-only tools. Affects:
 - Admin role lookups (`assertAdmin`)
 - Admin Insights dataset LUID resolution
 - Project ID → name resolution used by `get-stale-content-report`
-
 - Default: `5`
 - Minimum: `1`
 - Maximum: `1440` (24 hours)
@@ -506,12 +555,14 @@ TTL (in minutes) for caches used by admin-only tools. Affects:
 Tune lower if site role / project metadata changes need to propagate faster. Tune higher under
 memory pressure to reduce REST traffic.
 
-<hr />
+---
+
+
 
 ## `MUTATION_PREVIEW_TTL_MINUTES`
 
 TTL (in minutes) for the single-use confirmation tokens minted by the preview phase of two-phase
-mutation tools (e.g. [`delete-content`](../../tools/content/delete-content.md)).
+mutation tools (e.g. `[delete-content](../../tools/content/delete-content.md)`).
 A token must be supplied on the confirmed call before it expires, otherwise the caller must re-run
 the preview.
 
@@ -522,12 +573,14 @@ the preview.
 Tune lower to shorten the window in which a preview token is valid. Tune higher to give callers more
 time between preview and confirmation.
 
-<hr />
+---
+
+
 
 ## `STALE_CONTENT_MIN_AGE_DAYS`
 
 Default minimum days since last access for content to be considered stale by the
-[`query-admin-insights`](../../tools/admin-insights/query-admin-insights.md) tool's `kind: "stale-content"` backend. Callers
+`[query-admin-insights](../../tools/admin-insights/query-admin-insights.md)` tool's `kind: "stale-content"` backend. Callers
 can pass an explicit `minAgeDays` argument to override per-call.
 
 - Default: `90`
@@ -537,12 +590,14 @@ can pass an explicit `minAgeDays` argument to override per-call.
 Overridable per-site via [Site Settings](site-settings.md) and per-request via
 [Request Overrides](request-overrides.md#stale_content_min_age_days).
 
-<hr />
+---
+
+
 
 ## `STALE_CONTENT_MAX_ROWS`
 
 Maximum number of stale-content rows the
-[`query-admin-insights`](../../tools/admin-insights/query-admin-insights.md) tool's
+`[query-admin-insights](../../tools/admin-insights/query-admin-insights.md)` tool's
 `kind: "stale-content"` backend will return in a single call. This is a server-side safety cap that
 protects the destructive stale-content cleanup flow from acting on an unreviewed mass set.
 
@@ -559,30 +614,36 @@ re-running.
 Overridable per-site via [Site Settings](site-settings.md) and per-request via
 [Request Overrides](request-overrides.md#stale_content_max_rows).
 
-<hr />
+---
+
+
 
 ## `LICENSE_RECLAIM_INACTIVE_DAYS`
 
 Default minimum days of inactivity before a user is considered a license reclamation candidate by
-the [`user-license-reclamation-inform`](../../prompts/user-license-reclamation-inform.md) prompt.
+the `[user-license-reclamation-inform](../../prompts/user-license-reclamation-inform.md)` prompt.
 Callers can pass an explicit `inactiveDays` argument to override per-invocation.
 
 - Default: `90`
 - Minimum: `1`
 - Maximum: `3650` (10 years)
 
-<hr />
+---
+
+
 
 ## `LICENSE_RECLAIM_ROLES`
 
 Comma-separated list of site roles targeted for license reclamation by the
-[`user-license-reclamation-inform`](../../prompts/user-license-reclamation-inform.md) prompt.
+`[user-license-reclamation-inform](../../prompts/user-license-reclamation-inform.md)` prompt.
 Callers can pass an explicit `roles` argument to override per-invocation.
 
 - Default: `Creator,Explorer`
 - Values must be valid Tableau site role names (e.g., `Creator`, `Explorer`, `Viewer`).
 
-<hr />
+---
+
+
 
 ## `BREAK_GLASS_DISABLE_GLOBALLY`
 
@@ -604,14 +665,16 @@ discretion.
 }
 ```
 
-<hr />
+---
+
+
 
 ## `CSP_ALLOWED_DOMAINS`
 
 A comma-separated list of domains to allow in the Content-Security-Policy header for MCP apps (when the `mcp-apps` feature is enabled).
 
 - Default: `https://*.online.tableau.com,https://*.tableau.com`
-- The configured [`SERVER`](#server) origin is automatically appended to this list.
+- The configured `[SERVER](#server)` origin is automatically appended to this list.
 - Use this to quickly add or modify allowed domains without requiring a code change and release.
 
 **Example:**
@@ -622,7 +685,9 @@ CSP_ALLOWED_DOMAINS=https://*.mycompany.tableau.com,https://*.online.tableau.com
 
 This allows embedding Tableau visualizations from custom Tableau Server domains in addition to the default Tableau Cloud domains.
 
-<hr />
+---
+
+
 
 ## `MCP_S3_BUCKET`
 
@@ -633,6 +698,7 @@ instead of inlining it:
 - `get-view-image` / `get-custom-view-image` — rendered image (otherwise inline base64)
 - `get-view-data` / `get-custom-view-data` — CSV data (otherwise inline text)
 - `download-workbook` — workbook file (otherwise a local temp-file path)
+- `request-workbook-upload` / `validate-upload-and-publish-workbook`- stage workbook in S3 before publishing,(otherwise a local file path)
 
 The client fetches the files directly from S3, so the payload never streams back through the MCP
 server on read.
@@ -640,9 +706,9 @@ server on read.
 - Default: unset (tools return the payload inline or as a local temp path, the original behavior).
 - When set, must be a valid S3 bucket name (lowercase letters, numbers, dots, and hyphens only).
 - AWS credentials are resolved via the default AWS SDK credential chain (IAM role / instance
-  profile / standard `AWS_*` environment variables); no credentials are read from the MCP config.
+profile / standard `AWS_*` environment variables); no credentials are read from the MCP config.
 - If an upload fails, the tool falls back to the inline/temp-file result and logs a warning, so
-  retrieval never hard-fails.
+retrieval never hard-fails.
 
 **Example:**
 
@@ -650,15 +716,17 @@ server on read.
 MCP_S3_BUCKET=tableau-images
 ```
 
-<hr />
+---
+
+
 
 ## `AWS_DEFAULT_REGION`
 
 The AWS region of the S3 bucket used for payload offload.
 
 - Default: unset. If not set, the AWS SDK resolves the region from the environment via its standard
-  credential/region chain.
-- Only relevant when [`MCP_S3_BUCKET`](#mcp_s3_bucket) is set.
+credential/region chain.
+- Only relevant when `[MCP_S3_BUCKET](#mcp_s3_bucket)` is set.
 
 **Example:**
 
@@ -666,7 +734,9 @@ The AWS region of the S3 bucket used for payload offload.
 AWS_DEFAULT_REGION=us-east-1
 ```
 
-<hr />
+---
+
+
 
 ## `MCP_IMAGE_PREFIX`
 
@@ -676,13 +746,13 @@ normalized automatically.
 
 - Default: unset (empty). When unset, each tool uses only its own segment.
 - Per-tool segments: `get-view-image` → `view-images/`, `get-custom-view-image` →
-  `custom-view-images/`, `get-view-data` → `view-data/`, `get-custom-view-data` →
-  `custom-view-data/`, `download-workbook` → `workbook-files/`.
+`custom-view-images/`, `get-view-data` → `view-data/`, `get-custom-view-data` →
+`custom-view-data/`, `download-workbook` → `workbook-files/`.
 - Objects are keyed as `<base><tool-segment><resourceId>/<uuid>.<ext>`. For example, with
-  `MCP_IMAGE_PREFIX=tableau/`, a view image is keyed under `tableau/view-images/...` and a
-  workbook under `tableau/workbook-files/...`. Unset, they are keyed under `view-images/...`
-  and `workbook-files/...` respectively.
-- Only relevant when [`MCP_S3_BUCKET`](#mcp_s3_bucket) is set.
+`MCP_IMAGE_PREFIX=tableau/`, a view image is keyed under `tableau/view-images/...` and a
+workbook under `tableau/workbook-files/...`. Unset, they are keyed under `view-images/...`
+and `workbook-files/...` respectively.
+- Only relevant when `[MCP_S3_BUCKET](#mcp_s3_bucket)` is set.
 
 **Example:**
 
@@ -690,7 +760,9 @@ normalized automatically.
 MCP_IMAGE_PREFIX=tableau/
 ```
 
-<hr />
+---
+
+
 
 ## `FILE_TTL`
 
@@ -699,10 +771,11 @@ should be fetched promptly rather than stored.
 
 - Default: `30` (30 seconds).
 - Clamped to the range `5`–`900` (5 seconds–15 minutes).
-- Only relevant when [`MCP_S3_BUCKET`](#mcp_s3_bucket) is set.
+- Only relevant when `[MCP_S3_BUCKET](#mcp_s3_bucket)` is set.
 
 **Example:**
 
 ```bash
 FILE_TTL=30
 ```
+

--- a/docs/docs/configuration/mcp-config/env-vars.md
+++ b/docs/docs/configuration/mcp-config/env-vars.md
@@ -1,6 +1,6 @@
 ---
-
-## sidebar_position: 1
+sidebar_position: 1
+---
 
 # Environment Variables
 
@@ -13,7 +13,7 @@ The URL of the Tableau server.
 - For Tableau Cloud, specify your site's specific pod e.g.
 `https://prod-useast-c.online.tableau.com`
 
----
+<hr />
 
 ## `SITE_NAME`
 
@@ -24,7 +24,7 @@ Content URL `Internal` vs display name `[INTERNAL] My Company`).
 - For Tableau Server, you may leave this value blank to use the default site.
 - Required unless `[AUTH](#auth)` is `oauth`.
 
----
+<hr />
 
 
 
@@ -37,7 +37,7 @@ The MCP transport type to use for the server.
 - For `http`, see [HTTP Server Configuration](http-server.md) for additional variables.
 - See [MCP Transports](https://modelcontextprotocol.io/docs/concepts/transports) for details.
 
----
+<hr />
 
 
 
@@ -50,7 +50,7 @@ The method the MCP server uses to authenticate to the Tableau REST APIs.
 - See [Authentication](authentication) for additional required variables depending on the desired
 method.
 
----
+<hr />
 
 
 
@@ -81,7 +81,7 @@ MCP clients. Server log output (stderr/console) is controlled separately by
 - Secrets are masked by default in the log files. To reveal them for debugging purposes, set the
 `[DISABLE_LOG_MASKING](#disable_log_masking)` environment variable to `true`.
 
----
+<hr />
 
 
 
@@ -94,7 +94,7 @@ The directory server logs are written to when `[ENABLED_LOGGERS](#enabled_logger
 - The server will attempt to create the directory if it does not exist.
 - There is no cleanup of old log files. The server will continue to create log files indefinitely.
 
----
+<hr />
 
 
 
@@ -121,7 +121,7 @@ any time they want.
 
 Note: this variable was named DEFAULT_LOG_LEVEL until version 2.0.0
 
----
+<hr />
 
 
 
@@ -145,7 +145,7 @@ Log entries with a level below the configured value are silently dropped. This i
 `[DEFAULT_NOTIFICATION_LEVEL](#default_notification_level)`, which controls MCP client
 notifications.
 
----
+<hr />
 
 
 
@@ -155,7 +155,7 @@ Disable masking of credentials in MCP client notifications and server logs. For 
 
 - Default: `false`
 
----
+<hr />
 
 
 
@@ -170,7 +170,7 @@ are redacted or truncated.
 Binary payloads, large SVG/XML payloads, and large base64 image payloads are redacted. Other strings
 larger than this value are truncated.
 
----
+<hr />
 
 
 
@@ -202,7 +202,7 @@ API][tab-ds-connections].
 Future work will include a tool to automate this process. For more information, see [Connect to your
 data source][tab-connect-ds].
 
----
+<hr />
 
 
 
@@ -216,7 +216,7 @@ be available. This variable is site overridable, see [Site Settings](site-settin
 [toolName.ts](https://github.com/tableau/tableau-mcp/blob/main/src/tools/web/toolName.ts).
 - Mixing tool names and group names is allowed.
 
----
+<hr />
 
 
 
@@ -228,7 +228,7 @@ be available. This variable is site overridable, see [Site Settings](site-settin
 - Default: Empty string (*none* are excluded)
 - Cannot be provided with `INCLUDE_TOOLS`.
 
----
+<hr />
 
 
 
@@ -239,7 +239,7 @@ The maximum timeout for requests to the Tableau Server REST API.
 - Default: `600000` (10 minutes)
 - Must be a positive number between `5000` (5 seconds) and `3600000` (1 hour).
 
----
+<hr />
 
 
 
@@ -260,7 +260,7 @@ Take care when setting this value and be sure to set appropriate tool-specific l
 - Default: Empty string (*no limit*)
 - Must be a positive number.
 
----
+<hr />
 
 
 
@@ -298,7 +298,7 @@ tool can only return up to 1000 results.
 `[MAX_RESULT_LIMIT](#max_result_limit)` variable will be used instead.
 - Each limit must be a positive number, or `*` to indicate unbounded results.
 
----
+<hr />
 
 
 
@@ -313,7 +313,7 @@ query the datasource. This variable is site and request overridable, see
 - When `true`, skips validation of queries against metadata results and validation of SET and MATCH
 filters.
 
----
+<hr />
 
 
 
@@ -328,7 +328,7 @@ Disable validation of SET and MATCH filter values in the
 - Default: `false`
 - When `true`, skips the validation that checks if filter values exist in the target field.
 
----
+<hr />
 
 
 
@@ -346,7 +346,7 @@ metadata.
 `[get-datasource-metadata](../../tools/data-qna/get-datasource-metadata.md)` tool and the Tableau
 Metadata API is not enabled on your Tableau Server.
 
----
+<hr />
 
 
 
@@ -365,7 +365,7 @@ clients to provide that session ID in the `mcp-session-id` header for subsequent
 - Set this to `true` if you are using the HTTP transport and your client does not support or need
 session management.
 
----
+<hr />
 
 
 
@@ -379,7 +379,7 @@ variable.
 - Default: `1` hour
 - Must be a positive number between `1` and `168` (7 days).
 
----
+<hr />
 
 
 
@@ -393,7 +393,7 @@ The telemetry provider to use for metrics collection.
   - `custom` - Use a custom telemetry provider (requires
   `[TELEMETRY_PROVIDER_CONFIG](#telemetry_provider_config)`)
 
----
+<hr />
 
 
 
@@ -415,7 +415,7 @@ TELEMETRY_PROVIDER_CONFIG='{"module": "./my-telemetry-provider.js"}'
 The custom provider module should export a default class (or named export `TelemetryProvider`) that
 implements the `[TelemetryProvider](https://github.com/tableau/tableau-mcp/blob/main/src/telemetry/types.ts)` interface.
 
----
+<hr />
 
 
 
@@ -441,7 +441,7 @@ The custom provider module should export a default class or named export `Featur
 
 :::
 
----
+<hr />
 
 
 
@@ -464,7 +464,7 @@ The `module` field can be:
 FEATURE_GATE_PROVIDER_CONFIG='{"module":"./providers/cloud-feature-gate.js"}'
 ```
 
----
+<hr />
 
 
 
@@ -482,7 +482,7 @@ not tracked).
 LATENCY_METRIC_NAME=http_server_1agg1_request_duration
 ```
 
----
+<hr />
 
 
 
@@ -497,7 +497,7 @@ call, including tool name, request ID, session ID, and site name.
 [https://help.tableau.com/current/server/en-us/usage_data_basic_product_data.htm](https://help.tableau.com/current/server/en-us/usage_data_basic_product_data.htm) for more
 information
 
----
+<hr />
 
 
 
@@ -514,7 +514,7 @@ disabled.
 - When enabled, individual flow tools can still be excluded via
 `[EXCLUDE_TOOLS](#exclude_tools)` (e.g. `EXCLUDE_TOOLS=flow`).
 
----
+<hr />
 
 
 
@@ -537,7 +537,7 @@ Enables admin-only tools that require site administrator permissions.
 - Admin tools perform runtime role verification and will return a 403 error if the user does not
 have the required permissions.
 
----
+<hr />
 
 
 
@@ -555,7 +555,7 @@ TTL (in minutes) for caches used by admin-only tools. Affects:
 Tune lower if site role / project metadata changes need to propagate faster. Tune higher under
 memory pressure to reduce REST traffic.
 
----
+<hr />
 
 
 
@@ -573,7 +573,7 @@ the preview.
 Tune lower to shorten the window in which a preview token is valid. Tune higher to give callers more
 time between preview and confirmation.
 
----
+<hr />
 
 
 
@@ -590,7 +590,7 @@ can pass an explicit `minAgeDays` argument to override per-call.
 Overridable per-site via [Site Settings](site-settings.md) and per-request via
 [Request Overrides](request-overrides.md#stale_content_min_age_days).
 
----
+<hr />
 
 
 
@@ -614,7 +614,7 @@ re-running.
 Overridable per-site via [Site Settings](site-settings.md) and per-request via
 [Request Overrides](request-overrides.md#stale_content_max_rows).
 
----
+<hr />
 
 
 
@@ -628,7 +628,7 @@ Callers can pass an explicit `inactiveDays` argument to override per-invocation.
 - Minimum: `1`
 - Maximum: `3650` (10 years)
 
----
+<hr />
 
 
 
@@ -641,7 +641,7 @@ Callers can pass an explicit `roles` argument to override per-invocation.
 - Default: `Creator,Explorer`
 - Values must be valid Tableau site role names (e.g., `Creator`, `Explorer`, `Viewer`).
 
----
+<hr />
 
 
 
@@ -665,7 +665,7 @@ discretion.
 }
 ```
 
----
+<hr />
 
 
 
@@ -685,7 +685,7 @@ CSP_ALLOWED_DOMAINS=https://*.mycompany.tableau.com,https://*.online.tableau.com
 
 This allows embedding Tableau visualizations from custom Tableau Server domains in addition to the default Tableau Cloud domains.
 
----
+<hr />
 
 
 
@@ -716,7 +716,7 @@ retrieval never hard-fails.
 MCP_S3_BUCKET=tableau-images
 ```
 
----
+<hr />
 
 
 
@@ -734,7 +734,7 @@ credential/region chain.
 AWS_DEFAULT_REGION=us-east-1
 ```
 
----
+<hr />
 
 
 
@@ -760,7 +760,7 @@ and `workbook-files/...` respectively.
 MCP_IMAGE_PREFIX=tableau/
 ```
 
----
+<hr />
 
 
 

--- a/docs/docs/configuration/mcp-config/env-vars.md
+++ b/docs/docs/configuration/mcp-config/env-vars.md
@@ -626,19 +626,22 @@ This allows embedding Tableau visualizations from custom Tableau Server domains 
 
 ## `MCP_S3_BUCKET`
 
-Enables offloading rendered view images to Amazon S3. When set, the `get-view-image` and
-`get-custom-view-image` tools upload the rendered image to this bucket and return a short-lived
-presigned URL (as a `resource_link` content block) instead of inlining the image as base64. The
-client fetches the image bytes directly from S3, so the image never streams back through the MCP
+Enables offloading large tool payloads to Amazon S3. When set, the following tools upload the
+payload to this bucket and return a short-lived presigned URL (as a `resource_link` content block)
+instead of inlining it:
+
+- `get-view-image` / `get-custom-view-image` — rendered image (otherwise inline base64)
+- `get-view-data` / `get-custom-view-data` — CSV data (otherwise inline text)
+- `download-workbook` — workbook file (otherwise a local temp-file path)
+
+The client fetches the files directly from S3, so the payload never streams back through the MCP
 server on read.
 
-- Requires the `view-file-mode` feature flag to be enabled (see `features.json`). When the flag is
-  disabled, this variable has no effect and the tools return inline base64.
-- Default: unset (feature disabled — tools return inline base64, the original behavior).
+- Default: unset (tools return the payload inline or as a local temp path, the original behavior).
 - When set, must be a valid S3 bucket name (lowercase letters, numbers, dots, and hyphens only).
 - AWS credentials are resolved via the default AWS SDK credential chain (IAM role / instance
   profile / standard `AWS_*` environment variables); no credentials are read from the MCP config.
-- If an upload fails, the tool falls back to returning inline base64 and logs a warning, so image
+- If an upload fails, the tool falls back to the inline/temp-file result and logs a warning, so
   retrieval never hard-fails.
 
 **Example:**
@@ -651,7 +654,7 @@ MCP_S3_BUCKET=tableau-images
 
 ## `AWS_DEFAULT_REGION`
 
-The AWS region of the S3 bucket used for image offload.
+The AWS region of the S3 bucket used for payload offload.
 
 - Default: unset. If not set, the AWS SDK resolves the region from the environment via its standard
   credential/region chain.
@@ -667,17 +670,18 @@ AWS_DEFAULT_REGION=us-east-1
 
 ## `MCP_IMAGE_PREFIX`
 
-The base key prefix (folder path) under which uploaded images are stored in the bucket. Each
-view-image tool appends its own segment to this base, so images are namespaced per tool. Slashes are
+The base key prefix (folder path) under which uploaded payloads are stored in the bucket. Each
+tool appends its own segment to this base, so objects are namespaced per tool. Slashes are
 normalized automatically.
 
 - Default: unset (empty). When unset, each tool uses only its own segment.
 - Per-tool segments: `get-view-image` → `view-images/`, `get-custom-view-image` →
-  `custom-view-images/`.
+  `custom-view-images/`, `get-view-data` → `view-data/`, `get-custom-view-data` →
+  `custom-view-data/`, `download-workbook` → `workbook-files/`.
 - Objects are keyed as `<base><tool-segment><resourceId>/<uuid>.<ext>`. For example, with
-  `MCP_IMAGE_PREFIX=tableau/`, a view image is keyed under `tableau/view-images/...` and a custom
-  view image under `tableau/custom-view-images/...`. Unset, they are keyed under `view-images/...`
-  and `custom-view-images/...` respectively.
+  `MCP_IMAGE_PREFIX=tableau/`, a view image is keyed under `tableau/view-images/...` and a
+  workbook under `tableau/workbook-files/...`. Unset, they are keyed under `view-images/...`
+  and `workbook-files/...` respectively.
 - Only relevant when [`MCP_S3_BUCKET`](#mcp_s3_bucket) is set.
 
 **Example:**

--- a/docs/docs/tools/workbooks/download-workbook.md
+++ b/docs/docs/tools/workbooks/download-workbook.md
@@ -33,8 +33,8 @@ Example: `true`
 
 The tool returns one of two result shapes:
 
-- **S3 file mode enabled:** returns a `resource_link` with a short-lived presigned URL to the workbook file.
-- **S3 file mode disabled or upload failure:** writes the workbook to a local temporary directory and returns a JSON object containing a local file path.
+- **`MCP_S3_BUCKET` set:** returns a `resource_link` with a short-lived presigned URL to the workbook file.
+- **`MCP_S3_BUCKET` unset or upload failure:** writes the workbook to a local temporary directory and returns a JSON object containing a local file path.
 
 The tool preserves Tableau response metadata when present:
 

--- a/features.json
+++ b/features.json
@@ -1,7 +1,4 @@
 {
   "mcp-apps": false,
-  "authoring-tools": false,
-  "view-file-mode": false,
-  "view-data-file-mode": false,
-  "workbook-file-mode": true
+  "authoring-tools": false
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "4.5.0",
+  "version": "4.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "4.5.0",
+      "version": "4.5.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1095.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "4.5.0",
+  "version": "4.5.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/src/config.ts
+++ b/src/config.ts
@@ -322,13 +322,13 @@ export class Config extends BaseConfig {
     // INSIGHTS_TOOLS_ENABLED=true to register them.
     this.insightsToolsEnabled = insightsToolsEnabled === 'true';
 
-    // S3 offload: when MCP_S3_BUCKET is set, view-image and view-data tools
-    // upload the payload (rendered image or CSV) to S3 and return a short-lived
-    // presigned URL instead of inlining base64/text. AWS credentials are
-    // resolved via the default AWS SDK credential chain (IAM role / instance
-    // profile / standard AWS_* env vars), so no credentials are read here. When
-    // unset, the tools fall back to returning the payload inline (unchanged
-    // behavior).
+    // S3 offload: when MCP_S3_BUCKET is set, view-image, view-data, and
+    // download-workbook tools upload the payload to S3 and return a short-lived
+    // presigned URL instead of inlining it (or writing a local temp file, for
+    // workbooks). AWS credentials are resolved via the default AWS SDK
+    // credential chain (IAM role / instance profile / standard AWS_* env vars),
+    // so no credentials are read here. When unset, the tools fall back to
+    // returning the payload inline / as a local temp path (unchanged behavior).
     //
     // `keyPrefix` (MCP_IMAGE_PREFIX) is the shared base folder; each tool
     // appends its own segment (e.g. `view-images/`, `view-data/`), so an unset

--- a/src/tools/web/views/dataToolResult.ts
+++ b/src/tools/web/views/dataToolResult.ts
@@ -1,7 +1,6 @@
 import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 
 import { Config } from '../../../config.js';
-import { getFeatureGate } from '../../../features/init.js';
 import { log } from '../../../logging/logger.js';
 import { getExceptionMessage } from '../../../utils/getExceptionMessage.js';
 import { joinS3Prefix } from '../s3Client.js';
@@ -20,17 +19,14 @@ export type DataToolResult = { kind: 'url'; url: string } | { kind: 'inline'; cs
 
 /**
  * Given a view's CSV data, either upload it to S3 and return a presigned URL
- * (when the `view-data-file-mode` feature is enabled and MCP_S3_BUCKET is
- * configured), or carry the raw CSV for an inline text result. On any S3
- * failure this falls back to inline CSV so data retrieval never hard-fails; the
- * failure is logged as a warning so a persistently broken S3 configuration is
- * observable.
+ * (when MCP_S3_BUCKET is configured), or carry the raw CSV for an inline text
+ * result. On any S3 failure this falls back to inline CSV so data retrieval
+ * never hard-fails; the failure is logged as a warning so a persistently broken
+ * S3 configuration is observable.
  *
- * The `view-data-file-mode` feature gate governs the entire S3-offload path, so
- * disabling the flag keeps the presigned-URL result behind the gate and
- * preserves the original inline behavior. The `bucketS3.enabled` check still
- * guards against a missing bucket so an enabled flag without config doesn't
- * attempt a doomed upload on every request.
+ * `bucketS3.enabled` (MCP_S3_BUCKET) governs the entire S3-offload path, so an
+ * unset bucket keeps the presigned-URL result behind that gate and preserves
+ * the original inline behavior.
  *
  * `keyPrefixSegment` is the caller's per-tool folder (e.g. `view-data/`); it is
  * appended to the shared base prefix (MCP_IMAGE_PREFIX) so each tool namespaces
@@ -49,10 +45,7 @@ export async function buildDataToolResult({
   toolName: string;
   keyPrefixSegment: string;
 }): Promise<DataToolResult> {
-  if (
-    !config.bucketS3.enabled ||
-    !(await getFeatureGate().isFeatureEnabled('view-data-file-mode'))
-  ) {
+  if (!config.bucketS3.enabled) {
     return { kind: 'inline', csv };
   }
 
@@ -83,7 +76,7 @@ export async function buildDataToolResult({
  * Converts a {@link DataToolResult} into the final MCP tool result.
  *
  * The inline branch emits `JSON.stringify(csv)` as a text block — byte-for-byte
- * identical to the tools' previous default output — so disabling the feature
+ * identical to the tools' previous default output — so an unset MCP_S3_BUCKET
  * preserves the original behavior exactly. The URL branch emits a single
  * `resource_link` block carrying the short-lived presigned URL; the client
  * fetches the CSV bytes directly from S3.

--- a/src/tools/web/views/getCustomViewData.test.ts
+++ b/src/tools/web/views/getCustomViewData.test.ts
@@ -20,7 +20,6 @@ const mocks = vi.hoisted(() => ({
   mockGetCustomViewData: vi.fn(),
   mockUploadCsvToS3: vi.fn(),
   mockLog: vi.fn(),
-  mockIsFeatureEnabled: vi.fn(),
 }));
 
 vi.mock('../../../restApiInstance.js', () => ({
@@ -39,10 +38,6 @@ vi.mock('../../../restApiInstance.js', () => ({
 vi.mock('../uploadDataToS3.js', async (importActual) => ({
   ...(await importActual<typeof import('../uploadDataToS3.js')>()),
   uploadCsvToS3: mocks.mockUploadCsvToS3,
-}));
-
-vi.mock('../../../features/init.js', () => ({
-  getFeatureGate: vi.fn(() => ({ isFeatureEnabled: mocks.mockIsFeatureEnabled })),
 }));
 
 vi.mock('../../../logging/logger.js', async (importActual) => ({
@@ -143,11 +138,6 @@ describe('getCustomViewDataTool', () => {
   });
 
   describe('S3 data offload', () => {
-    beforeEach(() => {
-      // The S3-offload path is gated behind the `view-data-file-mode` feature flag.
-      mocks.mockIsFeatureEnabled.mockResolvedValue(true);
-    });
-
     it('should return a resource_link (no inline CSV) when MCP_S3_BUCKET is configured', async () => {
       vi.stubEnv('MCP_S3_BUCKET', 'tableau-data');
       mocks.mockUploadCsvToS3.mockResolvedValue('https://s3.example.com/signed-url');
@@ -199,18 +189,6 @@ describe('getCustomViewDataTool', () => {
           message: expect.stringContaining('access denied'),
         }),
       );
-    });
-
-    it('should return inline CSV (no S3 upload) when view-data-file-mode is disabled even if MCP_S3_BUCKET is configured', async () => {
-      mocks.mockIsFeatureEnabled.mockResolvedValue(false);
-      vi.stubEnv('MCP_S3_BUCKET', 'tableau-data');
-
-      const result = await getToolResult({ customViewId: mockCustomView.id });
-
-      expect(result.isError).toBe(false);
-      invariant(result.content[0].type === 'text');
-      expect(result.content[0].text).toBe(JSON.stringify(mockCsv));
-      expect(mocks.mockUploadCsvToS3).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/tools/web/views/getCustomViewImage.test.ts
+++ b/src/tools/web/views/getCustomViewImage.test.ts
@@ -37,7 +37,6 @@ const mocks = vi.hoisted(() => ({
   mockGetCustomViewImage: vi.fn(),
   mockUploadImageToS3: vi.fn(),
   mockLog: vi.fn(),
-  mockIsFeatureEnabled: vi.fn(),
 }));
 
 vi.mock('../../../restApiInstance.js', () => ({
@@ -56,10 +55,6 @@ vi.mock('../../../restApiInstance.js', () => ({
 vi.mock('../uploadImageToS3.js', async (importActual) => ({
   ...(await importActual<typeof import('../uploadImageToS3.js')>()),
   uploadImageToS3: mocks.mockUploadImageToS3,
-}));
-
-vi.mock('../../../features/init.js', () => ({
-  getFeatureGate: vi.fn(() => ({ isFeatureEnabled: mocks.mockIsFeatureEnabled })),
 }));
 
 vi.mock('../../../logging/logger.js', async (importActual) => ({
@@ -301,11 +296,6 @@ describe('getCustomViewImageTool', () => {
   });
 
   describe('S3 image offload', () => {
-    beforeEach(() => {
-      // The S3-offload path is gated behind the `view-file-mode` feature flag.
-      mocks.mockIsFeatureEnabled.mockResolvedValue(true);
-    });
-
     it('should return a resource_link (no base64) when MCP_S3_BUCKET is configured', async () => {
       vi.stubEnv('MCP_S3_BUCKET', 'tableau-images');
       mocks.mockGetCustomViewImage.mockResolvedValue(Ok(mockPngData));
@@ -382,22 +372,6 @@ describe('getCustomViewImageTool', () => {
           message: expect.stringContaining('access denied'),
         }),
       );
-    });
-
-    it('should return inline base64 (no S3 upload) when view-file-mode is disabled even if MCP_S3_BUCKET is configured', async () => {
-      mocks.mockIsFeatureEnabled.mockResolvedValue(false);
-      vi.stubEnv('MCP_S3_BUCKET', 'tableau-images');
-      mocks.mockGetCustomViewImage.mockResolvedValue(Ok(mockPngData));
-
-      const result = await getToolResult({ customViewId: mockCustomView.id });
-
-      expect(result.isError).toBe(false);
-      expect(result.content[0]).toMatchObject({
-        type: 'image',
-        data: base64PngData,
-        mimeType: 'image/png',
-      });
-      expect(mocks.mockUploadImageToS3).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/tools/web/views/getViewData.test.ts
+++ b/src/tools/web/views/getViewData.test.ts
@@ -19,7 +19,6 @@ const mocks = vi.hoisted(() => ({
   mockQueryViewData: vi.fn(),
   mockUploadCsvToS3: vi.fn(),
   mockLog: vi.fn(),
-  mockIsFeatureEnabled: vi.fn(),
 }));
 
 vi.mock('../../../restApiInstance.js', () => ({
@@ -37,10 +36,6 @@ vi.mock('../../../restApiInstance.js', () => ({
 vi.mock('../uploadDataToS3.js', async (importActual) => ({
   ...(await importActual<typeof import('../uploadDataToS3.js')>()),
   uploadCsvToS3: mocks.mockUploadCsvToS3,
-}));
-
-vi.mock('../../../features/init.js', () => ({
-  getFeatureGate: vi.fn(() => ({ isFeatureEnabled: mocks.mockIsFeatureEnabled })),
 }));
 
 vi.mock('../../../logging/logger.js', async (importActual) => ({
@@ -157,8 +152,6 @@ describe('getViewDataTool', () => {
 
   describe('S3 data offload', () => {
     beforeEach(() => {
-      // The S3-offload path is gated behind the `view-data-file-mode` feature flag.
-      mocks.mockIsFeatureEnabled.mockResolvedValue(true);
       mocks.mockQueryViewData.mockResolvedValue(mockViewData);
     });
 
@@ -229,18 +222,6 @@ describe('getViewDataTool', () => {
           message: expect.stringContaining('access denied'),
         }),
       );
-    });
-
-    it('should return inline CSV (no S3 upload) when view-data-file-mode is disabled even if MCP_S3_BUCKET is configured', async () => {
-      mocks.mockIsFeatureEnabled.mockResolvedValue(false);
-      vi.stubEnv('MCP_S3_BUCKET', 'tableau-data');
-
-      const result = await getToolResult({ viewId: mockView.id });
-
-      expect(result.isError).toBe(false);
-      invariant(result.content[0].type === 'text');
-      expect(result.content[0].text).toBe(JSON.stringify(mockViewData));
-      expect(mocks.mockUploadCsvToS3).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/tools/web/views/getViewImage.test.ts
+++ b/src/tools/web/views/getViewImage.test.ts
@@ -36,7 +36,6 @@ const mocks = vi.hoisted(() => ({
   mockQueryViewImage: vi.fn(),
   mockUploadImageToS3: vi.fn(),
   mockLog: vi.fn(),
-  mockIsFeatureEnabled: vi.fn(),
 }));
 
 vi.mock('../../../restApiInstance.js', () => ({
@@ -54,10 +53,6 @@ vi.mock('../../../restApiInstance.js', () => ({
 vi.mock('../uploadImageToS3.js', async (importActual) => ({
   ...(await importActual<typeof import('../uploadImageToS3.js')>()),
   uploadImageToS3: mocks.mockUploadImageToS3,
-}));
-
-vi.mock('../../../features/init.js', () => ({
-  getFeatureGate: vi.fn(() => ({ isFeatureEnabled: mocks.mockIsFeatureEnabled })),
 }));
 
 vi.mock('../../../logging/logger.js', async (importActual) => ({
@@ -301,11 +296,6 @@ describe('getViewImageTool', () => {
   });
 
   describe('S3 image offload', () => {
-    beforeEach(() => {
-      // The S3-offload path is gated behind the `view-file-mode` feature flag.
-      mocks.mockIsFeatureEnabled.mockResolvedValue(true);
-    });
-
     it('should return a resource_link (no base64) when MCP_S3_BUCKET is configured', async () => {
       vi.stubEnv('MCP_S3_BUCKET', 'tableau-images');
       mocks.mockQueryViewImage.mockResolvedValue(Ok(mockPngData));
@@ -383,22 +373,6 @@ describe('getViewImageTool', () => {
           message: expect.stringContaining('access denied'),
         }),
       );
-    });
-
-    it('should return inline base64 (no S3 upload) when view-file-mode is disabled even if MCP_S3_BUCKET is configured', async () => {
-      mocks.mockIsFeatureEnabled.mockResolvedValue(false);
-      vi.stubEnv('MCP_S3_BUCKET', 'tableau-images');
-      mocks.mockQueryViewImage.mockResolvedValue(Ok(mockPngData));
-
-      const result = await getToolResult({ viewId: '4d18c547-bbb1-4187-ae5a-7f78b35adf2d' });
-
-      expect(result.isError).toBe(false);
-      expect(result.content[0]).toMatchObject({
-        type: 'image',
-        data: base64PngData,
-        mimeType: 'image/png',
-      });
-      expect(mocks.mockUploadImageToS3).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/tools/web/views/imageToolResult.ts
+++ b/src/tools/web/views/imageToolResult.ts
@@ -1,7 +1,6 @@
 import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 
 import { Config } from '../../../config.js';
-import { getFeatureGate } from '../../../features/init.js';
 import { log } from '../../../logging/logger.js';
 import { getExceptionMessage } from '../../../utils/getExceptionMessage.js';
 import {
@@ -25,18 +24,16 @@ export type ImageToolResult =
 
 /**
  * Given rendered image bytes, either upload them to S3 and return a presigned
- * URL (when the `view-file-mode` feature is enabled and MCP_S3_BUCKET is
- * configured), or carry the raw bytes for inline base64. On any S3 failure this
- * falls back to inline bytes so image retrieval never hard-fails; the failure is
- * logged as a warning so a persistently broken S3 configuration is observable.
+ * URL (when MCP_S3_BUCKET is configured), or carry the raw bytes for inline
+ * base64. On any S3 failure this falls back to inline bytes so image retrieval
+ * never hard-fails; the failure is logged as a warning so a persistently broken
+ * S3 configuration is observable.
  *
- * The `view-file-mode` feature gate governs the entire S3-offload path: the
+ * `bucketS3.enabled` (MCP_S3_BUCKET) governs the entire S3-offload path: the
  * presigned-URL result and the Slack `_meta` block it carries (emitted in
  * `convertViewImageUrlToToolResult`) only exist on the `kind: 'url'` branch, so
- * disabling the flag keeps both behind the gate and preserves the original
- * inline-base64 behavior. The `bucketS3.enabled` check still guards against a
- * missing bucket so an enabled flag without config doesn't attempt a doomed
- * upload on every request.
+ * an unset bucket keeps both behind that gate and preserves the original
+ * inline-base64 behavior.
  *
  * `keyPrefixSegment` is the caller's per-tool folder (e.g. `view-images/`); it
  * is appended to the shared base prefix (MCP_IMAGE_PREFIX) so each tool
@@ -58,7 +55,7 @@ export async function buildImageToolResult({
   toolName: string;
   keyPrefixSegment: string;
 }): Promise<ImageToolResult> {
-  if (!config.bucketS3.enabled || !(await getFeatureGate().isFeatureEnabled('view-file-mode'))) {
+  if (!config.bucketS3.enabled) {
     return { kind: 'inline', imageData, format };
   }
 

--- a/src/tools/web/workbooks/downloadWorkbook.test.ts
+++ b/src/tools/web/workbooks/downloadWorkbook.test.ts
@@ -99,7 +99,7 @@ describe('downloadWorkbookTool', () => {
     expect(mocks.mockUploadBufferToS3).not.toHaveBeenCalled();
   });
 
-  it('should return an S3 resource link when MCP_S3_BUCKET is configured and feature is enabled', async () => {
+  it('should return an S3 resource link when MCP_S3_BUCKET is configured', async () => {
     vi.stubEnv('MCP_S3_BUCKET', 'tableau-data');
     const workbookBytes = Buffer.from('<workbook/>', 'utf-8');
     mocks.mockDownloadWorkbook.mockResolvedValue({
@@ -115,7 +115,6 @@ describe('downloadWorkbookTool', () => {
     });
 
     expect(result.isError).toBe(false);
-    expect(mocks.mockIsFeatureEnabled).toHaveBeenCalledWith('workbook-file-mode');
     invariant(result.content[0].type === 'resource_link');
     expect(result.content[0].uri).toBe('https://s3.example.com/signed-url');
     expect(result.content[0].name).toBe('Superstore.twb');
@@ -158,29 +157,6 @@ describe('downloadWorkbookTool', () => {
         message: expect.stringContaining('access denied'),
       }),
     );
-  });
-
-  it('should return temp path when feature flag is disabled even with MCP_S3_BUCKET', async () => {
-    vi.stubEnv('MCP_S3_BUCKET', 'tableau-data');
-    mocks.mockIsFeatureEnabled.mockResolvedValue(false);
-    const workbookBytes = Buffer.from('<workbook/>', 'utf-8');
-    mocks.mockDownloadWorkbook.mockResolvedValue({
-      content: workbookBytes,
-      contentType: 'application/xml',
-      filename: 'Superstore.twb',
-    });
-
-    const result = await getToolResult({
-      workbookId: '96a43833-27db-40b6-aa80-751efc776b9a',
-    });
-
-    expect(result.isError).toBe(false);
-    expect(mocks.mockIsFeatureEnabled).toHaveBeenCalledWith('workbook-file-mode');
-    invariant(result.content[0].type === 'text');
-    const payload = JSON.parse(result.content[0].text);
-    tempPathsToCleanup.push(payload.path);
-    await expect(readFile(payload.path)).resolves.toEqual(workbookBytes);
-    expect(mocks.mockUploadBufferToS3).not.toHaveBeenCalled();
   });
 
   it('should return workbook not allowed error when workbook is not allowed', async () => {

--- a/src/tools/web/workbooks/downloadWorkbook.test.ts
+++ b/src/tools/web/workbooks/downloadWorkbook.test.ts
@@ -15,7 +15,6 @@ const mocks = vi.hoisted(() => ({
   mockDownloadWorkbook: vi.fn(),
   mockUploadBufferToS3: vi.fn(),
   mockLog: vi.fn(),
-  mockIsFeatureEnabled: vi.fn(),
 }));
 
 vi.mock('../../../restApiInstance.js', () => ({
@@ -34,10 +33,6 @@ vi.mock('../s3Client.js', async (importActual) => ({
   uploadBufferToS3: mocks.mockUploadBufferToS3,
 }));
 
-vi.mock('../../../features/init.js', () => ({
-  getFeatureGate: vi.fn(() => ({ isFeatureEnabled: mocks.mockIsFeatureEnabled })),
-}));
-
 vi.mock('../../../logging/logger.js', async (importActual) => ({
   ...(await importActual<typeof import('../../../logging/logger.js')>()),
   log: mocks.mockLog,
@@ -51,7 +46,6 @@ describe('downloadWorkbookTool', () => {
     vi.unstubAllEnvs();
     stubDefaultEnvVars();
     resetResourceAccessCheckerSingleton();
-    mocks.mockIsFeatureEnabled.mockResolvedValue(true);
   });
 
   afterEach(async () => {

--- a/src/tools/web/workbooks/workbookToolResult.ts
+++ b/src/tools/web/workbooks/workbookToolResult.ts
@@ -6,7 +6,6 @@ import { tmpdir } from 'os';
 import { join } from 'path';
 
 import { Config } from '../../../config.js';
-import { getFeatureGate } from '../../../features/init.js';
 import { log } from '../../../logging/logger.js';
 import { getExceptionMessage } from '../../../utils/getExceptionMessage.js';
 import { joinS3Prefix, uploadBufferToS3 } from '../s3Client.js';
@@ -32,10 +31,7 @@ export async function buildWorkbookToolResult({
   toolName: string;
   keyPrefixSegment: string;
 }): Promise<WorkbookToolResult> {
-  if (
-    !config.bucketS3.enabled ||
-    !(await getFeatureGate().isFeatureEnabled('workbook-file-mode'))
-  ) {
+  if (!config.bucketS3.enabled) {
     return await persistWorkbookToTempPath({ content, mimeType, filename });
   }
 


### PR DESCRIPTION
### Summary

there are 3 feature flags that essentially determine the same behavior:

- ```view-file-mode```
  - when true, upload view image files to S3 for staging and return presigned url
  - when false, return a base64 encoded data uri
- ```view-data-file-mode```
  - when true, upload view data csv files to S3 for staging and return presigned url
  - when false, return raw csv text
- ```workbook-file-mode```
  - when true, store the workbook in a local tmp drive and return the file path
  - when false, upload the workbook file to S3 and return a presigned URL

Instead of keeping identical logic, we should be keying off the MCP_S3_BUCKET env var. If it's set, then we should attempt to stage these files in S3. If not set, we should return the data inline (csv, dataUri, file path).

### Testing

- npm test
- npm run lint
- npm run build