### PR TITLE
chore: bump version to 2.67.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "2.67.0",
+  "version": "2.67.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "2.67.0",
+      "version": "2.67.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.7.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "2.67.0",
+  "version": "2.67.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"


### PR DESCRIPTION
## Summary

- bump `@tableau/mcp-server` from `2.67.0` to `2.67.1`
- keep `package.json` and `package-lock.json` synchronized using `npm run version:patch`

## Testing

- `git diff --check`
- verified all three package version fields are `2.67.1`
- full repository validation deferred to CI because the existing local dependency tree is older than the latest `feature/desktop` branch