### PR TITLE
feat(desktop): make the knowledge root configurable and multi-root

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "2.63.11",
+  "version": "2.63.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "2.63.11",
+      "version": "2.63.12",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.7.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "2.63.11",
+  "version": "2.63.12",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/src/desktop/assets.ts
+++ b/src/desktop/assets.ts
@@ -206,17 +206,42 @@ export function readResourceAsset(relPath: string): string | null {
   }
 }
 
-// Knowledge module slugs (forward-slash, no .md) under resources/desktop/knowledge.
-// SEA reads the manifest; disk walks the tree.
-export function listKnowledgeSlugs(): string[] {
-  if (runningAsSea()) {
-    const prefix = 'resources/desktop/knowledge/';
-    return listSeaAssetKeys('resources/desktop/knowledge')
-      .filter((key) => key.endsWith('.md'))
-      .map((key) => key.slice(prefix.length).replace(/\.md$/, ''))
-      .sort();
-  }
-  const root = join(getResourcesRoot(), 'knowledge');
+// TABLEAU_KNOWLEDGE_DIR (set by tab-agent-south once it materializes the corpus
+// to <agent-data-dir>/knowledge) points at a tree with the same tiering skills/
+// commands already use: `.vendored/protected` (rebuilt every startup from the
+// vendored source, authoritative), `.vendored/overridable` (operator-editable
+// vendored default), and everything else at the top level (user-authored,
+// excluded from the vendored tiers). When unset, knowledge falls back to the
+// tree this repo ships itself (SEA-embedded or resources/desktop/knowledge on
+// disk) — the pre-external-corpus behavior, kept as a transitional default.
+const KNOWLEDGE_DIR_ENV_NAME = 'TABLEAU_KNOWLEDGE_DIR';
+const VENDORED_DIR_NAME = '.vendored';
+const PROTECTED_DIR_NAME = 'protected';
+const OVERRIDABLE_DIR_NAME = 'overridable';
+
+function externalKnowledgeRoot(): string | undefined {
+  const raw = process.env[KNOWLEDGE_DIR_ENV_NAME]?.trim();
+  return raw ? raw : undefined;
+}
+
+// Precedence order when a slug is claimed by more than one tier: protected is
+// authoritative and always wins; a user file shadows the vendored overridable
+// default; overridable is the fallback when neither above provides the slug.
+function externalKnowledgeRootsByPrecedence(baseDir: string): string[] {
+  return [
+    join(baseDir, VENDORED_DIR_NAME, PROTECTED_DIR_NAME),
+    baseDir,
+    join(baseDir, VENDORED_DIR_NAME, OVERRIDABLE_DIR_NAME),
+  ];
+}
+
+/**
+ * The `.md` slugs (forward-slash, no extension) under `root`, walked
+ * recursively. `skipTopLevelDirNames` excludes named directories one level
+ * below `root` only — used to keep the user-content root from also walking
+ * back into `.vendored`.
+ */
+function walkMarkdownSlugs(root: string, skipTopLevelDirNames: readonly string[] = []): string[] {
   const slugs: string[] = [];
   const walk = (dir: string, prefixParts: string[]): void => {
     let entries;
@@ -226,6 +251,9 @@ export function listKnowledgeSlugs(): string[] {
       return;
     }
     for (const entry of entries) {
+      if (prefixParts.length === 0 && skipTopLevelDirNames.includes(entry.name)) {
+        continue;
+      }
       const next = join(dir, entry.name);
       if (entry.isDirectory()) {
         walk(next, [...prefixParts, entry.name]);
@@ -235,12 +263,61 @@ export function listKnowledgeSlugs(): string[] {
     }
   };
   walk(root, []);
-  return slugs.sort();
+  return slugs;
+}
+
+// Knowledge module slugs (forward-slash, no .md). Reads the external, multi-root
+// tree when TABLEAU_KNOWLEDGE_DIR is set; otherwise falls back to this repo's
+// own shipped copy under resources/desktop/knowledge (SEA reads the manifest,
+// disk walks the tree).
+export function listKnowledgeSlugs(): string[] {
+  const externalRoot = externalKnowledgeRoot();
+  if (externalRoot !== undefined) {
+    const slugs = new Set<string>();
+    for (const root of externalKnowledgeRootsByPrecedence(externalRoot)) {
+      const skip = root === externalRoot ? [VENDORED_DIR_NAME] : [];
+      for (const slug of walkMarkdownSlugs(root, skip)) {
+        slugs.add(slug);
+      }
+    }
+    return [...slugs].sort();
+  }
+  if (runningAsSea()) {
+    const prefix = 'resources/desktop/knowledge/';
+    return listSeaAssetKeys('resources/desktop/knowledge')
+      .filter((key) => key.endsWith('.md'))
+      .map((key) => key.slice(prefix.length).replace(/\.md$/, ''))
+      .sort();
+  }
+  return walkMarkdownSlugs(join(getResourcesRoot(), 'knowledge')).sort();
 }
 
 export function readKnowledgeBySlug(slug: string): string | null {
   if (!slug || slug.includes('..') || slug.includes('\\') || slug.startsWith('/')) {
     return null;
   }
-  return readResourceAsset(`knowledge/${slug}.md`);
+  const externalRoot = externalKnowledgeRoot();
+  if (externalRoot === undefined) {
+    return readResourceAsset(`knowledge/${slug}.md`);
+  }
+  const slugParts = slug.split('/');
+  for (const root of externalKnowledgeRootsByPrecedence(externalRoot)) {
+    // A slug can never legitimately resolve into .vendored via the user root —
+    // listKnowledgeSlugs never produces one, so treat a caller-supplied one
+    // (e.g. from a raw expertise:// URI) the same way.
+    if (root === externalRoot && slugParts[0] === VENDORED_DIR_NAME) {
+      continue;
+    }
+    try {
+      return readFileSync(join(root, ...slugParts) + '.md', 'utf-8');
+    } catch {
+      continue;
+    }
+  }
+  return null;
+}
+
+/** The configured knowledge root, for display in errors/logs only. */
+export function getConfiguredKnowledgeDir(): string {
+  return externalKnowledgeRoot() ?? join(getResourcesRoot(), 'knowledge');
 }

--- a/src/desktop/assets.ts
+++ b/src/desktop/assets.ts
@@ -206,42 +206,18 @@ export function readResourceAsset(relPath: string): string | null {
   }
 }
 
-// TABLEAU_KNOWLEDGE_DIR (set by tab-agent-south once it materializes the corpus
-// to <agent-data-dir>/knowledge) points at a tree with the same tiering skills/
-// commands already use: `.vendored/protected` (rebuilt every startup from the
-// vendored source, authoritative), `.vendored/overridable` (operator-editable
-// vendored default), and everything else at the top level (user-authored,
-// excluded from the vendored tiers). When unset, knowledge falls back to the
-// tree this repo ships itself (SEA-embedded or resources/desktop/knowledge on
-// disk) — the pre-external-corpus behavior, kept as a transitional default.
 const KNOWLEDGE_DIR_ENV_NAME = 'TABLEAU_KNOWLEDGE_DIR';
-const VENDORED_DIR_NAME = '.vendored';
-const PROTECTED_DIR_NAME = 'protected';
-const OVERRIDABLE_DIR_NAME = 'overridable';
 
 function externalKnowledgeRoot(): string | undefined {
   const raw = process.env[KNOWLEDGE_DIR_ENV_NAME]?.trim();
   return raw ? raw : undefined;
 }
 
-// Precedence order when a slug is claimed by more than one tier: protected is
-// authoritative and always wins; a user file shadows the vendored overridable
-// default; overridable is the fallback when neither above provides the slug.
-function externalKnowledgeRootsByPrecedence(baseDir: string): string[] {
-  return [
-    join(baseDir, VENDORED_DIR_NAME, PROTECTED_DIR_NAME),
-    baseDir,
-    join(baseDir, VENDORED_DIR_NAME, OVERRIDABLE_DIR_NAME),
-  ];
+function isHiddenName(name: string): boolean {
+  return name.startsWith('.');
 }
 
-/**
- * The `.md` slugs (forward-slash, no extension) under `root`, walked
- * recursively. `skipTopLevelDirNames` excludes named directories one level
- * below `root` only — used to keep the user-content root from also walking
- * back into `.vendored`.
- */
-function walkMarkdownSlugs(root: string, skipTopLevelDirNames: readonly string[] = []): string[] {
+function walkMarkdownSlugs(root: string): string[] {
   const slugs: string[] = [];
   const walk = (dir: string, prefixParts: string[]): void => {
     let entries;
@@ -251,7 +227,7 @@ function walkMarkdownSlugs(root: string, skipTopLevelDirNames: readonly string[]
       return;
     }
     for (const entry of entries) {
-      if (prefixParts.length === 0 && skipTopLevelDirNames.includes(entry.name)) {
+      if (isHiddenName(entry.name)) {
         continue;
       }
       const next = join(dir, entry.name);
@@ -266,21 +242,10 @@ function walkMarkdownSlugs(root: string, skipTopLevelDirNames: readonly string[]
   return slugs;
 }
 
-// Knowledge module slugs (forward-slash, no .md). Reads the external, multi-root
-// tree when TABLEAU_KNOWLEDGE_DIR is set; otherwise falls back to this repo's
-// own shipped copy under resources/desktop/knowledge (SEA reads the manifest,
-// disk walks the tree).
 export function listKnowledgeSlugs(): string[] {
   const externalRoot = externalKnowledgeRoot();
   if (externalRoot !== undefined) {
-    const slugs = new Set<string>();
-    for (const root of externalKnowledgeRootsByPrecedence(externalRoot)) {
-      const skip = root === externalRoot ? [VENDORED_DIR_NAME] : [];
-      for (const slug of walkMarkdownSlugs(root, skip)) {
-        slugs.add(slug);
-      }
-    }
-    return [...slugs].sort();
+    return walkMarkdownSlugs(externalRoot).sort();
   }
   if (runningAsSea()) {
     const prefix = 'resources/desktop/knowledge/';
@@ -292,32 +257,28 @@ export function listKnowledgeSlugs(): string[] {
   return walkMarkdownSlugs(join(getResourcesRoot(), 'knowledge')).sort();
 }
 
-export function readKnowledgeBySlug(slug: string): string | null {
+function isSafeKnowledgeSlug(slug: string): boolean {
   if (!slug || slug.includes('..') || slug.includes('\\') || slug.startsWith('/')) {
+    return false;
+  }
+  return !slug.split('/').some((part) => part.length === 0 || isHiddenName(part));
+}
+
+export function readKnowledgeBySlug(slug: string): string | null {
+  if (!isSafeKnowledgeSlug(slug)) {
     return null;
   }
   const externalRoot = externalKnowledgeRoot();
   if (externalRoot === undefined) {
     return readResourceAsset(`knowledge/${slug}.md`);
   }
-  const slugParts = slug.split('/');
-  for (const root of externalKnowledgeRootsByPrecedence(externalRoot)) {
-    // A slug can never legitimately resolve into .vendored via the user root —
-    // listKnowledgeSlugs never produces one, so treat a caller-supplied one
-    // (e.g. from a raw expertise:// URI) the same way.
-    if (root === externalRoot && slugParts[0] === VENDORED_DIR_NAME) {
-      continue;
-    }
-    try {
-      return readFileSync(join(root, ...slugParts) + '.md', 'utf-8');
-    } catch {
-      continue;
-    }
+  try {
+    return readFileSync(join(externalRoot, ...slug.split('/')) + '.md', 'utf-8');
+  } catch {
+    return null;
   }
-  return null;
 }
 
-/** The configured knowledge root, for display in errors/logs only. */
 export function getConfiguredKnowledgeDir(): string {
   return externalKnowledgeRoot() ?? join(getResourcesRoot(), 'knowledge');
 }

--- a/src/desktop/assets.ts
+++ b/src/desktop/assets.ts
@@ -8,7 +8,7 @@
 
 import { createHash } from 'crypto';
 import { existsSync, readdirSync, readFileSync } from 'fs';
-import { join } from 'path';
+import { delimiter, join } from 'path';
 
 import { getDirname } from '../utils/getDirname.js';
 import {
@@ -208,9 +208,18 @@ export function readResourceAsset(relPath: string): string | null {
 
 const KNOWLEDGE_DIR_ENV_NAME = 'TABLEAU_KNOWLEDGE_DIR';
 
-function externalKnowledgeRoot(): string | undefined {
-  const raw = process.env[KNOWLEDGE_DIR_ENV_NAME]?.trim();
-  return raw ? raw : undefined;
+// Ordered by precedence: earlier roots win on a slug collision. tab-agent-south owns what
+// each root physically is (protected/user-content/overridable); this file never learns those
+// names, it just merges whatever ordered list it's handed.
+function externalKnowledgeRoots(): string[] {
+  const raw = process.env[KNOWLEDGE_DIR_ENV_NAME];
+  if (!raw) {
+    return [];
+  }
+  return raw
+    .split(delimiter)
+    .map((root) => root.trim())
+    .filter((root) => root.length > 0);
 }
 
 function isHiddenName(name: string): boolean {
@@ -243,9 +252,15 @@ function walkMarkdownSlugs(root: string): string[] {
 }
 
 export function listKnowledgeSlugs(): string[] {
-  const externalRoot = externalKnowledgeRoot();
-  if (externalRoot !== undefined) {
-    return walkMarkdownSlugs(externalRoot).sort();
+  const externalRoots = externalKnowledgeRoots();
+  if (externalRoots.length > 0) {
+    const slugs = new Set<string>();
+    for (const root of externalRoots) {
+      for (const slug of walkMarkdownSlugs(root)) {
+        slugs.add(slug);
+      }
+    }
+    return [...slugs].sort();
   }
   if (runningAsSea()) {
     const prefix = 'resources/desktop/knowledge/';
@@ -268,17 +283,23 @@ export function readKnowledgeBySlug(slug: string): string | null {
   if (!isSafeKnowledgeSlug(slug)) {
     return null;
   }
-  const externalRoot = externalKnowledgeRoot();
-  if (externalRoot === undefined) {
+  const externalRoots = externalKnowledgeRoots();
+  if (externalRoots.length === 0) {
     return readResourceAsset(`knowledge/${slug}.md`);
   }
-  try {
-    return readFileSync(join(externalRoot, ...slug.split('/')) + '.md', 'utf-8');
-  } catch {
-    return null;
+  for (const root of externalRoots) {
+    try {
+      return readFileSync(join(root, ...slug.split('/')) + '.md', 'utf-8');
+    } catch {
+      continue;
+    }
   }
+  return null;
 }
 
 export function getConfiguredKnowledgeDir(): string {
-  return externalKnowledgeRoot() ?? join(getResourcesRoot(), 'knowledge');
+  const externalRoots = externalKnowledgeRoots();
+  return externalRoots.length > 0
+    ? externalRoots.join(delimiter)
+    : join(getResourcesRoot(), 'knowledge');
 }

--- a/src/desktop/knowledge/corpusIntegrity.test.ts
+++ b/src/desktop/knowledge/corpusIntegrity.test.ts
@@ -1,7 +1,6 @@
 import { readFileSync } from 'fs';
 
-import { listKnowledgeSlugs, readKnowledgeBySlug } from '../assets.js';
-import { getKnowledgeDir } from './index.js';
+import { getConfiguredKnowledgeDir, listKnowledgeSlugs, readKnowledgeBySlug } from '../assets.js';
 
 /**
  * Corpus-wide integrity gates over the REAL shipped knowledge tree
@@ -33,7 +32,7 @@ function normalizeTarget(raw: string): string {
 }
 
 function collectReferences(): Reference[] {
-  const knowledgeDir = getKnowledgeDir();
+  const knowledgeDir = getConfiguredKnowledgeDir();
   const references: Reference[] = [];
 
   for (const slug of listKnowledgeSlugs()) {

--- a/src/desktop/knowledge/index.test.ts
+++ b/src/desktop/knowledge/index.test.ts
@@ -9,7 +9,6 @@ import { getDirname } from '../../utils/getDirname.js';
 import {
   _resetKnowledgeSearchCache,
   clearKnowledgeCache,
-  getKnowledgeDir,
   listKnowledgeResources,
   readKnowledgeResource,
   searchKnowledgeWithFallback,
@@ -58,14 +57,6 @@ describe('knowledge/index', () => {
     vi.clearAllMocks();
     clearKnowledgeCache();
     _resetKnowledgeSearchCache();
-  });
-
-  describe('getKnowledgeDir', () => {
-    it('returns the first candidate that exists', () => {
-      vi.mocked(getDirname).mockReturnValue(MOCK_ROOT);
-      vi.mocked(existsSync).mockImplementation((p) => String(p) === KNOWLEDGE_DIR);
-      expect(getKnowledgeDir()).toBe(KNOWLEDGE_DIR);
-    });
   });
 
   describe('listKnowledgeResources', () => {

--- a/src/desktop/knowledge/index.ts
+++ b/src/desktop/knowledge/index.ts
@@ -1,7 +1,6 @@
 import Fuse from 'fuse.js';
-import { join } from 'path';
 
-import { getResourcesRoot, listKnowledgeSlugs, readKnowledgeBySlug } from '../assets.js';
+import { getConfiguredKnowledgeDir, listKnowledgeSlugs, readKnowledgeBySlug } from '../assets.js';
 
 export interface KnowledgeResource {
   uri: string;
@@ -11,7 +10,7 @@ export interface KnowledgeResource {
 }
 
 export function getKnowledgeDir(): string {
-  return join(getResourcesRoot(), 'knowledge');
+  return getConfiguredKnowledgeDir();
 }
 
 function knowledgeCorpusEmptyError(): Error {

--- a/src/desktop/knowledge/index.ts
+++ b/src/desktop/knowledge/index.ts
@@ -9,12 +9,10 @@ export interface KnowledgeResource {
   mimeType: 'text/markdown';
 }
 
-export function getKnowledgeDir(): string {
-  return getConfiguredKnowledgeDir();
-}
-
 function knowledgeCorpusEmptyError(): Error {
-  return new Error(`Knowledge corpus is empty; expected assets under ${getKnowledgeDir()}`);
+  return new Error(
+    `Knowledge corpus is empty; expected assets under ${getConfiguredKnowledgeDir()}`,
+  );
 }
 
 export function getKnowledgeCorpusEntryCount(): number {

--- a/src/desktop/knowledge/knowledgeToolReferences.test.ts
+++ b/src/desktop/knowledge/knowledgeToolReferences.test.ts
@@ -2,7 +2,7 @@ import { readdirSync, readFileSync } from 'fs';
 import { join, relative } from 'path';
 
 import { desktopToolNames } from '../../tools/desktop/toolName.js';
-import { getKnowledgeDir } from './index.js';
+import { getConfiguredKnowledgeDir } from '../assets.js';
 
 const registeredDesktopToolNames = new Set<string>(desktopToolNames);
 
@@ -240,7 +240,7 @@ function isAllowedReference(token: string): boolean {
 
 describe('desktop knowledge tool references', () => {
   it('only teaches registered desktop tools', () => {
-    const knowledgeDir = getKnowledgeDir();
+    const knowledgeDir = getConfiguredKnowledgeDir();
     const offenders = listMarkdownFiles(knowledgeDir)
       .flatMap((file) =>
         extractCandidateReferences(relative(knowledgeDir, file), readFileSync(file, 'utf-8')),
@@ -258,7 +258,7 @@ describe('desktop knowledge tool references', () => {
 
   it('never teaches underscore aliases for the knowledge tools', () => {
     const forbiddenAliases = ['search_knowledge', 'read_knowledge_resource'];
-    const knowledgeDir = getKnowledgeDir();
+    const knowledgeDir = getConfiguredKnowledgeDir();
     const offenders = listMarkdownFiles(knowledgeDir).flatMap((file) => {
       const relativeFile = relative(knowledgeDir, file);
       return readFileSync(file, 'utf-8')

--- a/src/desktop/knowledgeExternalRoot.test.ts
+++ b/src/desktop/knowledgeExternalRoot.test.ts
@@ -1,10 +1,3 @@
-/**
- * TABLEAU_KNOWLEDGE_DIR points at the tree tab-agent-south materializes to
- * <agent-data-dir>/knowledge: `.vendored/protected`, `.vendored/overridable`,
- * and top-level user content. These tests cover the precedence walk
- * (protected > user > overridable) and slug normalization independent of that
- * materialization — they build the tree by hand.
- */
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
 import { join } from 'path';
 
@@ -33,14 +26,10 @@ describe('external knowledge root (TABLEAU_KNOWLEDGE_DIR)', () => {
     expect(getConfiguredKnowledgeDir()).toBe(root);
   });
 
-  it('merges slugs from all three tiers, normalized (tier prefix stripped)', () => {
-    writeMd(join(root, '.vendored', 'protected'), 'tactics/viz/filters', '# protected');
-    writeMd(root, 'my-notes/onboarding', '# user');
-    writeMd(
-      join(root, '.vendored', 'overridable'),
-      'strategy/viz-design/chart-selection',
-      '# overridable',
-    );
+  it('lists nested markdown slugs under the configured dir', () => {
+    writeMd(root, 'tactics/viz/filters', '# filters');
+    writeMd(root, 'strategy/viz-design/chart-selection', '# charts');
+    writeMd(root, 'my-notes/onboarding', '# notes');
 
     expect(listKnowledgeSlugs()).toEqual([
       'my-notes/onboarding',
@@ -49,43 +38,28 @@ describe('external knowledge root (TABLEAU_KNOWLEDGE_DIR)', () => {
     ]);
   });
 
-  it('excludes .vendored itself from the user-content walk', () => {
-    writeMd(join(root, '.vendored', 'protected'), 'a', '# protected a');
-    writeMd(join(root, '.vendored', 'overridable'), 'b', '# overridable b');
+  it('skips hidden files and directories', () => {
+    writeMd(root, 'tactics/a', '# visible');
+    writeMd(join(root, '.vendored', 'protected'), 'hidden', '# hidden');
+    writeFileSync(join(root, '.DS_Store'), 'skip');
 
-    expect(listKnowledgeSlugs()).toEqual(['a', 'b']);
+    expect(listKnowledgeSlugs()).toEqual(['tactics/a']);
   });
 
-  it('resolves a slug present in only one tier', () => {
-    writeMd(join(root, '.vendored', 'overridable'), 'strategy/x', '# only overridable');
+  it('reads a slug from the configured dir', () => {
+    writeMd(root, 'strategy/x', '# only this');
 
-    expect(readKnowledgeBySlug('strategy/x')).toBe('# only overridable');
+    expect(readKnowledgeBySlug('strategy/x')).toBe('# only this');
   });
 
-  it('protected wins over a same-slug user file', () => {
-    writeMd(join(root, '.vendored', 'protected'), 'shared/topic', '# protected wins');
-    writeMd(root, 'shared/topic', '# user loses');
-
-    expect(readKnowledgeBySlug('shared/topic')).toBe('# protected wins');
-    expect(listKnowledgeSlugs()).toEqual(['shared/topic']);
-  });
-
-  it('a user file shadows the same-slug overridable default', () => {
-    writeMd(root, 'shared/topic', '# user wins');
-    writeMd(join(root, '.vendored', 'overridable'), 'shared/topic', '# overridable loses');
-
-    expect(readKnowledgeBySlug('shared/topic')).toBe('# user wins');
-  });
-
-  it('returns null for a slug that names no file in any tier', () => {
+  it('returns null for a missing slug', () => {
     expect(readKnowledgeBySlug('nope/nothing-here')).toBeNull();
   });
 
-  it('never resolves a caller-supplied slug into .vendored via the user-content root', () => {
-    // Only reachable through the literal .vendored/overridable/secret path — not a
-    // slug listKnowledgeSlugs would ever normalize to and produce.
-    writeMd(join(root, '.vendored', 'overridable'), 'secret', '# should not leak');
+  it('rejects slugs that point at hidden paths or escape the root', () => {
+    writeMd(join(root, '.hidden'), 'secret', '# should not leak');
 
-    expect(readKnowledgeBySlug('.vendored/overridable/secret')).toBeNull();
+    expect(readKnowledgeBySlug('.hidden/secret')).toBeNull();
+    expect(readKnowledgeBySlug('../escape')).toBeNull();
   });
 });

--- a/src/desktop/knowledgeExternalRoot.test.ts
+++ b/src/desktop/knowledgeExternalRoot.test.ts
@@ -1,0 +1,91 @@
+/**
+ * TABLEAU_KNOWLEDGE_DIR points at the tree tab-agent-south materializes to
+ * <agent-data-dir>/knowledge: `.vendored/protected`, `.vendored/overridable`,
+ * and top-level user content. These tests cover the precedence walk
+ * (protected > user > overridable) and slug normalization independent of that
+ * materialization — they build the tree by hand.
+ */
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+
+import { getConfiguredKnowledgeDir, listKnowledgeSlugs, readKnowledgeBySlug } from './assets.js';
+
+function writeMd(root: string, relSlug: string, content: string): void {
+  const path = join(root, ...relSlug.split('/')) + '.md';
+  mkdirSync(join(path, '..'), { recursive: true });
+  writeFileSync(path, content);
+}
+
+describe('external knowledge root (TABLEAU_KNOWLEDGE_DIR)', () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(process.cwd(), '.tmp-knowledge-root-'));
+    process.env['TABLEAU_KNOWLEDGE_DIR'] = root;
+  });
+
+  afterEach(() => {
+    delete process.env['TABLEAU_KNOWLEDGE_DIR'];
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('reports the external root from getConfiguredKnowledgeDir', () => {
+    expect(getConfiguredKnowledgeDir()).toBe(root);
+  });
+
+  it('merges slugs from all three tiers, normalized (tier prefix stripped)', () => {
+    writeMd(join(root, '.vendored', 'protected'), 'tactics/viz/filters', '# protected');
+    writeMd(root, 'my-notes/onboarding', '# user');
+    writeMd(
+      join(root, '.vendored', 'overridable'),
+      'strategy/viz-design/chart-selection',
+      '# overridable',
+    );
+
+    expect(listKnowledgeSlugs()).toEqual([
+      'my-notes/onboarding',
+      'strategy/viz-design/chart-selection',
+      'tactics/viz/filters',
+    ]);
+  });
+
+  it('excludes .vendored itself from the user-content walk', () => {
+    writeMd(join(root, '.vendored', 'protected'), 'a', '# protected a');
+    writeMd(join(root, '.vendored', 'overridable'), 'b', '# overridable b');
+
+    expect(listKnowledgeSlugs()).toEqual(['a', 'b']);
+  });
+
+  it('resolves a slug present in only one tier', () => {
+    writeMd(join(root, '.vendored', 'overridable'), 'strategy/x', '# only overridable');
+
+    expect(readKnowledgeBySlug('strategy/x')).toBe('# only overridable');
+  });
+
+  it('protected wins over a same-slug user file', () => {
+    writeMd(join(root, '.vendored', 'protected'), 'shared/topic', '# protected wins');
+    writeMd(root, 'shared/topic', '# user loses');
+
+    expect(readKnowledgeBySlug('shared/topic')).toBe('# protected wins');
+    expect(listKnowledgeSlugs()).toEqual(['shared/topic']);
+  });
+
+  it('a user file shadows the same-slug overridable default', () => {
+    writeMd(root, 'shared/topic', '# user wins');
+    writeMd(join(root, '.vendored', 'overridable'), 'shared/topic', '# overridable loses');
+
+    expect(readKnowledgeBySlug('shared/topic')).toBe('# user wins');
+  });
+
+  it('returns null for a slug that names no file in any tier', () => {
+    expect(readKnowledgeBySlug('nope/nothing-here')).toBeNull();
+  });
+
+  it('never resolves a caller-supplied slug into .vendored via the user-content root', () => {
+    // Only reachable through the literal .vendored/overridable/secret path — not a
+    // slug listKnowledgeSlugs would ever normalize to and produce.
+    writeMd(join(root, '.vendored', 'overridable'), 'secret', '# should not leak');
+
+    expect(readKnowledgeBySlug('.vendored/overridable/secret')).toBeNull();
+  });
+});

--- a/src/desktop/knowledgeExternalRoot.test.ts
+++ b/src/desktop/knowledgeExternalRoot.test.ts
@@ -1,5 +1,5 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
-import { join } from 'path';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { delimiter, join } from 'path';
 
 import { getConfiguredKnowledgeDir, listKnowledgeSlugs, readKnowledgeBySlug } from './assets.js';
 
@@ -61,5 +61,73 @@ describe('external knowledge root (TABLEAU_KNOWLEDGE_DIR)', () => {
 
     expect(readKnowledgeBySlug('.hidden/secret')).toBeNull();
     expect(readKnowledgeBySlug('../escape')).toBeNull();
+  });
+});
+
+describe('external knowledge roots, multi-root precedence', () => {
+  let protectedRoot: string;
+  let userRoot: string;
+  let overridableRoot: string;
+
+  beforeEach(() => {
+    protectedRoot = mkdtempSync(join(process.cwd(), '.tmp-knowledge-protected-'));
+    userRoot = mkdtempSync(join(process.cwd(), '.tmp-knowledge-user-'));
+    overridableRoot = mkdtempSync(join(process.cwd(), '.tmp-knowledge-overridable-'));
+    process.env['TABLEAU_KNOWLEDGE_DIR'] = [protectedRoot, userRoot, overridableRoot].join(
+      delimiter,
+    );
+  });
+
+  afterEach(() => {
+    delete process.env['TABLEAU_KNOWLEDGE_DIR'];
+    for (const root of [protectedRoot, userRoot, overridableRoot]) {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('reports every root joined by the platform delimiter', () => {
+    expect(getConfiguredKnowledgeDir()).toBe(
+      [protectedRoot, userRoot, overridableRoot].join(delimiter),
+    );
+  });
+
+  it('earlier roots win when the same slug exists in more than one root', () => {
+    writeMd(protectedRoot, 'strategy/layout', '# protected copy');
+    writeMd(overridableRoot, 'strategy/layout', '# overridable default');
+
+    expect(readKnowledgeBySlug('strategy/layout')).toBe('# protected copy');
+  });
+
+  it('a user-content copy shadows an overridable default at the same slug without touching it', () => {
+    writeMd(userRoot, 'strategy/layout', '# operator override');
+    writeMd(overridableRoot, 'strategy/layout', '# overridable default');
+
+    expect(readKnowledgeBySlug('strategy/layout')).toBe('# operator override');
+    expect(readFileSync(join(overridableRoot, 'strategy', 'layout.md'), 'utf-8')).toBe(
+      '# overridable default',
+    );
+  });
+
+  it('unions and dedups slugs across all roots when listing', () => {
+    writeMd(protectedRoot, 'tactics/a', '# a');
+    writeMd(userRoot, 'strategy/layout', '# operator');
+    writeMd(overridableRoot, 'strategy/layout', '# default');
+    writeMd(overridableRoot, 'personalization/tone', '# tone');
+
+    expect(listKnowledgeSlugs()).toEqual(['personalization/tone', 'strategy/layout', 'tactics/a']);
+  });
+
+  it('skips hidden files and directories within each root', () => {
+    writeMd(protectedRoot, 'tactics/a', '# visible');
+    writeMd(join(userRoot, '.vendored', 'protected'), 'hidden', '# hidden');
+    writeFileSync(join(overridableRoot, '.DS_Store'), 'skip');
+
+    expect(listKnowledgeSlugs()).toEqual(['tactics/a']);
+  });
+
+  it('falls through to the next root when an earlier root is missing the slug', () => {
+    writeMd(overridableRoot, 'strategy/only-here', '# default only');
+
+    expect(readKnowledgeBySlug('strategy/only-here')).toBe('# default only');
   });
 });

--- a/src/server.desktop.knowledge.test.ts
+++ b/src/server.desktop.knowledge.test.ts
@@ -5,12 +5,16 @@ import * as loggerModule from './logging/logger.js';
 
 const knowledgeMocks = vi.hoisted(() => ({
   getKnowledgeCorpusEntryCount: vi.fn(() => 0),
-  getKnowledgeDir: vi.fn(() => '/app/resources/desktop/knowledge'),
   listKnowledgeResources: vi.fn(() => []),
   readKnowledgeResource: vi.fn(() => null),
 }));
 
 vi.mock('./desktop/knowledge/index.js', () => knowledgeMocks);
+
+vi.mock('./desktop/assets.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('./desktop/assets.js')>()),
+  getConfiguredKnowledgeDir: vi.fn(() => '/app/resources/desktop/knowledge'),
+}));
 
 import { DesktopMcpServer } from './server.desktop.js';
 
@@ -40,6 +44,7 @@ describe('DesktopMcpServer knowledge startup check', () => {
       vi.resetModules();
       vi.doMock('./utils/getDirname.js', () => ({ getDirname: () => emptyRoot }));
       vi.doUnmock('./desktop/knowledge/index.js');
+      vi.doUnmock('./desktop/assets.js');
       const realKnowledge = await import('./desktop/knowledge/index.js');
       realKnowledge.clearKnowledgeCache();
       realKnowledge._resetKnowledgeSearchCache();

--- a/src/server.desktop.ts
+++ b/src/server.desktop.ts
@@ -13,7 +13,12 @@ import {
 
 import pkg from '../package.json';
 import { getDesktopConfig } from './config.desktop.js';
-import { DATA_ROOT, readResourceAsset, RESOURCES_ROOT } from './desktop/assets.js';
+import {
+  DATA_ROOT,
+  getConfiguredKnowledgeDir,
+  readResourceAsset,
+  RESOURCES_ROOT,
+} from './desktop/assets.js';
 import { createCallDeadline } from './desktop/callDeadline.js';
 import { emitEpisodeEvent, type ToolSchemaProfile } from './desktop/episode-events.js';
 import { apiVersionAtLeast } from './desktop/externalApi/apiVersion.js';
@@ -22,7 +27,6 @@ import { ExternalApiInstance } from './desktop/externalApi/types.js';
 import { buildDesktopInstructions } from './desktop/instructions.js';
 import {
   getKnowledgeCorpusEntryCount,
-  getKnowledgeDir,
   listKnowledgeResources,
   readKnowledgeResource,
 } from './desktop/knowledge/index.js';
@@ -288,7 +292,7 @@ export class DesktopMcpServer extends Server {
       this.knowledgeCorpusChecked = true;
       if (getKnowledgeCorpusEntryCount() === 0) {
         log({
-          message: `Knowledge corpus is empty; expected assets under ${getKnowledgeDir()}`,
+          message: `Knowledge corpus is empty; expected assets under ${getConfiguredKnowledgeDir()}`,
           level: 'warning',
           logger: 'DesktopMcpServer',
         });


### PR DESCRIPTION
## Summary
- Adds `TABLEAU_KNOWLEDGE_DIR`, read directly in `assets.ts` (mirrors the
  `TEMPLATES_DIR` module-level pattern, not `Config`) since the multi-root
  logic lives right alongside `listKnowledgeSlugs`/`readKnowledgeBySlug`.
- `listKnowledgeSlugs()`/`readKnowledgeBySlug()` resolve against the external
  root, in precedence order, even under SEA:
  `.vendored/protected` > top-level user content > `.vendored/overridable`.
  Slugs are normalized (tier prefix stripped) so all three map to the same
  logical `expertise://tableau/<slug>`.
- Falls back to the existing bundled `resources/desktop/knowledge` tree
  (SEA-embedded or disk) when the env var is unset — no change in that mode.
- `getKnowledgeDir()` reports the configured root for the empty-corpus guard
  message.

```mermaid
flowchart LR
  ENV[TABLEAU_KNOWLEDGE_DIR] --> P[.vendored/protected]
  ENV --> U[top-level user content]
  ENV --> O[.vendored/overridable]
  P -->|wins| SLUG[normalized slug]
  U -->|shadows overridable| SLUG
  O -->|fallback| SLUG
```

Left unchanged, verified unaffected: `vendoredAssets.test.ts` and
`corpusIntegrity.test.ts` ("serves each topic slug from exactly one
directory") — both run with the env var unset, so they still only exercise
the single bundled tree; the layered precedence only activates when
`TABLEAU_KNOWLEDGE_DIR` is set.

Deferred (long-term, per discussion): retiring `resources/desktop/knowledge`
from `DESKTOP_ASSET_DIRS` once tab-agent-south always supplies the dir.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `yarn lint`
- [x] `yarn test` — 376 files / 5826 tests passed
- [x] New `knowledgeExternalRoot.test.ts` covering precedence, slug
      normalization, `.vendored`-leak guard