### PR TITLE
fix(desktop): preserve requested KPI order

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "2.65.0",
+  "version": "2.65.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "2.65.0",
+      "version": "2.65.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.7.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "2.65.0",
+  "version": "2.65.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/src/server.desktop.test.ts
+++ b/src/server.desktop.test.ts
@@ -260,7 +260,9 @@ async function serializeDesktopToolSurface(tool: DesktopTool<any>): Promise<stri
 // +1; dynamic authoring 45_742 -> 45_743 (18-char slack kept, 46k product ceiling untouched).
 // Re-pinned 2026-08-21: executive-summary adds KPI names to run-dashboard-batch while trimming its
 // older field prose; dynamic authoring 45_743 -> 45_758 without raising the 46k product ceiling.
-const DYNAMIC_AUTHORING_SURFACE_EXPECTED = 45_758;
+// Re-pinned 2026-08-21: mark KPI names as ordered; 45_758 -> 45_761 consumes the existing slack
+// without raising either budget.
+const DYNAMIC_AUTHORING_SURFACE_EXPECTED = 45_761;
 const DYNAMIC_AUTHORING_SURFACE_BUDGET = 45_761;
 const DYNAMIC_AUTHORING_PRODUCT_CEILING = 46_000;
 const FULL_TOOL_SURFACE_BUDGET = 60_022;

--- a/src/tools/desktop/authoring/sheets/composeDashboardCore.test.ts
+++ b/src/tools/desktop/authoring/sheets/composeDashboardCore.test.ts
@@ -34,6 +34,11 @@ const WITH_EXISTING = PRISTINE.replace(
   '<window class="dashboard" name="Sales Dashboard"><viewpoints><viewpoint name="Sales"/></viewpoints></window></windows>',
 );
 
+const WITH_ORDERS = PRISTINE.replace(
+  '</worksheets>',
+  '<worksheet name="Orders"><table/></worksheet></worksheets>',
+).replace('</windows>', '<window class="worksheet" name="Orders"/></windows>');
+
 describe('buildDashboardCandidateXml', () => {
   it('builds an escaped dashboard with layout zones and viewpoints into the baseline workbook', () => {
     const candidateXml = buildDashboardCandidateXml({
@@ -71,6 +76,22 @@ describe('buildDashboardCandidateXml', () => {
 
     expect(candidateXml).toContain('h="20000" id="11" name="Sales" w="100000" x="0" y="8000"');
     expect(candidateXml).toContain('h="72000" id="12" name="Profit" w="100000" x="0" y="28000"');
+  });
+
+  it('places multiple KPI worksheets left to right in the requested order', () => {
+    const candidateXml = buildDashboardCandidateXml({
+      baselineXml: WITH_ORDERS,
+      dashboardName: 'Sales Dashboard',
+      canonicalWorksheetNames: ['Sales', 'Profit', 'Orders'],
+      layout: {
+        layoutType: 'executive-summary',
+        kpiWorksheetNames: ['Profit', 'Sales'],
+      },
+    });
+
+    expect(candidateXml).toContain('h="20000" id="10" name="Profit" w="50000" x="0" y="0"');
+    expect(candidateXml).toContain('h="20000" id="11" name="Sales" w="50000" x="50000" y="0"');
+    expect(candidateXml).toContain('h="80000" id="12" name="Orders" w="100000" x="0" y="20000"');
   });
 });
 

--- a/src/tools/desktop/authoring/sheets/composeDashboardCore.ts
+++ b/src/tools/desktop/authoring/sheets/composeDashboardCore.ts
@@ -74,22 +74,21 @@ export function buildDashboardCandidateXml({
 }: BuildDashboardCandidateXmlArgs): string {
   const inputError = validateComposeDashboardInput(canonicalWorksheetNames, layout);
   if (inputError) throw inputError;
-  const kpis =
-    layout?.layoutType === 'executive-summary'
-      ? canonicalWorksheetNames.filter((name) =>
-          layout.kpiWorksheetNames?.some((kpiName) => xmlNamesEqual(kpiName, name)),
-        )
-      : [];
+  const layoutType = layout?.layoutType;
+  const isExecutiveSummary = layoutType === 'executive-summary';
+  const kpis = isExecutiveSummary
+    ? (layout?.kpiWorksheetNames ?? []).flatMap((kpiName) => {
+        const canonicalName = canonicalWorksheetNames.find((name) => xmlNamesEqual(kpiName, name));
+        return canonicalName ? [canonicalName] : [];
+      })
+    : [];
   const charts = canonicalWorksheetNames.filter(
     (name) => !kpis.some((kpiName) => xmlNamesEqual(kpiName, name)),
   );
   const zones = computeZones(title, {
     kpis,
     charts,
-    layoutType:
-      layout?.layoutType === 'executive-summary'
-        ? 'auto-grid'
-        : (layout?.layoutType ?? 'auto-grid'),
+    layoutType: isExecutiveSummary ? 'auto-grid' : (layoutType ?? 'auto-grid'),
     gridColumns: layout?.gridColumns,
   });
   const dashboardXml = buildDashboardXml(dashboardName, zones);

--- a/src/tools/desktop/authoring/sheets/runDashboardBatch.test.ts
+++ b/src/tools/desktop/authoring/sheets/runDashboardBatch.test.ts
@@ -78,7 +78,11 @@ describe('runDashboardBatchTool', () => {
         title: { type: 'string' },
         layoutType: { type: 'string' },
         gridColumns: { type: 'integer' },
-        kpiWorksheetNames: { type: 'array', items: { type: 'string' } },
+        kpiWorksheetNames: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Ordered KPIs.',
+        },
       },
       required: expect.arrayContaining(['dashboardName']),
     });
@@ -366,6 +370,43 @@ describe('runDashboardBatchTool', () => {
     expect(bodyOf(conflict)).toMatchObject({ applied: false, retrySafe: true });
     expect(missingHarness.posts).toHaveLength(0);
     expect(conflictHarness.posts).toHaveLength(0);
+  });
+
+  it.each([
+    {
+      name: 'a missing KPI list',
+      worksheetNames: ['Existing A', 'Existing B'],
+      kpiWorksheetNames: undefined,
+      error: 'layoutType "executive-summary" requires at least one KPI worksheet name.',
+    },
+    {
+      name: 'duplicate KPI names',
+      worksheetNames: ['Existing A', 'Existing B'],
+      kpiWorksheetNames: ['Existing A', 'Existing A'],
+      error: 'Duplicate KPI worksheet name(s): "Existing A".',
+    },
+    {
+      name: 'only KPI worksheets',
+      worksheetNames: ['Existing A', 'Existing B'],
+      kpiWorksheetNames: ['Existing A', 'Existing B'],
+      error: 'layoutType "executive-summary" requires at least one non-KPI worksheet.',
+    },
+  ])('rejects $name before writing', async ({ worksheetNames, kpiWorksheetNames, error }) => {
+    const harness = statefulExecutor();
+
+    const result = await callBatch([], {
+      existingWorksheetNames: worksheetNames,
+      layoutType: 'executive-summary',
+      kpiWorksheetNames,
+      executor: harness.executor,
+    });
+
+    expect(bodyOf(result)).toMatchObject({
+      applied: false,
+      retrySafe: true,
+      steps: [expect.objectContaining({ stage: 'inputValidation', error })],
+    });
+    expect(harness.posts).toHaveLength(0);
   });
 
   it('keeps six-artifact warning and failure receipts below the SDK truncation limit', async () => {

--- a/src/tools/desktop/authoring/sheets/runDashboardBatch.ts
+++ b/src/tools/desktop/authoring/sheets/runDashboardBatch.ts
@@ -78,7 +78,7 @@ const paramsSchema = {
     .min(1)
     .max(5)
     .optional()
-    .describe('KPI names.'),
+    .describe('Ordered KPIs.'),
 };
 
 type AppliedState = true | false | 'unknown';


### PR DESCRIPTION
`kpiWorksheetNames` now defines the left-to-right order of KPI cards in an executive dashboard. This is the ordering rule for the existing `executive-summary` layout, not a new layout path.

This follow-up to #818 preserves the caller's KPI order, tells the agent that the list is ordered, and adds the missing multi-KPI and fail-before-write cases from Michael's review. It does not change dashboard sizing, styling, or the other layout modes.

Future changes must preserve the requested KPI order and reject missing, duplicate, or KPI-only worksheet sets before writing the workbook.

Evidence:

- The ordering regression failed against #818 and passes with this change.
- The full `scripts/agent-check` gate passes.
- Package version bumped with `npm run version:patch` to `2.65.1`.

Approving this means callers can control KPI strip order through `kpiWorksheetNames`.

Authored by MattGPT.
