### PR TITLE
@W-23941819: Disable render-interactive-viz for pat and embedded-oauth auth

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "4.5.3",
+  "version": "4.5.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "4.5.3",
+      "version": "4.5.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1095.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "4.5.4",
+  "version": "4.5.5",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/plans/disable-render-interactive-viz-for-pat-and-embedded-oauth.md
+++ b/plans/disable-render-interactive-viz-for-pat-and-embedded-oauth.md
@@ -1,0 +1,53 @@
+# Disable `render-interactive-viz` for PAT and embedded-OAuth auth modes
+
+## Context
+
+`render-interactive-viz` (`/Users/j.song/work/orchestrator/tableau-mcp/src/tools/web/renderInteractiveViz/renderInteractiveViz.ts`) renders a live, interactive embedded Tableau viz using the MCP-Apps embed flow. Today it is gated only on the `mcp-apps` feature flag:
+
+```ts
+disabled: new Provider(async () => !(await getFeatureGate().isFeatureEnabled('mcp-apps'))),
+```
+
+The interactive embed relies on auth flows that can mint/refresh a session-scoped token suitable for the client-side embed (Bearer from a real Tableau-hosted OAuth authz server, or a JWT via UAT/direct-trust). Two auth configurations don't fit that model and should disable the tool:
+- **`pat`** — PAT credentials aren't usable for the embed handoff.
+- **embedded OAuth** — when this MCP server is itself acting as the OAuth authorization server (`config.oauth.embeddedAuthzServer === true`, as opposed to delegating to Tableau's own authz server), there's no external Tableau-hosted session to hand to the embed.
+
+The user's requirement: disable render-interactive-viz for PAT and for embedded-OAuth mode (not for delegated/Tableau-authz-server OAuth, nor for uat/direct-trust).
+
+## Change
+
+**File:** `src/tools/web/renderInteractiveViz/renderInteractiveViz.ts`
+
+1. Import `getConfig` from `../../../config.js` and call it once inside `getRenderInteractiveVizTool` (mirrors `revokeAccessToken.ts:4,30`).
+2. Extend the existing `disabled` Provider to also check auth mode, combining with the current feature-gate check (mirrors the combined-condition pattern in `src/tools/web/_lib/confirmDeleteContent.ts:45-48`):
+
+```ts
+disabled: new Provider(
+  async () =>
+    !(await getFeatureGate().isFeatureEnabled('mcp-apps')) ||
+    config.auth === 'pat' ||
+    (config.auth === 'oauth' && config.oauth.embeddedAuthzServer),
+),
+```
+
+No other files need to change — `WebMcpServer` (`src/server.web.ts:135`) already resolves `tool.disabled` via `Provider.from` and skips registration when `true`; this is the sole registration-filtering mechanism (confirmed via `revokeAccessToken.ts`'s identical `config.auth`-based precedent).
+
+## Tests
+
+**File:** `src/tools/web/renderInteractiveViz/renderInteractiveViz.test.ts`
+
+Add a `describe('disabled property', ...)` block mirroring `revokeAccessToken.test.ts:39-65`, using `stubDefaultEnvVars()` (already imported/used in this file) plus env stubs for each case:
+
+- disabled when `AUTH=pat` (default test env) and `mcp-apps` feature is on
+- disabled when `AUTH=oauth` and `OAUTH_EMBEDDED_AUTHZ_SERVER=true`
+- enabled when `AUTH=oauth` and `OAUTH_EMBEDDED_AUTHZ_SERVER=false` (delegated to Tableau authz server), with `mcp-apps` on
+- enabled when `AUTH=uat` or `AUTH=direct-trust`, with `mcp-apps` on
+- still disabled regardless of auth type when the `mcp-apps` feature gate is off (existing behavior, just confirm it still composes correctly)
+
+Use `await Provider.from(tool.disabled)` to resolve, and mock/stub the feature gate the same way the existing tests in this file already do (check current file for the feature-gate mocking pattern — if none exists yet, may need `vi.mock('../../../features/init.js', ...)` or to rely on default `features.json`/env-based provider behavior already exercised by `stubDefaultEnvVars()`).
+
+## Verification
+
+- `npx vitest run src/tools/web/renderInteractiveViz/renderInteractiveViz.test.ts`
+- `npx vitest run` (full suite) to ensure no regressions elsewhere (e.g. any test currently asserting render-interactive-viz is enabled under default test env, which is PAT — that assumption will now flip since PAT disables it, so search for and update any such assertions)
+- `npx tsc --noEmit`

--- a/src/tools/web/renderInteractiveViz/renderInteractiveViz.test.ts
+++ b/src/tools/web/renderInteractiveViz/renderInteractiveViz.test.ts
@@ -19,6 +19,11 @@ const mocks = vi.hoisted(() => ({
     isViewAllowed: vi.fn(),
     isWorkbookAllowed: vi.fn(),
   },
+  mockIsFeatureEnabled: vi.fn(),
+}));
+
+vi.mock('../../../features/init.js', () => ({
+  getFeatureGate: vi.fn(() => ({ isFeatureEnabled: mocks.mockIsFeatureEnabled })),
 }));
 
 vi.mock('../../../restApiInstance.js', () => ({
@@ -50,6 +55,7 @@ describe('renderInteractiveVizTool', () => {
     resetResourceAccessCheckerSingleton();
     mocks.mockResourceAccessChecker.isViewAllowed.mockResolvedValue({ allowed: true });
     mocks.mockResourceAccessChecker.isWorkbookAllowed.mockResolvedValue({ allowed: true });
+    mocks.mockIsFeatureEnabled.mockResolvedValue(true);
   });
 
   afterEach(() => {
@@ -65,6 +71,61 @@ describe('renderInteractiveVizTool', () => {
       objectType: expect.any(Object),
     });
     expect(tool.app?.resourceUri).toBe('ui://render-interactive-viz/mcp-app.html');
+  });
+
+  describe('disabled property', () => {
+    it('should be disabled when AUTH is pat (default test env), even with mcp-apps enabled', async () => {
+      const tool = getRenderInteractiveVizTool(new WebMcpServer());
+      expect(await Provider.from(tool.disabled)).toBe(true);
+    });
+
+    it('should be disabled when AUTH=oauth with embedded authz server, even with mcp-apps enabled', async () => {
+      vi.stubEnv('AUTH', 'oauth');
+      vi.stubEnv('OAUTH_ISSUER', 'https://sso.online.tableau.com');
+      vi.stubEnv('OAUTH_EMBEDDED_AUTHZ_SERVER', 'true');
+      vi.stubEnv('OAUTH_JWE_PRIVATE_KEY_PATH', './private_key.test.pem');
+      const tool = getRenderInteractiveVizTool(new WebMcpServer());
+      expect(await Provider.from(tool.disabled)).toBe(true);
+    });
+
+    it('should be enabled when AUTH=oauth delegated to the Tableau authz server, with mcp-apps enabled', async () => {
+      vi.stubEnv('AUTH', 'oauth');
+      vi.stubEnv('OAUTH_ISSUER', 'https://sso.online.tableau.com');
+      vi.stubEnv('OAUTH_EMBEDDED_AUTHZ_SERVER', 'false');
+      const tool = getRenderInteractiveVizTool(new WebMcpServer());
+      expect(await Provider.from(tool.disabled)).toBe(false);
+    });
+
+    it('should be enabled when AUTH=uat, with mcp-apps enabled', async () => {
+      vi.stubEnv('AUTH', 'uat');
+      vi.stubEnv('UAT_TENANT_ID', 'test-tenant-id');
+      vi.stubEnv('UAT_ISSUER', 'https://tableau-mcp.local/uat');
+      vi.stubEnv('UAT_USERNAME_CLAIM', 'test@example.com');
+      vi.stubEnv('UAT_PRIVATE_KEY', 'test-private-key');
+      const tool = getRenderInteractiveVizTool(new WebMcpServer());
+      expect(await Provider.from(tool.disabled)).toBe(false);
+    });
+
+    it('should be enabled when AUTH=direct-trust, with mcp-apps enabled', async () => {
+      vi.stubEnv('AUTH', 'direct-trust');
+      vi.stubEnv('JWT_SUB_CLAIM', 'test-user');
+      vi.stubEnv('CONNECTED_APP_CLIENT_ID', 'test-client-id');
+      vi.stubEnv('CONNECTED_APP_SECRET_ID', 'test-secret-id');
+      vi.stubEnv('CONNECTED_APP_SECRET_VALUE', 'test-secret-value');
+      const tool = getRenderInteractiveVizTool(new WebMcpServer());
+      expect(await Provider.from(tool.disabled)).toBe(false);
+    });
+
+    it('should stay disabled when mcp-apps is off, regardless of auth type', async () => {
+      mocks.mockIsFeatureEnabled.mockResolvedValue(false);
+      vi.stubEnv('AUTH', 'uat');
+      vi.stubEnv('UAT_TENANT_ID', 'test-tenant-id');
+      vi.stubEnv('UAT_ISSUER', 'https://tableau-mcp.local/uat');
+      vi.stubEnv('UAT_USERNAME_CLAIM', 'test@example.com');
+      vi.stubEnv('UAT_PRIVATE_KEY', 'test-private-key');
+      const tool = getRenderInteractiveVizTool(new WebMcpServer());
+      expect(await Provider.from(tool.disabled)).toBe(true);
+    });
   });
 
   it('should return correct payload for an allowed view', async () => {

--- a/src/tools/web/renderInteractiveViz/renderInteractiveViz.ts
+++ b/src/tools/web/renderInteractiveViz/renderInteractiveViz.ts
@@ -2,6 +2,7 @@ import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { Ok } from 'ts-results-es';
 import { z } from 'zod';
 
+import { getConfig } from '../../../config.js';
 import { ViewNotAllowedError, WorkbookNotAllowedError } from '../../../errors/mcpToolError.js';
 import { getFeatureGate } from '../../../features/init.js';
 import { useRestApi } from '../../../restApiInstance.js';
@@ -25,6 +26,8 @@ const paramsSchema = {
 type RenderInteractiveVizResult = { luid: string; objectType: 'workbook' | 'view'; name: string };
 
 export const getRenderInteractiveVizTool = (server: WebMcpServer): WebTool<typeof paramsSchema> => {
+  const config = getConfig();
+
   const renderInteractiveVizTool = new WebTool({
     server,
     name: 'render-interactive-viz',
@@ -39,7 +42,12 @@ export const getRenderInteractiveVizTool = (server: WebMcpServer): WebTool<typeo
       openWorldHint: false,
     },
     app: getAppConfig('render-interactive-viz'),
-    disabled: new Provider(async () => !(await getFeatureGate().isFeatureEnabled('mcp-apps'))),
+    disabled: new Provider(
+      async () =>
+        !(await getFeatureGate().isFeatureEnabled('mcp-apps')) ||
+        config.auth === 'pat' ||
+        (config.auth === 'oauth' && config.oauth.embeddedAuthzServer),
+    ),
     callback: async ({ luid, objectType }, extra): Promise<CallToolResult> => {
       return await renderInteractiveVizTool.logAndExecute<
         AppToolResult<RenderInteractiveVizResult>


### PR DESCRIPTION
GUS: W-23941819

## Description

Disables the `render-interactive-viz` tool when the server is configured with PAT credentials or embedded-OAuth (server acting as its own authz server), since neither can produce a session-scoped token usable by the client-side embed. Remains enabled for uat/direct-trust and delegated OAuth. Still behind the `mcp-apps` feature gate.

See `plans/disable-render-interactive-viz-for-pat-and-embedded-oauth.md` for details.

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

Added unit tests covering the disabled-property behavior across auth types in `renderInteractiveViz.test.ts`.

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes