### PR TITLE
@W-23864452 Add shared datasource-reference shape with datasourceType discriminator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "4.6.0",
+  "version": "4.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "4.6.0",
+      "version": "4.6.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1095.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "4.6.0",
+  "version": "4.6.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/src/sdks/tableau/methods/lineageUtils.ts
+++ b/src/sdks/tableau/methods/lineageUtils.ts
@@ -1,14 +1,15 @@
 import { z } from 'zod';
 
+import { LineageContent } from '../types/lineageContent.js';
 import { View } from '../types/view.js';
 import { Workbook } from '../types/workbook.js';
 
-export type LineageContent = {
-  luid: string;
-  name: string;
-};
+export type { LineageContent };
 
-const lineageContentSchema = z.object({
+// Lenient wire-parse schema for Metadata-API GraphQL responses: luid is absent for embedded
+// datasources and name can be null, so both are optional here. normalizeLineageContents drops
+// entries without a luid before producing the strict LineageContent output shape.
+const metadataLineageContentSchema = z.object({
   luid: z.string().optional(),
   name: z.string().nullable().optional(),
 });
@@ -19,7 +20,7 @@ const workbookLineageResponseSchema = z.object({
       nodes: z.array(
         z.object({
           luid: z.string(),
-          upstreamDatasources: z.array(lineageContentSchema).nullish(),
+          upstreamDatasources: z.array(metadataLineageContentSchema).nullish(),
         }),
       ),
     }),
@@ -28,7 +29,7 @@ const workbookLineageResponseSchema = z.object({
 
 const viewLineageNodeSchema = z.object({
   luid: z.string(),
-  upstreamDatasources: z.array(lineageContentSchema).nullish(),
+  upstreamDatasources: z.array(metadataLineageContentSchema).nullish(),
   workbook: z
     .object({
       luid: z.string(),
@@ -331,14 +332,14 @@ function toGraphqlStringArray(values: Array<string>): string {
 }
 
 function normalizeLineageContents(
-  contents: Array<z.infer<typeof lineageContentSchema>> | null | undefined,
+  contents: Array<z.infer<typeof metadataLineageContentSchema>> | null | undefined,
 ): Array<LineageContent> {
   return (contents ?? [])
     .filter((content): content is { luid: string; name?: string | null } => !!content.luid)
     .map((content) => ({ luid: content.luid, name: content.name ?? content.luid }));
 }
 
-function filterLineageContentsByAllowedIds(
+export function filterLineageContentsByAllowedIds(
   contents: Array<LineageContent> | undefined,
   allowedIds?: Set<string> | null,
 ): Array<LineageContent> {

--- a/src/sdks/tableau/types/lineageContent.test.ts
+++ b/src/sdks/tableau/types/lineageContent.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+
+import { lineageContentSchema } from './lineageContent.js';
+
+describe('lineageContentSchema', () => {
+  it('parses a published-only reference', () => {
+    const result = lineageContentSchema.safeParse({
+      luid: 'ds-1',
+      name: 'Published DS',
+      datasourceType: 'published',
+    });
+    expect(result.success).toBe(true);
+    expect(result.data).toEqual({
+      luid: 'ds-1',
+      name: 'Published DS',
+      datasourceType: 'published',
+    });
+  });
+
+  it('parses an embedded-only reference', () => {
+    const result = lineageContentSchema.safeParse({
+      luid: 'ds-2',
+      name: 'Embedded DS',
+      datasourceType: 'embedded',
+    });
+    expect(result.success).toBe(true);
+    expect(result.data?.datasourceType).toBe('embedded');
+    expect(result.data?.publishedParent).toBeUndefined();
+  });
+
+  it('parses an embedded reference with a published parent', () => {
+    const result = lineageContentSchema.safeParse({
+      luid: 'ds-3',
+      name: 'Embedded DS',
+      datasourceType: 'embedded',
+      publishedParent: { luid: 'ds-parent', name: 'Parent DS' },
+    });
+    expect(result.success).toBe(true);
+    expect(result.data?.publishedParent).toEqual({ luid: 'ds-parent', name: 'Parent DS' });
+  });
+
+  it('stays backward compatible: { luid, name } without the additive fields', () => {
+    const result = lineageContentSchema.safeParse({ luid: 'ds-4', name: 'Legacy DS' });
+    expect(result.success).toBe(true);
+    expect(result.data).toEqual({ luid: 'ds-4', name: 'Legacy DS' });
+  });
+
+  it('rejects an unknown datasourceType', () => {
+    const result = lineageContentSchema.safeParse({
+      luid: 'ds-5',
+      name: 'Bad DS',
+      datasourceType: 'workbook',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a missing luid or name', () => {
+    expect(lineageContentSchema.safeParse({ name: 'No luid' }).success).toBe(false);
+    expect(lineageContentSchema.safeParse({ luid: 'ds-6' }).success).toBe(false);
+  });
+
+  it('rejects a publishedParent missing its own luid/name', () => {
+    const result = lineageContentSchema.safeParse({
+      luid: 'ds-7',
+      name: 'Embedded DS',
+      datasourceType: 'embedded',
+      publishedParent: { luid: 'ds-parent' },
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/sdks/tableau/types/lineageContent.ts
+++ b/src/sdks/tableau/types/lineageContent.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod';
+
+// Shared output shape for upstream-datasource references emitted by workbook/view/search-content
+// tools. datasourceType and publishedParent are additive/optional so existing consumers that only
+// read { luid, name } are unaffected. This is the emitted shape, not the lenient Metadata-API
+// wire-parse schema in lineageUtils.ts.
+export const lineageContentSchema = z.object({
+  luid: z.string(),
+  name: z.string(),
+  datasourceType: z.enum(['published', 'embedded']).optional(),
+  publishedParent: z
+    .object({
+      luid: z.string(),
+      name: z.string(),
+    })
+    .optional(),
+});
+
+export type LineageContent = z.infer<typeof lineageContentSchema>;

--- a/src/sdks/tableau/types/view.ts
+++ b/src/sdks/tableau/types/view.ts
@@ -1,11 +1,7 @@
 import { z } from 'zod';
 
+import { lineageContentSchema } from './lineageContent.js';
 import { tagsSchema } from './tags.js';
-
-const lineageContentSchema = z.object({
-  luid: z.string(),
-  name: z.string(),
-});
 
 export const viewSchema = z.object({
   id: z.string(),

--- a/src/sdks/tableau/types/workbook.ts
+++ b/src/sdks/tableau/types/workbook.ts
@@ -1,13 +1,9 @@
 import { z } from 'zod';
 
+import { lineageContentSchema } from './lineageContent.js';
 import { projectSchema } from './project.js';
 import { tagsSchema } from './tags.js';
 import { viewSchema } from './view.js';
-
-export const lineageContentSchema = z.object({
-  luid: z.string(),
-  name: z.string(),
-});
 
 export const workbookSchema = z.object({
   id: z.string(),

--- a/src/tools/web/contentExploration/searchContent.ts
+++ b/src/tools/web/contentExploration/searchContent.ts
@@ -5,6 +5,7 @@ import { z } from 'zod';
 import { log } from '../../../logging/logger.js';
 import { useRestApi } from '../../../restApiInstance.js';
 import {
+  filterLineageContentsByAllowedIds,
   getSearchContentLineageQuery,
   getViewLineageByLuid,
   getWorkbookLineageByLuid,
@@ -143,7 +144,7 @@ async function enrichSearchResultsWithLineage({
 
   return searchResults.map((item) => {
     if (item.type === 'workbook' && typeof item.luid === 'string') {
-      const upstreamDatasources = filterUpstreamDatasources(
+      const upstreamDatasources = filterLineageContentsByAllowedIds(
         workbookLineageByLuid.get(item.luid),
         datasourceIds,
       );
@@ -151,7 +152,7 @@ async function enrichSearchResultsWithLineage({
     }
 
     if (item.type === 'view' && typeof item.luid === 'string') {
-      const upstreamDatasources = filterUpstreamDatasources(
+      const upstreamDatasources = filterLineageContentsByAllowedIds(
         viewLineageByLuid.get(item.luid)?.upstreamDatasources,
         datasourceIds,
       );
@@ -201,21 +202,5 @@ function getSearchResultLuids(
 ): Array<string> {
   return searchResults.flatMap((item) =>
     item.type === type && typeof item.luid === 'string' ? [item.luid] : [],
-  );
-}
-
-function filterUpstreamDatasources(
-  upstreamDatasources: unknown,
-  datasourceIds?: Set<string> | null,
-): Array<{ luid: string; name: string }> {
-  if (!Array.isArray(upstreamDatasources)) {
-    return [];
-  }
-
-  return upstreamDatasources.filter(
-    (datasource): datasource is { luid: string; name: string } =>
-      typeof datasource?.luid === 'string' &&
-      typeof datasource.name === 'string' &&
-      (!datasourceIds || datasourceIds.has(datasource.luid)),
   );
 }


### PR DESCRIPTION
## Summary

Implements **Item 2** of the Workbook (Embedded) Data Sources MVP: a single shared datasource-reference shape with a `datasourceType` discriminator.

Today the upstream-datasource reference shape is defined in three divergent places on the output side (`workbook.ts`, `view.ts`, and an inline filter in `searchContent.ts`). This PR consolidates them into one shared schema and extends it — additively — so a later item can tag each entry as `published` or `embedded` and link an embedded copy back to its published parent.

This is a pure refactor + additive schema change. No behavior changes and no values are populated yet (that's Item 3).

## Changes

- **New `src/sdks/tableau/types/lineageContent.ts`** — the single shared output schema:
  ```ts
  { luid: string; name: string;
    datasourceType?: 'published' | 'embedded';
    publishedParent?: { luid: string; name: string } }
  Both new fields are optional, so existing { luid, name } consumers are unaffected.
- workbook.ts / view.ts — removed their local lineageContentSchema copies; both now import the shared schema.
- lineageUtils.ts — left the lenient Metadata-API wire-parse schema intact (renamed metadataLineageContentSchema to disambiguate it from the output shape, since luid is legitimately absent for embedded nodes there), re-exports the shared LineageContent type, and exports filterLineageContentsByAllowedIds.
- searchContent.ts — deleted the inline filterUpstreamDatasources duplicate; now reuses the shared filterLineageContentsByAllowedIds.

Why the wire-parse schema stays separate

The lineageUtils.ts schema parses raw Metadata-API GraphQL responses where luid can be missing and name can be null. That leniency is required for correct parsing and is a different concern from the strict, emitted output shape. Consolidating only the output shape keeps both correct.

Testing

- New src/sdks/tableau/types/lineageContent.test.ts — 7 runtime schema-parse cases: published-only, embedded-only, embedded-with-parent, backward-compatible { luid, name }, invalid datasourceType, missing luid/name, and malformed publishedParent.
- tsc --noEmit clean, eslint clean.
- Existing searchContent and lineageUtils test suites pass unchanged (81 tests total).
