### PR TITLE
fix(desktop): accept null index and storyPointCount from External Client API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "2.63.6",
+  "version": "2.63.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "2.63.6",
+      "version": "2.63.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.7.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "2.63.6",
+  "version": "2.63.7",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/src/desktop/externalApi/externalApiContract.test.ts
+++ b/src/desktop/externalApi/externalApiContract.test.ts
@@ -237,6 +237,27 @@ describe('external client API contract (captured openapi fixture)', () => {
         true,
       );
     });
+
+    it.each([
+      ['WorksheetItem', worksheetItemSchema],
+      ['DashboardItem', dashboardItemSchema],
+      ['StoryboardItem', storyboardItemSchema],
+    ] as const)('%s accepts a hidden sheet with index: null', (_name, schema) => {
+      expect(
+        schema.safeParse({ id: 'sheet-1', name: 'Sheet 1', hidden: true, index: null }).success,
+      ).toBe(true);
+    });
+
+    it('StoryboardItem accepts storyPointCount: null', () => {
+      expect(
+        storyboardItemSchema.safeParse({
+          id: 'story-1',
+          name: 'Story 1',
+          hidden: false,
+          storyPointCount: null,
+        }).success,
+      ).toBe(true);
+    });
   });
 
   describe('Problem ↔ problemResponseSchema', () => {

--- a/src/desktop/externalApi/types.ts
+++ b/src/desktop/externalApi/types.ts
@@ -458,7 +458,7 @@ export const worksheetItemSchema = z
     hidden: z.boolean(),
     isActiveSheet: z.boolean().optional(),
     isAutoUpdatesPaused: z.boolean().optional(),
-    index: z.number().int().optional(),
+    index: z.number().int().nullish(),
     datasources: z.array(z.string()).optional(),
   })
   .passthrough();
@@ -481,7 +481,7 @@ export const dashboardItemSchema = z
     hidden: z.boolean(),
     isActiveSheet: z.boolean().optional(),
     isAutoUpdatesPaused: z.boolean().optional(),
-    index: z.number().int().optional(),
+    index: z.number().int().nullish(),
     containedSheets: z.array(z.string()).optional(),
   })
   .passthrough();
@@ -503,8 +503,8 @@ export const storyboardItemSchema = z
     type: z.string().optional(),
     hidden: z.boolean(),
     isActiveSheet: z.boolean().optional(),
-    index: z.number().int().optional(),
-    storyPointCount: z.number().int().optional(),
+    index: z.number().int().nullish(),
+    storyPointCount: z.number().int().nullish(),
   })
   .passthrough();
 export type StoryboardItem = z.infer<typeof storyboardItemSchema>;


### PR DESCRIPTION
**Decision:** our External Client API read schemas now accept an explicit `null` for the sheet-item fields the API declares nullable — `index` (worksheet/dashboard/storyboard) and `storyPointCount` (storyboard). This is a rule we keep going forward: where the API types a field as `["integer","null"]`, our Zod uses `.nullish()`, not `.optional()`.

**Why:** the API contract for `index` changed. It used to be a plain `integer` that hidden sheets *omitted*; it is now required-and-nullable, and hidden sheets send `index: null`. `.optional()` accepts a missing key but rejects an explicit `null`, so `list-worksheets` (and the dashboard/storyboard reads) threw a ZodError on any workbook containing a hidden sheet. `storyPointCount` is the same class — the spec marks it nullable and we were rejecting null.

**Tests:** added contract-test cases asserting the three item schemas accept `index: null`, and that `StoryboardItem` accepts `storyPointCount: null`.

**Follow-up (not in this PR):** the captured contract fixture is still v0.2.6 — it documents `index` as an omitted plain integer, not nullable — and the contract harness checks property presence and requiredness but *not* nullability. That gap is why this drift shipped silently. Refreshing the fixture and adding nullability parity to the harness would catch the next one automatically.
