### PR TITLE
fix(oauth): click the Allow button on consent pages

### DIFF
--- a/tests/oauth/tableau-authz/flows/consentFlow.test.ts
+++ b/tests/oauth/tableau-authz/flows/consentFlow.test.ts
@@ -1,0 +1,36 @@
+import { expect, test } from '@playwright/test';
+
+import { ConsentFlow } from './consentFlow.js';
+
+test('clicks Allow when the consent page has several submit buttons', async ({ page }) => {
+  await page.setContent(`
+    <h1>An OAuth client requests access to Tableau</h1>
+    <form id="relogin_form"></form>
+    <button
+      id="switch-site-link"
+      type="submit"
+      name="switchType"
+      value="site"
+      form="relogin_form"
+      onclick="document.body.dataset.action = 'switch-site'"
+    >Switch site</button>
+    <button
+      id="switch-username-link"
+      type="submit"
+      name="switchType"
+      value="username"
+      form="relogin_form"
+      onclick="document.body.dataset.action = 'switch-username'"
+    >Switch username</button>
+    <button
+      id="allow-button"
+      type="submit"
+      onclick="document.body.dataset.action = 'allow'"
+    >Allow</button>
+  `);
+
+  const authorizationPending = new Promise(() => undefined);
+  await new ConsentFlow(page).grantConsentIfNecessary(authorizationPending);
+
+  await expect(page.locator('body')).toHaveAttribute('data-action', 'allow');
+});

--- a/tests/oauth/tableau-authz/flows/consentFlow.ts
+++ b/tests/oauth/tableau-authz/flows/consentFlow.ts
@@ -17,6 +17,6 @@ export class ConsentFlow extends Flow {
   };
 
   private fill = async (): Promise<void> => {
-    await this.page.locator('button[type="submit"]').click();
+    await this.page.locator('#allow-button').click();
   };
 }


### PR DESCRIPTION
## Decision

The OAuth test flow must click the consent page's Allow button by its stable ID. This is a test-harness fix: it does not change Tableau MCP authorization behavior.

## Scope

- Replace the broad submit-button selector with `#allow-button`.
- Add a browser test for the real three-button consent-page shape.
- Leave login, site switching, username switching, and product OAuth code unchanged.

Future consent-page tests must keep the action explicit; adding another submit button must not make the flow ambiguous.

## Evidence

- RED reproduced the Node 22 CI strict-mode failure: the old selector matched Switch site, Switch username, and Allow.
- Focused Playwright test: 1 passed.
- ESLint, TypeScript, Desktop build, lockstep, and diff checks passed.
- Native Sol adversarial review: clean.

The full local unit gate hit unrelated External API mock-server hook timeouts. GitHub's Node 22 job is the final integration proof.

Approving this PR means the OAuth harness grants consent through the exact Allow control instead of whichever submit button happens to be present.

Authored by MattGPT for Matt Filbert.
