### PR TITLE
fix(desktop): fail a worksheet apply when Tableau drops part of the document

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "2.66.2",
+  "version": "2.66.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "2.66.2",
+      "version": "2.66.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.7.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "2.66.2",
+  "version": "2.66.3",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/src/desktop/externalApi/externalApiContract.test.ts
+++ b/src/desktop/externalApi/externalApiContract.test.ts
@@ -287,7 +287,7 @@ describe('external client API contract (captured openapi fixture)', () => {
   describe('Problem ↔ problemResponseSchema', () => {
     const problem = specSchema('Problem');
 
-    it('declares every spec property (extras `type`/`detail` are RFC-9457 members additionalProperties admits)', () => {
+    it('declares every spec property (extras `type`/`detail` are standard RFC-9457 members, `tableauErrorCode` Tableau’s extension member)', () => {
       const missing = Object.keys(problem.properties ?? {}).filter(
         (key) => !declaredKeys(problemResponseSchema).includes(key),
       );
@@ -295,7 +295,7 @@ describe('external client API contract (captured openapi fixture)', () => {
       const extras = declaredKeys(problemResponseSchema).filter(
         (key) => !(key in (problem.properties ?? {})),
       );
-      expect(extras.sort()).toEqual(['detail', 'type']);
+      expect(extras.sort()).toEqual(['detail', 'tableauErrorCode', 'type']);
     });
 
     it('PROBLEM_CODES equals the spec x-extensible-enum exactly', () => {

--- a/src/desktop/externalApi/externalApiHttp.ts
+++ b/src/desktop/externalApi/externalApiHttp.ts
@@ -505,6 +505,7 @@ async function mapErrorResponse(res: Response): Promise<ExternalApiError> {
       code: problem.data.code,
       title: problem.data.title,
       detail: problem.data.detail ?? (text || undefined),
+      tableauErrorCode: problem.data.tableauErrorCode,
     };
   }
 

--- a/src/desktop/externalApi/externalApiToolExecutor.test.ts
+++ b/src/desktop/externalApi/externalApiToolExecutor.test.ts
@@ -135,6 +135,35 @@ describe('ExternalApiToolExecutor', () => {
       expect(last?.body).toBe(xml);
     });
 
+    it('surfaces the tableauErrorCode extension from a client-rejected apply as tableau-error-code', async () => {
+      server.setOverride('POST /v0/workbook/worksheets/sheet-sales/document', {
+        status: 422,
+        contentType: 'application/problem+json',
+        body: JSON.stringify({
+          type: 'problem',
+          title: 'Invalid workbook DOM',
+          status: 422,
+          instance: '/v0/mock',
+          detail: 'Tableau could not load the submitted worksheet.',
+          code: 'operation-failed',
+          tableauErrorCode: '0xC0FFEE',
+        }),
+      });
+      const executor = new ExternalApiToolExecutor({ discover: () => [instanceFor(server)] });
+      await executor.start();
+
+      const result = await executor.applyWorksheetDocument('sheet-sales', '<worksheet />', signal);
+
+      expect(result.isErr()).toBe(true);
+      const error = result.unwrapErr();
+      expect(error.type).toBe('command-failed');
+      if (error.type === 'command-failed') {
+        expect(error.error?.code).toBe('operation-failed');
+        expect(error.error?.message).toBe('Tableau could not load the submitted worksheet.');
+        expect((error.error as Record<string, unknown>)['tableau-error-code']).toBe('0xC0FFEE');
+      }
+    });
+
     it('rejects a different expected instance before the workbook POST', async () => {
       const executor = new ExternalApiToolExecutor({
         discover: () => [{ ...instanceFor(server), instanceId: 'inst-new' }],

--- a/src/desktop/externalApi/externalApiToolExecutor.ts
+++ b/src/desktop/externalApi/externalApiToolExecutor.ts
@@ -976,16 +976,21 @@ function mapClientError(
         type: 'unknown',
         error: `External Client API instance changed from ${error.expected} to ${error.actual}. Build a fresh artifact for the current Desktop instance.`,
       };
-    case 'problem':
+    case 'problem': {
+      // A client-rejected document apply reports the generic `operation-failed` in `code`
+      // and the real Tableau code in the RFC-9457 `tableauErrorCode` extension. Surface that
+      // extension when present so the agent sees the specific code, not `operation-failed`.
+      const tableauErrorCode = error.tableauErrorCode ?? error.code;
       return {
         type: 'command-failed',
         error: {
           code: error.code ?? String(error.status),
           message: error.detail ?? error.title ?? `External Client API problem (${error.status})`,
           recoverable: false,
-          ...(error.code ? { 'tableau-error-code': error.code } : {}),
+          ...(tableauErrorCode ? { 'tableau-error-code': tableauErrorCode } : {}),
         },
       };
+    }
     case 'unauthorized':
       return {
         type: 'unknown',

--- a/src/desktop/externalApi/types.ts
+++ b/src/desktop/externalApi/types.ts
@@ -427,6 +427,8 @@ export const problemResponseSchema = z
     instance: z.string().optional(),
     detail: z.string().optional(),
     code: z.string().optional(),
+    // RFC-9457 extension member carrying the underlying Tableau error code, distinct from `code`.
+    tableauErrorCode: z.string().optional(),
   })
   .passthrough();
 export type ProblemResponse = z.infer<typeof problemResponseSchema>;
@@ -733,7 +735,14 @@ export type AppInfo = z.infer<typeof appInfoSchema>;
  */
 export type ExternalApiError =
   | { type: 'unauthorized'; status: number }
-  | { type: 'problem'; status: number; code?: string; title?: string; detail?: string }
+  | {
+      type: 'problem';
+      status: number;
+      code?: string;
+      title?: string;
+      detail?: string;
+      tableauErrorCode?: string;
+    }
   | { type: 'invalid-response'; error: unknown }
   | { type: 'network'; error: unknown; aborted?: boolean }
   // 503: retry the whole request (there is no operation to poll).

--- a/src/desktop/wrappers/loadWorkbookXml.ts
+++ b/src/desktop/wrappers/loadWorkbookXml.ts
@@ -4,6 +4,7 @@ import { log } from '../../logging/logger.js';
 import {
   ApplyWorkbookDocumentOptions,
   ExecuteCommandError,
+  ExecuteCommandWarning,
   WithExecutorAndAbortSignal,
 } from '../externalApi/executorTypes.js';
 import {
@@ -194,7 +195,9 @@ export async function applyWorkbookText({
   xml: string;
   focus: ApplyFocus;
   applyOptions?: ApplyWorkbookDocumentOptions;
-} & WithExecutorAndAbortSignal): Promise<Result<void, ExecuteCommandError>> {
+} & WithExecutorAndAbortSignal): Promise<
+  Result<{ documentWarnings: ExecuteCommandWarning[] }, ExecuteCommandError>
+> {
   const result = await executor.applyWorkbookDocument(xml, signal, applyOptions);
 
   if (result.isErr()) {
@@ -221,5 +224,5 @@ export async function applyWorkbookText({
   // fails the apply that already landed.
   await dispatchApplyFocus({ focus, postedXml: xml, executor, signal });
 
-  return Ok.EMPTY;
+  return Ok({ documentWarnings: result.value.warnings ?? [] });
 }

--- a/src/desktop/wrappers/loadWorksheetXml.test.ts
+++ b/src/desktop/wrappers/loadWorksheetXml.test.ts
@@ -1002,6 +1002,126 @@ describe('loadWorksheetXml (External Client API transport)', () => {
       vi.useRealTimers();
     }
   });
+
+  it('hard-fails a per-sheet apply that reports SUCCEEDED with a document-warning drop', async () => {
+    const applyWorksheetDocument = vi.fn().mockResolvedValue(
+      Ok({
+        command_id: 'cmd-apply',
+        status: 'completed',
+        submitted_at: '',
+        warnings: [{ code: 'document-warning', message: 'Dropped filter on [Country/Region].' }],
+      }),
+    );
+    const executor = makeExecutorMock({
+      listWorksheets: vi
+        .fn()
+        .mockResolvedValue(Ok({ worksheets: [{ id: 'sheet-1', name: worksheetName }] })),
+      getWorksheetDocument: vi.fn().mockResolvedValue(Ok({ xml: validXml })),
+      applyWorksheetDocument,
+    });
+
+    const result = await loadWorksheetXml({
+      worksheetName,
+      xml: validXml,
+      executor,
+      signal: mockSignal,
+      focus: NO_FOCUS,
+      requireExistingSheet: true,
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      invariant(result.error.type === 'load-worksheet-xml-error');
+      invariant(result.error.error.type === 'document-warning');
+      expect(result.error.error.warnings).toEqual([
+        { code: 'document-warning', message: 'Dropped filter on [Country/Region].' },
+      ]);
+      expect(result.error.error.message).toContain('Dropped filter on [Country/Region].');
+      expect(result.error.error.message).toContain('does NOT match the intent');
+    }
+    expect(applyWorksheetDocument).toHaveBeenCalledOnce();
+  });
+
+  it('hard-fails the whole-workbook worksheet apply on a document-warning drop', async () => {
+    const applyWorkbookDocument = vi.fn().mockResolvedValue(
+      Ok({
+        command_id: 'cmd-apply',
+        status: 'completed',
+        submitted_at: '',
+        warnings: [{ code: 'document-warning', message: 'Dropped rows shelf field.' }],
+      }),
+    );
+    const executor = makeExecutorMock({
+      getWorkbookDocument: vi.fn().mockResolvedValue(
+        Ok({
+          xml: liveWorkbook(['Sheet 1']),
+          applicationVersion: undefined,
+          xsdPayloadVersion: undefined,
+        }),
+      ),
+      applyWorkbookDocument,
+    });
+
+    const result = await loadWorksheetXml({
+      worksheetName,
+      xml: validXml,
+      executor,
+      signal: mockSignal,
+      focus: NO_FOCUS,
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      invariant(result.error.type === 'load-worksheet-xml-error');
+      invariant(result.error.error.type === 'document-warning');
+      expect(result.error.error.message).toContain('Dropped rows shelf field.');
+    }
+    expect(applyWorkbookDocument).toHaveBeenCalledOnce();
+  });
+
+  it('hard-fails an artifact apply on a document-warning drop', async () => {
+    const baseline = liveWorkbook(['Sheet 1']);
+    const dispatchState = { attempted: false };
+    const applyWorkbookDocument = vi.fn(
+      async (_xml: string, _signal: AbortSignal, options?: { onDispatch?: () => void }) => {
+        options?.onDispatch?.();
+        return Ok({
+          command_id: 'apply-artifact',
+          status: 'completed' as const,
+          submitted_at: '',
+          warnings: [{ code: 'document-warning', message: 'Dropped color encoding.' }],
+        });
+      },
+    );
+    const executor = makeExecutorMock({
+      getWorkbookDocument: vi.fn(async () =>
+        Ok({ xml: baseline, applicationVersion: undefined, xsdPayloadVersion: undefined }),
+      ),
+      applyWorkbookDocument,
+    });
+
+    const result = await loadWorksheetXml({
+      worksheetName,
+      xml: validXml,
+      executor,
+      signal: mockSignal,
+      focus: NO_FOCUS,
+      artifactApply: {
+        windowXml: `<window class='worksheet' name='${worksheetName}' />`,
+        expectedTargetState: captureTargetWorksheetState(baseline, worksheetName, validXml),
+        expectedInstanceId: 'inst-build',
+        dispatchState,
+      },
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      invariant(result.error.type === 'load-worksheet-xml-error');
+      invariant(result.error.error.type === 'document-warning');
+      expect(result.error.error.message).toContain('Dropped color encoding.');
+    }
+    expect(dispatchState.attempted).toBe(true);
+  });
 });
 
 describe('verifyPostApplyWorksheetReadback (async-settle poll)', () => {

--- a/src/desktop/wrappers/loadWorksheetXml.ts
+++ b/src/desktop/wrappers/loadWorksheetXml.ts
@@ -2,7 +2,11 @@ import { Err, Ok, Result } from 'ts-results-es';
 
 import { log } from '../../logging/logger.js';
 import { sanitizeValue } from '../../logging/sanitize.js';
-import { ExecuteCommandError, WithExecutorAndAbortSignal } from '../externalApi/executorTypes.js';
+import {
+  ExecuteCommandError,
+  ExecuteCommandWarning,
+  WithExecutorAndAbortSignal,
+} from '../externalApi/executorTypes.js';
 import { normalizeArray, parseXML } from '../metadata/parser.js';
 import {
   extractSheetXml,
@@ -52,6 +56,10 @@ export type LoadWorksheetXmlError =
   // changed an intent-bearing node (the silently-dropped-pill killer, W4). `message`
   // carries the agent-facing fix recipe; `findings` the structured evidence.
   | { type: 'readback-failed'; findings: ReadbackFinding[]; message: string }
+  // Apply reported SUCCEEDED, but Desktop attached a document-warning: it accepted the
+  // document while dropping part of what was submitted. `message` carries Desktop's own
+  // warning text — the only per-drop detail that survives the wire; `warnings` the raw list.
+  | { type: 'document-warning'; warnings: ExecuteCommandWarning[]; message: string }
   | { type: 'source-drift'; message: string }
   // Only surfaced when a caller opts in with `requireExistingSheet` (apply-worksheet);
   // flag-off callers take the whole-workbook path and never see this (create sheet and apply).
@@ -233,6 +241,25 @@ function readbackOutcome(
   return Ok({
     readbackWarnings: findings,
     readbackVerification: publicReadbackVerificationResult(verification),
+  });
+}
+
+// The per-drop Tableau code is discarded before the wire, so a warning's message text is
+// the only field-level detail — join and surface it verbatim for the agent to act on.
+function documentWarningOutcome(warnings: ExecuteCommandWarning[]): LoadWorksheetXmlResult {
+  const details = warnings
+    .map((warning) => warning.message)
+    .filter(Boolean)
+    .join('; ');
+  return Err({
+    type: 'load-worksheet-xml-error',
+    error: {
+      type: 'document-warning',
+      warnings,
+      message:
+        `apply succeeded but Tableau could not honor part of the document and dropped it: ${details}. ` +
+        'The rendered chart does NOT match the intent. Fix the flagged node(s) in the worksheet XML and re-apply.',
+    },
   });
 }
 
@@ -455,6 +482,9 @@ export async function loadWorksheetXml({
       if (applyResult.isErr()) {
         return Err({ type: 'execute-command-error', error: applyResult.error });
       }
+      if (applyResult.value.documentWarnings.length > 0) {
+        return documentWarningOutcome(applyResult.value.documentWarnings);
+      }
 
       const verification = await verifyPostApplyArtifactReadback(
         canonicalName,
@@ -493,6 +523,9 @@ export async function loadWorksheetXml({
       }
       const applyOutcome = outcome.value;
       if (typeof applyOutcome === 'object' && 'status' in applyOutcome) {
+        if (applyOutcome.documentWarnings.length > 0) {
+          return documentWarningOutcome(applyOutcome.documentWarnings);
+        }
         const verification = await verifyPostApplyWorksheetReadback(
           applyOutcome.id,
           applyOutcome.fragmentXml,
@@ -649,6 +682,9 @@ async function loadWorksheetXmlViaExternalApi({
     const applyResult = await applyWorkbookText({ xml: workbookDoc, focus, executor, signal });
     if (applyResult.isErr()) {
       return Err({ type: 'execute-command-error', error: applyResult.error });
+    }
+    if (applyResult.value.documentWarnings.length > 0) {
+      return documentWarningOutcome(applyResult.value.documentWarnings);
     }
 
     log({

--- a/src/desktop/wrappers/perSheetDocumentApply.test.ts
+++ b/src/desktop/wrappers/perSheetDocumentApply.test.ts
@@ -106,6 +106,7 @@ describe('tryApplyViaPerSheetRoute', () => {
           id,
           name: sheetName,
           fragmentXml,
+          documentWarnings: [],
         });
       }
       // The route resolves by id, and the posted body is the sheet fragment as-is (Tableau Desktop

--- a/src/desktop/wrappers/perSheetDocumentApply.ts
+++ b/src/desktop/wrappers/perSheetDocumentApply.ts
@@ -3,7 +3,12 @@ import { Err, Ok, Result } from 'ts-results-es';
 
 import { log } from '../../logging/logger.js';
 import { escapeXml } from '../binder/escape.js';
-import { ExecuteCommandError, WithExecutorAndAbortSignal } from '../externalApi/executorTypes.js';
+import {
+  ExecuteCommandError,
+  ExecuteCommandResult,
+  ExecuteCommandWarning,
+  WithExecutorAndAbortSignal,
+} from '../externalApi/executorTypes.js';
 import { ExternalApiToolExecutor } from '../externalApi/externalApiToolExecutor.js';
 import { isRouteMissing, resolveItemByNameOrId } from '../externalApi/toolUtils.js';
 import { introducedBlockingValidationIssues, runValidation } from '../validation/registry.js';
@@ -23,7 +28,14 @@ export type PerSheetKind = 'worksheet' | 'dashboard' | 'storyboard';
  * whole-workbook upsert resolves by first-match).
  */
 export type PerSheetApplyOutcome =
-  | { status: 'applied'; id: string; name: string; fragmentXml: string }
+  | {
+      status: 'applied';
+      id: string;
+      name: string;
+      fragmentXml: string;
+      // Empty on a clean apply; every entry is a node Tableau dropped, never a benign notice.
+      documentWarnings: ExecuteCommandWarning[];
+    }
   | { type: 'dashboard-member-blank-transition'; dashboards: string[] }
   | 'sheet-absent'
   | 'route-missing'
@@ -162,6 +174,7 @@ export async function tryApplyViaPerSheetRoute({
     id: resolved.value.id,
     name: resolved.value.name,
     fragmentXml: retitledFragment.value,
+    documentWarnings: applyResult.value.warnings ?? [],
   });
 }
 
@@ -304,7 +317,7 @@ async function applyDocumentForKind(
   documentXml: string,
   client: ExternalApiToolExecutor,
   signal: AbortSignal,
-): Promise<Result<unknown, ExecuteCommandError>> {
+): Promise<Result<ExecuteCommandResult<undefined>, ExecuteCommandError>> {
   switch (kind) {
     case 'worksheet':
       return client.applyWorksheetDocument(id, documentXml, signal);


### PR DESCRIPTION
## Decision

A worksheet apply now **fails** whenever the External Client API reports the apply SUCCEEDED but attaches a `document-warning` — Desktop's signal that it accepted the document while dropping part of what we submitted (a filter, a shelf field, an encoding). Previously that warning was discarded on every apply path, so the tool returned success while the rendered chart silently did not match the intent. This is a rule the worksheet apply paths now keep, not a one-off.

This is the bug behind the report: `apply-worksheet` returning success while Tableau dropped the Country/Region filter and calc-heavy rows/cols.

## Why hard-failing is safe

Investigation of every `document-warning` source reachable from the document-apply path in the monolith found they are all the same class: *"the client asked for X, Desktop dropped/ignored/fell back."* There are no benign notices on this path, and a clean apply emits an **empty** warnings list. So failing on any non-empty `document-warning` cannot over-trigger on a healthy apply.

The per-node Tableau code is collapsed to the single generic `document-warning` wire code before it reaches us, so the warning's **message text** is the only field-level detail that survives — we surface it verbatim for the agent to act on.

## What changed

- **Consume the drop signal.** Thread `documentWarnings` through `applyWorkbookText` and the per-sheet apply, and hard-fail with a new `document-warning` error on the three worksheet apply routes (per-sheet, whole-workbook, artifact). This is complementary to the existing post-apply readback verifier: it is an authoritative in-band signal that does not depend on a re-read succeeding.
- **Keep the real error code on a rejection.** On the client-rejected 4xx (RFC-9457 Problem) path, the specific Tableau code rides in the `tableauErrorCode` extension member while `code` is the generic `operation-failed`. We now surface `tableauErrorCode` when present instead of the generic code, so a rejection reports the code Tableau actually raised.

## Deliberate scope

Only the three **worksheet** apply routes fail on a `document-warning` here. `apply-workbook`, `apply-dashboard`, and `bind-template` go through `loadWorkbookXml`/`loadDashboardXml`, whose callers (dashboard compose, batch) run a retry classifier that would mistake this new error for a retry-safe one and loop. Extending the hard-fail to those paths is a documented follow-up gated on that classifier work.

## Testing

- New unit tests assert the hard-fail on all three worksheet routes (per-sheet, whole-workbook, artifact) and that the dropped-node message is surfaced.
- New unit test asserts `tableauErrorCode` is preferred over the generic `code` on a Problem rejection; contract test updated for the new schema extension member.
- `npx tsc --noEmit`, `npm run lint`, and `npm run build:desktop` all clean. Full unit suite green except a pre-existing flaky timeout test (`unreachableInstance.test.ts`, `timeoutMs: 60` on real timers) unrelated to these paths.

## Verified live

Smoke-tested against Tableau Desktop (External Client API 0.2.9) with Sample - Superstore:

- **No-regression control:** a clean worksheet apply still returns success — the empty warnings list does not trip the new hard-fail.
- **Reproduced the bug:** applying a worksheet with a quantitative (range) filter on a real string dimension (`Category`) made Desktop return SUCCEEDED while silently dropping the filter (*"Error parsing filter for field 'Category', ignoring filter"*). Before this change the tool reported success; with the fix it now hard-fails with the dropped-filter message, and a readback confirmed the filter was in fact dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
