### PR TITLE
fix(desktop): reject apply-dashboard zones naming unwindowed worksheets

### DIFF
--- a/src/desktop/metadata/parser.ts
+++ b/src/desktop/metadata/parser.ts
@@ -2,7 +2,7 @@ import { randomUUID } from 'crypto';
 import { XMLBuilder, XMLParser } from 'fast-xml-parser';
 
 import { xmlNamesEqual } from '../xmlElement.js';
-import type { ParsedWorkbook, ParsedWorksheet } from './types.js';
+import type { ParsedWindow, ParsedWorkbook, ParsedWorksheet } from './types.js';
 
 const parserOptions = {
   ignoreAttributes: false,
@@ -214,6 +214,18 @@ export function findWorksheet(workbook: ParsedWorkbook, sheetName: string): Pars
 
 export function findAllWorksheets(workbook: ParsedWorkbook): ParsedWorksheet[] {
   return normalizeArray(workbook.workbook?.worksheets?.worksheet);
+}
+
+export function listWindowedWorksheetNames(workbook: ParsedWorkbook): string[] {
+  const worksheetNames = findAllWorksheets(workbook)
+    .map((worksheet) => worksheet['@_name'])
+    .filter((name): name is string => Boolean(name));
+  const worksheetWindowNames = normalizeArray<ParsedWindow>(workbook.workbook?.windows?.window)
+    .filter((window) => window['@_class'] === 'worksheet')
+    .map((window) => window['@_name']);
+  return worksheetNames.filter((name) =>
+    worksheetWindowNames.some((windowName) => xmlNamesEqual(windowName, name)),
+  );
 }
 
 // fast-xml-parser attaches an `xmlns`/`xmlns:*` declaration as a plain attribute on whichever

--- a/src/desktop/wrappers/loadDashboardXml.test.ts
+++ b/src/desktop/wrappers/loadDashboardXml.test.ts
@@ -534,6 +534,177 @@ describe('loadDashboardXml (External Client API transport)', () => {
     }
   });
 
+  // A dashboard sheet zone that names a worksheet Desktop has no registered worksheet-class
+  // window for makes Desktop assert (oWindowID) the moment it resolves the zone — and then
+  // delete/undo on that dashboard hard-fail. apply-dashboard applies only the <dashboard>
+  // fragment, so the workbook-context rules that catch this never run; this guard reads live
+  // state and refuses before the POST. See dashboardZonesReferenceIncludedWorksheets /
+  // worksheetMissingWindow (both workbook-context only).
+  describe('zone worksheet-window guard (requireExistingSheet dashboards)', () => {
+    function guardWorkbook(
+      worksheets: Array<{ name: string; windowed: boolean }>,
+      dashboards: string[] = [dashboardName],
+    ): string {
+      const worksheetXml = worksheets
+        .map((worksheet) => `<worksheet name='${worksheet.name}'><table /></worksheet>`)
+        .join('');
+      const dashboardXml = dashboards
+        .map((name) => `<dashboard name='${name}'><zones /></dashboard>`)
+        .join('');
+      const worksheetWindows = worksheets
+        .filter((worksheet) => worksheet.windowed)
+        .map((worksheet) => `<window class='worksheet' name='${worksheet.name}' />`)
+        .join('');
+      const dashboardWindows = dashboards
+        .map((name) => `<window class='dashboard' name='${name}' />`)
+        .join('');
+      return `<?xml version='1.0'?><workbook><worksheets>${worksheetXml}</worksheets><dashboards>${dashboardXml}</dashboards><windows>${worksheetWindows}${dashboardWindows}</windows></workbook>`;
+    }
+
+    function perSheetExecutor(workbookXml: string): {
+      executor: ExternalApiToolExecutor;
+      applyDashboardDocument: ReturnType<typeof vi.fn>;
+      getWorkbookDocument: ReturnType<typeof vi.fn>;
+    } {
+      const applyDashboardDocument = vi
+        .fn()
+        .mockResolvedValue(
+          Ok({ command_id: 'cmd-apply', status: 'completed' as const, submitted_at: '' }),
+        );
+      const getWorkbookDocument = vi
+        .fn()
+        .mockResolvedValue(
+          Ok({ xml: workbookXml, applicationVersion: undefined, xsdPayloadVersion: undefined }),
+        );
+      const executor = makeExecutorMock({
+        listDashboards: vi
+          .fn()
+          .mockResolvedValue(Ok({ dashboards: [{ id: 'dash-1', name: dashboardName }] })),
+        getDashboardDocument: vi.fn().mockResolvedValue(Ok({ xml: validXml })),
+        getWorkbookDocument,
+        applyDashboardDocument,
+      });
+      return { executor, applyDashboardDocument, getWorkbookDocument };
+    }
+
+    const zoneFragment = (worksheetName: string): string =>
+      `<dashboard name='${dashboardName}'><zones><zone id='9' type-v2='layout-basic' w='100000' h='100000' x='0' y='0'><zone name='${worksheetName}' w='100000' h='100000' x='0' y='0' /></zone></zones></dashboard>`;
+
+    it('blocks the apply when a zone references a worksheet with no live worksheet window', async () => {
+      const { executor, applyDashboardDocument } = perSheetExecutor(
+        guardWorkbook([{ name: 'Sheet 1', windowed: true }]),
+      );
+
+      const result = await loadDashboardXml({
+        dashboardName,
+        xml: zoneFragment('Ghost Sheet'),
+        executor,
+        signal: mockSignal,
+        focus: NO_FOCUS,
+        requireExistingSheet: true,
+      });
+
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        invariant(result.error.type === 'load-dashboard-xml-error');
+        invariant(result.error.error.type === 'validation-failed');
+        expect(result.error.error.issues.map((issue) => issue.message).join(' ')).toContain(
+          'Ghost Sheet',
+        );
+      }
+      expect(applyDashboardDocument).not.toHaveBeenCalled();
+    });
+
+    it('blocks a worksheet that exists in the document but has no worksheet-class window', async () => {
+      const { executor, applyDashboardDocument } = perSheetExecutor(
+        guardWorkbook([
+          { name: 'Sheet 1', windowed: true },
+          { name: 'Sheet 2', windowed: false },
+        ]),
+      );
+
+      const result = await loadDashboardXml({
+        dashboardName,
+        xml: zoneFragment('Sheet 2'),
+        executor,
+        signal: mockSignal,
+        focus: NO_FOCUS,
+        requireExistingSheet: true,
+      });
+
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        invariant(result.error.type === 'load-dashboard-xml-error');
+        expect(result.error.error.type).toBe('validation-failed');
+      }
+      expect(applyDashboardDocument).not.toHaveBeenCalled();
+    });
+
+    it('applies when every zone worksheet is a live, windowed worksheet', async () => {
+      const { executor, applyDashboardDocument } = perSheetExecutor(
+        guardWorkbook([{ name: 'Sheet 1', windowed: true }]),
+      );
+
+      const result = await loadDashboardXml({
+        dashboardName,
+        xml: zoneFragment('Sheet 1'),
+        executor,
+        signal: mockSignal,
+        focus: NO_FOCUS,
+        requireExistingSheet: true,
+      });
+
+      expect(result.isOk()).toBe(true);
+      expect(applyDashboardDocument).toHaveBeenCalledOnce();
+    });
+
+    it('does not read the workbook when the fragment has no worksheet zones', async () => {
+      const { executor, applyDashboardDocument, getWorkbookDocument } = perSheetExecutor(
+        guardWorkbook([{ name: 'Sheet 1', windowed: true }]),
+      );
+
+      const result = await loadDashboardXml({
+        dashboardName,
+        xml: `<dashboard name='${dashboardName}'><zones><zone id='9' type-v2='layout-basic' w='100000' h='100000' x='0' y='0'/></zones></dashboard>`,
+        executor,
+        signal: mockSignal,
+        focus: NO_FOCUS,
+        requireExistingSheet: true,
+      });
+
+      expect(result.isOk()).toBe(true);
+      expect(getWorkbookDocument).not.toHaveBeenCalled();
+      expect(applyDashboardDocument).toHaveBeenCalledOnce();
+    });
+
+    it('surfaces a workbook read failure as an execute-command-error', async () => {
+      const readError = {
+        type: 'command-failed' as const,
+        error: { code: 'ERROR', message: 'Failed', recoverable: false },
+      };
+      const executor = makeExecutorMock({
+        listDashboards: vi
+          .fn()
+          .mockResolvedValue(Ok({ dashboards: [{ id: 'dash-1', name: dashboardName }] })),
+        getWorkbookDocument: vi.fn().mockResolvedValue(Err(readError)),
+      });
+
+      const result = await loadDashboardXml({
+        dashboardName,
+        xml: zoneFragment('Sheet 1'),
+        executor,
+        signal: mockSignal,
+        focus: NO_FOCUS,
+        requireExistingSheet: true,
+      });
+
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.type).toBe('execute-command-error');
+      }
+    });
+  });
+
   it('should pass the abort signal to the workbook apply', async () => {
     const customSignal = new AbortController().signal;
     const { executor } = dispatchingExecutor(liveWorkbook(['Sales Dashboard']));

--- a/src/desktop/wrappers/loadDashboardXml.ts
+++ b/src/desktop/wrappers/loadDashboardXml.ts
@@ -1,10 +1,12 @@
+import { DOMParser } from '@xmldom/xmldom';
 import { Err, Ok, Result } from 'ts-results-es';
+import * as xpath from 'xpath';
 
 import { log } from '../../logging/logger.js';
 import { sanitizeValue } from '../../logging/sanitize.js';
 import { ExecuteCommandError, WithExecutorAndAbortSignal } from '../externalApi/executorTypes.js';
 import { dashboardFragmentSimpleId, upsertDashboardIntoWorkbook } from '../metadata/dashboards.js';
-import { normalizeArray, parseXML } from '../metadata/parser.js';
+import { listWindowedWorksheetNames, normalizeArray, parseXML } from '../metadata/parser.js';
 import type { ParsedDashboard } from '../metadata/types.js';
 import { blockingValidationIssues, runValidation } from '../validation/registry.js';
 import { ValidationIssue } from '../validation/types.js';
@@ -191,6 +193,26 @@ export async function loadDashboardXml({
     focus.navigate === 'artifact' ? { ...focus, sheetName: canonicalName } : focus;
 
   if (requireExistingSheet) {
+    if (kind === 'dashboard') {
+      const zoneGuard = await zoneWorksheetWindowIssues({ fragmentXml: xml, executor, signal });
+      if (zoneGuard.isErr()) {
+        return Err({ type: 'execute-command-error', error: zoneGuard.error });
+      }
+      if (zoneGuard.value.length > 0) {
+        log({
+          level: 'error',
+          message:
+            'Dashboard zone references a worksheet with no live window — not sent to Tableau',
+          logger: 'dashboardCommands',
+          data: { dashboardName, issues: zoneGuard.value },
+        });
+        return Err({
+          type: 'load-dashboard-xml-error',
+          error: { type: 'validation-failed', issues: zoneGuard.value },
+        });
+      }
+    }
+
     const targetRef = dashboardFragmentSimpleId(xml) ?? canonicalName;
     const perSheetResult = await withApplyLock(() =>
       tryApplyViaPerSheetRoute({
@@ -323,6 +345,69 @@ async function loadDashboardXmlViaExternalApi({
 
     return Ok.EMPTY;
   });
+}
+
+// A per-dashboard apply posts only the <dashboard> fragment, so nothing reconciles its sheet zones
+// against live worksheet windows. Tableau resolves each sheet zone to a worksheet-class window as
+// it renders and asserts (oWindowID) when none exists — corrupting the dashboard so delete and undo
+// then fail. Refuse the apply when a zone names a worksheet with no live window.
+async function zoneWorksheetWindowIssues({
+  fragmentXml,
+  executor,
+  signal,
+}: { fragmentXml: string } & WithExecutorAndAbortSignal): Promise<
+  Result<ValidationIssue[], ExecuteCommandError>
+> {
+  const zoneWorksheetNames = dashboardZoneWorksheetNames(fragmentXml);
+  if (zoneWorksheetNames.length === 0) {
+    return Ok([]);
+  }
+  const workbookResult = await getWorkbookXml({ executor, signal });
+  if (workbookResult.isErr()) {
+    return Err(workbookResult.error);
+  }
+  const windowed = listWindowedWorksheetNames(parseXML(workbookResult.value));
+  const missing = zoneWorksheetNames.filter(
+    (name) => !windowed.some((windowName) => xmlNamesEqual(windowName, name)),
+  );
+  return Ok(missing.map(zoneWorksheetWindowIssue));
+}
+
+function dashboardZoneWorksheetNames(fragmentXml: string): string[] {
+  let doc: Document;
+  try {
+    doc = new DOMParser({ errorHandler: () => {} }).parseFromString(
+      fragmentXml.trim() || '<empty/>',
+      'text/xml',
+    ) as unknown as Document;
+  } catch {
+    return [];
+  }
+  // Worksheet zones are <zone name="Worksheet Name" .../>; layout, text, and blank zones carry
+  // type-v2 and do not name a worksheet.
+  const zones = xpath.select(
+    '//zone[@name and not(@type-v2)]',
+    doc as unknown as Node,
+  ) as Element[];
+  const names = zones
+    .map((zone) => zone.getAttribute('name'))
+    .filter((name): name is string => !!name);
+  return [...new Set(names)];
+}
+
+function zoneWorksheetWindowIssue(worksheetName: string): ValidationIssue {
+  return {
+    ruleId: 'dashboard-zone-worksheet-window',
+    severity: 'error',
+    message:
+      `This apply adds a zone for worksheet "${worksheetName}", but that worksheet has no live ` +
+      'window in the open workbook, so Tableau would leave the dashboard unable to delete or undo. ' +
+      'FIX: create the worksheet first (build-and-apply-worksheet or add-worksheet), then rebuild ' +
+      'the dashboard with compose-dashboard or run-dashboard-batch so its zones and windows are ' +
+      'created together.',
+    suggestion:
+      'Create the worksheet, then compose the dashboard so its zone and window are registered together.',
+  };
 }
 
 function sheetAbsentMessage(kind: LoadDashboardKind, canonicalName: string): string {

--- a/src/tools/desktop/authoring/sheets/composeDashboardCore.ts
+++ b/src/tools/desktop/authoring/sheets/composeDashboardCore.ts
@@ -5,12 +5,7 @@ import {
   deleteDashboard,
   listWorkbookDashboards,
 } from '../../../../desktop/metadata/dashboards.js';
-import {
-  findAllWorksheets,
-  normalizeArray,
-  parseXML,
-} from '../../../../desktop/metadata/parser.js';
-import type { ParsedWindow } from '../../../../desktop/metadata/types.js';
+import { listWindowedWorksheetNames, parseXML } from '../../../../desktop/metadata/parser.js';
 import { injectTemplate } from '../../../../desktop/templates/injectTemplate.js';
 import { targetDashboardInvariantIssues } from '../../../../desktop/validation/targetDashboardInvariant.js';
 import { getWorkbookXml } from '../../../../desktop/wrappers/getWorkbookXml.js';
@@ -514,17 +509,9 @@ export function resolveRenderedWorksheetNames(
   workbookXml: string,
   requestedNames: string[],
 ): Array<string | undefined> {
-  const workbook = parseXML(workbookXml);
-  const worksheetNames = findAllWorksheets(workbook).map((worksheet) => worksheet['@_name']);
-  const worksheetWindowNames = normalizeArray<ParsedWindow>(workbook.workbook?.windows?.window)
-    .filter((window) => window['@_class'] === 'worksheet')
-    .map((window) => window['@_name']);
+  const windowedWorksheetNames = listWindowedWorksheetNames(parseXML(workbookXml));
   return requestedNames.map((requestedName) =>
-    worksheetNames.find(
-      (worksheetName) =>
-        xmlNamesEqual(worksheetName, requestedName) &&
-        worksheetWindowNames.some((windowName) => xmlNamesEqual(windowName, worksheetName)),
-    ),
+    windowedWorksheetNames.find((worksheetName) => xmlNamesEqual(worksheetName, requestedName)),
   );
 }
 


### PR DESCRIPTION
## What this changes

`apply-dashboard` now refuses an in-place dashboard apply when one of the dashboard's sheet zones names a worksheet that has no live worksheet-class `<window>` in the open workbook. This is a rule the codebase now keeps for the per-dashboard (`requireExistingSheet`) route, not a one-off.

## Why

A dashboard sheet zone references its worksheet by `name=`. Tableau Desktop resolves that name to a registered worksheet-class window the instant it renders the zone, and asserts (`oWindowID` in `WindowCollection::GetWorksheetPointer`) when none exists. Once that happens the dashboard is wedged: `delete-sheet` and `undo-workbook` on it both hard-fail with an internal error, leaving no recovery path short of discarding the session.

A per-dashboard apply posts only the `<dashboard>` fragment, so the existing whole-workbook consistency rules — `dashboard-zones-reference-included-worksheets` and `worksheet-missing-window` — never run (they are workbook-context only, by design). That left a gap: a hand-edited cached dashboard XML that adds a zone for a not-yet-windowed worksheet applied "successfully" and corrupted live window state. The whole-workbook create paths (`build-and-apply-dashboard`, `compose-dashboard`, `run-dashboard-batch`) are unaffected — they register the window alongside the zone.

## How

- New `zoneWorksheetWindowIssues` preflight in `loadDashboardXml`, gated to the `requireExistingSheet` + `kind === 'dashboard'` path so batch/compose and storyboard routes are untouched.
- It only reads live state when the fragment actually contains worksheet zones (`//zone[@name and not(@type-v2)]`); otherwise it skips the read entirely.
- Reuses the windowed-worksheet check by extracting `listWindowedWorksheetNames` into `metadata/parser.ts` and having `composeDashboardCore`'s `resolveRenderedWorksheetNames` delegate to it (behavior-preserving).
- On violation, returns a `validation-failed` error whose message steers the agent to create the worksheet first, then rebuild the dashboard with `compose-dashboard` / `run-dashboard-batch`.

## Tests

Added five cases to `loadDashboardXml.test.ts`: blocks a zone naming an absent/unwindowed worksheet; blocks a worksheet present in the document but with no worksheet-class window; applies when the zone worksheet is live and windowed; skips the workbook read when the fragment has no worksheet zones; surfaces a workbook read failure as `execute-command-error`. Full desktop unit suite green; `npm run build:desktop` clean. (One pre-existing, unrelated HTTP-timeout test flake — fails identically on the clean tree.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
