### PR TITLE
feat(desktop): measure worksheet summary-data round trips

### DIFF
--- a/src/server.desktop.test.ts
+++ b/src/server.desktop.test.ts
@@ -233,12 +233,13 @@ async function serializeDesktopToolSurface(tool: DesktopTool<any>): Promise<stri
 // served profile, while the full schema-only surface moves 56_650 -> 56_799.
 // Re-pinned 2026-08-19: apply-worksheet now infers the target from a cached worksheet fragment, so
 // its worksheetName describe drops the redundant "worksheet" (-3 bytes); dynamic authoring 40_099 -> 40_096.
-// Re-pinned 2026-08-20: profile-summary-data adds a bounded, read-only performance probe.
-// Dynamic authoring moves 40_096 -> 40_883; full moves 56_799 -> 57_586.
-const DYNAMIC_AUTHORING_SURFACE_EXPECTED = 40_883;
-const DYNAMIC_AUTHORING_SURFACE_BUDGET = 40_904;
+// Re-pinned 2026-08-20: profile-summary-data adds a bounded, read-only query probe and directs
+// render-performance questions to Tableau's native tools. Dynamic authoring moves 40_096 ->
+// 40_979; full moves 56_799 -> 57_682.
+const DYNAMIC_AUTHORING_SURFACE_EXPECTED = 40_979;
+const DYNAMIC_AUTHORING_SURFACE_BUDGET = 41_000;
 const DYNAMIC_AUTHORING_PRODUCT_CEILING = 46_000;
-const FULL_TOOL_SURFACE_BUDGET = 57_604;
+const FULL_TOOL_SURFACE_BUDGET = 57_700;
 
 describe('desktop tools/list serialized surface', () => {
   it('keeps the served dynamic authoring profile under the tool-search auto-deferral threshold budget', async () => {

--- a/src/server.desktop.test.ts
+++ b/src/server.desktop.test.ts
@@ -233,10 +233,12 @@ async function serializeDesktopToolSurface(tool: DesktopTool<any>): Promise<stri
 // served profile, while the full schema-only surface moves 56_650 -> 56_799.
 // Re-pinned 2026-08-19: apply-worksheet now infers the target from a cached worksheet fragment, so
 // its worksheetName describe drops the redundant "worksheet" (-3 bytes); dynamic authoring 40_099 -> 40_096.
-const DYNAMIC_AUTHORING_SURFACE_EXPECTED = 40_096;
-const DYNAMIC_AUTHORING_SURFACE_BUDGET = 40_117;
+// Re-pinned 2026-08-20: profile-summary-data adds a bounded, read-only performance probe.
+// Dynamic authoring moves 40_096 -> 40_883; full moves 56_799 -> 57_586.
+const DYNAMIC_AUTHORING_SURFACE_EXPECTED = 40_883;
+const DYNAMIC_AUTHORING_SURFACE_BUDGET = 40_904;
 const DYNAMIC_AUTHORING_PRODUCT_CEILING = 46_000;
-const FULL_TOOL_SURFACE_BUDGET = 56_817;
+const FULL_TOOL_SURFACE_BUDGET = 57_604;
 
 describe('desktop tools/list serialized surface', () => {
   it('keeps the served dynamic authoring profile under the tool-search auto-deferral threshold budget', async () => {
@@ -493,10 +495,10 @@ describe('selectToolsForProfile (TOOL_PROFILE, W60 spike lever 1 / preamble P1)'
     expect(selected.map((t) => t.name)).toContain('execute-tableau-command');
   });
 
-  it('TOOL_PROFILE=dynamic-authoring registers exactly the 51-tool modern surface with scoped XML fallbacks', () => {
+  it('TOOL_PROFILE=dynamic-authoring registers exactly the 52-tool modern surface with scoped XML fallbacks', () => {
     const selected = selectToolsForProfile(allTools(), 'dynamic-authoring');
     expect(new Set(selected.map((t) => t.name))).toEqual(DYNAMIC_AUTHORING_TOOL_PROFILE);
-    expect(selected).toHaveLength(51);
+    expect(selected).toHaveLength(52);
     // The full dynamic dialect, semantically named — every author-* verb present,
     // plus the ask-for-help, command-discovery, deterministic fast-path, and the two
     // knowledge doors the system prompt's "consult the expertise library" law routes to.
@@ -519,6 +521,7 @@ describe('selectToolsForProfile (TOOL_PROFILE, W60 spike lever 1 / preamble P1)'
       'read-knowledge-resource',
       'search-knowledge',
       'get-summary-data',
+      'profile-summary-data',
       'get-workbook-inventory',
       'list-workbook-datasources',
       'list-site-datasources',

--- a/src/server.desktop.ts
+++ b/src/server.desktop.ts
@@ -164,6 +164,7 @@ export const DYNAMIC_AUTHORING_TOOL_PROFILE: ReadonlySet<DesktopToolName> =
     'list-worksheets',
     'list-dashboards',
     'get-summary-data',
+    'profile-summary-data',
     'list-worksheet-logical-tables',
     'get-worksheet-underlying-data',
     'get-workbook-inventory',

--- a/src/tools/desktop/api/profileSummaryData.test.ts
+++ b/src/tools/desktop/api/profileSummaryData.test.ts
@@ -49,6 +49,8 @@ describe('getProfileSummaryDataTool', () => {
 
     expect(tool.name).toBe('profile-summary-data');
     expect(tool.description).toContain('not worksheet render time');
+    expect(tool.description).toContain('ask the user to run Tableau Performance Recorder');
+    expect(tool.description).toContain('Workbook Optimizer');
     expect(tool.annotations).toMatchObject({
       readOnlyHint: true,
       destructiveHint: false,

--- a/src/tools/desktop/api/profileSummaryData.test.ts
+++ b/src/tools/desktop/api/profileSummaryData.test.ts
@@ -1,0 +1,338 @@
+import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { Err, Ok } from 'ts-results-es';
+import { z } from 'zod';
+
+import { ExecuteCommandError } from '../../../desktop/externalApi/executorTypes.js';
+import { ExternalApiToolExecutor } from '../../../desktop/externalApi/externalApiToolExecutor.js';
+import * as sessionResolution from '../../../desktop/session/sessionResolution.js';
+import * as readHarness from '../../../desktop/wrappers/readHarness.js';
+import { DesktopMcpServer } from '../../../server.desktop.js';
+import invariant from '../../../utils/invariant.js';
+import { Provider } from '../../../utils/provider.js';
+import { getMockRequestHandlerExtra } from '../toolContext.mock.js';
+import { getProfileSummaryDataTool } from './profileSummaryData.js';
+
+vi.mock('../../../desktop/session/sessionResolution.js');
+
+const worksheet = {
+  id: 'sheet-1',
+  name: 'Sales by Category',
+  hidden: false,
+  datasources: ['Sample - Superstore'],
+};
+type SummaryFixture = { columns: Array<Record<string, unknown>>; rows: unknown[][] };
+
+const baseData: SummaryFixture = {
+  columns: [{ name: 'Category' }, { name: 'SUM(Sales)' }],
+  rows: [
+    ['Furniture', 100],
+    ['Technology', 200],
+  ],
+};
+
+describe('getProfileSummaryDataTool', () => {
+  let nowSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(sessionResolution.resolveSession).mockReturnValue(Ok('resolved-42'));
+    nowSpy = vi.spyOn(performance, 'now');
+  });
+
+  afterEach(() => {
+    nowSpy.mockRestore();
+  });
+
+  it('declares a bounded read-only profiling contract', async () => {
+    const tool = getProfileSummaryDataTool(new DesktopMcpServer());
+    const schema = z.object(await Provider.from(tool.paramsSchema));
+
+    expect(tool.name).toBe('profile-summary-data');
+    expect(tool.description).toContain('not worksheet render time');
+    expect(tool.annotations).toMatchObject({
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    });
+    expect(schema.safeParse({ worksheetName: 'Sheet 1', sampleCount: 1 }).success).toBe(false);
+    expect(schema.safeParse({ worksheetName: 'Sheet 1', sampleCount: 11 }).success).toBe(false);
+    expect(schema.safeParse({ worksheetName: '' }).success).toBe(false);
+  });
+
+  it('resolves one exact worksheet and runs sequential summary requests with stable statistics', async () => {
+    mockDurations([10, 20, 30, 40, 50]);
+    const harness = makeHarness([baseData, baseData, baseData, baseData, baseData]);
+    const readToolSpy = vi.spyOn(readHarness, 'runExternalApiReadTool');
+
+    const result = await harness.callTool({
+      session: '42',
+      worksheetName: worksheet.name,
+    });
+
+    expect(result.isError).toBe(false);
+    const body = parseResult(result);
+    expect(body).toMatchObject({
+      status: 'success',
+      session: 'resolved-42',
+      worksheet: { id: 'sheet-1', name: 'Sales by Category' },
+      sampleCount: 5,
+      maxRows: 200,
+      measurement:
+        'Summary-data API query/compute round trip proxy; excludes worksheet resolution and worksheet render time.',
+      statistics: {
+        medianDurationMs: 30,
+        minDurationMs: 10,
+        maxDurationMs: 50,
+        spreadDurationMs: 40,
+      },
+      resultsStable: true,
+    });
+    expect(body.samples.map((sample) => sample.durationMs)).toEqual([10, 20, 30, 40, 50]);
+    expect(body.samples.map((sample) => [sample.rowCount, sample.columnCount])).toEqual([
+      [2, 2],
+      [2, 2],
+      [2, 2],
+      [2, 2],
+      [2, 2],
+    ]);
+    expect(body.stableResultFingerprint).toMatch(/^[a-f0-9]{64}$/);
+    expect(readToolSpy).toHaveBeenCalledTimes(1);
+    expect(sessionResolution.resolveSession).toHaveBeenCalledWith('42');
+    expect(harness.getExecutor).toHaveBeenCalledWith('resolved-42');
+    expect(harness.executor.listWorksheets).toHaveBeenCalledTimes(1);
+    expect(harness.executor.getWorksheetSummaryData).toHaveBeenCalledTimes(5);
+    for (const call of harness.executor.getWorksheetSummaryData.mock.calls) {
+      expect(call[0]).toBe('sheet-1');
+      expect(call[1]).toEqual({ maxRows: 200, ignoreSelection: true });
+      expect(call[2]).toBeInstanceOf(AbortSignal);
+    }
+    expect(harness.executor.exportWorksheetImage).not.toHaveBeenCalled();
+  });
+
+  it('uses the average of the two middle samples for an even median and clamps maxRows', async () => {
+    mockDurations([40, 10, 30, 20]);
+    const harness = makeHarness([baseData, baseData, baseData, baseData]);
+
+    const result = await harness.callTool({
+      worksheetName: worksheet.name,
+      sampleCount: 4,
+      maxRows: 5000,
+    });
+
+    const body = parseResult(result);
+    expect(body.maxRows).toBe(1000);
+    expect(body.statistics).toEqual({
+      medianDurationMs: 25,
+      minDurationMs: 10,
+      maxDurationMs: 40,
+      spreadDurationMs: 30,
+    });
+    expect(harness.executor.getWorksheetSummaryData).toHaveBeenCalledTimes(4);
+    expect(harness.executor.getWorksheetSummaryData.mock.calls[0][1]).toEqual({
+      maxRows: 1000,
+      ignoreSelection: true,
+    });
+  });
+
+  it('canonicalizes object keys recursively while preserving array order', async () => {
+    mockDurations([1, 2]);
+    const harness = makeHarness([
+      {
+        columns: [{ name: 'Sales', metadata: { z: 2, a: 1 } }],
+        rows: [[{ b: 2, a: 1 }, 100]],
+      },
+      {
+        columns: [{ metadata: { a: 1, z: 2 }, name: 'Sales' }],
+        rows: [[{ a: 1, b: 2 }, 100]],
+      },
+    ]);
+
+    const body = parseResult(
+      await harness.callTool({ worksheetName: worksheet.name, sampleCount: 2 }),
+    );
+
+    expect(body.resultsStable).toBe(true);
+    expect(body.stableResultFingerprint).toBe(
+      '8cb55e4061f317ed1fcb62672725b1268edfa7b774da0e2b3398679f99d90e17',
+    );
+    expect(body.samples[0].resultFingerprint).toBe(body.samples[1].resultFingerprint);
+  });
+
+  it('reports instability when returned values or array order changes', async () => {
+    mockDurations([1, 2, 3]);
+    const harness = makeHarness([
+      baseData,
+      { ...baseData, rows: [...baseData.rows].reverse() },
+      { ...baseData, rows: [['Furniture', 101]] },
+    ]);
+
+    const body = parseResult(
+      await harness.callTool({ worksheetName: worksheet.name, sampleCount: 3 }),
+    );
+
+    expect(body.resultsStable).toBe(false);
+    expect(body.status).toBe('unstable_results');
+    expect(body.stableResultFingerprint).toBeNull();
+    expect(new Set(body.samples.map((sample) => sample.resultFingerprint)).size).toBe(3);
+  });
+
+  it.each([
+    ['no datasource', { ...worksheet, datasources: [] }, baseData, 'has no datasource'],
+    ['no columns', worksheet, { columns: [], rows: [] }, 'returned no columns'],
+    ['no rows', worksheet, { columns: [{ name: 'Sales' }], rows: [] }, 'returned no rows'],
+  ])('fails before producing a misleading profile for %s', async (_label, sheet, data, message) => {
+    mockDurations([1, 2]);
+    const harness = makeHarness([data, data], sheet);
+
+    const result = await harness.callTool({ worksheetName: sheet.name, sampleCount: 2 });
+
+    expect(result.isError).toBe(true);
+    expect(textResult(result)).toContain(message);
+    expect(harness.executor.exportWorksheetImage).not.toHaveBeenCalled();
+  });
+
+  it('fails fast on a partial summary error', async () => {
+    mockDurations([1, 2, 3]);
+    const failure: ExecuteCommandError = {
+      type: 'command-failed',
+      error: { code: 'query-failed', message: 'query failed', recoverable: false },
+    };
+    const harness = makeHarness([baseData, failure, baseData]);
+
+    const result = await harness.callTool({ worksheetName: worksheet.name, sampleCount: 3 });
+
+    expect(result.isError).toBe(true);
+    expect(harness.executor.getWorksheetSummaryData).toHaveBeenCalledTimes(2);
+  });
+
+  it.each([
+    [
+      'missing route',
+      {
+        type: 'command-failed',
+        error: {
+          code: 'not-found',
+          message: 'No route matches the request path.',
+          recoverable: false,
+        },
+      } satisfies ExecuteCommandError,
+      'does not serve the summary-data endpoint',
+    ],
+    [
+      'abort',
+      {
+        type: 'command-timed-out',
+        error: 'External Client API request was aborted before completion.',
+      } satisfies ExecuteCommandError,
+      'aborted',
+    ],
+  ])(
+    'returns an error and stops after the first sample on %s',
+    async (_label, failure, message) => {
+      mockDurations([1, 2]);
+      const harness = makeHarness([failure, baseData]);
+
+      const result = await harness.callTool({ worksheetName: worksheet.name, sampleCount: 2 });
+
+      expect(result.isError).toBe(true);
+      expect(textResult(result).toLowerCase()).toContain(message);
+      expect(harness.executor.getWorksheetSummaryData).toHaveBeenCalledTimes(1);
+    },
+  );
+});
+
+type ProfileArgs = {
+  session?: string;
+  worksheetName: string;
+  sampleCount?: number;
+  maxRows?: number;
+};
+
+type ProfileBody = {
+  status: 'success' | 'unstable_results';
+  session: string;
+  worksheet: { id: string; name: string };
+  sampleCount: number;
+  maxRows: number;
+  measurement: string;
+  samples: Array<{
+    index: number;
+    durationMs: number;
+    rowCount: number;
+    columnCount: number;
+    resultFingerprint: string;
+  }>;
+  statistics: {
+    medianDurationMs: number;
+    minDurationMs: number;
+    maxDurationMs: number;
+    spreadDurationMs: number;
+  };
+  resultsStable: boolean;
+  stableResultFingerprint: string | null;
+};
+
+function makeHarness(
+  responses: Array<SummaryFixture | ExecuteCommandError>,
+  targetWorksheet = worksheet,
+): {
+  executor: {
+    listWorksheets: ReturnType<typeof vi.fn>;
+    getWorksheetSummaryData: ReturnType<typeof vi.fn>;
+    exportWorksheetImage: ReturnType<typeof vi.fn>;
+  };
+  getExecutor: ReturnType<typeof vi.fn>;
+  callTool: (args: ProfileArgs) => Promise<CallToolResult>;
+} {
+  const queue = [...responses];
+  const executor = {
+    listWorksheets: vi.fn().mockResolvedValue(Ok({ worksheets: [targetWorksheet] })),
+    getWorksheetSummaryData: vi.fn().mockImplementation(async () => {
+      const response = queue.shift();
+      invariant(response !== undefined);
+      return 'type' in response ? Err(response) : Ok(response);
+    }),
+    exportWorksheetImage: vi.fn(),
+  };
+  const getExecutor = vi.fn().mockResolvedValue(executor as unknown as ExternalApiToolExecutor);
+  const extra = { ...getMockRequestHandlerExtra(), getExecutor };
+
+  return {
+    executor,
+    getExecutor,
+    callTool: async (args) => {
+      const tool = getProfileSummaryDataTool(new DesktopMcpServer());
+      const callback = await Provider.from(tool.callback);
+      return await callback(
+        {
+          session: args.session,
+          worksheetName: args.worksheetName,
+          sampleCount: args.sampleCount,
+          maxRows: args.maxRows,
+        },
+        extra,
+      );
+    },
+  };
+}
+
+function mockDurations(durations: number[]): void {
+  const values = [0];
+  let cursor = 10;
+  for (const duration of durations) {
+    values.push(cursor, cursor + duration);
+    cursor += duration + 10;
+  }
+  values.push(cursor);
+  vi.spyOn(performance, 'now').mockImplementation(() => values.shift() ?? cursor);
+}
+
+function parseResult(result: CallToolResult): ProfileBody {
+  return JSON.parse(textResult(result)) as ProfileBody;
+}
+
+function textResult(result: CallToolResult): string {
+  invariant(result.content[0].type === 'text');
+  return result.content[0].text;
+}

--- a/src/tools/desktop/api/profileSummaryData.ts
+++ b/src/tools/desktop/api/profileSummaryData.ts
@@ -1,0 +1,196 @@
+import { createHash } from 'node:crypto';
+
+import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { Ok, Result } from 'ts-results-es';
+import { z } from 'zod';
+
+import { SummaryData, WorksheetItem } from '../../../desktop/externalApi/types.js';
+import { runExternalApiReadTool } from '../../../desktop/wrappers/readHarness.js';
+import { ArgsValidationError } from '../../../errors/mcpToolError.js';
+import { DesktopMcpServer } from '../../../server.desktop.js';
+import { DesktopTool } from '../tool.js';
+
+const DEFAULT_SAMPLE_COUNT = 5;
+const DEFAULT_MAX_ROWS = 200;
+const MAX_ROWS_CAP = 1000;
+
+const paramsSchema = {
+  session: z.string().optional().describe('Session ID; optional if pinned or unique.'),
+  worksheetName: z.string().min(1).describe('Exact worksheet name.'),
+  sampleCount: z
+    .number()
+    .int()
+    .min(2)
+    .max(10)
+    .optional()
+    .describe('Sequential samples; default 5, min 2, max 10.'),
+  maxRows: z
+    .number()
+    .int()
+    .positive()
+    .optional()
+    .describe('Rows per sample; default 200, max 1000.'),
+};
+
+type ProfileSample = {
+  index: number;
+  durationMs: number;
+  rowCount: number;
+  columnCount: number;
+  resultFingerprint: string;
+};
+
+const title = 'Profile Summary Data';
+export const getProfileSummaryDataTool = (
+  server: DesktopMcpServer,
+): DesktopTool<typeof paramsSchema> => {
+  const profileSummaryData = new DesktopTool({
+    server,
+    name: 'profile-summary-data',
+    title,
+    description:
+      'Measure repeated summary-data query/compute round trips for one worksheet; not worksheet render time.',
+    paramsSchema,
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
+    callback: async (
+      { session, worksheetName, sampleCount, maxRows },
+      extra,
+    ): Promise<CallToolResult> => {
+      return await profileSummaryData.logAndExecute({
+        extra,
+        args: { session, worksheetName, sampleCount, maxRows },
+        callback: async () => {
+          const resolvedSampleCount = sampleCount ?? DEFAULT_SAMPLE_COUNT;
+          const resolvedMaxRows = Math.min(maxRows ?? DEFAULT_MAX_ROWS, MAX_ROWS_CAP);
+          return await runExternalApiReadTool({
+            session,
+            extra,
+            callback: async (_executor, _signal, read, resolvedSession) => {
+              const worksheetsResult = await read(
+                'worksheet list',
+                async (executor, signal) => await executor.listWorksheets(signal),
+              );
+              if (worksheetsResult.isErr()) return worksheetsResult;
+
+              const worksheetResult = resolveExactWorksheet(
+                worksheetName,
+                worksheetsResult.value.worksheets ?? [],
+              );
+              if (worksheetResult.isErr()) return worksheetResult;
+              const worksheet = worksheetResult.value;
+              if (worksheet.datasources?.length === 0) {
+                return new ArgsValidationError(
+                  `Worksheet "${worksheet.name}" has no datasource, so summary data cannot be profiled.`,
+                ).toErr();
+              }
+
+              const samples: ProfileSample[] = [];
+              for (let index = 1; index <= resolvedSampleCount; index += 1) {
+                const startedAt = performance.now();
+                const summaryResult = await read(
+                  'summary-data',
+                  async (executor, signal) =>
+                    await executor.getWorksheetSummaryData(
+                      worksheet.id,
+                      { maxRows: resolvedMaxRows, ignoreSelection: true },
+                      signal,
+                    ),
+                );
+                const durationMs = performance.now() - startedAt;
+                if (summaryResult.isErr()) return summaryResult;
+
+                const columns = summaryResult.value.columns ?? [];
+                const rows = summaryResult.value.rows ?? [];
+                if (columns.length === 0) {
+                  return new ArgsValidationError(
+                    `Worksheet "${worksheet.name}" returned no columns, so the profile would be misleading.`,
+                  ).toErr();
+                }
+                if (rows.length === 0) {
+                  return new ArgsValidationError(
+                    `Worksheet "${worksheet.name}" returned no rows, so the profile would be misleading.`,
+                  ).toErr();
+                }
+
+                samples.push({
+                  index,
+                  durationMs,
+                  rowCount: rows.length,
+                  columnCount: columns.length,
+                  resultFingerprint: fingerprint({ columns, rows }),
+                });
+              }
+
+              const durations = samples.map((sample) => sample.durationMs);
+              const firstFingerprint = samples[0].resultFingerprint;
+              const resultsStable = samples.every(
+                (sample) => sample.resultFingerprint === firstFingerprint,
+              );
+
+              return new Ok({
+                status: resultsStable ? ('success' as const) : ('unstable_results' as const),
+                session: resolvedSession,
+                worksheet: { id: worksheet.id, name: worksheet.name },
+                sampleCount: resolvedSampleCount,
+                maxRows: resolvedMaxRows,
+                measurement:
+                  'Summary-data API query/compute round trip proxy; excludes worksheet resolution and worksheet render time.',
+                samples,
+                statistics: {
+                  medianDurationMs: median(durations),
+                  minDurationMs: Math.min(...durations),
+                  maxDurationMs: Math.max(...durations),
+                  spreadDurationMs: Math.max(...durations) - Math.min(...durations),
+                },
+                resultsStable,
+                stableResultFingerprint: resultsStable ? firstFingerprint : null,
+              });
+            },
+          });
+        },
+      });
+    },
+  });
+
+  return profileSummaryData;
+};
+
+function resolveExactWorksheet(
+  worksheetName: string,
+  worksheets: WorksheetItem[],
+): Result<WorksheetItem, ArgsValidationError> {
+  const matches = worksheets.filter((worksheet) => worksheet.name === worksheetName);
+  if (matches.length === 1) return new Ok(matches[0]);
+  const available = worksheets.map((worksheet) => worksheet.name).join(', ') || '(none)';
+  const detail = matches.length > 1 ? 'matched more than one worksheet' : 'was not found';
+  return new ArgsValidationError(
+    `Worksheet "${worksheetName}" ${detail}. Use one exact worksheet name. Available worksheets: ${available}`,
+  ).toErr();
+}
+
+function fingerprint(value: Pick<SummaryData, 'columns' | 'rows'>): string {
+  return createHash('sha256')
+    .update(JSON.stringify(canonicalize(value)))
+    .digest('hex');
+}
+
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalize);
+  if (typeof value !== 'object' || value === null) return value;
+  return Object.fromEntries(
+    Object.entries(value)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, nested]) => [key, canonicalize(nested)]),
+  );
+}
+
+function median(values: number[]): number {
+  const sorted = [...values].sort((left, right) => left - right);
+  const middle = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0 ? (sorted[middle - 1] + sorted[middle]) / 2 : sorted[middle];
+}

--- a/src/tools/desktop/api/profileSummaryData.ts
+++ b/src/tools/desktop/api/profileSummaryData.ts
@@ -49,7 +49,7 @@ export const getProfileSummaryDataTool = (
     name: 'profile-summary-data',
     title,
     description:
-      'Measure repeated summary-data query/compute round trips for one worksheet; not worksheet render time.',
+      'Measure repeated summary-data query/compute round trips for one worksheet; not worksheet render time. For render bottlenecks, ask the user to run Tableau Performance Recorder or Workbook Optimizer.',
     paramsSchema,
     annotations: {
       readOnlyHint: true,

--- a/src/tools/desktop/toolName.ts
+++ b/src/tools/desktop/toolName.ts
@@ -56,6 +56,7 @@ export const desktopToolNames = [
   'get-dashboard-info',
   'get-storyboard-info',
   'get-summary-data',
+  'profile-summary-data',
   'list-worksheet-logical-tables',
   'get-worksheet-underlying-data',
   'export-worksheet-image',

--- a/src/tools/desktop/tools.ts
+++ b/src/tools/desktop/tools.ts
@@ -35,6 +35,7 @@ import { getListWorksheetLogicalTablesTool } from './api/listWorksheetLogicalTab
 import { getListWorksheetsTool } from './api/listWorksheets.js';
 import { getOpenFileTool } from './api/openFile.js';
 import { getPauseAutoUpdatesTool } from './api/pauseAutoUpdates.js';
+import { getProfileSummaryDataTool } from './api/profileSummaryData.js';
 import { getRedoWorkbookTool } from './api/redoWorkbook.js';
 import { getRenameSheetTool } from './api/renameSheet.js';
 import { getResumeAutoUpdatesTool } from './api/resumeAutoUpdates.js';
@@ -142,6 +143,7 @@ export const desktopToolFactories = [
   getDashboardInfoTool,
   getStoryboardInfoTool,
   getSummaryDataTool,
+  getProfileSummaryDataTool,
   getListWorksheetLogicalTablesTool,
   getWorksheetUnderlyingDataTool,
   exportWorksheetImageTool,


### PR DESCRIPTION
This adds one read-only Desktop tool for repeated worksheet summary-data measurements. The tool reports API query and compute round-trip time; it does not claim Tableau render time. For real render bottlenecks, the agent sends the user to Tableau Performance Recorder or Workbook Optimizer.

Scope:

- Profile one exact worksheet in one pinned Studio session.
- Return each timing, result shape, stable fingerprints, and median/min/max/spread.
- Fail closed on missing data or partial API errors.
- Keep the tool in the normal dynamic-authoring profile so Studio TAS can use it without a separate path.

Future changes must preserve the session pin, sequential samples, stable-result check, and the explicit render-time exclusion.

Evidence:

- Canonical agent check: all five gates passed; 379 test files and 5,924 tests passed.
- GitHub Node 22 and Node 24 builds passed, including the real Tableau authorization test.
- Live Mac Studio run against Superstore: 5/5 samples returned the same 200x3 result fingerprint; median 196 ms.
- No workbook data rows are returned by the profiler.

This PR stays in draft until #797 is reviewed and merged. After that, it needs one normal merge from the updated `feature/desktop`, the combined tool-count ratchet, and a final check run. No rebase or force-push is needed.

Approving this PR means accepting summary-data timing as a bounded diagnostic signal, not as proof of worksheet render performance.

Authored by MattGPT for Matt Filbert.
