### PR TITLE
@W-23757366: Add MCP server instructions string

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "4.5.3",
+  "version": "4.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "4.5.3",
+      "version": "4.6.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1095.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "4.5.4",
+  "version": "4.6.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/src/index.combined.ts
+++ b/src/index.combined.ts
@@ -13,6 +13,7 @@ import { isNotificationLevel, notifier, setNotificationLevel } from './logging/n
 import { RestApi } from './sdks/tableau/restApi.js';
 import { DesktopMcpServer } from './server.desktop.js';
 import { WebMcpServer } from './server.web.js';
+import { buildServerInstructions } from './serverInstructions.js';
 
 const serverName = 'tableau-combined-mcp';
 const serverVersion = pkg.version;
@@ -61,6 +62,7 @@ async function startServer(): Promise<void> {
         logging: {},
         tools: {},
       },
+      instructions: buildServerInstructions({ adminToolsEnabled: config.adminToolsEnabled }),
     },
   );
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -29,11 +29,13 @@ export abstract class Server {
     clientInfo,
     serverName,
     serverVersion,
+    instructions,
   }: {
     mcpServer?: McpServer;
     clientInfo?: ClientInfo;
     serverName: string;
     serverVersion: string;
+    instructions?: string;
   }) {
     const description =
       'When opening local .twb/.twbx files, derive the full Tableau Desktop app path and choose the newest installed version when multiple are present.';
@@ -52,6 +54,7 @@ export abstract class Server {
             tools: {},
             prompts: {},
           },
+          instructions,
         },
       );
 

--- a/src/server.web.test.ts
+++ b/src/server.web.test.ts
@@ -1,3 +1,5 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
 import { ServiceUnavailableError } from './errors/mcpToolError.js';
 import { serverName, WebMcpServer } from './server.web.js';
 import { stubDefaultEnvVars, testProductVersion } from './testShared.js';
@@ -391,5 +393,38 @@ describe('server', () => {
     // Should NOT register as app tool
     expect(mocks.mockRegisterAppTool).not.toHaveBeenCalled();
     expect(mocks.mockRegisterAppResource).not.toHaveBeenCalled();
+  });
+
+  describe('server instructions', () => {
+    // Constructs a fresh WebMcpServer and returns the `instructions` passed to the McpServer
+    // constructor (arg 2). The base Server ctor builds the McpServer when none is injected, so the
+    // globally-mocked McpServer captures the options object here.
+    function getConstructedInstructions(): string | undefined {
+      vi.mocked(McpServer).mockClear();
+      new WebMcpServer();
+      const calls = vi.mocked(McpServer).mock.calls;
+      return calls[calls.length - 1]?.[1]?.instructions;
+    }
+
+    it('passes non-empty instructions with the grounding pattern to the McpServer', () => {
+      const instructions = getConstructedInstructions();
+      expect(instructions).toBeTruthy();
+      expect(instructions).toContain('list-datasources');
+      expect(instructions).toContain('get-datasource-metadata');
+      expect(instructions).toContain('query-datasource');
+    });
+
+    it('omits the admin-insights taxonomy when ADMIN_TOOLS_ENABLED is unset', () => {
+      const instructions = getConstructedInstructions();
+      expect(instructions).not.toContain('query-admin-insights');
+    });
+
+    it('includes the admin-insights taxonomy when ADMIN_TOOLS_ENABLED is "true"', () => {
+      vi.stubEnv('ADMIN_TOOLS_ENABLED', 'true');
+      const instructions = getConstructedInstructions();
+      expect(instructions).toContain('query-admin-insights');
+      expect(instructions).toContain('ts-users');
+      expect(instructions).toContain('stale-content');
+    });
   });
 });

--- a/src/server.web.ts
+++ b/src/server.web.ts
@@ -23,6 +23,7 @@ import { ClientInfo, Server } from './server.js';
 import { getTableauAuthInfo } from './server/oauth/getTableauAuthInfo.js';
 import { TableauAuthInfo } from './server/oauth/schemas.js';
 import { getRequestOverridesFromHeader, X_TABLEAU_MCP_CONFIG_HEADER } from './server/requestUtils';
+import { buildServerInstructions } from './serverInstructions.js';
 import { WebTool } from './tools/web/tool.js';
 import { TableauWebRequestHandlerExtra } from './tools/web/toolContext.js';
 import { webToolFactories } from './tools/web/tools.js';
@@ -38,7 +39,18 @@ const __dirname = getDirname();
 
 export class WebMcpServer extends Server {
   constructor({ mcpServer, clientInfo }: { mcpServer?: McpServer; clientInfo?: ClientInfo } = {}) {
-    super({ mcpServer, clientInfo, serverName, serverVersion });
+    super({
+      mcpServer,
+      clientInfo,
+      serverName,
+      serverVersion,
+      // Read the env var directly rather than getConfig(): this ctor runs once per HTTP request, so
+      // it must not construct a full Config on the hot path. adminToolsEnabled is not per-request
+      // overridable, so the raw env read matches Config's derivation (config.ts).
+      instructions: buildServerInstructions({
+        adminToolsEnabled: process.env.ADMIN_TOOLS_ENABLED === 'true',
+      }),
+    });
   }
 
   registerTools = async (tableauAuthInfo?: TableauAuthInfo): Promise<void> => {

--- a/src/serverInstructions.test.ts
+++ b/src/serverInstructions.test.ts
@@ -1,0 +1,59 @@
+import { buildServerInstructions } from './serverInstructions.js';
+
+describe('buildServerInstructions', () => {
+  it('always includes the whole-server orientation and grounding pattern', () => {
+    for (const adminToolsEnabled of [false, true]) {
+      const instructions = buildServerInstructions({ adminToolsEnabled });
+      expect(instructions).toContain('list-datasources');
+      expect(instructions).toContain('get-datasource-metadata');
+      expect(instructions).toContain('query-datasource');
+      // The discover -> ground -> query grounding pattern.
+      expect(instructions).toMatch(/ground before querying/i);
+    }
+  });
+
+  it('omits the admin-insights taxonomy when admin tools are disabled', () => {
+    const instructions = buildServerInstructions({ adminToolsEnabled: false });
+    expect(instructions).not.toContain('query-admin-insights');
+    for (const kind of [
+      'ts-events',
+      'ts-users',
+      'site-content',
+      'job-performance',
+      'stale-content',
+    ]) {
+      expect(instructions).not.toContain(kind);
+    }
+  });
+
+  it('appends the admin-insights taxonomy with all five kinds when admin tools are enabled', () => {
+    const instructions = buildServerInstructions({ adminToolsEnabled: true });
+    expect(instructions).toContain('query-admin-insights');
+    for (const kind of [
+      'ts-events',
+      'ts-users',
+      'site-content',
+      'job-performance',
+      'stale-content',
+    ]) {
+      expect(instructions).toContain(kind);
+    }
+  });
+
+  it('attributes login signals to ts-users, not ts-events', () => {
+    // Guards the taxonomy correction: audit-event history is ts-events; per-user login/last-access
+    // signals are ts-users. Regressing this reintroduces the "which kind" ambiguity the field fixes.
+    const instructions = buildServerInstructions({ adminToolsEnabled: true });
+    const tsUsersLine = instructions.split('\n').find((line) => line.includes('`ts-users`'));
+    const tsEventsLine = instructions.split('\n').find((line) => line.includes('`ts-events`'));
+    expect(tsUsersLine).toMatch(/last login/i);
+    expect(tsEventsLine).not.toMatch(/login/i);
+  });
+
+  it('builds admin-enabled instructions as a superset of the disabled ones', () => {
+    const base = buildServerInstructions({ adminToolsEnabled: false });
+    const withAdmin = buildServerInstructions({ adminToolsEnabled: true });
+    expect(withAdmin.startsWith(base)).toBe(true);
+    expect(withAdmin.length).toBeGreaterThan(base.length);
+  });
+});

--- a/src/serverInstructions.ts
+++ b/src/serverInstructions.ts
@@ -1,0 +1,30 @@
+/**
+ * Builds the MCP server `instructions` string returned once at `initialize`. The host injects this
+ * into the model's context every session, so it stays terse: a whole-server orientation plus, when
+ * the admin tools are enabled, an intent map for `query-admin-insights`'s `kind` values.
+ *
+ * The admin-insights section is appended only when `adminToolsEnabled` so hosts without the admin
+ * tools don't carry guidance for a tool they never see. Kept in one place so every server variant
+ * (web, combined) emits identical instructions.
+ */
+
+const ORIENTATION = `\
+Tableau MCP provides tools to explore and query a Tableau site's content, users, jobs, and published data.
+
+To answer questions about the data inside a published datasource, follow the grounding pattern: (1) discover the datasource with \`list-datasources\` or \`search-content\`; (2) ground on its schema with \`get-datasource-metadata\` to get exact field names; (3) query it with \`query-datasource\`. Always ground before querying — never guess field names.`;
+
+const ADMIN_INSIGHTS = `\
+\`query-admin-insights\` answers questions about the site itself via Admin Insights (Tableau Cloud, site administrators only). Pick \`kind\` by what the user is asking about:
+- \`ts-events\`: audit-event history — access, publish, update, and delete events over time. Use for "who did what, when" activity trails.
+- \`ts-users\`: per-user signals — last login, days since last login, and Tableau Desktop / Prep / Web Authoring last-access dates. Use for user activity, inactive users, and license reclamation.
+- \`site-content\`: content inventory — workbook and datasource metadata, ownership, and size. Use for "what content exists and who owns it".
+- \`job-performance\`: extract-refresh and subscription execution history. Use for refresh and subscription reliability and performance.
+- \`stale-content\`: unused-content report (items past a last-access threshold). Use for cleanup and archival; pass \`minAgeDays\` / \`projectIds\` / \`itemTypes\`, not a \`query\`.`;
+
+export function buildServerInstructions({
+  adminToolsEnabled,
+}: {
+  adminToolsEnabled: boolean;
+}): string {
+  return adminToolsEnabled ? `${ORIENTATION}\n\n${ADMIN_INSIGHTS}` : ORIENTATION;
+}


### PR DESCRIPTION
## Description

Sets the MCP server `instructions` string — the field a server returns once at `initialize` that the host injects into the model's context every session. tableau-mcp never set it, so hosts started every session with no orientation to the server and no guidance for choosing a `query-admin-insights` `kind`.

The instructions are built in a single module, [`src/serverInstructions.ts`](../blob/w-23757366-server-instructions/src/serverInstructions.ts), and have two parts:

- **Always-on orientation** — the tool families plus the *discover → ground → query* pattern:
  > `list-datasources` / `search-content` → `get-datasource-metadata` → `query-datasource`

  with an explicit "always ground before querying — never guess field names".
- **Admin Insights taxonomy** — appended **only when the admin tools are enabled** — maps each `query-admin-insights` `kind` to the user intent it serves:

  | `kind` | Answers |
  | --- | --- |
  | `ts-events` | audit-event history (access / publish / update / delete) — "who did what, when" |
  | `ts-users` | per-user signals: last login, days since last login, Desktop / Prep / Web Authoring last-access |
  | `site-content` | content inventory: workbook & datasource metadata, ownership, size |
  | `job-performance` | extract-refresh & subscription execution history |
  | `stale-content` | unused-content report past a last-access threshold |

## Motivation and Context

Contributes to the "AI cannot determine which `query-admin-insights` `kind` to invoke" problem: with no server-level guidance, the model had to guess `kind` from the tool schema alone. The MCP `instructions` field is the protocol-sanctioned place to fix this once, server-wide, rather than bloating every tool description.

> **Design constraints honored:**
> - **Conditional inclusion** — orientation is always emitted; the Admin Insights block is appended only when `adminToolsEnabled`, so hosts without the admin tools don't carry guidance for a tool they never see.
> - **Single source of truth** — one module both server variants import, so web and combined emit identical text.
> - **Hot-path safe** — `WebMcpServer`'s constructor runs once per HTTP request, so it reads `process.env.ADMIN_TOOLS_ENABLED` directly instead of constructing a full `Config`.

**Variant coverage:** wired into the **web** (`tableau-mcp`) and **combined** (`tableau-combined-mcp`) servers. **Desktop is intentionally unaffected** — its local-file toolset is unrelated to this cloud/admin surface, and `adminToolsEnabled` is web-only.

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

Full local pre-commit validation, all green:

```
npm run build      # exit 0
npx tsc --noEmit   # clean
npm run lint       # clean
npm test           # 174 files / 2788 tests passed
```

New tests:
- **`src/serverInstructions.test.ts`** (5) — orientation always present (both `adminToolsEnabled` states); admin taxonomy absent when disabled and present with all five `kind`s when enabled; `login` attributed to `ts-users` not `ts-events` (guards the taxonomy fix); admin variant is a strict superset of the base.
- **`src/server.web.test.ts`** (+3) — asserts `WebMcpServer` passes non-empty instructions carrying the grounding trio to the `McpServer` constructor, and that the admin block toggles on `ADMIN_TOOLS_ENABLED`.

## Related Issues

Tracked in GUS as **@W-23757366**.

## Checklist

- [x] I have bumped the version in `package.json` (4.5.2 → **4.6.0**, minor for a new feature)
- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] No breaking changes — the field was previously unset; behavior is purely additive
