### PR TITLE
feat(desktop): report live UI state from GET /v0/app

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "2.63.13",
+  "version": "2.64.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "2.63.13",
+      "version": "2.64.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.7.2",
@@ -19,7 +19,7 @@
         "express": "^5.1.0",
         "fast-levenshtein": "^3.0.0",
         "fast-xml-parser": "^5.9.0",
-        "fuse.js": "^7.4.2",
+        "fuse.js": "7.4.2",
         "jose": "^6.0.12",
         "ssrfcheck": "^1.2.0",
         "ts-results-es": "^7.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "2.63.13",
+  "version": "2.64.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/src/desktop/externalApi/__fixtures__/externalClientApi-openapi.json
+++ b/src/desktop/externalApi/__fixtures__/externalClientApi-openapi.json
@@ -96,11 +96,11 @@
     "/v0/app": {
       "get": {
         "summary": "Get application info",
-        "description": "Returns the running Tableau Desktop application version, build, edition, operating system, locale, and repository/log paths.",
+        "description": "Returns the running Tableau Desktop application version, build, edition, operating system, locale, and repository/log paths, plus live UI state: isStartPageVisible (whether the Start Page is showing; it can be visible even while a workbook is open), isDataSourcePageActive (whether the Data Source page is the active tab), and isPresentationMode (whether presentation mode is on).",
         "operationId": "getApp",
         "responses": {
           "200": {
-            "description": "Returns the running Tableau Desktop application version, build, edition, operating system, locale, and repository/log paths.",
+            "description": "Returns the running Tableau Desktop application version, build, edition, operating system, locale, and repository/log paths, plus live UI state: isStartPageVisible (whether the Start Page is showing; it can be visible even while a workbook is open), isDataSourcePageActive (whether the Data Source page is the active tab), and isPresentationMode (whether presentation mode is on).",
             "content": {
               "application/json": {
                 "schema": {
@@ -108,6 +108,9 @@
                 }
               }
             }
+          },
+          "202": {
+            "$ref": "#/components/responses/Accepted"
           },
           "400": {
             "$ref": "#/components/responses/BadRequest"
@@ -806,7 +809,7 @@
       },
       "post": {
         "summary": "Apply a dashboard document",
-        "description": "Replaces a single dashboard with the submitted Tableau XML, leaving the workbook's other sheets intact. A missing or empty body is rejected with 400 and a non-XML Content-Type with 415; a non-empty but malformed (not well-formed) XML body is not a 400 -- it is reported as a failed operation (HTTP 200 with state FAILED and an error). The payload is NOT validated against the schema; use POST /v0/workbook/document:validate for XSD validation. This apply is unconditional last-writer-wins: it performs no precondition/If-Match check and will overwrite a concurrent edit to the same sheet. The apply fails as a failed operation if the submitted payload's sheet name does not match the target sheet's current name -- for example, if you renamed the sheet in the payload, or another editor renamed it after you read the document. It also fails as a failed operation when the name-matching payload element is the wrong sheet subtype -- a story (<dashboard type='storyboard'>) where the target is a dashboard.",
+        "description": "Replaces a single dashboard with the submitted Tableau XML, leaving the workbook's other sheets intact. A missing or empty body is rejected with 400 and a non-XML Content-Type with 415. A non-empty XML body that is not well-formed, or that the product cannot load into a valid workbook, is rejected with 422. The payload is NOT validated against the schema; use POST /v0/workbook/document:validate for XSD validation. This apply is unconditional last-writer-wins: it performs no precondition/If-Match check and will overwrite a concurrent edit to the same sheet. The apply is rejected with 409 when the submitted payload's sheet name does not match the target sheet's current name -- for example, if you renamed the sheet in the payload, or another editor renamed it after you read the document -- or when the name-matching payload element is the wrong sheet subtype (a story, <dashboard type='storyboard'>, where the target is a dashboard). A client error returns a Problem Details response with code operation-failed carrying the underlying tableauErrorCode. The 4xx rejection applies when the apply completes synchronously; an apply that returns 202 instead reports the same failure through the polled operation (HTTP 200 with state FAILED and the error).",
         "operationId": "applyDashboardDocument",
         "parameters": [
           {
@@ -830,7 +833,7 @@
         ],
         "requestBody": {
           "required": true,
-          "description": "The dashboard's Tableau XML -- either the bare <dashboard> element returned by GET .../dashboards/{id}/document, or that element inside a <workbook> envelope. Only the dashboard whose name matches the target sheet's name is applied, and any other sheets in the payload are ignored. Top-level <datasources> definitions in the payload are ignored, but the applied dashboard's datasource references must still resolve to a datasource already present in the open workbook -- a reference to an absent datasource fails the apply.",
+          "description": "The dashboard's Tableau XML -- either the bare <dashboard> element returned by GET .../dashboards/{id}/document, or that element inside a <workbook> envelope. Only the dashboard whose name matches the target sheet's name is applied, and any other sheets in the payload are ignored. Top-level <datasources> definitions in the payload are ignored, but the applied dashboard's datasource references must still resolve to a datasource already present in the open workbook -- a reference to an absent datasource is rejected with 409.",
           "content": {
             "application/xml": {
               "schema": {
@@ -846,7 +849,7 @@
         },
         "responses": {
           "200": {
-            "description": "Replaces a single dashboard with the submitted Tableau XML, leaving the workbook's other sheets intact. A missing or empty body is rejected with 400 and a non-XML Content-Type with 415; a non-empty but malformed (not well-formed) XML body is not a 400 -- it is reported as a failed operation (HTTP 200 with state FAILED and an error). The payload is NOT validated against the schema; use POST /v0/workbook/document:validate for XSD validation. This apply is unconditional last-writer-wins: it performs no precondition/If-Match check and will overwrite a concurrent edit to the same sheet. The apply fails as a failed operation if the submitted payload's sheet name does not match the target sheet's current name -- for example, if you renamed the sheet in the payload, or another editor renamed it after you read the document. It also fails as a failed operation when the name-matching payload element is the wrong sheet subtype -- a story (<dashboard type='storyboard'>) where the target is a dashboard.",
+            "description": "Replaces a single dashboard with the submitted Tableau XML, leaving the workbook's other sheets intact. A missing or empty body is rejected with 400 and a non-XML Content-Type with 415. A non-empty XML body that is not well-formed, or that the product cannot load into a valid workbook, is rejected with 422. The payload is NOT validated against the schema; use POST /v0/workbook/document:validate for XSD validation. This apply is unconditional last-writer-wins: it performs no precondition/If-Match check and will overwrite a concurrent edit to the same sheet. The apply is rejected with 409 when the submitted payload's sheet name does not match the target sheet's current name -- for example, if you renamed the sheet in the payload, or another editor renamed it after you read the document -- or when the name-matching payload element is the wrong sheet subtype (a story, <dashboard type='storyboard'>, where the target is a dashboard). A client error returns a Problem Details response with code operation-failed carrying the underlying tableauErrorCode. The 4xx rejection applies when the apply completes synchronously; an apply that returns 202 instead reports the same failure through the polled operation (HTTP 200 with state FAILED and the error).",
             "content": {
               "application/json": {
                 "schema": {
@@ -884,11 +887,17 @@
           "404": {
             "$ref": "#/components/responses/NotFound"
           },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
           "415": {
             "$ref": "#/components/responses/UnsupportedMediaType"
           },
           "421": {
             "$ref": "#/components/responses/MisdirectedRequest"
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableContent"
           },
           "500": {
             "$ref": "#/components/responses/ServerError"
@@ -1409,7 +1418,7 @@
       },
       "post": {
         "summary": "Apply a workbook document",
-        "description": "Replaces the open workbook with the submitted Tableau XML. A missing or empty body is rejected with 400 and a non-XML Content-Type with 415; a non-empty but malformed (not well-formed) XML body is not a 400 -- it is reported as a failed operation (HTTP 200 with state FAILED and an error). The payload is NOT validated against the schema; use POST /v0/workbook/document:validate for XSD validation. This apply is unconditional last-writer-wins: it performs no precondition/If-Match check; it overwrites concurrent edits and (Overwrite policy) deletes sheets the payload omits. A payload that would leave the workbook with no sheets is rejected as a failed operation.",
+        "description": "Replaces the open workbook with the submitted Tableau XML. A missing or empty body is rejected with 400 and a non-XML Content-Type with 415. A non-empty XML body that is not well-formed, or that the product cannot load into a valid workbook, is rejected with 422 (a Problem Details response with code operation-failed carrying the underlying tableauErrorCode). The payload is NOT validated against the schema; use POST /v0/workbook/document:validate for XSD validation. This apply is unconditional last-writer-wins: it performs no precondition/If-Match check; it overwrites concurrent edits and (Overwrite policy) deletes sheets the payload omits. A payload that would leave the workbook with no sheets is rejected as a failed operation (HTTP 200 with state FAILED and an error). The 4xx rejection applies when the apply completes synchronously; an apply that returns 202 instead reports the same failure through the polled operation (HTTP 200 with state FAILED and the error).",
         "operationId": "applyWorkbookDocument",
         "parameters": [
           {
@@ -1440,7 +1449,7 @@
         },
         "responses": {
           "200": {
-            "description": "Replaces the open workbook with the submitted Tableau XML. A missing or empty body is rejected with 400 and a non-XML Content-Type with 415; a non-empty but malformed (not well-formed) XML body is not a 400 -- it is reported as a failed operation (HTTP 200 with state FAILED and an error). The payload is NOT validated against the schema; use POST /v0/workbook/document:validate for XSD validation. This apply is unconditional last-writer-wins: it performs no precondition/If-Match check; it overwrites concurrent edits and (Overwrite policy) deletes sheets the payload omits. A payload that would leave the workbook with no sheets is rejected as a failed operation.",
+            "description": "Replaces the open workbook with the submitted Tableau XML. A missing or empty body is rejected with 400 and a non-XML Content-Type with 415. A non-empty XML body that is not well-formed, or that the product cannot load into a valid workbook, is rejected with 422 (a Problem Details response with code operation-failed carrying the underlying tableauErrorCode). The payload is NOT validated against the schema; use POST /v0/workbook/document:validate for XSD validation. This apply is unconditional last-writer-wins: it performs no precondition/If-Match check; it overwrites concurrent edits and (Overwrite policy) deletes sheets the payload omits. A payload that would leave the workbook with no sheets is rejected as a failed operation (HTTP 200 with state FAILED and an error). The 4xx rejection applies when the apply completes synchronously; an apply that returns 202 instead reports the same failure through the polled operation (HTTP 200 with state FAILED and the error).",
             "content": {
               "application/json": {
                 "schema": {
@@ -1480,6 +1489,9 @@
           },
           "421": {
             "$ref": "#/components/responses/MisdirectedRequest"
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableContent"
           },
           "500": {
             "$ref": "#/components/responses/ServerError"
@@ -1723,7 +1735,7 @@
       },
       "post": {
         "summary": "Apply a storyboard document",
-        "description": "Replaces a single storyboard with the submitted Tableau XML, leaving the workbook's other sheets intact. A missing or empty body is rejected with 400 and a non-XML Content-Type with 415; a non-empty but malformed (not well-formed) XML body is not a 400 -- it is reported as a failed operation (HTTP 200 with state FAILED and an error). The payload is NOT validated against the schema; use POST /v0/workbook/document:validate for XSD validation. This apply is unconditional last-writer-wins: it performs no precondition/If-Match check and will overwrite a concurrent edit to the same sheet. The apply fails as a failed operation if the submitted payload's sheet name does not match the target sheet's current name -- for example, if you renamed the sheet in the payload, or another editor renamed it after you read the document. It also fails as a failed operation when the name-matching payload element is the wrong sheet subtype -- a plain <dashboard> where the target is a story (<dashboard type='storyboard'>).",
+        "description": "Replaces a single storyboard with the submitted Tableau XML, leaving the workbook's other sheets intact. A missing or empty body is rejected with 400 and a non-XML Content-Type with 415. A non-empty XML body that is not well-formed, or that the product cannot load into a valid workbook, is rejected with 422. The payload is NOT validated against the schema; use POST /v0/workbook/document:validate for XSD validation. This apply is unconditional last-writer-wins: it performs no precondition/If-Match check and will overwrite a concurrent edit to the same sheet. The apply is rejected with 409 when the submitted payload's sheet name does not match the target sheet's current name -- for example, if you renamed the sheet in the payload, or another editor renamed it after you read the document -- or when the name-matching payload element is the wrong sheet subtype (a plain <dashboard> where the target is a story, <dashboard type='storyboard'>). A client error returns a Problem Details response with code operation-failed carrying the underlying tableauErrorCode. The 4xx rejection applies when the apply completes synchronously; an apply that returns 202 instead reports the same failure through the polled operation (HTTP 200 with state FAILED and the error).",
         "operationId": "applyStoryboardDocument",
         "parameters": [
           {
@@ -1747,7 +1759,7 @@
         ],
         "requestBody": {
           "required": true,
-          "description": "The storyboard's Tableau XML -- either the bare <dashboard> element (storyboards serialize as <dashboard type='storyboard'>) returned by GET .../storyboards/{id}/document, or that element inside a <workbook> envelope. Only the storyboard whose name matches the target sheet's name is applied, and any other sheets in the payload are ignored. Top-level <datasources> definitions in the payload are ignored, but the applied storyboard's datasource references must still resolve to a datasource already present in the open workbook -- a reference to an absent datasource fails the apply.",
+          "description": "The storyboard's Tableau XML -- either the bare <dashboard> element (storyboards serialize as <dashboard type='storyboard'>) returned by GET .../storyboards/{id}/document, or that element inside a <workbook> envelope. Only the storyboard whose name matches the target sheet's name is applied, and any other sheets in the payload are ignored. Top-level <datasources> definitions in the payload are ignored, but the applied storyboard's datasource references must still resolve to a datasource already present in the open workbook -- a reference to an absent datasource is rejected with 409.",
           "content": {
             "application/xml": {
               "schema": {
@@ -1763,7 +1775,7 @@
         },
         "responses": {
           "200": {
-            "description": "Replaces a single storyboard with the submitted Tableau XML, leaving the workbook's other sheets intact. A missing or empty body is rejected with 400 and a non-XML Content-Type with 415; a non-empty but malformed (not well-formed) XML body is not a 400 -- it is reported as a failed operation (HTTP 200 with state FAILED and an error). The payload is NOT validated against the schema; use POST /v0/workbook/document:validate for XSD validation. This apply is unconditional last-writer-wins: it performs no precondition/If-Match check and will overwrite a concurrent edit to the same sheet. The apply fails as a failed operation if the submitted payload's sheet name does not match the target sheet's current name -- for example, if you renamed the sheet in the payload, or another editor renamed it after you read the document. It also fails as a failed operation when the name-matching payload element is the wrong sheet subtype -- a plain <dashboard> where the target is a story (<dashboard type='storyboard'>).",
+            "description": "Replaces a single storyboard with the submitted Tableau XML, leaving the workbook's other sheets intact. A missing or empty body is rejected with 400 and a non-XML Content-Type with 415. A non-empty XML body that is not well-formed, or that the product cannot load into a valid workbook, is rejected with 422. The payload is NOT validated against the schema; use POST /v0/workbook/document:validate for XSD validation. This apply is unconditional last-writer-wins: it performs no precondition/If-Match check and will overwrite a concurrent edit to the same sheet. The apply is rejected with 409 when the submitted payload's sheet name does not match the target sheet's current name -- for example, if you renamed the sheet in the payload, or another editor renamed it after you read the document -- or when the name-matching payload element is the wrong sheet subtype (a plain <dashboard> where the target is a story, <dashboard type='storyboard'>). A client error returns a Problem Details response with code operation-failed carrying the underlying tableauErrorCode. The 4xx rejection applies when the apply completes synchronously; an apply that returns 202 instead reports the same failure through the polled operation (HTTP 200 with state FAILED and the error).",
             "content": {
               "application/json": {
                 "schema": {
@@ -1801,11 +1813,17 @@
           "404": {
             "$ref": "#/components/responses/NotFound"
           },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
           "415": {
             "$ref": "#/components/responses/UnsupportedMediaType"
           },
           "421": {
             "$ref": "#/components/responses/MisdirectedRequest"
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableContent"
           },
           "500": {
             "$ref": "#/components/responses/ServerError"
@@ -2259,7 +2277,7 @@
       },
       "post": {
         "summary": "Apply a worksheet document",
-        "description": "Replaces a single worksheet with the submitted Tableau XML, leaving the workbook's other sheets intact. A missing or empty body is rejected with 400 and a non-XML Content-Type with 415; a non-empty but malformed (not well-formed) XML body is not a 400 -- it is reported as a failed operation (HTTP 200 with state FAILED and an error). The payload is NOT validated against the schema; use POST /v0/workbook/document:validate for XSD validation. This apply is unconditional last-writer-wins: it performs no precondition/If-Match check and will overwrite a concurrent edit to the same sheet. The apply fails as a failed operation if the submitted payload's sheet name does not match the target sheet's current name -- for example, if you renamed the sheet in the payload, or another editor renamed it after you read the document.",
+        "description": "Replaces a single worksheet with the submitted Tableau XML, leaving the workbook's other sheets intact. A missing or empty body is rejected with 400 and a non-XML Content-Type with 415. A non-empty XML body that is not well-formed, or that the product cannot load into a valid workbook, is rejected with 422. The payload is NOT validated against the schema; use POST /v0/workbook/document:validate for XSD validation. This apply is unconditional last-writer-wins: it performs no precondition/If-Match check and will overwrite a concurrent edit to the same sheet. The apply is rejected with 409 if the submitted payload's sheet name does not match the target sheet's current name -- for example, if you renamed the sheet in the payload, or another editor renamed it after you read the document. A client error returns a Problem Details response with code operation-failed carrying the underlying tableauErrorCode. The 4xx rejection applies when the apply completes synchronously; an apply that returns 202 instead reports the same failure through the polled operation (HTTP 200 with state FAILED and the error).",
         "operationId": "applyWorksheetDocument",
         "parameters": [
           {
@@ -2283,7 +2301,7 @@
         ],
         "requestBody": {
           "required": true,
-          "description": "The worksheet's Tableau XML -- either the bare <worksheet> element returned by GET .../worksheets/{id}/document, or that element inside a <workbook> envelope. Only the worksheet whose name matches the target sheet's name is applied, and any other sheets in the payload are ignored. Top-level <datasources> definitions in the payload are ignored, but the applied worksheet's datasource references must still resolve to a datasource already present in the open workbook -- a reference to an absent datasource fails the apply.",
+          "description": "The worksheet's Tableau XML -- either the bare <worksheet> element returned by GET .../worksheets/{id}/document, or that element inside a <workbook> envelope. Only the worksheet whose name matches the target sheet's name is applied, and any other sheets in the payload are ignored. Top-level <datasources> definitions in the payload are ignored, but the applied worksheet's datasource references must still resolve to a datasource already present in the open workbook -- a reference to an absent datasource is rejected with 409.",
           "content": {
             "application/xml": {
               "schema": {
@@ -2299,7 +2317,7 @@
         },
         "responses": {
           "200": {
-            "description": "Replaces a single worksheet with the submitted Tableau XML, leaving the workbook's other sheets intact. A missing or empty body is rejected with 400 and a non-XML Content-Type with 415; a non-empty but malformed (not well-formed) XML body is not a 400 -- it is reported as a failed operation (HTTP 200 with state FAILED and an error). The payload is NOT validated against the schema; use POST /v0/workbook/document:validate for XSD validation. This apply is unconditional last-writer-wins: it performs no precondition/If-Match check and will overwrite a concurrent edit to the same sheet. The apply fails as a failed operation if the submitted payload's sheet name does not match the target sheet's current name -- for example, if you renamed the sheet in the payload, or another editor renamed it after you read the document.",
+            "description": "Replaces a single worksheet with the submitted Tableau XML, leaving the workbook's other sheets intact. A missing or empty body is rejected with 400 and a non-XML Content-Type with 415. A non-empty XML body that is not well-formed, or that the product cannot load into a valid workbook, is rejected with 422. The payload is NOT validated against the schema; use POST /v0/workbook/document:validate for XSD validation. This apply is unconditional last-writer-wins: it performs no precondition/If-Match check and will overwrite a concurrent edit to the same sheet. The apply is rejected with 409 if the submitted payload's sheet name does not match the target sheet's current name -- for example, if you renamed the sheet in the payload, or another editor renamed it after you read the document. A client error returns a Problem Details response with code operation-failed carrying the underlying tableauErrorCode. The 4xx rejection applies when the apply completes synchronously; an apply that returns 202 instead reports the same failure through the polled operation (HTTP 200 with state FAILED and the error).",
             "content": {
               "application/json": {
                 "schema": {
@@ -2337,11 +2355,17 @@
           "404": {
             "$ref": "#/components/responses/NotFound"
           },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
           "415": {
             "$ref": "#/components/responses/UnsupportedMediaType"
           },
           "421": {
             "$ref": "#/components/responses/MisdirectedRequest"
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableContent"
           },
           "500": {
             "$ref": "#/components/responses/ServerError"
@@ -3557,12 +3581,18 @@
             "items": {
               "$ref": "#/components/schemas/WindowInfo"
             }
+          },
+          "progressWindows": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/WindowInfo"
+            }
           }
         }
       },
       "WindowInfo": {
         "type": "object",
-        "description": "A visible modal Qt top-level window currently blocking the command queue from progressing. The content fields (messageText, informativeText, detailedText, iconLevel, buttons) are best-effort: QMessageBox exposes them precisely, while generic dialogs scrape visible QLabel/QAbstractButton children and may include incidental labels alongside diagnostic text.",
+        "description": "A visible modal Qt top-level window observed at read time. Whether a client must act on it is conveyed by which array carries it: blockingWindows for a window that needs a human decision, progressWindows for a self-clearing one. The content fields (messageText, informativeText, detailedText, iconLevel, buttons) are best-effort: QMessageBox exposes them precisely, while generic dialogs scrape visible QLabel/QAbstractButton children and may include incidental labels alongside diagnostic text.",
         "required": [
           "objectName",
           "title",
@@ -3887,6 +3917,12 @@
             }
           },
           "blockingWindows": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/WindowInfo"
+            }
+          },
+          "progressWindows": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/WindowInfo"
@@ -4321,16 +4357,13 @@
             "type": "string"
           },
           "isStartPageVisible": {
-            "type": "boolean",
-            "description": "Whether the Start Page is currently visible."
+            "type": "boolean"
           },
           "isDataSourcePageActive": {
-            "type": "boolean",
-            "description": "Whether the Data Source page is the active tab."
+            "type": "boolean"
           },
           "isPresentationMode": {
-            "type": "boolean",
-            "description": "Whether Tableau Desktop is in presentation mode."
+            "type": "boolean"
           }
         }
       },
@@ -4458,6 +4491,16 @@
       },
       "MisdirectedRequest": {
         "description": "The request Host header was not a loopback address.",
+        "content": {
+          "application/problem+json": {
+            "schema": {
+              "$ref": "#/components/schemas/Problem"
+            }
+          }
+        }
+      },
+      "UnprocessableContent": {
+        "description": "The request was well-formed but semantically invalid and could not be applied, such as a document whose structure the product rejects. The code field identifies the specific problem.",
         "content": {
           "application/problem+json": {
             "schema": {

--- a/src/desktop/externalApi/__fixtures__/externalClientApi-openapi.json
+++ b/src/desktop/externalApi/__fixtures__/externalClientApi-openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Tableau External Client API",
-    "version": "0.2.8",
+    "version": "0.2.9",
     "description": "Loopback HTTP interface for reading and authoring the open Tableau Desktop document. Clients authenticate with the bearer token published in the per-user discovery file."
   },
   "servers": [
@@ -4285,7 +4285,7 @@
       },
       "AppInfo": {
         "type": "object",
-        "description": "Running Tableau Desktop process information.",
+        "description": "Running Tableau Desktop process information and live UI state.",
         "required": [
           "applicationVersion",
           "edition",
@@ -4293,7 +4293,10 @@
           "os",
           "locale",
           "repositoryLocation",
-          "logLocation"
+          "logLocation",
+          "isStartPageVisible",
+          "isDataSourcePageActive",
+          "isPresentationMode"
         ],
         "properties": {
           "applicationVersion": {
@@ -4316,6 +4319,18 @@
           },
           "logLocation": {
             "type": "string"
+          },
+          "isStartPageVisible": {
+            "type": "boolean",
+            "description": "Whether the Start Page is currently visible."
+          },
+          "isDataSourcePageActive": {
+            "type": "boolean",
+            "description": "Whether the Data Source page is the active tab."
+          },
+          "isPresentationMode": {
+            "type": "boolean",
+            "description": "Whether Tableau Desktop is in presentation mode."
           }
         }
       },

--- a/src/desktop/externalApi/externalApiContract.test.ts
+++ b/src/desktop/externalApi/externalApiContract.test.ts
@@ -48,7 +48,9 @@ import {
  * with `type`/`isExtract`/`hasDownloadFilePermission`, marks `index`/`type` (and
  * `StoryboardItem.storyPointCount`) required on the sheet items, and adds the
  * `unsupported-target-version` problem code, on top of the 0.2.6 surface
- * (`app:openFile`, `workbook:save`, `*:new`). No hand-edits.
+ * (`app:openFile`, `workbook:save`, `*:new`). No hand-edits, except the 0.2.9 `AppInfo`
+ * delta (`isStartPageVisible`/`isDataSourcePageActive`/`isPresentationMode`), hand-applied
+ * from the monolith PR that shipped it — no live 0.2.9 spec was captured.
  */
 
 type SpecSchema = {
@@ -87,6 +89,9 @@ const KNOWN_READ_REQUIREDNESS_EXCEPTIONS: Readonly<Record<string, readonly strin
     'locale',
     'repositoryLocation',
     'logLocation',
+    'isStartPageVisible',
+    'isDataSourcePageActive',
+    'isPresentationMode',
   ],
   DashboardItem: ['isActiveSheet', 'isAutoUpdatesPaused', 'containedSheets', 'index', 'type'],
   DashboardList: ['dashboards'],
@@ -197,7 +202,7 @@ describe('external client API contract (captured openapi fixture)', () => {
       },
     );
 
-    it('pins the complete 0.2.8 requiredness exception set', () => {
+    it('pins the complete 0.2.8 requiredness exception set, plus the hand-applied 0.2.9 AppInfo delta', () => {
       expect(KNOWN_READ_REQUIREDNESS_EXCEPTIONS).toEqual({
         ApiRoot: ['apiVersion', 'applicationVersion', 'links'],
         AppInfo: [
@@ -208,6 +213,9 @@ describe('external client API contract (captured openapi fixture)', () => {
           'locale',
           'repositoryLocation',
           'logLocation',
+          'isStartPageVisible',
+          'isDataSourcePageActive',
+          'isPresentationMode',
         ],
         DashboardItem: ['isActiveSheet', 'isAutoUpdatesPaused', 'containedSheets', 'index', 'type'],
         DashboardList: ['dashboards'],

--- a/src/desktop/externalApi/externalApiContract.test.ts
+++ b/src/desktop/externalApi/externalApiContract.test.ts
@@ -42,15 +42,14 @@ import {
  * fixture with it and rerun — every drift (new field, changed requiredness, enum
  * growth, route add/remove) surfaces as a red/green diff instead of a manual reread.
  *
- * Fixture provenance: live Desktop `/openapi.json`, `info.version` 0.2.8 — adds the
- * `workbook:publish` and `datasources/{id}:refreshData`/`:refreshExtract` routes, now
- * documents `workbook:exportAs` and `storyboards/{id}/image`, grows `DatasourceItem`
- * with `type`/`isExtract`/`hasDownloadFilePermission`, marks `index`/`type` (and
- * `StoryboardItem.storyPointCount`) required on the sheet items, and adds the
- * `unsupported-target-version` problem code, on top of the 0.2.6 surface
- * (`app:openFile`, `workbook:save`, `*:new`). No hand-edits, except the 0.2.9 `AppInfo`
- * delta (`isStartPageVisible`/`isDataSourcePageActive`/`isPresentationMode`), hand-applied
- * from the monolith PR that shipped it — no live 0.2.9 spec was captured.
+ * Fixture provenance: live Desktop `/openapi.json`, `info.version` 0.2.9 — grows `AppInfo`
+ * with `isStartPageVisible`/`isDataSourcePageActive`/`isPresentationMode` and `Operation`/
+ * `OperationList` with `progressWindows`, documents `UnprocessableContent` (422) on the
+ * document-replace routes, on top of the 0.2.8 surface (`workbook:publish`,
+ * `datasources/{id}:refreshData`/`:refreshExtract`, `workbook:exportAs`,
+ * `storyboards/{id}/image`, `DatasourceItem.type`/`isExtract`/`hasDownloadFilePermission`,
+ * required `index`/`type`/`StoryboardItem.storyPointCount`, `unsupported-target-version`).
+ * No hand-edits.
  */
 
 type SpecSchema = {
@@ -202,7 +201,7 @@ describe('external client API contract (captured openapi fixture)', () => {
       },
     );
 
-    it('pins the complete 0.2.8 requiredness exception set, plus the hand-applied 0.2.9 AppInfo delta', () => {
+    it('pins the complete 0.2.9 requiredness exception set', () => {
       expect(KNOWN_READ_REQUIREDNESS_EXCEPTIONS).toEqual({
         ApiRoot: ['apiVersion', 'applicationVersion', 'links'],
         AppInfo: [

--- a/src/desktop/externalApi/mockExternalApiServer.ts
+++ b/src/desktop/externalApi/mockExternalApiServer.ts
@@ -422,6 +422,9 @@ export async function startMockExternalApiServer(
         locale: 'en_US',
         repositoryLocation: '/Users/tableau/Documents/My Tableau Repository',
         logLocation: '/Users/tableau/Library/Logs/Tableau',
+        isStartPageVisible: false,
+        isDataSourcePageActive: false,
+        isPresentationMode: false,
       });
       return;
     }

--- a/src/desktop/externalApi/types.ts
+++ b/src/desktop/externalApi/types.ts
@@ -4,7 +4,7 @@ import { z } from 'zod';
  * Types and schemas for the Tableau Desktop "External Client API" (Athena V0).
  *
  * Contract derived from the External Client API rollout, then tightened against the
- * live `/openapi.json` (OpenAPI 3.1, `info.version` 0.2.8, captured 2026-08-18).
+ * live `/openapi.json` (OpenAPI 3.1, `info.version` 0.2.9, captured 2026-08-20).
  * Envelope fields the spec marks required are required here; everything else stays
  * permissive (`.passthrough()` / optional) because the spec is read-complete but
  * write-thin, and an older Desktop build may omit a field a newer spec marks required.
@@ -449,7 +449,7 @@ export const operationWarningSchema = z
   .passthrough();
 export type OperationWarning = z.infer<typeof operationWarningSchema>;
 
-/** A modal window blocking the command queue, reported on an Operation that cannot progress. */
+/** A visible modal Qt window on an Operation: rides `blockingWindows` when it needs a human decision, `progressWindows` when it is self-clearing. */
 export const windowInfoSchema = z
   .object({
     objectName: z.string(),
@@ -481,6 +481,7 @@ export const operationEnvelopeSchema = z
     error: operationErrorSchema.optional(),
     warnings: z.array(operationWarningSchema).optional(),
     blockingWindows: z.array(windowInfoSchema).optional(),
+    progressWindows: z.array(windowInfoSchema).optional(),
     createdAt: z.string().optional(),
     updatedAt: z.string().optional(),
     completedAt: z.string().optional(),

--- a/src/desktop/externalApi/types.ts
+++ b/src/desktop/externalApi/types.ts
@@ -708,7 +708,7 @@ export const imageResultSchema = z
   .passthrough();
 export type ImageResult = z.infer<typeof imageResultSchema>;
 
-/** Running Desktop application info returned by `GET /v0/app`. */
+/** Running Desktop application info and live UI state returned by `GET /v0/app`. */
 export const appInfoSchema = z
   .object({
     applicationVersion: z.string().optional(),
@@ -718,6 +718,9 @@ export const appInfoSchema = z
     locale: z.string().optional(),
     repositoryLocation: z.string().optional(),
     logLocation: z.string().optional(),
+    isStartPageVisible: z.boolean().optional(),
+    isDataSourcePageActive: z.boolean().optional(),
+    isPresentationMode: z.boolean().optional(),
   })
   .passthrough();
 export type AppInfo = z.infer<typeof appInfoSchema>;

--- a/src/server.desktop.test.ts
+++ b/src/server.desktop.test.ts
@@ -242,11 +242,11 @@ async function serializeDesktopToolSurface(tool: DesktopTool<any>): Promise<stri
 // Re-pinned 2026-08-20: get-app-info's description now also documents the live UI-state fields
 // (Start Page visibility, Data Source page active, presentation mode) added to /v0/app in External
 // Client API 0.2.9. get-app-info is outside DYNAMIC_AUTHORING_TOOL_PROFILE, so only the full surface
-// moves.
+// moves: 59_224 -> 59_313 (retaining the 18-char slack).
 const DYNAMIC_AUTHORING_SURFACE_EXPECTED = 42_521;
 const DYNAMIC_AUTHORING_SURFACE_BUDGET = 42_539;
 const DYNAMIC_AUTHORING_PRODUCT_CEILING = 46_000;
-const FULL_TOOL_SURFACE_BUDGET = 59_242;
+const FULL_TOOL_SURFACE_BUDGET = 59_331;
 
 describe('desktop tools/list serialized surface', () => {
   it('keeps the served dynamic authoring profile under the tool-search auto-deferral threshold budget', async () => {

--- a/src/server.desktop.test.ts
+++ b/src/server.desktop.test.ts
@@ -239,6 +239,10 @@ async function serializeDesktopToolSurface(tool: DesktopTool<any>): Promise<stri
 // routes, gated to a 0.2.8 floor. All three join DYNAMIC_AUTHORING_TOOL_PROFILE, so dynamic
 // authoring moves 40_096 -> 42_521 (budget kept at the 18-char slack) and the full surface
 // 56_799 -> 59_224. Dynamic still clears the 46k cliff.
+// Re-pinned 2026-08-20: get-app-info's description now also documents the live UI-state fields
+// (Start Page visibility, Data Source page active, presentation mode) added to /v0/app in External
+// Client API 0.2.9. get-app-info is outside DYNAMIC_AUTHORING_TOOL_PROFILE, so only the full surface
+// moves.
 const DYNAMIC_AUTHORING_SURFACE_EXPECTED = 42_521;
 const DYNAMIC_AUTHORING_SURFACE_BUDGET = 42_539;
 const DYNAMIC_AUTHORING_PRODUCT_CEILING = 46_000;

--- a/src/tools/desktop/api/getAppInfo.test.ts
+++ b/src/tools/desktop/api/getAppInfo.test.ts
@@ -22,6 +22,9 @@ const resultSchema = z.object({
   build: z.string().optional(),
   edition: z.string().optional(),
   os: z.string().optional(),
+  isStartPageVisible: z.boolean().optional(),
+  isDataSourcePageActive: z.boolean().optional(),
+  isPresentationMode: z.boolean().optional(),
 });
 
 describe('getAppInfoTool', () => {
@@ -34,7 +37,9 @@ describe('getAppInfoTool', () => {
     const tool = getAppInfoTool(new DesktopMcpServer());
 
     expect(tool.name).toBe('get-app-info');
-    expect(tool.description).toBe('Identify the Desktop build when an endpoint 404s as too-new.');
+    expect(tool.description).toBe(
+      'Identify the Desktop build when an endpoint 404s as too-new, and read live UI state (Start Page visibility, Data Source page active, presentation mode).',
+    );
     expect(tool.paramsSchema).toMatchObject({ session: expect.any(Object) });
     expect(tool.annotations).toMatchObject({
       readOnlyHint: true,
@@ -42,7 +47,7 @@ describe('getAppInfoTool', () => {
     });
   });
 
-  it('returns application version, build, edition, and OS', async () => {
+  it('returns application version, build, edition, OS, and live UI state', async () => {
     const server = await startMockExternalApiServer();
     const executor = new ExternalApiToolExecutor({ discover: () => [instanceFor(server)] });
     await executor.start();
@@ -60,13 +65,16 @@ describe('getAppInfoTool', () => {
       expect(result.isError).toBe(false);
       invariant(result.content[0].type === 'text');
       expect(result.content[0].text).toBe(
-        '{"applicationVersion":"2026.1","build":"20261.26.0701.1234","edition":"Professional","os":"macOS"}',
+        '{"applicationVersion":"2026.1","build":"20261.26.0701.1234","edition":"Professional","os":"macOS","isStartPageVisible":false,"isDataSourcePageActive":false,"isPresentationMode":false}',
       );
       expect(parseResult(result)).toEqual({
         applicationVersion: '2026.1',
         build: '20261.26.0701.1234',
         edition: 'Professional',
         os: 'macOS',
+        isStartPageVisible: false,
+        isDataSourcePageActive: false,
+        isPresentationMode: false,
       });
       expect(server.requests.at(-1)?.path).toBe('/v0/app');
     } finally {

--- a/src/tools/desktop/api/getAppInfo.ts
+++ b/src/tools/desktop/api/getAppInfo.ts
@@ -16,6 +16,9 @@ type GetAppInfoResult =
       build?: string;
       edition?: string;
       os?: string;
+      isStartPageVisible?: boolean;
+      isDataSourcePageActive?: boolean;
+      isPresentationMode?: boolean;
     }
   | {
       status: 'unavailable';
@@ -28,7 +31,8 @@ export const getAppInfoTool = (server: DesktopMcpServer): DesktopTool<typeof par
     server,
     name: 'get-app-info',
     title,
-    description: 'Identify the Desktop build when an endpoint 404s as too-new.',
+    description:
+      'Identify the Desktop build when an endpoint 404s as too-new, and read live UI state (Start Page visibility, Data Source page active, presentation mode).',
     paramsSchema,
     annotations: {
       readOnlyHint: true,
@@ -58,6 +62,15 @@ export const getAppInfoTool = (server: DesktopMcpServer): DesktopTool<typeof par
             ...(result.value.build !== undefined ? { build: result.value.build } : {}),
             ...(result.value.edition !== undefined ? { edition: result.value.edition } : {}),
             ...(result.value.os !== undefined ? { os: result.value.os } : {}),
+            ...(result.value.isStartPageVisible !== undefined
+              ? { isStartPageVisible: result.value.isStartPageVisible }
+              : {}),
+            ...(result.value.isDataSourcePageActive !== undefined
+              ? { isDataSourcePageActive: result.value.isDataSourcePageActive }
+              : {}),
+            ...(result.value.isPresentationMode !== undefined
+              ? { isPresentationMode: result.value.isPresentationMode }
+              : {}),
           };
 
           if (Object.keys(appInfo).length === 0) {


### PR DESCRIPTION
## What
Adds live UI-state fields to `AppInfo` (`GET /v0/app`) and syncs the External Client API contract to the live 0.2.9 spec, folding in Lauren's #806.

- `AppInfo` gains `isStartPageVisible`, `isDataSourcePageActive`, `isPresentationMode` — mirrors monolith [sf-analyticscloud/monolith#63456](https://github.com/sf-analyticscloud/monolith/pull/63456). Kept optional (spec marks them required) so an older Desktop build still parses.
- `Operation`/`OperationList` gain `progressWindows` (self-clearing windows, vs. `blockingWindows` which need a human decision) — added to `operationEnvelopeSchema` as an optional array.
- Fixture (`__fixtures__/externalClientApi-openapi.json`) is now a live capture at 0.2.9 (supersedes my earlier hand-edit): also documents 409/422 on the document-replace routes and a 202 on `GET /v0/app`. No code changes needed for those — error mapping and polling are already generic.
- `get-app-info` now also surfaces the 3 UI-state booleans, not just build-id fields (this repo's addition on top of the contract sync).

## Why
Lauren's monolith PR shipped the UI-state fields on Desktop; her follow-up tableau-mcp PR (#806) did the proper live-capture sync including `progressWindows`. Merging both changes into one PR so this ships as a single coherent update to the External Client API contract.

## Changes
- `types.ts`: `appInfoSchema` gains the 3 booleans; `operationEnvelopeSchema` gains `progressWindows`; `windowInfoSchema` doc comment updated
- `getAppInfo.ts` / `.test.ts`: surface the 3 booleans in the tool's output
- `externalApiContract.test.ts`: requiredness-exception lists + provenance comment updated for the live 0.2.9 capture
- `__fixtures__/externalClientApi-openapi.json`: live-captured 0.2.9 spec (AppInfo booleans, progressWindows, 409/422/202 docs)
- `mockExternalApiServer.ts`: stub the 3 `AppInfo` booleans on the `/v0/app` mock response
- `server.desktop.test.ts`: re-pinned `FULL_TOOL_SURFACE_BUDGET` for the longer `get-app-info` description
- Version bump: 2.63.12 → 2.64.0 (minor, new optional capability)

## Test plan
- [x] `npm test` — 5923 passed
- [x] `npm run lint` — clean
- [x] `npm run build:desktop` — succeeds
- [x] Contract test confirms `appInfoSchema`/`operationEnvelopeSchema` ↔ fixture ↔ exception-list stay in lockstep