### PR TITLE
feat(desktop): gate tools by minimum External Client API version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "2.63.7",
+  "version": "2.63.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "2.63.7",
+      "version": "2.63.8",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.7.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "2.63.7",
+  "version": "2.63.8",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/src/desktop/externalApi/apiVersion.test.ts
+++ b/src/desktop/externalApi/apiVersion.test.ts
@@ -1,0 +1,33 @@
+import { apiVersionAtLeast } from './apiVersion.js';
+
+describe('apiVersionAtLeast', () => {
+  it.each([
+    ['0.2.6', '0.2.6', true],
+    ['0.2.6', '0.2.5', true],
+    ['0.2.5', '0.2.6', false],
+    ['0.3.0', '0.2.9', true],
+    ['1.0.0', '0.9.9', true],
+    ['0.9.9', '1.0.0', false],
+    ['0.2.10', '0.2.9', true],
+    ['0.1.1', '0.1.1', true],
+    ['0.1.0', '0.1.1', false],
+  ])('%s >= %s → %s', (current, minimum, expected) => {
+    expect(apiVersionAtLeast(current, minimum)).toBe(expected);
+  });
+
+  it('treats a shorter version as zero-padded (0.2 === 0.2.0)', () => {
+    expect(apiVersionAtLeast('0.2', '0.2.0')).toBe(true);
+    expect(apiVersionAtLeast('0.2', '0.2.1')).toBe(false);
+  });
+
+  it('parses undefined and empty as 0.0.0 — below every real floor', () => {
+    expect(apiVersionAtLeast(undefined, '0.2.5')).toBe(false);
+    expect(apiVersionAtLeast('', '0.2.5')).toBe(false);
+    expect(apiVersionAtLeast(undefined, '0.0.0')).toBe(true);
+  });
+
+  it('reads unparseable parts as zero rather than throwing', () => {
+    expect(apiVersionAtLeast('0.x.y', '0.0.0')).toBe(true);
+    expect(apiVersionAtLeast('0.x.y', '0.1.0')).toBe(false);
+  });
+});

--- a/src/desktop/externalApi/apiVersion.ts
+++ b/src/desktop/externalApi/apiVersion.ts
@@ -1,0 +1,19 @@
+/**
+ * Numeric SemVer comparison ("0.2.6" >= "0.2.5"). Missing/unparseable parts read as 0,
+ * so `undefined` and `""` compare as 0.0.0 — below every real floor.
+ */
+export function apiVersionAtLeast(current: string | undefined, minimum: string): boolean {
+  const [cMajor, cMinor, cPatch] = parseApiVersion(current);
+  const [mMajor, mMinor, mPatch] = parseApiVersion(minimum);
+  if (cMajor !== mMajor) return cMajor > mMajor;
+  if (cMinor !== mMinor) return cMinor > mMinor;
+  return cPatch >= mPatch;
+}
+
+function parseApiVersion(version: string | undefined): [number, number, number] {
+  const [major = 0, minor = 0, patch = 0] = (version ?? '')
+    .split('.')
+    .map((part) => Number.parseInt(part, 10))
+    .map((part) => (Number.isFinite(part) ? part : 0));
+  return [major, minor, patch];
+}

--- a/src/desktop/externalApi/apiVersion.ts
+++ b/src/desktop/externalApi/apiVersion.ts
@@ -1,3 +1,5 @@
+export type ApiVersionFloor = `${number}.${number}.${number}`;
+
 /**
  * Numeric SemVer comparison ("0.2.6" >= "0.2.5"). Missing/unparseable parts read as 0,
  * so `undefined` and `""` compare as 0.0.0 — below every real floor.

--- a/src/desktop/externalApi/externalApiToolExecutor.ts
+++ b/src/desktop/externalApi/externalApiToolExecutor.ts
@@ -12,6 +12,7 @@ import {
   unknownInstanceUnreachableMessage,
   unreachableInstanceMessage,
 } from '../session/unreachableInstance.js';
+import { apiVersionAtLeast } from './apiVersion.js';
 import {
   ApplyWorkbookDocumentOptions,
   ExecuteCommandArgs,
@@ -897,11 +898,7 @@ function getTableauErrorCode(error: OperationError | undefined): string | undefi
 }
 
 function supportsOperationResult(apiVersion: string | undefined): boolean {
-  const [major = 0, minor = 0, patch = 0] = (apiVersion ?? '')
-    .split('.')
-    .map((part) => Number.parseInt(part, 10))
-    .map((part) => (Number.isFinite(part) ? part : 0));
-  return major > 0 || (major === 0 && (minor > 1 || (minor === 1 && patch >= 1)));
+  return apiVersionAtLeast(apiVersion, '0.1.1');
 }
 
 function describeBlockingWindows(windows: Array<WindowInfo> | undefined): string {

--- a/src/server.desktop.test.ts
+++ b/src/server.desktop.test.ts
@@ -9,6 +9,7 @@ import {
 
 import * as configModule from './config.desktop.js';
 import * as episodeEvents from './desktop/episode-events.js';
+import { ExternalApiInstance } from './desktop/externalApi/types.js';
 import {
   buildDesktopInstructions,
   SESSION_RESOLUTION_TEXT_PINNED,
@@ -20,7 +21,9 @@ import {
   DESKTOP_INSTRUCTIONS,
   DesktopMcpServer,
   DYNAMIC_AUTHORING_TOOL_PROFILE,
+  filterToolsByApiVersion,
   getDesktopToolListEntry,
+  resolveConnectedApiVersion,
   selectToolsForProfile,
   SPEC_LOOP_TOOL_PROFILE,
 } from './server.desktop.js';
@@ -613,6 +616,108 @@ describe('selectToolsForProfile (TOOL_PROFILE, W60 spike lever 1 / preamble P1)'
     const selected = selectToolsForProfile(tools, 'bogus');
     expect(selected).toBe(tools);
     expect(logSpy).toHaveBeenCalledWith(expect.objectContaining({ level: 'warning' }));
+  });
+});
+
+describe('API-version tool gate (interim minApiVersion floor)', () => {
+  const instance = (pid: number, apiVersion?: string): ExternalApiInstance => ({
+    baseUrl: `http://127.0.0.1:${pid}`,
+    token: 't',
+    pid,
+    instanceId: `i-${pid}`,
+    apiVersion,
+  });
+
+  describe('resolveConnectedApiVersion', () => {
+    it('unpinned → the newest instance (the discovery list is newest-first)', () => {
+      expect(
+        resolveConnectedApiVersion([instance(1, '0.2.6'), instance(2, '0.2.5')], undefined),
+      ).toBe('0.2.6');
+    });
+
+    it('pinned → the matching instance version, not the newest', () => {
+      expect(resolveConnectedApiVersion([instance(1, '0.2.6'), instance(2, '0.2.5')], '2')).toBe(
+        '0.2.5',
+      );
+    });
+
+    it('pinned but no match → undefined so the gate fails open', () => {
+      expect(resolveConnectedApiVersion([instance(1, '0.2.6')], '999')).toBeUndefined();
+    });
+
+    it('no instances → undefined', () => {
+      expect(resolveConnectedApiVersion([], undefined)).toBeUndefined();
+      expect(resolveConnectedApiVersion([], '1')).toBeUndefined();
+    });
+  });
+
+  describe('filterToolsByApiVersion', () => {
+    const tools: Array<{ name: string; minApiVersion?: string }> = [
+      { name: 'a', minApiVersion: '0.2.6' },
+      { name: 'b', minApiVersion: '0.2.5' },
+      { name: 'c' },
+    ];
+
+    it('drops tools whose floor exceeds the connected version', () => {
+      expect(filterToolsByApiVersion(tools, '0.2.5').map((t) => t.name)).toEqual(['b', 'c']);
+    });
+
+    it('keeps a tool whose floor equals the connected version', () => {
+      expect(filterToolsByApiVersion(tools, '0.2.6').map((t) => t.name)).toEqual(['a', 'b', 'c']);
+    });
+
+    it('fails open when the connected version is unknown — keeps everything unchanged', () => {
+      expect(filterToolsByApiVersion(tools, undefined)).toBe(tools);
+    });
+  });
+
+  it('the version-gated tools declare the expected floors', () => {
+    const floors = new Map(
+      desktopToolFactories
+        .map((factory) => factory(new DesktopMcpServer()))
+        .map((tool) => [tool.name, tool.minApiVersion]),
+    );
+    expect(floors.get('pause-auto-updates')).toBe('0.2.5');
+    expect(floors.get('resume-auto-updates')).toBe('0.2.5');
+    expect(floors.get('open-file')).toBe('0.2.6');
+    expect(floors.get('save-workbook')).toBe('0.2.6');
+    expect(floors.get('add-worksheet')).toBe('0.2.6');
+    expect(floors.get('add-dashboard')).toBe('0.2.6');
+    expect(floors.get('add-storyboard')).toBe('0.2.6');
+    expect(floors.get('export-storyboard-image')).toBe('0.2.7');
+  });
+
+  it('a connected 0.2.5 Desktop hides only the 0.2.6 tools from the profile surface', () => {
+    const profileTools = selectToolsForProfile(
+      desktopToolFactories.map((factory) => factory(new DesktopMcpServer())),
+      'dynamic-authoring',
+    );
+    const gated = filterToolsByApiVersion(profileTools, '0.2.5').map((tool) => tool.name);
+
+    for (const dropped of [
+      'open-file',
+      'save-workbook',
+      'add-worksheet',
+      'add-dashboard',
+      'add-storyboard',
+    ]) {
+      expect(gated).not.toContain(dropped);
+    }
+    for (const kept of ['pause-auto-updates', 'resume-auto-updates', 'apply-worksheet']) {
+      expect(gated).toContain(kept);
+    }
+  });
+
+  it('a connected 0.2.6 Desktop still hides the 0.2.7 story-image route', () => {
+    const fullTools = selectToolsForProfile(
+      desktopToolFactories.map((factory) => factory(new DesktopMcpServer())),
+      'full',
+    );
+    const at26 = filterToolsByApiVersion(fullTools, '0.2.6').map((tool) => tool.name);
+    const at27 = filterToolsByApiVersion(fullTools, '0.2.7').map((tool) => tool.name);
+
+    expect(at26).not.toContain('export-storyboard-image');
+    expect(at27).toContain('export-storyboard-image');
   });
 });
 

--- a/src/server.desktop.test.ts
+++ b/src/server.desktop.test.ts
@@ -629,13 +629,25 @@ describe('API-version tool gate (interim minApiVersion floor)', () => {
   });
 
   describe('resolveConnectedApiVersion', () => {
-    it('unpinned → the newest instance (the discovery list is newest-first)', () => {
+    it('unpinned → the highest version across live instances, not the newest-started', () => {
+      // Discovery is newest-first, so instances[0] here is the LOWER-version build; the gate
+      // must still resolve 0.2.6 so a tool the other running Desktop serves is not hidden.
       expect(
-        resolveConnectedApiVersion([instance(1, '0.2.6'), instance(2, '0.2.5')], undefined),
+        resolveConnectedApiVersion([instance(1, '0.2.5'), instance(2, '0.2.6')], undefined),
       ).toBe('0.2.6');
     });
 
-    it('pinned → the matching instance version, not the newest', () => {
+    it('unpinned → ignores instances with an unknown version when others report one', () => {
+      expect(resolveConnectedApiVersion([instance(1), instance(2, '0.2.6')], undefined)).toBe(
+        '0.2.6',
+      );
+    });
+
+    it('unpinned → undefined when no instance reports a version', () => {
+      expect(resolveConnectedApiVersion([instance(1), instance(2)], undefined)).toBeUndefined();
+    });
+
+    it('pinned → the matching instance version, not the highest', () => {
       expect(resolveConnectedApiVersion([instance(1, '0.2.6'), instance(2, '0.2.5')], '2')).toBe(
         '0.2.5',
       );
@@ -648,6 +660,18 @@ describe('API-version tool gate (interim minApiVersion floor)', () => {
     it('no instances → undefined', () => {
       expect(resolveConnectedApiVersion([], undefined)).toBeUndefined();
       expect(resolveConnectedApiVersion([], '1')).toBeUndefined();
+    });
+
+    it('unpinned mixed-version fleet → a tool only the newer instance serves stays visible', () => {
+      const version = resolveConnectedApiVersion(
+        [instance(1, '0.2.6'), instance(2, '0.2.7')],
+        undefined,
+      );
+      const tools = [{ name: 'story', minApiVersion: '0.2.7' }, { name: 'plain' }];
+      expect(filterToolsByApiVersion(tools, version).map((t) => t.name)).toEqual([
+        'story',
+        'plain',
+      ]);
     });
   });
 

--- a/src/server.desktop.ts
+++ b/src/server.desktop.ts
@@ -16,6 +16,9 @@ import { getDesktopConfig } from './config.desktop.js';
 import { DATA_ROOT, readResourceAsset, RESOURCES_ROOT } from './desktop/assets.js';
 import { createCallDeadline } from './desktop/callDeadline.js';
 import { emitEpisodeEvent, type ToolSchemaProfile } from './desktop/episode-events.js';
+import { apiVersionAtLeast } from './desktop/externalApi/apiVersion.js';
+import { discoverInstances } from './desktop/externalApi/discovery.js';
+import { ExternalApiInstance } from './desktop/externalApi/types.js';
 import { buildDesktopInstructions } from './desktop/instructions.js';
 import {
   getKnowledgeCorpusEntryCount,
@@ -209,6 +212,44 @@ export function selectToolsForProfile<T extends { name: DesktopToolName }>(
   return tools;
 }
 
+/**
+ * Pick the External Client API version to gate against from the discovered instances
+ * (newest-first): the pinned session's instance when pinned, else the newest. Undefined —
+ * which makes the gate fail open — when no instance matches, so a not-yet-written discovery
+ * file never hides tools.
+ *
+ * Interim: the planned `GET /v0/capabilities` endpoint is the eventual source of truth for
+ * whether an endpoint is served, and replaces this discovery-file version read.
+ */
+export function resolveConnectedApiVersion(
+  instances: Array<ExternalApiInstance>,
+  pinnedSessionId: string | undefined,
+): string | undefined {
+  if (pinnedSessionId !== undefined) {
+    return instances.find((instance) => String(instance.pid) === pinnedSessionId)?.apiVersion;
+  }
+  return instances[0]?.apiVersion;
+}
+
+/**
+ * Drop tools whose {@link DesktopTool.minApiVersion} floor exceeds the connected Desktop's
+ * API version. Fails open: an unknown connected version keeps every tool, leaving the
+ * per-call `endpointNotInThisBuild` guard as the backstop.
+ */
+export function filterToolsByApiVersion<T extends { minApiVersion?: string }>(
+  tools: T[],
+  connectedApiVersion: string | undefined,
+): T[] {
+  if (connectedApiVersion === undefined) {
+    return tools;
+  }
+  return tools.filter(
+    (tool) =>
+      tool.minApiVersion === undefined ||
+      apiVersionAtLeast(connectedApiVersion, tool.minApiVersion),
+  );
+}
+
 export { DATA_ROOT, RESOURCES_ROOT };
 
 // Routing guidance every connecting client receives at initialize (W60 adoption P5 —
@@ -332,7 +373,23 @@ export class DesktopMcpServer extends Server {
       ...(config.episodeEventsEnabled ? episodeToolFactories : []),
     ];
     const allTools = factories.map((toolFactory) => toolFactory(this));
-    return selectToolsForProfile(allTools, config.toolProfile);
+    const profileTools = selectToolsForProfile(allTools, config.toolProfile);
+
+    const instances = discoverInstances({ discoveryDir: config.externalApiDiscoveryDir });
+    const connectedApiVersion = resolveConnectedApiVersion(instances, config.desktopSessionId);
+    const gatedTools = filterToolsByApiVersion(profileTools, connectedApiVersion);
+
+    if (gatedTools.length < profileTools.length) {
+      const dropped = profileTools
+        .filter((tool) => !gatedTools.includes(tool))
+        .map((tool) => tool.name);
+      log({
+        message: `Hiding ${dropped.length} tool(s) the connected Desktop API v${connectedApiVersion} does not serve: ${dropped.join(', ')}`,
+        level: 'info',
+        logger: 'DesktopMcpServer',
+      });
+    }
+    return gatedTools;
   };
 
   private _registerKnowledgeResources = (): void => {

--- a/src/server.desktop.ts
+++ b/src/server.desktop.ts
@@ -213,13 +213,13 @@ export function selectToolsForProfile<T extends { name: DesktopToolName }>(
 }
 
 /**
- * Pick the External Client API version to gate against from the discovered instances
- * (newest-first): the pinned session's instance when pinned, else the newest. Undefined —
- * which makes the gate fail open — when no instance matches, so a not-yet-written discovery
- * file never hides tools.
+ * The External Client API version the registration gate compares tool floors against: the
+ * pinned instance's version when pinned, otherwise the highest version among live instances
+ * (undefined when none is known, which fails the gate open).
  *
- * Interim: the planned `GET /v0/capabilities` endpoint is the eventual source of truth for
- * whether an endpoint is served, and replaces this discovery-file version read.
+ * Unpinned resolves the highest — not the newest-started — so a tool is hidden only when no
+ * running Desktop can serve it; whether the instance a call actually reaches serves it is a
+ * per-call concern, not the gate's.
  */
 export function resolveConnectedApiVersion(
   instances: Array<ExternalApiInstance>,
@@ -228,7 +228,14 @@ export function resolveConnectedApiVersion(
   if (pinnedSessionId !== undefined) {
     return instances.find((instance) => String(instance.pid) === pinnedSessionId)?.apiVersion;
   }
-  return instances[0]?.apiVersion;
+  return instances.reduce<string | undefined>(
+    (highest, instance) =>
+      instance.apiVersion !== undefined &&
+      (highest === undefined || apiVersionAtLeast(instance.apiVersion, highest))
+        ? instance.apiVersion
+        : highest,
+    undefined,
+  );
 }
 
 /**

--- a/src/tools/desktop/api/addDashboard.ts
+++ b/src/tools/desktop/api/addDashboard.ts
@@ -22,6 +22,7 @@ export const getAddDashboardTool = (server: DesktopMcpServer): DesktopTool<typeo
   const addDashboardTool = new DesktopTool({
     server,
     name: 'add-dashboard',
+    minApiVersion: '0.2.6',
     title,
     description: 'Add a blank dashboard to the open workbook.',
     annotations: {

--- a/src/tools/desktop/api/addStoryboard.ts
+++ b/src/tools/desktop/api/addStoryboard.ts
@@ -24,6 +24,7 @@ export const getAddStoryboardTool = (
   const addStoryboardTool = new DesktopTool({
     server,
     name: 'add-storyboard',
+    minApiVersion: '0.2.6',
     title,
     description: 'Add a blank storyboard to the open workbook.',
     annotations: {

--- a/src/tools/desktop/api/addWorksheet.ts
+++ b/src/tools/desktop/api/addWorksheet.ts
@@ -22,6 +22,7 @@ export const getAddWorksheetTool = (server: DesktopMcpServer): DesktopTool<typeo
   const addWorksheetTool = new DesktopTool({
     server,
     name: 'add-worksheet',
+    minApiVersion: '0.2.6',
     title,
     description: 'Add a blank worksheet to the open workbook.',
     annotations: {

--- a/src/tools/desktop/api/exportStoryboardImage.ts
+++ b/src/tools/desktop/api/exportStoryboardImage.ts
@@ -38,6 +38,7 @@ export const exportStoryboardImageTool = (
   const exportStoryboardImage = new DesktopTool({
     server,
     name: 'export-storyboard-image',
+    minApiVersion: '0.2.7',
     title,
     description:
       "Render a storyboard's active story point as an image. Only the active point is rendered; other story points are not included and cannot be selected.",

--- a/src/tools/desktop/api/openFile.ts
+++ b/src/tools/desktop/api/openFile.ts
@@ -20,6 +20,7 @@ export const getOpenFileTool = (server: DesktopMcpServer): DesktopTool<typeof pa
   const openFileTool = new DesktopTool({
     server,
     name: 'open-file',
+    minApiVersion: '0.2.6',
     title,
     description:
       'Open a local file in Tableau Desktop by absolute path: a .twb/.twbx opens as a workbook, ' +

--- a/src/tools/desktop/api/pauseAutoUpdates.ts
+++ b/src/tools/desktop/api/pauseAutoUpdates.ts
@@ -24,6 +24,7 @@ export const getPauseAutoUpdatesTool = (
   const pauseAutoUpdatesTool = new DesktopTool({
     server,
     name: 'pause-auto-updates',
+    minApiVersion: '0.2.5',
     title,
     description:
       'Pause automatic query execution for a worksheet or dashboard to batch edits before the next refresh. Resume with resume-auto-updates.',

--- a/src/tools/desktop/api/resumeAutoUpdates.ts
+++ b/src/tools/desktop/api/resumeAutoUpdates.ts
@@ -24,6 +24,7 @@ export const getResumeAutoUpdatesTool = (
   const resumeAutoUpdatesTool = new DesktopTool({
     server,
     name: 'resume-auto-updates',
+    minApiVersion: '0.2.5',
     title,
     description:
       'Resume automatic query execution paused with pause-auto-updates. Resuming a dashboard re-enables it and every worksheet it contains, not only ones this paused.',

--- a/src/tools/desktop/api/saveWorkbook.ts
+++ b/src/tools/desktop/api/saveWorkbook.ts
@@ -23,6 +23,7 @@ export const getSaveWorkbookTool = (server: DesktopMcpServer): DesktopTool<typeo
   const saveWorkbookTool = new DesktopTool({
     server,
     name: 'save-workbook',
+    minApiVersion: '0.2.6',
     title,
     description:
       'Save the open workbook in place, or pass an absolute .twb/.twbx path to save a copy there. ' +

--- a/src/tools/desktop/tool.ts
+++ b/src/tools/desktop/tool.ts
@@ -13,7 +13,7 @@ import {
 import { log } from '../../logging/logger.js';
 import { DesktopMcpServer } from '../../server.desktop.js';
 import { getExceptionMessage } from '../../utils/getExceptionMessage.js';
-import { LogAndExecuteParams, Tool } from '../tool.js';
+import { LogAndExecuteParams, Tool, ToolParams } from '../tool.js';
 import { getStructuredContent } from './structuredContent.js';
 import { TableauDesktopRequestHandlerExtra, TableauDesktopToolCallback } from './toolContext.js';
 import { DesktopToolName } from './toolName.js';
@@ -29,6 +29,14 @@ export type DesktopToolLogAndExecuteParams<
   Args extends undefined | ZodRawShapeCompat | AnySchema,
 > = LogAndExecuteParams<T, DesktopMcpServer, TableauDesktopRequestHandlerExtra, Args>;
 
+export type DesktopToolParams<Args extends ZodRawShape | undefined = undefined> = ToolParams<
+  DesktopMcpServer,
+  DesktopToolName,
+  TableauDesktopRequestHandlerExtra,
+  TableauDesktopToolCallback<Args>,
+  Args
+> & { minApiVersion?: string };
+
 export class DesktopTool<Args extends ZodRawShape | undefined = undefined> extends Tool<
   DesktopMcpServer,
   DesktopToolName,
@@ -36,6 +44,17 @@ export class DesktopTool<Args extends ZodRawShape | undefined = undefined> exten
   TableauDesktopToolCallback<Args>,
   Args
 > {
+  /**
+   * Minimum External Client API version whose Desktop build serves the endpoint this tool
+   * drives; unset means no floor.
+   */
+  readonly minApiVersion?: string;
+
+  constructor(params: DesktopToolParams<Args>) {
+    super(params);
+    this.minApiVersion = params.minApiVersion;
+  }
+
   async logAndExecute<T>({
     extra,
     args,

--- a/src/tools/desktop/tool.ts
+++ b/src/tools/desktop/tool.ts
@@ -10,6 +10,7 @@ import {
   emitToolErrorEvent,
   episodeSessionIdFromArgs,
 } from '../../desktop/episode-events.js';
+import { ApiVersionFloor } from '../../desktop/externalApi/apiVersion.js';
 import { log } from '../../logging/logger.js';
 import { DesktopMcpServer } from '../../server.desktop.js';
 import { getExceptionMessage } from '../../utils/getExceptionMessage.js';
@@ -35,7 +36,7 @@ export type DesktopToolParams<Args extends ZodRawShape | undefined = undefined> 
   TableauDesktopRequestHandlerExtra,
   TableauDesktopToolCallback<Args>,
   Args
-> & { minApiVersion?: string };
+> & { minApiVersion?: ApiVersionFloor };
 
 export class DesktopTool<Args extends ZodRawShape | undefined = undefined> extends Tool<
   DesktopMcpServer,
@@ -48,7 +49,7 @@ export class DesktopTool<Args extends ZodRawShape | undefined = undefined> exten
    * Minimum External Client API version whose Desktop build serves the endpoint this tool
    * drives; unset means no floor.
    */
-  readonly minApiVersion?: string;
+  readonly minApiVersion?: ApiVersionFloor;
 
   constructor(params: DesktopToolParams<Args>) {
     super(params);


### PR DESCRIPTION
Adds a per-tool `minApiVersion` floor for desktop MCP tools. At registration the server reads the connected Desktop's External Client API version from its discovery file and drops any tool whose floor exceeds it.

**Fail-open:** when the connected version is unknown (no discoverable instance yet), every tool registers and the existing per-call `endpointNotInThisBuild` guard stays the backstop. This is a rule the codebase now keeps — any tool can set `minApiVersion` and be gated — not a one-off.

**Interim:** the planned `GET /v0/capabilities` endpoint is the eventual source of truth for whether an endpoint is served; this discovery-file version read is the stopgap until it lands.

### Floors set
| Tools | Floor |
| --- | --- |
| `pause-auto-updates`, `resume-auto-updates` | 0.2.5 |
| `open-file`, `save-workbook`, `add-worksheet`, `add-dashboard`, `add-storyboard` | 0.2.6 |
| `export-storyboard-image` | 0.2.7 |

### Verified
- Unit tests: version compare, `resolveConnectedApiVersion`, `filterToolsByApiVersion`, plus a floor-pinning test. Full desktop suite green (3567 tests).
- Live against Tableau Desktop @ apiVersion 0.2.6: the seven ≤0.2.6 tools register and pause→resume round-trips; under `TOOL_PROFILE=full` the gate drops exactly `export-storyboard-image` (needs 0.2.7) and re-exposes it at 0.2.7.

### Note
`supportsOperationResult` now reuses the new `apiVersionAtLeast` helper (behavior-identical, ≥0.1.1).

**Reviewer checkpoint:** the floor *values* — the mechanism is version-agnostic; the specific numbers are the thing to sanity-check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)