### PR TITLE
fix(desktop): give a self-clearing progress dialog its own poll-timeout guidance

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "2.66.1",
+  "version": "2.66.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "2.66.1",
+      "version": "2.66.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.7.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "2.66.1",
+  "version": "2.66.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/src/desktop/externalApi/externalApiHttp.ts
+++ b/src/desktop/externalApi/externalApiHttp.ts
@@ -10,6 +10,7 @@ import {
   OperationEnvelope,
   operationEnvelopeSchema,
   problemResponseSchema,
+  WindowInfo,
 } from './types.js';
 
 export type ExternalApiHttpOptions = {
@@ -269,10 +270,15 @@ export class ExternalApiHttp {
 
     let retryAfterMs = parseRetryAfterMs(accepted.headers.get(HEADER_RETRY_AFTER));
     const deadline = Date.now() + this.pollDeadlineMs;
+    let lastProgressWindows: Array<WindowInfo> | undefined;
 
     for (;;) {
       if (Date.now() >= deadline) {
-        return Err({ type: 'poll-timeout', operationId });
+        return Err({
+          type: 'poll-timeout',
+          operationId,
+          ...(lastProgressWindows ? { progressWindows: lastProgressWindows } : {}),
+        });
       }
 
       await delay(retryAfterMs, signal);
@@ -310,6 +316,8 @@ export class ExternalApiHttp {
           blockingWindows,
         });
       }
+
+      lastProgressWindows = envelope.progressWindows;
 
       retryAfterMs = parseRetryAfterMs(res.headers.get(HEADER_RETRY_AFTER));
     }

--- a/src/desktop/externalApi/externalApiHttpAsyncDispatch.test.ts
+++ b/src/desktop/externalApi/externalApiHttpAsyncDispatch.test.ts
@@ -175,6 +175,66 @@ describe('ExternalApiHttp async dispatch (0.2.0)', () => {
       }
     });
 
+    it('does not fail fast on progressWindows — self-clearing, polling continues to success', async () => {
+      server.setOverride('POST /v0/app:invokeCommand', accepted202('op-progress-1'));
+      server.setOperation('op-progress-1', {
+        retryAfterSeconds: 0,
+        poll: [
+          {
+            id: 'op-progress-1',
+            kind: 'tabdoc:sort',
+            state: 'RUNNING',
+            progressWindows: [
+              { objectName: 'progress', title: 'Exporting…', className: 'QProgressDialog' },
+            ],
+          },
+          {
+            id: 'op-progress-1',
+            kind: 'tabdoc:sort',
+            state: 'SUCCEEDED',
+            result: { sorted: true },
+          },
+        ],
+      });
+
+      const result = await http.postJsonEnvelope(
+        EXTERNAL_API_ROUTES.invokeCommand,
+        invokeBody('tabdoc', 'sort'),
+      );
+      expect(result.isOk()).toBe(true);
+      expect(result.unwrap().state).toBe('SUCCEEDED');
+    });
+
+    it('returns poll-timeout carrying the last-seen progressWindows', async () => {
+      server.setOverride('POST /v0/app:invokeCommand', accepted202('op-progress-2'));
+      server.setOperation('op-progress-2', {
+        poll: [
+          {
+            id: 'op-progress-2',
+            kind: 'tabdoc:sort',
+            state: 'RUNNING',
+            progressWindows: [
+              { objectName: 'progress', title: 'Exporting…', className: 'QProgressDialog' },
+            ],
+          },
+        ],
+      });
+      const shortHttp = new ExternalApiHttp(makeInstance(server.baseUrl), { pollDeadlineMs: 50 });
+
+      const result = await shortHttp.postJsonEnvelope(
+        EXTERNAL_API_ROUTES.invokeCommand,
+        invokeBody('tabdoc', 'sort'),
+      );
+      expect(result.isErr()).toBe(true);
+      const error = result.unwrapErr();
+      expect(error.type).toBe('poll-timeout');
+      if (error.type === 'poll-timeout') {
+        expect(error.progressWindows).toEqual([
+          { objectName: 'progress', title: 'Exporting…', className: 'QProgressDialog' },
+        ]);
+      }
+    });
+
     it('returns operation-expired when the polled operation 404s', async () => {
       server.setOverride('POST /v0/app:invokeCommand', accepted202('op-gone-1'));
       // No setOperation → the poll route 404s operation-not-found.

--- a/src/desktop/externalApi/externalApiToolExecutor.test.ts
+++ b/src/desktop/externalApi/externalApiToolExecutor.test.ts
@@ -868,6 +868,42 @@ describe('ExternalApiToolExecutor', () => {
       }
     });
 
+    it('reports a poll-timeout behind a self-clearing progress dialog without blocking-dialog guidance', async () => {
+      server.setOverride('POST /v0/app:invokeCommand', accepted202('op-progress'));
+      server.setOperation('op-progress', {
+        poll: [
+          {
+            id: 'op-progress',
+            kind: 'tabdoc:sort',
+            state: 'RUNNING',
+            progressWindows: [
+              { objectName: 'progress', title: 'Exporting…', className: 'QProgressDialog' },
+            ],
+          },
+        ],
+      });
+      const executor = new ExternalApiToolExecutor({
+        discover: () => [instanceFor(server)],
+        clientOptions: { pollDeadlineMs: 50 },
+      });
+      await executor.start();
+
+      const result = await executor.executeCommand({
+        namespace: 'tabdoc',
+        command: 'sort',
+        signal,
+      });
+
+      expect(result.isErr()).toBe(true);
+      const error = result.unwrapErr();
+      expect(error.type).toBe('command-timed-out');
+      if (error.type === 'command-timed-out') {
+        expect(error.error).toContain('Exporting…');
+        expect(error.error).toContain('list-instances');
+        expect(error.error).not.toContain('Do not retry');
+      }
+    });
+
     it('maps a CANCELLED terminal operation to a command-failed error', async () => {
       server.setOverride('POST /v0/app:invokeCommand', accepted202('op-cancel'));
       server.setOperation('op-cancel', {

--- a/src/desktop/externalApi/externalApiToolExecutor.test.ts
+++ b/src/desktop/externalApi/externalApiToolExecutor.test.ts
@@ -900,6 +900,7 @@ describe('ExternalApiToolExecutor', () => {
       if (error.type === 'command-timed-out') {
         expect(error.error).toContain('Exporting…');
         expect(error.error).toContain('list-instances');
+        expect(error.error).toContain('may still be running');
         expect(error.error).not.toContain('Do not retry');
       }
     });

--- a/src/desktop/externalApi/externalApiToolExecutor.ts
+++ b/src/desktop/externalApi/externalApiToolExecutor.ts
@@ -953,7 +953,7 @@ function supportsOperationResult(apiVersion: string | undefined): boolean {
   return apiVersionAtLeast(apiVersion, '0.1.1');
 }
 
-function describeBlockingWindows(windows: Array<WindowInfo> | undefined): string {
+function describeWindows(windows: Array<WindowInfo> | undefined): string {
   if (windows === undefined || windows.length === 0) {
     return '';
   }
@@ -1012,7 +1012,7 @@ function mapClientError(
           code: 'awaiting-user',
           message:
             'The operation is blocked on a Tableau Desktop dialog and cannot complete over the API ' +
-            `until a person dismisses it.${describeBlockingWindows(error.blockingWindows)}`,
+            `until a person dismisses it.${describeWindows(error.blockingWindows)}`,
           recoverable: false,
         },
       };
@@ -1021,11 +1021,23 @@ function mapClientError(
         type: 'command-timed-out',
         error: `The async operation expired before it completed (polled past the Desktop retention window). ${BLOCKING_DIALOG_GUIDANCE}`,
       };
-    case 'poll-timeout':
+    case 'poll-timeout': {
+      const progressWindows = error.progressWindows;
+      if (progressWindows !== undefined && progressWindows.length > 0) {
+        return {
+          type: 'command-timed-out',
+          error:
+            'The async operation did not reach a terminal state within the poll deadline. Desktop was ' +
+            'last seen showing a self-clearing progress dialog rather than one a person must dismiss, ' +
+            'so this is most likely a slow operation rather than a wedged instance. If it keeps ' +
+            `happening, call list-instances to confirm the session is still reachable before retrying.${describeWindows(progressWindows)}`,
+        };
+      }
       return {
         type: 'command-timed-out',
         error: `The async operation did not reach a terminal state within the poll deadline. ${BLOCKING_DIALOG_GUIDANCE}`,
       };
+    }
     case 'no-instance':
       return {
         type: 'unknown',

--- a/src/desktop/externalApi/externalApiToolExecutor.ts
+++ b/src/desktop/externalApi/externalApiToolExecutor.ts
@@ -1027,10 +1027,10 @@ function mapClientError(
         return {
           type: 'command-timed-out',
           error:
-            'The async operation did not reach a terminal state within the poll deadline. Desktop was ' +
-            'last seen showing a self-clearing progress dialog rather than one a person must dismiss, ' +
-            'so this is most likely a slow operation rather than a wedged instance. If it keeps ' +
-            `happening, call list-instances to confirm the session is still reachable before retrying.${describeWindows(progressWindows)}`,
+            'The async operation did not reach a terminal state within the poll deadline. It may ' +
+            'still be running on Desktop — the poll gave up locally but did not cancel it, so only ' +
+            'retry if the command is safe to run twice. Desktop was last seen showing a self-clearing ' +
+            `progress dialog, so this is likely just slow; if it recurs, call list-instances to confirm the session is still reachable.${describeWindows(progressWindows)}`,
         };
       }
       return {

--- a/src/desktop/externalApi/types.ts
+++ b/src/desktop/externalApi/types.ts
@@ -741,4 +741,5 @@ export type ExternalApiError =
   // Blocked on a human; a poll can never clear it.
   | { type: 'awaiting-user'; operationId?: string; blockingWindows?: Array<WindowInfo> }
   | { type: 'operation-expired'; operationId?: string }
-  | { type: 'poll-timeout'; operationId?: string };
+  // Diagnostic only: unlike blockingWindows, progressWindows never fails fast on its own.
+  | { type: 'poll-timeout'; operationId?: string; progressWindows?: Array<WindowInfo> };


### PR DESCRIPTION
## Summary

`progressWindows` was added to `OperationEnvelope` in the 0.2.9 contract sync (parses, passes the openapi-drift test) but nothing ever read it — unlike `blockingWindows`, which drives the `awaiting-user` fail-fast and its error message, `progressWindows` was dead weight on the wire. This PR wires it through so it's incorporated at the same level as `blockingWindows`:

- `pollOperation` now tracks the last-seen `progressWindows` during the poll loop (still never fails fast on it — self-clearing dialogs are meant to be waited out) and attaches it to a `poll-timeout` error if the deadline is hit.
- `mapClientError`'s `poll-timeout` case now gives accurate guidance when a progress dialog (not a blocking one) was last seen: it says the operation is most likely just slow, not wedged behind a dialog a person must dismiss, and drops the "do not retry" line that's specific to blocking dialogs.
- Generalized the `describeBlockingWindows` formatter to `describeWindows` since it's now shared between the `awaiting-user` and `poll-timeout` messages.

Rule going forward: a new field on `OperationEnvelope`/`ExternalApiError` isn't done until something reads it — schema-only additions that just satisfy the contract-drift test are incomplete.

## Test plan
- [x] `npx vitest run src/desktop/externalApi/externalApiHttpAsyncDispatch.test.ts src/desktop/externalApi/externalApiToolExecutor.test.ts src/desktop/externalApi/externalApiContract.test.ts` — new tests cover progressWindows not fail-fasting to success, `poll-timeout` carrying the last-seen progressWindows, and the tailored (non-blocking) timeout message
- [x] `npm test` — full unit suite (5926 tests) passes
- [x] `npm run lint` — clean
- [x] `npm run build:desktop` — builds