### PR TITLE
fix(sea): generate the SEA blob with a downloaded official Node dist

### DIFF
--- a/src/scripts/buildSea.ts
+++ b/src/scripts/buildSea.ts
@@ -161,7 +161,7 @@ async function downloadNodeDist(platform: SeaPlatform, downloadDir: string): Pro
   return nodeBinary;
 }
 
-async function generateBlob(variant: SeaVariant): Promise<string> {
+async function generateBlob(variant: SeaVariant, downloadDir: string): Promise<string> {
   if (!existsSync(join(repoRoot, variant.entry))) {
     throw new Error(
       `Entry point missing: ${variant.entry}. Run the build first (omit --skip-build).`,
@@ -179,8 +179,12 @@ async function generateBlob(variant: SeaVariant): Promise<string> {
     config.assets = assets;
   }
   await writeFile(configPath, JSON.stringify(config, null, 2));
+  // Some provisioned Node builds ship with SEA disabled ("Single executable
+  // application is disabled."), so generate the blob with a downloaded official
+  // Node dist rather than the runner's `node`.
+  const hostNode = await downloadNodeDist(platforms[hostPlatformKey()], downloadDir);
   try {
-    run('node', ['--experimental-sea-config', configPath]);
+    run(hostNode, ['--experimental-sea-config', configPath]);
   } finally {
     await rm(configPath, { force: true });
     if (manifestPath) {
@@ -265,7 +269,7 @@ async function buildBinary(
 
   for (const variantKey of variantKeys) {
     console.log(`\n🧬 Generating SEA blob for ${variantKey}...`);
-    const blobPath = await generateBlob(seaVariants[variantKey]);
+    const blobPath = await generateBlob(seaVariants[variantKey], downloadDir);
     blobs.push(blobPath);
     for (const platformKey of platformKeys) {
       console.log(`🚀 Building SEA binary for ${variantKey}/${platformKey}...`);


### PR DESCRIPTION
## Decision

**Rule we now keep:** the desktop SEA build generates the preparation blob with a **downloaded official Node dist**, never the runner's `node`. The SEA build must not depend on the runtime the CI runner happens to ship.

## Why

The GitLab mirror's desktop packaging pipeline (`mcp-ci.yml@browser-clients/tab-agent-knowledge-ci`) has failed on every commit since the weekend of Aug 22–24. The build jobs run bare `node`/`npm` on the `nerv` runners with no pinned Node version. Those runners' Node auto-upgraded **v26.0.0 → v26.7.0**, and the v26.7.0 build ships with SEA compiled out:

```
🧬 Generating SEA blob for desktop...
Single executable application is disabled.
Error: Command failed (1): node --experimental-sea-config .../sea-config.desktop.generated.json
```

The last green pipeline was #798's own merge commit on v26.0.0 (`Wrote single executable preparation blob … ✅`); the first pipeline after the Node bump was the first red one. Nothing in tableau-mcp changed — the break tracks the runner's Node, not any commit. GitHub CI stays green because it never builds SEA binaries.

`buildSea.ts` already downloads an official Node dist for the *injection* step precisely because a provisioned/package-manager Node lacks the SEA fuse. This applies the same reasoning to the *generation* step, so the whole SEA build is immune to runner Node drift.

## What changed

`generateBlob()` now runs `node --experimental-sea-config` using the host's downloaded official Node dist (same version, keyed to `process.version`) instead of the runner's PATH `node`. One helper call plus threading `downloadDir` through; the dist is cached, so no extra download when host == target.

## Verification

- `npm run build:sea:desktop -- --platform macos-arm64` produces a valid 104 MB Mach-O arm64 binary with the `NODE_SEA` / `__NODE_SEA_BLOB` segment embedded.
- Typecheck and lint clean.

Draft: opened for review before it syncs to the mirror.