### PR TITLE
@W-23977289: Accept localhost and 127.0.0.1 interchangeably in OAuth audience validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "4.5.5",
+  "version": "4.5.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "4.5.5",
+      "version": "4.5.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1095.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "4.5.5",
+  "version": "4.5.6",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/src/server/oauth/accessTokenValidator.test.ts
+++ b/src/server/oauth/accessTokenValidator.test.ts
@@ -386,6 +386,20 @@ describe('TableauAccessTokenValidator', () => {
       }
     });
 
+    it('rejects a loopback-form aud when the resource URI is a custom (non-loopback) host', async () => {
+      // Default validator from beforeEach is configured with MOCK_RESOURCE_URI
+      // ('https://mcp.example.com'), a custom deployment host. Loopback-host canonicalization
+      // must not widen matching to accept localhost/127.0.0.1/[::1] against it.
+      for (const aud of [
+        'http://localhost:3927/tableau-mcp',
+        'http://127.0.0.1:3927/tableau-mcp',
+        'http://[::1]:3927/tableau-mcp',
+      ]) {
+        const result = await validator.validate(makeBearer(basePayload({ aud })));
+        expect(result.isErr()).toBe(true);
+      }
+    });
+
     it('rejects an aud not present in a comma-separated OAUTH_GLOBAL_RESOURCE_URIS', async () => {
       vi.stubEnv(
         'OAUTH_GLOBAL_RESOURCE_URIS',

--- a/src/server/oauth/accessTokenValidator.test.ts
+++ b/src/server/oauth/accessTokenValidator.test.ts
@@ -357,6 +357,35 @@ describe('TableauAccessTokenValidator', () => {
       expect(result.isOk()).toBe(true);
     });
 
+    it('accepts a loopback aud whose host differs from the resource URI form (localhost vs 127.0.0.1)', async () => {
+      // Resource URI configured with the 127.0.0.1 default form; token stamped with the
+      // equivalent localhost form (a locally-run server is reached at either).
+      vi.stubEnv('OAUTH_RESOURCE_URI', 'http://127.0.0.1:3927');
+      const audValidator = new TableauAccessTokenValidator();
+
+      for (const aud of [
+        'http://localhost:3927/tableau-mcp',
+        'http://127.0.0.1:3927/tableau-mcp',
+        'http://[::1]:3927/tableau-mcp',
+      ]) {
+        const result = await audValidator.validate(makeBearer(basePayload({ aud })));
+        expect(result.isOk()).toBe(true);
+      }
+    });
+
+    it('still rejects a loopback aud on a different port or scheme', async () => {
+      vi.stubEnv('OAUTH_RESOURCE_URI', 'http://127.0.0.1:3927');
+      const audValidator = new TableauAccessTokenValidator();
+
+      for (const aud of [
+        'http://localhost:9999/tableau-mcp', // wrong port
+        'https://localhost:3927/tableau-mcp', // wrong scheme
+      ]) {
+        const result = await audValidator.validate(makeBearer(basePayload({ aud })));
+        expect(result.isErr()).toBe(true);
+      }
+    });
+
     it('rejects an aud not present in a comma-separated OAUTH_GLOBAL_RESOURCE_URIS', async () => {
       vi.stubEnv(
         'OAUTH_GLOBAL_RESOURCE_URIS',

--- a/src/server/oauth/accessTokenValidator.ts
+++ b/src/server/oauth/accessTokenValidator.ts
@@ -8,7 +8,11 @@ import { getConfig } from '../../config.js';
 import { log } from '../../logging/logger.js';
 import { RestApi } from '../../sdks/tableau/restApi.js';
 import { getSiteLuidFromAccessToken } from '../../utils/getSiteLuidFromAccessToken.js';
-import { buildResourceIdentifier, stripTrailingSlash } from './resourceIdentifier.js';
+import {
+  buildResourceIdentifier,
+  canonicalizeLoopbackHost,
+  stripTrailingSlash,
+} from './resourceIdentifier.js';
 import {
   mcpAccessTokenSchema,
   mcpAccessTokenUserOnlySchema,
@@ -180,12 +184,17 @@ export class TableauAccessTokenValidator extends AccessTokenValidator {
       // identifier (OAUTH_RESOURCE_URI domain + /tableau-mcp path) is always accepted; each global
       // resource URL (when configured) is matched as the AS stamps it. Both the allowed values and
       // the token's aud are compared with trailing slashes stripped so a cosmetic `/` difference
-      // (RFC 3986 treats `https://host` and `https://host/` as the same resource) is not a mismatch.
+      // (RFC 3986 treats `https://host` and `https://host/` as the same resource) is not a mismatch,
+      // and with loopback hosts canonicalized so the interchangeable local-dev forms `localhost`,
+      // `127.0.0.1`, and `[::1]` (the resource URI defaults to `http://127.0.0.1:<port>`) are not a
+      // mismatch either. Both normalizations only collapse equivalent forms; remote hosts are exact.
+      const normalizeAudience = (uri: string): string =>
+        stripTrailingSlash(canonicalizeLoopbackHost(uri));
       const allowedAudiences = [
         buildResourceIdentifier(this.config.oauth.resourceUri),
         ...this.config.oauth.globalResourceUris,
-      ].map(stripTrailingSlash);
-      if (!allowedAudiences.includes(stripTrailingSlash(aud))) {
+      ].map(normalizeAudience);
+      if (!allowedAudiences.includes(normalizeAudience(aud))) {
         log({
           message: `Access token audience mismatch: expected one of [${allowedAudiences.join(', ')}], got '${truncateForLog(aud)}'`,
           level: 'error',

--- a/src/server/oauth/resourceIdentifier.ts
+++ b/src/server/oauth/resourceIdentifier.ts
@@ -1,4 +1,5 @@
 import { serverName } from '../../server.web.js';
+import { LOOPBACK_HOSTS } from './loopbackHosts.js';
 
 /**
  * Builds the canonical OAuth protected-resource identifier for this MCP server.
@@ -31,4 +32,34 @@ export function buildResourceIdentifier(resourceUri: string): string {
  */
 export function stripTrailingSlash(uri: string): string {
   return uri.replace(/\/+$/, '');
+}
+
+/**
+ * Canonicalizes the loopback host of a URI so the interchangeable local-dev forms `localhost`,
+ * `127.0.0.1`, and `[::1]` compare equal in the audience check. The `OAUTH_RESOURCE_URI` default
+ * is `http://127.0.0.1:<port>` while a locally-run server is just as often reached at
+ * `http://localhost:<port>`, so a token stamped with one loopback form must still match a resource
+ * identifier configured with another. Only URIs whose host is one of those loopback forms are
+ * rewritten (to `127.0.0.1`); every other value — including all remote hosts and non-URL audiences
+ * — is returned unchanged, so the relaxation cannot broaden matching to any unintended host.
+ * Scheme, port, and path are preserved, so e.g. `https://localhost` still will not match
+ * `http://127.0.0.1`.
+ *
+ * @param uri - The URI to canonicalize.
+ * @returns The URI with a loopback host normalized to `127.0.0.1`, or the input unchanged.
+ */
+export function canonicalizeLoopbackHost(uri: string): string {
+  let url: URL;
+  try {
+    url = new URL(uri);
+  } catch {
+    return uri;
+  }
+
+  if (!LOOPBACK_HOSTS.has(url.hostname)) {
+    return uri;
+  }
+
+  url.hostname = '127.0.0.1';
+  return url.toString();
 }


### PR DESCRIPTION
## Description
<img width="656" height="601" alt="Screenshot 2026-08-24 at 5 22 31 PM" src="https://github.com/user-attachments/assets/097fb1b4-0ecc-4188-9608-788ae5cb2a53" />



fixing the most irritating part of working in tableau mcp where now we can use localhost as our url!

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## How Has This Been Tested?
- Added test cases to `accessTokenValidator.test.ts` asserting `localhost`/`127.0.0.1`/`[::1]` audiences are accepted against each other for the same scheme/port/path, and that a wrong port or wrong scheme is still rejected.
- `npx vitest run src/server/oauth/accessTokenValidator.test.ts` — 25/25 passed.

## Related Issues
None.

## Checklist
- [x] I have updated the version in the package.json file by using `npm run version`. For example, use `npm run version:patch` for a patch version bump.
- [ ] I have made any necessary changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have documented any breaking changes in the PR description. For example, renaming a config environment variable or changing its default value.

## Contributor Agreement

By submitting this pull request, I confirm that:

- [x] I have read the [CONTRIBUTING guidelines](../../CONTRIBUTING.md) for this project and followed its Contribution Checklist.