### PR TITLE
fix(apply): infer cached worksheet names

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "2.63.9",
+  "version": "2.63.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "2.63.9",
+      "version": "2.63.10",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.7.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "2.63.9",
+  "version": "2.63.10",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/src/desktop/wrappers/loadWorksheetXml.ts
+++ b/src/desktop/wrappers/loadWorksheetXml.ts
@@ -236,9 +236,10 @@ function readbackOutcome(
 }
 
 /**
- * Canonical-name gate. Require the caller's `worksheetName` to identify the authored fragment —
- * matching either its stable id (the `<simple-id uuid>`, the External Client API worksheet id) or
- * its `<worksheet name>` — before we touch Desktop. Names are compared after trim and Unicode NFC
+ * Canonical-name gate. When the caller provides `worksheetName`, require it to identify the authored
+ * fragment — matching either its stable id (the `<simple-id uuid>`, the External Client API worksheet
+ * id) or its `<worksheet name>` — before we touch Desktop. When omitted, adopt the fragment's own name
+ * as the target. Names are compared after trim and Unicode NFC
  * normalization (case-sensitive) so visually identical NFD/NFC spellings do not false-mismatch.
  * Returns the fragment's name exactly as authored (trimmed) — the identity Tableau stores when it
  * applies the raw XML, and what upsertSheetIntoWorkbook's own name check matches.
@@ -249,10 +250,10 @@ function readbackOutcome(
  * failing as a misleading mismatch against an empty XML name.
  */
 export function resolveCanonicalWorksheetName(
-  worksheetName: string,
+  worksheetName: string | undefined,
   xml: string,
 ): Result<string, Extract<LoadWorksheetXmlError, { type: 'name-mismatch' }>> {
-  const callerRef = worksheetName.trim();
+  const callerRef = worksheetName?.trim() ?? '';
   let xmlName = '';
   let xmlId = '';
   let isWorkbookDocument = false;
@@ -273,13 +274,18 @@ export function resolveCanonicalWorksheetName(
       type: 'name-mismatch',
       message: isWorkbookDocument
         ? 'apply-worksheet expects a single <worksheet name="..."> fragment, but the cached file ' +
-          `holds a whole <workbook> document. FIX: read-cached-xml with worksheet="${callerRef}" to pull ` +
+          `holds a whole <workbook> document. FIX: read-cached-xml with worksheet="${callerRef || '<sheet name>'}" to pull ` +
           'just that element, write-cached-xml with the same selector to splice your edit back, then ' +
           'apply-worksheet with that file.'
         : 'apply-worksheet could not find a top-level <worksheet name="..."> element in the cached file. ' +
-          `FIX: get-worksheet-xml for "${callerRef}" mints a file holding exactly that fragment; edit it ` +
+          `FIX: get-worksheet-xml for ${callerRef ? `"${callerRef}"` : 'the worksheet'} mints a file holding exactly that fragment; edit it ` +
           'with read-cached-xml/write-cached-xml and pass that path to apply-worksheet.',
     });
+  }
+
+  if (!callerRef) {
+    // No caller ref: the cached fragment names its own target.
+    return Ok(xmlName);
   }
 
   if (!xmlNamesEqual(xmlName, callerRef) && !(xmlId && xmlId === callerRef)) {

--- a/src/server.desktop.test.ts
+++ b/src/server.desktop.test.ts
@@ -231,7 +231,9 @@ async function serializeDesktopToolSurface(tool: DesktopTool<any>): Promise<stri
 // Re-pinned 2026-08-19: list-templates now exposes derived template-fit metadata and filters by
 // required visible channels. Its schema adds 149 bytes; tighter route prose removes 131 from the
 // served profile, while the full schema-only surface moves 56_650 -> 56_799.
-const DYNAMIC_AUTHORING_SURFACE_EXPECTED = 40_099;
+// Re-pinned 2026-08-19: apply-worksheet now infers the target from a cached worksheet fragment, so
+// its worksheetName describe drops the redundant "worksheet" (-3 bytes); dynamic authoring 40_099 -> 40_096.
+const DYNAMIC_AUTHORING_SURFACE_EXPECTED = 40_096;
 const DYNAMIC_AUTHORING_SURFACE_BUDGET = 40_117;
 const DYNAMIC_AUTHORING_PRODUCT_CEILING = 46_000;
 const FULL_TOOL_SURFACE_BUDGET = 56_817;
@@ -329,7 +331,7 @@ describe('desktop tools/list per-tool byte accounting', () => {
     ['bind-template', 2585], // raised 2026-08-10 (#734 review fold): +skip_validation, the server-gated trust flag for the deterministic build_viz path — a genuinely new param (name + boolean schema, description dropped since the LLM must never set it), ~118B over the prior cap so shrinking prose could not fund it; ratcheted to the measured 2585 (down from a transient 2675) once the description was removed; earlier raise with sign-off (2026-08-05): agreed UI-label title 'Matching template' costs a few bytes over 'Bind Template'; earlier raise (2026-07-27, #643 review fold): calcs[]/auto_apply describes + datatype/role enums for the one-call derived-metric path — the same undescribed-param class that cost 299 repeat binds (2,562s) in shipped v10; restoring gutted descriptions was refused as funding
     ['add-field', 1396], // ratcheted down 2026-08-12: worksheetName/worksheetFile describes trimmed to fund the sticky edit-buffer nudge while staying under budget
     ['inject-template', 1229], // ratcheted down 2026-08-06 after removing the fork-only output mode; session remains optional
-    ['apply-worksheet', 1607], // ratcheted down 2026-08-12 trimming the worksheetName describe to id-or-name; earlier raise 2026-08-10: direct templatePlan folds an exact single-view build into the existing guarded apply tool; no new tool surface
+    ['apply-worksheet', 1604], // ratcheted down 2026-08-19: worksheetName inferred from a cached fragment, describe drops the redundant "worksheet"; earlier ratchet 2026-08-12 trimming the worksheetName describe to id-or-name; earlier raise 2026-08-10: direct templatePlan folds an exact single-view build into the existing guarded apply tool; no new tool surface
     ['refine-worksheet', 1466], // raised with sign-off (2026-08-05): agreed UI-label title 'Refining worksheet'; earlier raise for omitted-targetField axis detection, funded by a ~500-byte same-tool describe trim
     ['plan-dashboard-creation', 1378], // ratcheted down in the author-set/action/format-labels funding trim (CODA, empty describe stubs); do not grow
     ['build-and-apply-dashboard', 1423], // ratcheted down in the CODA funding trim; do not grow

--- a/src/tools/desktop/api/applyWorksheet.test.ts
+++ b/src/tools/desktop/api/applyWorksheet.test.ts
@@ -352,6 +352,80 @@ describe('applyWorksheetTool', () => {
     );
   });
 
+  it('infers the worksheet name from a cached fragment when worksheetName is omitted', async () => {
+    const mockXml = "<worksheet name='Sales &amp; Profit'><table></table></worksheet>";
+    const mockLoadWorksheetXml = vi
+      .spyOn(loadWorksheetXmlModule, 'loadWorksheetXml')
+      .mockResolvedValue(Ok({ readbackWarnings: [] }));
+
+    const result = await getToolResult({
+      session: '12345',
+      worksheetXml: mockXml,
+      mockExecutor: vi.fn().mockResolvedValue({}),
+    });
+
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+    const resultObj = resultSchema.parse(JSON.parse(result.content[0].text));
+    expect(resultObj.message).toContain(
+      'Successfully applied worksheet update for "Sales & Profit"',
+    );
+    expect(mockLoadWorksheetXml).toHaveBeenCalledWith(
+      expect.objectContaining({ worksheetName: 'Sales & Profit' }),
+    );
+  });
+
+  it('rejects an explicit worksheetName that conflicts with the cached fragment before touching Desktop', async () => {
+    const mockXml = "<worksheet name='Real Name'><table></table></worksheet>";
+    const mockLoadWorksheetXml = vi.spyOn(loadWorksheetXmlModule, 'loadWorksheetXml');
+
+    const result = await getToolResult({
+      session: '12345',
+      worksheetName: 'Wrong Name',
+      worksheetXml: mockXml,
+      mockExecutor: vi.fn().mockResolvedValue({}),
+    });
+
+    expect(result.isError).toBe(true);
+    invariant(result.content[0].type === 'text');
+    expect(result.content[0].text).toContain('does not match the <worksheet name> in the XML');
+    expect(mockLoadWorksheetXml).not.toHaveBeenCalled();
+  });
+
+  it('fails safely on a whole-workbook document even when worksheetName is omitted', async () => {
+    const mockXml = '<workbook><worksheets><worksheet name="Sheet 1" /></worksheets></workbook>';
+    const mockLoadWorksheetXml = vi.spyOn(loadWorksheetXmlModule, 'loadWorksheetXml');
+
+    const result = await getToolResult({
+      session: '12345',
+      worksheetXml: mockXml,
+      mockExecutor: vi.fn().mockResolvedValue({}),
+    });
+
+    expect(result.isError).toBe(true);
+    invariant(result.content[0].type === 'text');
+    expect(result.content[0].text).toContain('holds a whole <workbook> document');
+    expect(mockLoadWorksheetXml).not.toHaveBeenCalled();
+  });
+
+  it('fails safely on a non-worksheet fragment when worksheetName is omitted', async () => {
+    const mockXml = '<dashboard name="Dash 1"><zones /></dashboard>';
+    const mockLoadWorksheetXml = vi.spyOn(loadWorksheetXmlModule, 'loadWorksheetXml');
+
+    const result = await getToolResult({
+      session: '12345',
+      worksheetXml: mockXml,
+      mockExecutor: vi.fn().mockResolvedValue({}),
+    });
+
+    expect(result.isError).toBe(true);
+    invariant(result.content[0].type === 'text');
+    expect(result.content[0].text).toContain(
+      'could not find a top-level <worksheet name="..."> element',
+    );
+    expect(mockLoadWorksheetXml).not.toHaveBeenCalled();
+  });
+
   it('reports skipped readback honestly for inline worksheet XML apply', async () => {
     const mockXml = '<worksheet name="Sheet 1"><table></table></worksheet>';
     vi.spyOn(loadWorksheetXmlModule, 'loadWorksheetXml').mockResolvedValue(
@@ -960,7 +1034,7 @@ async function getToolResult({
   configOverrides,
 }: {
   session: string;
-  worksheetName: string;
+  worksheetName?: string;
   worksheetFile?: string;
   worksheetXml?: string;
   mockExecutor: TableauDesktopToolContext['getExecutor'];

--- a/src/tools/desktop/api/applyWorksheet.ts
+++ b/src/tools/desktop/api/applyWorksheet.ts
@@ -72,7 +72,7 @@ const paramsSchema = {
     .describe('Exact template binding to build and apply in this call.'),
   worksheetName: artifactNameParam('worksheet', { min: 1, max: 255 })
     .optional()
-    .describe('Worksheet id or name for cached-file apply; omit with other modes.'),
+    .describe('Existing worksheet id or name; inferred from a cached fragment.'),
   worksheetFile: artifactFileParam('worksheet', { max: 4096 })
     .optional()
     .describe('Cached worksheet path for manual apply; omit with other modes.'),
@@ -135,12 +135,7 @@ export const getApplyWorksheetTool = (
             Number(cachedModeSelected);
           if (modeCount !== 1) {
             return new ArgsValidationError(
-              'Provide exactly one apply mode: artifactId, templatePlan, or worksheetName with worksheetFile.',
-            ).toErr();
-          }
-          if (cachedModeSelected && !worksheetName?.trim()) {
-            return new ArgsValidationError(
-              'A worksheetName is required when applying a cached worksheet file.',
+              'Provide exactly one apply mode: artifactId, templatePlan, or worksheetFile (worksheetName optional).',
             ).toErr();
           }
 
@@ -324,7 +319,7 @@ export const getApplyWorksheetTool = (
           }
           const { xml: worksheetXml, resolvedSession, sourceHash } = preamble.value;
 
-          const canonical = resolveCanonicalWorksheetName(worksheetName!, worksheetXml);
+          const canonical = resolveCanonicalWorksheetName(worksheetName, worksheetXml);
           if (canonical.isErr()) {
             return new WorksheetXmlLoadFailedError(canonical.error).toErr();
           }


### PR DESCRIPTION
## Decision

`apply-worksheet` can now infer the target worksheet from a cached file's own `<worksheet name>`, so a caller no longer has to pass `worksheetName` when it applies a cached fragment. This is a **one-off relaxation of one input rule** on this tool, not a new project-wide convention — the other apply modes (`artifactId`, `templatePlan`) are unchanged, and the safety gate that rejects a wrong or malformed fragment stays exactly as strict.

Replaces #756 (which was stacked on the now-obsolete #755). This branch is a clean re-implementation on top of current `feature/desktop` — no template changes from #755, no rebase of the old stack.

## What changed

- `applyWorksheet.ts`: removed the guard that required `worksheetName` in cached-file mode. Drop the `worksheetName!` non-null assertion — the gate now accepts `undefined`.
- `loadWorksheetXml.ts` (`resolveCanonicalWorksheetName`): param widens to `string | undefined`; when the caller omits the name, it adopts the fragment's own name **after** the existing no-identity rejection and **before** the name-mismatch check.
- Schema describe updated to say the name is inferred from a cached fragment (net −3 bytes; per-tool and surface byte pins ratcheted down to match).

## What future work must preserve

The order inside `resolveCanonicalWorksheetName` is load-bearing: reject "no top-level `<worksheet>` identity" (malformed / whole-`<workbook>` / non-worksheet) **first**, then infer on empty caller ref, then check for mismatch. Inferring before that rejection would let a garbage fragment adopt an empty name. Every existing guard — sidecar/source-hash, stale-write, `requireExistingSheet`, per-sheet apply — is untouched.

## Validation

- `scripts/agent-check` green (lint + `tsc --noEmit` + full `vitest run`, 5896 tests).
- Added focused tests: inferred name (with XML-entity decode `Sales &amp; Profit` → `Sales & Profit`), explicit-mismatch rejection before Desktop, whole-`<workbook>` and non-worksheet fragments fail safely with the name omitted. Existing mode-rejection and id-resolution tests still pass.
- **Live smoke against Tableau Desktop (External Client API 0.2.7):** `get-worksheet-xml` → `apply-worksheet` with `worksheetFile` only (no name) inferred "Sheet 1", applied, readback clean. Negative check: an explicit wrong name still rejects before any Desktop mutation.

## Reviewer decision

Approving this accepts that a cached-file `apply-worksheet` call may omit `worksheetName` and take the target from the fragment, while every existing correctness guard holds.
