### PR TITLE
@W-23864448 Add REST GET /workbooks/{id}/connections to the SDK

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "4.5.2",
+  "version": "4.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "4.5.2",
+      "version": "4.6.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1095.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "4.5.5",
+  "version": "4.5.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "4.5.5",
+      "version": "4.5.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1095.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "4.6.0",
+  "version": "4.5.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "4.6.0",
+      "version": "4.5.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1095.0",
@@ -639,7 +639,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -688,7 +687,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -1754,7 +1752,6 @@
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
       "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@hono/node-server": "^1.19.9",
         "ajv": "^8.17.1",
@@ -2482,7 +2479,6 @@
       "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^5.0.0",
@@ -2661,7 +2657,6 @@
       "integrity": "sha512-A0M6ua6H252bVjPvvtSgl2QA4+ET9S5Mtkb2GDyTxIhH/C4qDItT7RQNO5PhMC6NXGYXOR9dIalcDDgBKT7oFA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.60.1",
         "@typescript-eslint/types": "8.60.1",
@@ -3086,7 +3081,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3109,6 +3103,7 @@
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "debug": "4"
       },
@@ -4162,7 +4157,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4223,7 +4217,6 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -4749,6 +4742,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=4.0"
       },
@@ -5220,7 +5214,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.27.tgz",
       "integrity": "sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -5277,6 +5270,7 @@
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
       "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "agent-base": "6",
         "debug": "4"
@@ -6878,7 +6872,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7005,7 +6998,6 @@
       "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -7060,6 +7052,7 @@
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
       "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -7219,7 +7212,6 @@
       "integrity": "sha512-I4KW6iuRpuu2uHBLraZ1wNZe0DP7lnRha+VJ9tNaYVaVgKhW0aI3h4RYnoRPeql0flHm/Co55b7snEDcOfOJrA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.9"
       },
@@ -8873,7 +8865,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9010,7 +9001,6 @@
       "integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -9630,7 +9620,6 @@
       "integrity": "sha512-xejya+bT/j/+R/AGa1XOfRxLmNUlLtlwjRsFUILF+xHfzElmGcmFydy2gqqIrd62ptIEfwVMofd19uNWD9L7Nw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.6",
@@ -10040,7 +10029,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "4.6.0",
+  "version": "4.5.3",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "4.5.5",
+  "version": "4.5.6",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "4.5.2",
+  "version": "4.6.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/src/sdks/tableau/apis/workbooksApi.ts
+++ b/src/sdks/tableau/apis/workbooksApi.ts
@@ -92,7 +92,7 @@ const addTagsToWorkbookEndpoint = makeEndpoint({
 const queryWorkbookConnectionsEndpoint = makeEndpoint({
   method: 'get',
   path: '/sites/:siteId/workbooks/:workbookId/connections',
-  alias: 'getWorkbookConnections',
+  alias: 'queryWorkbookConnections',
   description:
     'Returns a list of data connections for the specified workbook, including the datasource each connection points to.',
   response: z.object({

--- a/src/sdks/tableau/apis/workbooksApi.ts
+++ b/src/sdks/tableau/apis/workbooksApi.ts
@@ -89,7 +89,7 @@ const addTagsToWorkbookEndpoint = makeEndpoint({
   response: z.object({ tags: tagsSchema }),
 });
 
-const getWorkbookConnectionsEndpoint = makeEndpoint({
+const queryWorkbookConnectionsEndpoint = makeEndpoint({
   method: 'get',
   path: '/sites/:siteId/workbooks/:workbookId/connections',
   alias: 'getWorkbookConnections',
@@ -105,7 +105,7 @@ const getWorkbookConnectionsEndpoint = makeEndpoint({
 const workbooksApi = makeApi([
   queryWorkbooksForSiteEndpoint,
   getWorkbookEndpoint,
-  getWorkbookConnectionsEndpoint,
+  queryWorkbookConnectionsEndpoint,
   deleteWorkbookEndpoint,
   addTagsToWorkbookEndpoint,
 ]);

--- a/src/sdks/tableau/apis/workbooksApi.ts
+++ b/src/sdks/tableau/apis/workbooksApi.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 
 import { paginationSchema } from '../types/pagination.js';
 import { tagsSchema } from '../types/tags.js';
-import { workbookSchema } from '../types/workbook.js';
+import { workbookConnectionSchema, workbookSchema } from '../types/workbook.js';
 import { paginationParameters } from './paginationParameters.js';
 
 const getWorkbookEndpoint = makeEndpoint({
@@ -89,9 +89,23 @@ const addTagsToWorkbookEndpoint = makeEndpoint({
   response: z.object({ tags: tagsSchema }),
 });
 
+const queryWorkbookConnectionsEndpoint = makeEndpoint({
+  method: 'get',
+  path: '/sites/:siteId/workbooks/:workbookId/connections',
+  alias: 'getWorkbookConnections',
+  description:
+    'Returns a list of data connections for the specified workbook, including the datasource each connection points to.',
+  response: z.object({
+    connections: z.object({
+      connection: z.optional(z.array(workbookConnectionSchema)),
+    }),
+  }),
+});
+
 const workbooksApi = makeApi([
   queryWorkbooksForSiteEndpoint,
   getWorkbookEndpoint,
+  queryWorkbookConnectionsEndpoint,
   deleteWorkbookEndpoint,
   addTagsToWorkbookEndpoint,
 ]);

--- a/src/sdks/tableau/apis/workbooksApi.ts
+++ b/src/sdks/tableau/apis/workbooksApi.ts
@@ -89,7 +89,7 @@ const addTagsToWorkbookEndpoint = makeEndpoint({
   response: z.object({ tags: tagsSchema }),
 });
 
-const queryWorkbookConnectionsEndpoint = makeEndpoint({
+const getWorkbookConnectionsEndpoint = makeEndpoint({
   method: 'get',
   path: '/sites/:siteId/workbooks/:workbookId/connections',
   alias: 'getWorkbookConnections',
@@ -105,7 +105,7 @@ const queryWorkbookConnectionsEndpoint = makeEndpoint({
 const workbooksApi = makeApi([
   queryWorkbooksForSiteEndpoint,
   getWorkbookEndpoint,
-  queryWorkbookConnectionsEndpoint,
+  getWorkbookConnectionsEndpoint,
   deleteWorkbookEndpoint,
   addTagsToWorkbookEndpoint,
 ]);

--- a/src/sdks/tableau/methods/workbooksMethods.test.ts
+++ b/src/sdks/tableau/methods/workbooksMethods.test.ts
@@ -4,6 +4,73 @@ import { describe, expect, it, vi } from 'vitest';
 import WorkbooksMethods from './workbooksMethods.js';
 
 describe('WorkbooksMethods', () => {
+  describe('getWorkbookConnections', () => {
+    it('extracts each connection with its datasource id and name', async () => {
+      const mockGetWorkbookConnections = vi.fn().mockResolvedValue({
+        connections: {
+          connection: [
+            {
+              id: 'conn-1',
+              type: 'sqlserver',
+              datasource: { id: 'ds-1', name: 'Superstore' },
+            },
+            {
+              id: 'conn-2',
+              type: 'postgres',
+              datasource: { id: 'ds-2', name: 'Orders' },
+            },
+          ],
+        },
+      });
+      const workbooksMethods = new WorkbooksMethods(
+        'http://test',
+        { type: 'Bearer', token: 'test' },
+        {},
+      );
+      // @ts-expect-error - Mocking private property
+      workbooksMethods._apiClient = {
+        getWorkbookConnections: mockGetWorkbookConnections,
+      };
+
+      const connections = await workbooksMethods.getWorkbookConnections({
+        siteId: 'site-1',
+        workbookId: 'wb-1',
+      });
+
+      expect(connections).toEqual([
+        { id: 'conn-1', type: 'sqlserver', datasource: { id: 'ds-1', name: 'Superstore' } },
+        { id: 'conn-2', type: 'postgres', datasource: { id: 'ds-2', name: 'Orders' } },
+      ]);
+      expect(connections.map((c) => c.datasource)).toEqual([
+        { id: 'ds-1', name: 'Superstore' },
+        { id: 'ds-2', name: 'Orders' },
+      ]);
+      expect(mockGetWorkbookConnections).toHaveBeenCalledWith({
+        params: { siteId: 'site-1', workbookId: 'wb-1' },
+        headers: { Authorization: 'Bearer test' },
+      });
+    });
+
+    it('returns an empty array when the workbook has no connections', async () => {
+      const workbooksMethods = new WorkbooksMethods(
+        'http://test',
+        { type: 'Bearer', token: 'test' },
+        {},
+      );
+      // @ts-expect-error - Mocking private property
+      workbooksMethods._apiClient = {
+        getWorkbookConnections: vi.fn().mockResolvedValue({ connections: {} }),
+      };
+
+      const connections = await workbooksMethods.getWorkbookConnections({
+        siteId: 'site-1',
+        workbookId: 'wb-1',
+      });
+
+      expect(connections).toEqual([]);
+    });
+  });
+
   describe('publishWorkbook', () => {
     it('POSTs a single-part multipart/mixed body containing the tsRequest XML', async () => {
       const mockPost = vi.fn().mockResolvedValue({

--- a/src/sdks/tableau/methods/workbooksMethods.test.ts
+++ b/src/sdks/tableau/methods/workbooksMethods.test.ts
@@ -51,6 +51,22 @@ describe('WorkbooksMethods', () => {
       });
     });
 
+    it('passes through connections that omit datasource or its name', async () => {
+      const connection = [
+        { id: 'conn-1', type: 'sqlserver', datasource: { id: 'ds-1' } },
+        { id: 'conn-2', type: 'postgres' },
+      ];
+      const workbooksMethods = new WorkbooksMethods('http://test', { type: 'Bearer', token: 't' }, {});
+      // @ts-expect-error - Mocking private property
+      workbooksMethods._apiClient = {
+        getWorkbookConnections: vi.fn().mockResolvedValue({ connections: { connection } }),
+      };
+
+      expect(
+        await workbooksMethods.getWorkbookConnections({ siteId: 'site-1', workbookId: 'wb-1' }),
+      ).toEqual(connection);
+    });
+
     it('returns an empty array when the workbook has no connections', async () => {
       const workbooksMethods = new WorkbooksMethods(
         'http://test',

--- a/src/sdks/tableau/methods/workbooksMethods.test.ts
+++ b/src/sdks/tableau/methods/workbooksMethods.test.ts
@@ -4,9 +4,9 @@ import { describe, expect, it, vi } from 'vitest';
 import WorkbooksMethods from './workbooksMethods.js';
 
 describe('WorkbooksMethods', () => {
-  describe('getWorkbookConnections', () => {
+  describe('queryWorkbookConnections', () => {
     it('extracts each connection with its datasource id and name', async () => {
-      const mockGetWorkbookConnections = vi.fn().mockResolvedValue({
+      const mockQueryWorkbookConnections = vi.fn().mockResolvedValue({
         connections: {
           connection: [
             {
@@ -29,10 +29,10 @@ describe('WorkbooksMethods', () => {
       );
       // @ts-expect-error - Mocking private property
       workbooksMethods._apiClient = {
-        getWorkbookConnections: mockGetWorkbookConnections,
+        queryWorkbookConnections: mockQueryWorkbookConnections,
       };
 
-      const connections = await workbooksMethods.getWorkbookConnections({
+      const connections = await workbooksMethods.queryWorkbookConnections({
         siteId: 'site-1',
         workbookId: 'wb-1',
       });
@@ -45,7 +45,7 @@ describe('WorkbooksMethods', () => {
         { id: 'ds-1', name: 'Superstore' },
         { id: 'ds-2', name: 'Orders' },
       ]);
-      expect(mockGetWorkbookConnections).toHaveBeenCalledWith({
+      expect(mockQueryWorkbookConnections).toHaveBeenCalledWith({
         params: { siteId: 'site-1', workbookId: 'wb-1' },
         headers: { Authorization: 'Bearer test' },
       });
@@ -63,11 +63,11 @@ describe('WorkbooksMethods', () => {
       );
       // @ts-expect-error - Mocking private property
       workbooksMethods._apiClient = {
-        getWorkbookConnections: vi.fn().mockResolvedValue({ connections: { connection } }),
+        queryWorkbookConnections: vi.fn().mockResolvedValue({ connections: { connection } }),
       };
 
       expect(
-        await workbooksMethods.getWorkbookConnections({ siteId: 'site-1', workbookId: 'wb-1' }),
+        await workbooksMethods.queryWorkbookConnections({ siteId: 'site-1', workbookId: 'wb-1' }),
       ).toEqual(connection);
     });
 
@@ -79,10 +79,10 @@ describe('WorkbooksMethods', () => {
       );
       // @ts-expect-error - Mocking private property
       workbooksMethods._apiClient = {
-        getWorkbookConnections: vi.fn().mockResolvedValue({ connections: {} }),
+        queryWorkbookConnections: vi.fn().mockResolvedValue({ connections: {} }),
       };
 
-      const connections = await workbooksMethods.getWorkbookConnections({
+      const connections = await workbooksMethods.queryWorkbookConnections({
         siteId: 'site-1',
         workbookId: 'wb-1',
       });

--- a/src/sdks/tableau/methods/workbooksMethods.test.ts
+++ b/src/sdks/tableau/methods/workbooksMethods.test.ts
@@ -56,7 +56,11 @@ describe('WorkbooksMethods', () => {
         { id: 'conn-1', type: 'sqlserver', datasource: { id: 'ds-1' } },
         { id: 'conn-2', type: 'postgres' },
       ];
-      const workbooksMethods = new WorkbooksMethods('http://test', { type: 'Bearer', token: 't' }, {});
+      const workbooksMethods = new WorkbooksMethods(
+        'http://test',
+        { type: 'Bearer', token: 't' },
+        {},
+      );
       // @ts-expect-error - Mocking private property
       workbooksMethods._apiClient = {
         getWorkbookConnections: vi.fn().mockResolvedValue({ connections: { connection } }),

--- a/src/sdks/tableau/methods/workbooksMethods.ts
+++ b/src/sdks/tableau/methods/workbooksMethods.ts
@@ -6,7 +6,7 @@ import { buildMultipartMixedBody } from '../multipart.js';
 import { RestApiCredentials } from '../restApi.js';
 import { DownloadWorkbookResult } from '../types/downloadWorkbookResult.js';
 import { Pagination } from '../types/pagination.js';
-import { Workbook, workbookSchema } from '../types/workbook.js';
+import { Workbook, WorkbookConnection, workbookSchema } from '../types/workbook.js';
 import {
   WorkbookValidationResult,
   workbookValidationResultSchema,
@@ -80,6 +80,30 @@ export default class WorkbooksMethods extends AuthenticatedMethods<typeof workbo
       pagination: response.pagination,
       workbooks: response.workbooks.workbook ?? [],
     };
+  };
+
+  /**
+   * Returns the data connections for the specified workbook. Each connection's
+   * datasource id is the queryable embedded datasource LUID.
+   *
+   * Required scopes: `tableau:content:read`
+   *
+   * @param workbookId - The ID of the workbook to return connections for.
+   * @param siteId - The Tableau site ID
+   * @link https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref_workbooks_and_views.htm#query_workbook_connections
+   */
+  getWorkbookConnections = async ({
+    workbookId,
+    siteId,
+  }: {
+    workbookId: string;
+    siteId: string;
+  }): Promise<WorkbookConnection[]> => {
+    const response = await this._apiClient.getWorkbookConnections({
+      params: { siteId, workbookId },
+      ...this.authHeader,
+    });
+    return response.connections.connection ?? [];
   };
 
   /**

--- a/src/sdks/tableau/methods/workbooksMethods.ts
+++ b/src/sdks/tableau/methods/workbooksMethods.ts
@@ -92,14 +92,14 @@ export default class WorkbooksMethods extends AuthenticatedMethods<typeof workbo
    * @param siteId - The Tableau site ID
    * @link https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref_workbooks_and_views.htm#query_workbook_connections
    */
-  getWorkbookConnections = async ({
+  queryWorkbookConnections = async ({
     workbookId,
     siteId,
   }: {
     workbookId: string;
     siteId: string;
   }): Promise<WorkbookConnection[]> => {
-    const response = await this._apiClient.getWorkbookConnections({
+    const response = await this._apiClient.queryWorkbookConnections({
       params: { siteId, workbookId },
       ...this.authHeader,
     });

--- a/src/sdks/tableau/types/workbook.ts
+++ b/src/sdks/tableau/types/workbook.ts
@@ -40,7 +40,7 @@ export type Workbook = z.infer<typeof workbookSchema>;
 // deliberately omitted, following flow.ts's flowConnectionSchema.
 // Everything but `id` is optional because Tableau Server/Cloud versions are inconsistent about which
 // fields they emit; Zodios validates at the schema boundary, so one connection missing a datasource
-// (or its name) would otherwise fail the entire getWorkbookConnections() call.
+// (or its name) would otherwise fail the entire queryWorkbookConnections() call.
 export const workbookConnectionSchema = z.object({
   id: z.string(),
   type: z.string().optional(),

--- a/src/sdks/tableau/types/workbook.ts
+++ b/src/sdks/tableau/types/workbook.ts
@@ -38,13 +38,18 @@ export type Workbook = z.infer<typeof workbookSchema>;
 // The nested datasource id is the queryable embedded datasource LUID — the point of this endpoint.
 // Secret/host fields (serverAddress, serverPort, userName, embedPassword, connectionPassword) are
 // deliberately omitted, following flow.ts's flowConnectionSchema.
+// Everything but `id` is optional because Tableau Server/Cloud versions are inconsistent about which
+// fields they emit; Zodios validates at the schema boundary, so one connection missing a datasource
+// (or its name) would otherwise fail the entire getWorkbookConnections() call.
 export const workbookConnectionSchema = z.object({
   id: z.string(),
   type: z.string().optional(),
-  datasource: z.object({
-    id: z.string(),
-    name: z.string(),
-  }),
+  datasource: z
+    .object({
+      id: z.string(),
+      name: z.string().optional(),
+    })
+    .optional(),
 });
 
 export type WorkbookConnection = z.infer<typeof workbookConnectionSchema>;

--- a/src/sdks/tableau/types/workbook.ts
+++ b/src/sdks/tableau/types/workbook.ts
@@ -33,3 +33,18 @@ export const workbookSchema = z.object({
 });
 
 export type Workbook = z.infer<typeof workbookSchema>;
+
+// Query Workbook Connections response (rest_api_ref_workbooks_and_views.htm#query_workbook_connections).
+// The nested datasource id is the queryable embedded datasource LUID — the point of this endpoint.
+// Secret/host fields (serverAddress, serverPort, userName, embedPassword, connectionPassword) are
+// deliberately omitted, following flow.ts's flowConnectionSchema.
+export const workbookConnectionSchema = z.object({
+  id: z.string(),
+  type: z.string().optional(),
+  datasource: z.object({
+    id: z.string(),
+    name: z.string(),
+  }),
+});
+
+export type WorkbookConnection = z.infer<typeof workbookConnectionSchema>;

--- a/tests/oauth/tableau-authz/flows/consentFlow.ts
+++ b/tests/oauth/tableau-authz/flows/consentFlow.ts
@@ -18,6 +18,7 @@ export class ConsentFlow extends Flow {
   };
 
   private fill = async (): Promise<void> => {
-    await this.page.locator('button[type="submit"]').click();
+    // The consent page has multiple submit buttons (Switch site/username), so target Allow by id.
+    await this.page.locator('#allow-button').click();
   };
 }


### PR DESCRIPTION
## Summary

Adds the **Query Workbook Connections** endpoint (`GET /sites/{siteId}/workbooks/{workbookId}/connections`) to the workbooks SDK, modeled on the flow connections analog (`flowsApi.ts` / `flowsMethods.ts` / `flowConnectionSchema`). This is the only way to obtain a queryable embedded datasource LUID for a workbook — no such endpoint existed before (only flows had `queryFlowConnections`).

SDK-layer only; no new MCP tool is added in this change.

## Changes

- **`apis/workbooksApi.ts`** — `getWorkbookConnections` Zodios endpoint, registered in the workbooks API.
- **`methods/workbooksMethods.ts`** — `getWorkbookConnections({ siteId, workbookId })` returning `WorkbookConnection[]` (each carrying its `datasource`).
- **`types/workbook.ts`** — `workbookConnectionSchema` / `WorkbookConnection`. Shape is `{ id, type?, datasource?: { id, name? } }`. Everything but `id` is optional because Tableau Server/Cloud versions are inconsistent about which fields they emit, and Zodios validates at the schema boundary (one connection missing a `datasource` would otherwise fail the whole call). Connection secret/host fields (`serverAddress`, `serverPort`, `userName`, `embedPassword`, `connectionPassword`) are deliberately omitted, following the precedent in `flow.ts`'s `flowConnectionSchema`.
- **`methods/workbooksMethods.test.ts`** — colocated unit tests asserting datasource id/name extraction, optional-field pass-through, and the empty-connections case.

## Unrelated fix

- **`tests/oauth/tableau-authz/flows/consentFlow.ts`** — the Tableau OAuth consent page now renders multiple `type="submit"` buttons (Switch site / Switch username / Allow), which tripped Playwright strict mode. Target the Allow button by id (`#allow-button`) instead of the ambiguous `button[type="submit"]`. This is orthogonal to the SDK change but was blocking CI.

## Scope

Query Workbook Connections requires `tableau:content:read`, which is already wired across `TableauApiScope`, `JwtScopes`, and the existing `get-workbook`/`list-workbooks` tool maps. No new scope is needed — confirmed and documented in the method JSDoc.

## Testing

- `npx vitest run src/sdks/tableau/methods/workbooksMethods.test.ts` — 9 passed
- `eslint` + `tsc --noEmit` clean on the changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
