### PR TITLE
fix(templates): restore reliable field binding

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "2.63.10",
+  "version": "2.63.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "2.63.10",
+      "version": "2.63.11",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.7.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "2.63.10",
+  "version": "2.63.11",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/src/desktop/templates/buildTemplateWorksheetArtifact.ts
+++ b/src/desktop/templates/buildTemplateWorksheetArtifact.ts
@@ -17,11 +17,28 @@ import { createTemplateRuntimeSnapshot } from './templateRuntimeSnapshot.js';
 
 export const MAX_TEMPLATE_BINDINGS = 32;
 
-function normalizeDatasourceName(name: string): string {
-  const normalized = name.normalize('NFC').trim();
-  const unwrapped =
-    normalized.startsWith('[') && normalized.endsWith(']') ? normalized.slice(1, -1) : normalized;
-  return unwrapped.trim().toLocaleLowerCase();
+function datasourceNamesAreEquivalent(
+  requested: string,
+  bound: string,
+  liveDatasourceNames: ReadonlySet<string>,
+): boolean {
+  const normalizedRequested = requested.normalize('NFC');
+  const normalizedBound = bound.normalize('NFC');
+  if (normalizedRequested === normalizedBound) return true;
+
+  const [raw, unwrapped] =
+    normalizedRequested.startsWith('[') && normalizedRequested.endsWith(']')
+      ? [normalizedRequested, normalizedRequested.slice(1, -1)]
+      : normalizedBound.startsWith('[') && normalizedBound.endsWith(']')
+        ? [normalizedBound, normalizedBound.slice(1, -1)]
+        : [undefined, undefined];
+  if (raw === undefined || unwrapped === undefined) return false;
+  if (unwrapped !== normalizedRequested && unwrapped !== normalizedBound) return false;
+
+  const normalizedLiveNames = new Set(
+    [...liveDatasourceNames].map((name) => name.normalize('NFC')),
+  );
+  return !(normalizedLiveNames.has(raw) && normalizedLiveNames.has(unwrapped));
 }
 
 export interface WorksheetTemplatePlan {
@@ -80,23 +97,23 @@ export function buildTemplateWorksheetArtifact({
       ).toErr();
     }
 
-    const explicitBind = bindExplicitTemplate(
-      plan.templateName,
-      plan.fieldMapping,
-      summarizeSchema(workbookXml),
-      {
-        contract: snapshot.descriptor,
-        title: plan.title,
-        datasource: plan.datasource,
-      },
-    );
+    const schema = summarizeSchema(workbookXml);
+    const explicitBind = bindExplicitTemplate(plan.templateName, plan.fieldMapping, schema, {
+      contract: snapshot.descriptor,
+      title: plan.title,
+      datasource: plan.datasource,
+    });
     if (!explicitBind.ok) {
       return new ArgsValidationError(
         formatExplicitBindErrors(plan.templateName, explicitBind.errors),
       ).toErr();
     }
     if (
-      normalizeDatasourceName(explicitBind.datasource) !== normalizeDatasourceName(plan.datasource)
+      !datasourceNamesAreEquivalent(
+        plan.datasource,
+        explicitBind.datasource,
+        new Set(schema.fields.map((field) => field.datasource)),
+      )
     ) {
       return new ArgsValidationError(
         `Datasource "${plan.datasource}" does not match the bound datasource "${explicitBind.datasource}".`,

--- a/src/desktop/templates/buildTemplateWorksheetArtifact.ts
+++ b/src/desktop/templates/buildTemplateWorksheetArtifact.ts
@@ -17,6 +17,13 @@ import { createTemplateRuntimeSnapshot } from './templateRuntimeSnapshot.js';
 
 export const MAX_TEMPLATE_BINDINGS = 32;
 
+function normalizeDatasourceName(name: string): string {
+  const normalized = name.normalize('NFC').trim();
+  const unwrapped =
+    normalized.startsWith('[') && normalized.endsWith(']') ? normalized.slice(1, -1) : normalized;
+  return unwrapped.trim().toLocaleLowerCase();
+}
+
 export interface WorksheetTemplatePlan {
   templateName: string;
   title: string;
@@ -88,7 +95,9 @@ export function buildTemplateWorksheetArtifact({
         formatExplicitBindErrors(plan.templateName, explicitBind.errors),
       ).toErr();
     }
-    if (explicitBind.datasource !== plan.datasource) {
+    if (
+      normalizeDatasourceName(explicitBind.datasource) !== normalizeDatasourceName(plan.datasource)
+    ) {
       return new ArgsValidationError(
         `Datasource "${plan.datasource}" does not match the bound datasource "${explicitBind.datasource}".`,
       ).toErr();
@@ -99,7 +108,7 @@ export function buildTemplateWorksheetArtifact({
       templateXml: snapshot.xml,
       title: plan.title,
       sheetType: 'worksheet',
-      templateParameters: { DATASOURCE: plan.datasource },
+      templateParameters: { DATASOURCE: explicitBind.datasource },
       fieldMapping: explicitBind.fieldMapping,
       templateSlots: explicitBind.templateSlots,
       fieldMetadata: explicitBind.fieldMetadata,
@@ -124,7 +133,7 @@ export function buildTemplateWorksheetArtifact({
         templateName: plan.templateName,
         templateSourceHash: snapshot.sourceHash,
         title: plan.title,
-        datasource: plan.datasource,
+        datasource: explicitBind.datasource,
         fieldMapping: explicitBind.fieldMapping,
         worksheetXml,
         windowXml,

--- a/src/tools/desktop/authoring/binder/listTemplates.test.ts
+++ b/src/tools/desktop/authoring/binder/listTemplates.test.ts
@@ -201,12 +201,21 @@ describe('list-templates', () => {
             {
               slot_id: 'field_base_1',
               kind: 'categorical',
+              derivation: 'none',
+              role: ['rows'],
+              binding_usage: 'direct',
+              calculation_channels: [],
             },
             {
               slot_id: 'field_base_2',
               kind: 'quantitative',
+              derivation: 'sum',
+              role: ['cols'],
+              binding_usage: 'direct',
+              calculation_channels: [],
             },
           ],
+          optional_slots: [],
         },
         visible_channels: { direct: ['rows', 'cols'], calculated: [] },
         same_field_groups: [],
@@ -270,6 +279,26 @@ describe('list-templates', () => {
       ['field_base_2_sum', 'field_base_2_none'],
     ]);
     expect(template.visible_channels.direct).not.toContain('size');
+    expect(template.slot_signature.required_slots).toEqual(
+      expect.arrayContaining([
+        {
+          slot_id: 'field_base_1_sum',
+          kind: 'quantitative',
+          derivation: 'sum',
+          role: ['rows'],
+          binding_usage: 'direct',
+          calculation_channels: [],
+        },
+        {
+          slot_id: 'field_base_1_none',
+          kind: 'quantitative',
+          derivation: 'none',
+          role: [],
+          binding_usage: 'calculation-input',
+          calculation_channels: ['color'],
+        },
+      ]),
+    );
 
     for (const slotId of ['field_base_1_none', 'field_base_2_none']) {
       expect(
@@ -407,20 +436,20 @@ describe('list-templates', () => {
 
     expect(body.templates[0].slot_signature.required_slots).toEqual(
       expect.arrayContaining([
-        {
+        expect.objectContaining({
           slot_id: 'field_base_1',
           kind: 'quantitative',
-        },
-        {
+        }),
+        expect.objectContaining({
           slot_id: 'field_base_2',
           kind: 'geo',
           semantic_role: '[Country].[ISO3166_2]',
-        },
-        {
+        }),
+        expect.objectContaining({
           slot_id: 'field_base_3',
           kind: 'geo',
           semantic_role: '[State].[Name]',
-        },
+        }),
       ]),
     );
   });

--- a/src/tools/desktop/authoring/binder/listTemplates.test.ts
+++ b/src/tools/desktop/authoring/binder/listTemplates.test.ts
@@ -454,6 +454,29 @@ describe('list-templates', () => {
     );
   });
 
+  it('includes exact optional slot facts in a bounded compact real-template result', async () => {
+    delete process.env['TEMPLATES_DIR'];
+
+    const result = await getToolResult({ query: 'bullet-variance-chart', limit: 1 });
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+    expect(Buffer.byteLength(result.content[0].text, 'utf-8')).toBeLessThanOrEqual(16_384);
+    const body = JSON.parse(result.content[0].text);
+
+    expect(body.templates).toHaveLength(1);
+    expect(body.templates[0].template).toBe('bullet-variance-chart');
+    expect(body.templates[0].slot_signature.optional_slots).toEqual([
+      {
+        slot_id: 'field_base_3',
+        kind: 'quantitative',
+        derivation: 'sum',
+        role: ['lod', 'reference-line'],
+        binding_usage: 'direct',
+        calculation_channels: [],
+      },
+    ]);
+  });
+
   it('filters on eligibility computed from the TBM instead of catalog policy', async () => {
     const root = mkdtempSync(join(process.cwd(), 'tmp-list-templates-eligibility-'));
     temporaryRoots.push(root);

--- a/src/tools/desktop/authoring/binder/listTemplates.ts
+++ b/src/tools/desktop/authoring/binder/listTemplates.ts
@@ -62,6 +62,17 @@ interface SlotSummary {
   purpose?: string;
 }
 
+type CompactSlotSummary = Pick<
+  SlotSummary,
+  | 'slot_id'
+  | 'kind'
+  | 'derivation'
+  | 'role'
+  | 'binding_usage'
+  | 'calculation_channels'
+  | 'semantic_role'
+>;
+
 interface TemplateSummary {
   template: string;
   provenance: string;
@@ -72,11 +83,8 @@ interface TemplateSummary {
     total: number;
     required: number;
     kinds: string[];
-    required_slots: Array<{
-      slot_id: string;
-      kind: string;
-      semantic_role?: string;
-    }>;
+    required_slots: CompactSlotSummary[];
+    optional_slots: CompactSlotSummary[];
   };
   visible_channels: TemplateFitFacts['visible_channels'];
   same_field_groups: string[][];
@@ -147,6 +155,25 @@ function summarizeSlot(slot: SlotSpec, usage: TemplateFitFacts['slot_usage'][num
   };
 }
 
+function slotUsage(slot: SlotSpec, fit: TemplateFitFacts): TemplateFitFacts['slot_usage'][number] {
+  const usage = fit.slot_usage.find(({ slot_id }) => slot_id === slot.slot_id);
+  if (!usage) throw new Error(`Missing fit metadata for slot '${slot.slot_id}'.`);
+  return usage;
+}
+
+function summarizeCompactSlot(slot: SlotSpec, fit: TemplateFitFacts): CompactSlotSummary {
+  const usage = slotUsage(slot, fit);
+  return {
+    slot_id: slot.slot_id,
+    kind: slot.kind,
+    derivation: slot.derivation,
+    role: usage.direct_roles.slice(),
+    binding_usage: usage.binding_usage,
+    calculation_channels: usage.calculation_channels.slice(),
+    ...(slot.semantic_role ? { semantic_role: slot.semantic_role } : {}),
+  };
+}
+
 function summarizeTemplate(
   { entry, snapshot }: ResolvedTemplate,
   includeSlots: boolean,
@@ -165,21 +192,16 @@ function summarizeTemplate(
       kinds: [...new Set(slots.map((slot) => slot.kind))].sort(compareTemplateNames),
       required_slots: slots
         .filter((slot) => slot.required)
-        .map((slot) => ({
-          slot_id: slot.slot_id,
-          kind: slot.kind,
-          ...(slot.semantic_role ? { semantic_role: slot.semantic_role } : {}),
-        })),
+        .map((slot) => summarizeCompactSlot(slot, fit)),
+      optional_slots: slots
+        .filter((slot) => !slot.required)
+        .map((slot) => summarizeCompactSlot(slot, fit)),
     },
     visible_channels: fit.visible_channels,
     same_field_groups: fit.same_field_groups,
     ...(includeSlots
       ? {
-          slots: slots.map((slot) => {
-            const usage = fit.slot_usage.find(({ slot_id }) => slot_id === slot.slot_id);
-            if (!usage) throw new Error(`Missing fit metadata for slot '${slot.slot_id}'.`);
-            return summarizeSlot(slot, usage);
-          }),
+          slots: slots.map((slot) => summarizeSlot(slot, slotUsage(slot, fit))),
         }
       : {}),
   };

--- a/src/tools/desktop/authoring/templates/buildWorksheetsFromTemplates.test.ts
+++ b/src/tools/desktop/authoring/templates/buildWorksheetsFromTemplates.test.ts
@@ -178,6 +178,7 @@ describe('build-worksheets-from-templates', () => {
       );
 
       expect(result.isError).toBe(false);
+      expect(bodyOf(result).datasource).toBe(liveDatasource);
       const reserved = store.reserve('artifact-unicode', '12345');
       expect(reserved.ok).toBe(true);
       if (!reserved.ok) return;
@@ -185,6 +186,66 @@ describe('build-worksheets-from-templates', () => {
       expect(reserved.artifact.worksheetXml).toContain(liveDatasource);
     },
   );
+
+  it('rejects a case-different datasource name', async () => {
+    const store = new TemplateArtifactStore({ capacity: 4 });
+    const executor = makeExecutorMock({
+      getWorkbookDocument: vi.fn().mockResolvedValue(
+        Ok({
+          xml: LIVE_WORKBOOK,
+          applicationVersion: undefined,
+          xsdPayloadVersion: undefined,
+          instanceId: 'inst-build',
+        }),
+      ),
+      applyWorkbookDocument: vi.fn(),
+    });
+    const tool = getBuildWorksheetsFromTemplatesTool(new DesktopMcpServer(), {
+      store,
+      createId: () => 'artifact-case-different',
+    });
+
+    const result = await callTool(tool, { ...EXACT_ARGS, datasource: 'TARGET.ds' }, executor);
+
+    expect(result.isError).toBe(true);
+    expect(store.reserve('artifact-case-different', '12345')).toEqual({
+      ok: false,
+      reason: 'unknown',
+    });
+  });
+
+  it('rejects bracket equivalence when raw and bracketed datasource names coexist', async () => {
+    const store = new TemplateArtifactStore({ capacity: 4 });
+    const ambiguousWorkbook = LIVE_WORKBOOK.replace(
+      '</datasources>',
+      `<datasource name='[target.ds]'>
+        <column name='[Unrelated]' datatype='string' role='dimension' type='nominal'/>
+      </datasource></datasources>`,
+    );
+    const executor = makeExecutorMock({
+      getWorkbookDocument: vi.fn().mockResolvedValue(
+        Ok({
+          xml: ambiguousWorkbook,
+          applicationVersion: undefined,
+          xsdPayloadVersion: undefined,
+          instanceId: 'inst-build',
+        }),
+      ),
+      applyWorkbookDocument: vi.fn(),
+    });
+    const tool = getBuildWorksheetsFromTemplatesTool(new DesktopMcpServer(), {
+      store,
+      createId: () => 'artifact-ambiguous-datasource',
+    });
+
+    const result = await callTool(tool, { ...EXACT_ARGS, datasource: '[target.ds]' }, executor);
+
+    expect(result.isError).toBe(true);
+    expect(store.reserve('artifact-ambiguous-datasource', '12345')).toEqual({
+      ok: false,
+      reason: 'unknown',
+    });
+  });
 
   it('still rejects a field mapping from a different datasource', async () => {
     const store = new TemplateArtifactStore({ capacity: 4 });

--- a/src/tools/desktop/authoring/templates/buildWorksheetsFromTemplates.test.ts
+++ b/src/tools/desktop/authoring/templates/buildWorksheetsFromTemplates.test.ts
@@ -133,6 +133,86 @@ describe('build-worksheets-from-templates', () => {
     expect(reserved.artifact.instanceId).toBe('inst-build');
   });
 
+  it.each([
+    {
+      label: 'canonically equivalent Unicode',
+      liveDatasource: '슈퍼스토어 - 샘플'.normalize('NFD'),
+      requestedDatasource: '슈퍼스토어 - 샘플',
+    },
+    {
+      label: 'one layer of outer brackets',
+      liveDatasource: 'target.ds',
+      requestedDatasource: '[target.ds]',
+    },
+  ])(
+    'uses the live datasource identity when the requested name differs only by $label',
+    async ({ liveDatasource, requestedDatasource }) => {
+      const store = new TemplateArtifactStore({ capacity: 4 });
+      const executor = makeExecutorMock({
+        getWorkbookDocument: vi.fn().mockResolvedValue(
+          Ok({
+            xml: LIVE_WORKBOOK.replaceAll('target.ds', liveDatasource),
+            applicationVersion: undefined,
+            xsdPayloadVersion: undefined,
+            instanceId: 'inst-build',
+          }),
+        ),
+        applyWorkbookDocument: vi.fn(),
+      });
+      const tool = getBuildWorksheetsFromTemplatesTool(new DesktopMcpServer(), {
+        store,
+        createId: () => 'artifact-unicode',
+      });
+
+      const result = await callTool(
+        tool,
+        {
+          ...EXACT_ARGS,
+          datasource: requestedDatasource,
+          fieldMapping: {
+            field_base_1: `[${liveDatasource}].[none:Segment:nk]`,
+            field_base_2: `[${liveDatasource}].[sum:Revenue:qk]`,
+          },
+        },
+        executor,
+      );
+
+      expect(result.isError).toBe(false);
+      const reserved = store.reserve('artifact-unicode', '12345');
+      expect(reserved.ok).toBe(true);
+      if (!reserved.ok) return;
+      expect(reserved.artifact.datasource).toBe(liveDatasource);
+      expect(reserved.artifact.worksheetXml).toContain(liveDatasource);
+    },
+  );
+
+  it('still rejects a field mapping from a different datasource', async () => {
+    const store = new TemplateArtifactStore({ capacity: 4 });
+    const executor = makeExecutorMock({
+      getWorkbookDocument: vi.fn().mockResolvedValue(
+        Ok({
+          xml: LIVE_WORKBOOK,
+          applicationVersion: undefined,
+          xsdPayloadVersion: undefined,
+          instanceId: 'inst-build',
+        }),
+      ),
+      applyWorkbookDocument: vi.fn(),
+    });
+    const tool = getBuildWorksheetsFromTemplatesTool(new DesktopMcpServer(), {
+      store,
+      createId: () => 'artifact-cross-datasource',
+    });
+
+    const result = await callTool(tool, { ...EXACT_ARGS, datasource: 'other.ds' }, executor);
+
+    expect(result.isError).toBe(true);
+    expect(store.reserve('artifact-cross-datasource', '12345')).toEqual({
+      ok: false,
+      reason: 'unknown',
+    });
+  });
+
   it('keeps two previews built from the same live workbook independently available', async () => {
     const store = new TemplateArtifactStore({ capacity: 4 });
     const ids = ['artifact-A', 'artifact-B'];

--- a/src/tools/desktop/authoring/templates/buildWorksheetsFromTemplates.test.ts
+++ b/src/tools/desktop/authoring/templates/buildWorksheetsFromTemplates.test.ts
@@ -65,19 +65,21 @@ describe('build-worksheets-from-templates', () => {
     sessionRouteState.clear();
   });
 
-  it('has the singular live-only caller-neutral input contract', () => {
+  it('has the singular live-only caller-neutral input contract', async () => {
     const tool = getBuildWorksheetsFromTemplatesTool(new DesktopMcpServer());
+    const schema = await Provider.from(tool.paramsSchema);
     expect(tool.name).toBe('build-worksheets-from-templates');
-    expect(tool.paramsSchema).toMatchObject({
+    expect(schema).toMatchObject({
       session: expect.any(Object),
       templateName: expect.any(Object),
       title: expect.any(Object),
       datasource: expect.any(Object),
       fieldMapping: expect.any(Object),
     });
-    expect(tool.paramsSchema).not.toHaveProperty('templates');
-    expect(tool.paramsSchema).not.toHaveProperty('workbookFile');
-    expect(tool.paramsSchema).not.toHaveProperty('confirmation');
+    expect(schema.fieldMapping.description).toBe('Map slot ID to exact returned column_ref.');
+    expect(schema).not.toHaveProperty('templates');
+    expect(schema).not.toHaveProperty('workbookFile');
+    expect(schema).not.toHaveProperty('confirmation');
     expect(tool.annotations).toMatchObject({ readOnlyHint: true });
   });
 

--- a/src/tools/desktop/authoring/templates/buildWorksheetsFromTemplates.ts
+++ b/src/tools/desktop/authoring/templates/buildWorksheetsFromTemplates.ts
@@ -27,7 +27,7 @@ const paramsSchema = {
   datasource: z.string().trim().min(1).max(255).describe('Live datasource name.'),
   fieldMapping: z
     .record(z.string().trim().min(1).max(128), z.string().trim().min(1).max(255))
-    .describe('Template slot ID to live field reference.'),
+    .describe('Map slot ID to exact returned column_ref.'),
 };
 
 interface BuildWorksheetsFromTemplatesDependencies {

--- a/src/tools/desktop/authoring/templates/buildWorksheetsFromTemplates.ts
+++ b/src/tools/desktop/authoring/templates/buildWorksheetsFromTemplates.ts
@@ -101,7 +101,7 @@ export const getBuildWorksheetsFromTemplatesTool = (
             artifactId,
             templateName,
             title,
-            datasource,
+            datasource: built.value.artifact.datasource,
             provenance: built.value.provenance,
             bindings: built.value.bindings,
           });


### PR DESCRIPTION
This restores the information agents need to bind a template correctly on the first attempt. This is the rule going forward: compact template results must identify every slot, and field mappings must use the exact `column_ref` returned by field discovery.

This PR covers the template catalog and worksheet build path. It does not change template selection or add another authoring path. Future template changes must preserve complete slot metadata and report the exact live datasource that will be applied.

The build accepts NFC/NFD Unicode spellings and one unambiguous outer bracket wrapper. It rejects case differences, different datasources, and bracket aliases when both names exist in the workbook.

Validation:
- `scripts/agent-check` passed: 5,898 tests
- Live Studio replay passed on `se-eval-scratch` with Sample Superstore
- Category and SUM(Sales) column instances survived readback
- No donor Sub-Category field or template token leaked
- Summary data returned the expected three categories
- Final independent adversarial review: clean

Approving this PR makes complete slot metadata and exact field references the template binding contract.

Posted by MattGPT for Matt Filbert.