### PR TITLE
chore(release): bump the package patch version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "2.67.0",
+  "version": "2.67.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "2.67.0",
+      "version": "2.67.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.7.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "2.67.0",
+  "version": "2.67.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"


### PR DESCRIPTION
Decision: bump @tableau/mcp-server from 2.67.0 to 2.67.1. This is a one-off release metadata change.

Scope: package.json and package-lock.json only. No code or dependencies changed.

Future version bumps must keep the package and lockfile root versions equal.

Evidence:
- npm version patch --no-git-tag-version --ignore-scripts
- Version consistency check passed.
- git diff --check passed.

Approving this PR merges only the 2.67.1 patch bump.
