### PR TITLE
fix(oauth): pin TLS SNI to original hostname when fetching CIMD client metadata

### DIFF
--- a/src/server/oauth/authorize.test.ts
+++ b/src/server/oauth/authorize.test.ts
@@ -1,0 +1,63 @@
+import https from 'https';
+import { isSSRFSafeURL } from 'ssrfcheck';
+import { describe, expect, it, vi } from 'vitest';
+
+import { axios } from '../../utils/axios.js';
+import { getClientFromMetadataDoc } from './authorize.js';
+import { getDnsResolver } from './dnsResolver.js';
+
+vi.mock('ssrfcheck', () => ({
+  isSSRFSafeURL: vi.fn(),
+}));
+
+vi.mock('./dnsResolver.js', () => ({
+  getDnsResolver: vi.fn(),
+}));
+
+vi.mock('../../utils/axios.js', async () => {
+  const actual =
+    await vi.importActual<typeof import('../../utils/axios.js')>('../../utils/axios.js');
+  return {
+    ...actual,
+    axios: { create: vi.fn() },
+  };
+});
+
+describe('getClientFromMetadataDoc', () => {
+  it('pins TLS SNI to the original hostname, not the resolved IP', async () => {
+    const resolvedIp = '93.184.216.34';
+    vi.mocked(getDnsResolver).mockReturnValue({
+      resolve4: vi.fn().mockResolvedValue([resolvedIp]),
+      resolve6: vi.fn(),
+    } as unknown as ReturnType<typeof getDnsResolver>);
+    vi.mocked(isSSRFSafeURL).mockReturnValue(true);
+
+    const get = vi.fn().mockResolvedValue({
+      headers: { 'content-type': 'application/json' },
+      data: {
+        client_id: 'https://claude.ai/oauth/claude-code-client-metadata',
+        redirect_uris: ['http://localhost:12345/callback'],
+      },
+    });
+    vi.mocked(axios.create).mockReturnValue({ get } as unknown as ReturnType<typeof axios.create>);
+
+    const result = await getClientFromMetadataDoc(
+      new URL('https://claude.ai/oauth/claude-code-client-metadata'),
+    );
+
+    expect(result.isOk()).toBe(true);
+    expect(get).toHaveBeenCalledTimes(1);
+
+    const [requestedUrl, requestConfig] = get.mock.calls[0];
+
+    // The request is still pinned to the resolved IP (SSRF protection intact).
+    expect(requestedUrl).toBe(`https://${resolvedIp}/oauth/claude-code-client-metadata`);
+    expect(requestConfig.headers.Host).toBe('claude.ai');
+
+    // The fix: SNI must be pinned to the original hostname, not the IP, so
+    // SNI-routing CDNs (e.g. Cloudflare) fronting the client_id host resolve
+    // the request correctly instead of rejecting it with a 403.
+    expect(requestConfig.httpsAgent).toBeInstanceOf(https.Agent);
+    expect(requestConfig.httpsAgent.options.servername).toBe('claude.ai');
+  });
+});

--- a/src/server/oauth/authorize.ts
+++ b/src/server/oauth/authorize.ts
@@ -242,7 +242,8 @@ async function getOAuthRedirectUrl(
 }
 
 // https://client.dev/servers
-async function getClientFromMetadataDoc(
+// Exported for testing.
+export async function getClientFromMetadataDoc(
   clientMetadataUrl: URL,
 ): Promise<Result<ClientMetadata, { error: string; error_description: string }>> {
   const originalUrl = clientMetadataUrl.toString();

--- a/src/server/oauth/authorize.ts
+++ b/src/server/oauth/authorize.ts
@@ -1,5 +1,6 @@
 import { randomBytes, randomInt, randomUUID } from 'crypto';
 import express from 'express';
+import https from 'https';
 import { isIP } from 'net';
 import { isSSRFSafeURL } from 'ssrfcheck';
 import { Err, Ok, Result } from 'ts-results-es';
@@ -298,12 +299,20 @@ async function getClientFromMetadataDoc(
   let response: AxiosResponse;
   try {
     const client = axios.create();
+    // The request URL's hostname was replaced with a resolved IP address above (to
+    // pin the connection and prevent DNS-rebinding SSRF). For HTTPS targets, the TLS
+    // layer would otherwise derive SNI from that IP, which breaks CDN-fronted hosts
+    // (e.g. Cloudflare) that route/serve certificates by SNI rather than the Host
+    // header alone. Pin SNI back to the original hostname so those hosts resolve
+    // correctly while the connection still only ever talks to the vetted IP.
+    const httpsAgent = new https.Agent({ servername: originalHostname });
     response = await retry(
       () =>
         client.get(clientMetadataUrl.toString(), {
           timeout: 5000,
           maxContentLength: 5 * 1024, // 5 KB
           maxRedirects: 3,
+          httpsAgent,
           headers: {
             Accept: 'application/json',
             Host: originalHostname,


### PR DESCRIPTION
## Summary

Fixes #837.

`getClientFromMetadataDoc()` resolves the CIMD `client_id` metadata URL's hostname to an IP address (DNS-rebinding SSRF mitigation) and rewrites the request URL to that IP before fetching it, overriding only the `Host` header to the original hostname.

For HTTPS targets, Node/axios derive TLS **SNI** from the request URL's host, which is now the raw IP. CDNs that route/serve certificates by SNI (e.g. Cloudflare) reject requests with an unrecognized IP-based SNI, regardless of the `Host` header — surfacing as `invalid_request: Unable to fetch client metadata` to the OAuth caller. This reproduces for `client_id=https://claude.ai/oauth/claude-code-client-metadata` (Claude Code / Claude Desktop) against any self-hosted tableau-mcp server, and will affect any CIMD client whose `client_id` host sits behind a similar CDN.

## Fix

Pin the outbound TLS SNI to the original hostname via `https.Agent({ servername: originalHostname })`, passed as `httpsAgent` on the existing `axios.get()` call. The connection still only ever talks to the pre-resolved, SSRF-checked IP — `isSSRFSafeURL` and the IP-resolution step are unchanged — so DNS-rebinding protection is preserved. This also fixes TLS certificate hostname validation, which previously validated against the wrong identity (the IP) rather than the original hostname.

## Before / after

- Before: `axios.get(<ip-url>, { headers: { Host: originalHostname } })` → SNI = IP → 403 from SNI-routing CDNs.
- After: same call + `httpsAgent: new https.Agent({ servername: originalHostname })` → SNI = original hostname → CDN routes correctly; SSRF pinning to the resolved IP unchanged.

## Testing

- `tsc --noEmit`: clean.
- `eslint` / `prettier --check`: clean.
- Full unit suite (`npm test`, Node 22): **177 files / 2823 tests pass**, no regressions.
- Added `src/server/oauth/authorize.test.ts`, a new regression test for `getClientFromMetadataDoc` (exported for testability). It mocks DNS resolution, the SSRF check, and axios, then asserts:
  - the outbound request URL is still the resolved IP (SSRF pinning to the vetted IP is unaffected), and
  - the `httpsAgent`'s TLS `servername` is the original hostname, not the IP.
- Verified the test is meaningful: reverting just the `authorize.ts` fix makes this test fail; restoring the fix makes it pass again.
- Manually reproduced the underlying failure by resolving `claude.ai` and issuing a raw `axios.get()` against the resolved IP with only a `Host` header override (403); confirmed the fix resolves it locally with the same `servername`-pinned `https.Agent`.

## Additional info

Root cause and reproduction details are in #837.