### PR TITLE
@W-24004480: Raise staged workbook upload cap to 5GB

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "4.7.0",
+  "version": "4.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "4.7.0",
+      "version": "4.7.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1095.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "4.7.0",
+  "version": "4.7.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/src/tools/web/workbooks/stagedWorkbookUpload.ts
+++ b/src/tools/web/workbooks/stagedWorkbookUpload.ts
@@ -8,7 +8,7 @@ import {
   joinS3Prefix,
 } from '../s3Client.js';
 
-// Intentionally decimal GB (not GiB) to leave headroom under S3's 5,368,709,120-byte single-PUT ceiling.
+// Intentionally decimal GB (not GiB) to leave headroom under S3's 5GB single-PUT ceiling.
 export const MAX_STAGED_WORKBOOK_BYTES = 5 * 1000 * 1000 * 1000;
 export const WORKBOOK_UPLOAD_PREFIX_SEGMENT = 'workbook-uploads';
 

--- a/src/tools/web/workbooks/stagedWorkbookUpload.ts
+++ b/src/tools/web/workbooks/stagedWorkbookUpload.ts
@@ -8,7 +8,8 @@ import {
   joinS3Prefix,
 } from '../s3Client.js';
 
-export const MAX_STAGED_WORKBOOK_BYTES = 100 * 1024 * 1024;
+// Intentionally decimal GB (not GiB) to leave headroom under S3's 5,368,709,120-byte single-PUT ceiling.
+export const MAX_STAGED_WORKBOOK_BYTES = 5 * 1000 * 1000 * 1000;
 export const WORKBOOK_UPLOAD_PREFIX_SEGMENT = 'workbook-uploads';
 
 export type WorkbookFileType = 'twb' | 'twbx';


### PR DESCRIPTION
## Summary
- Raise `MAX_STAGED_WORKBOOK_BYTES` in `stagedWorkbookUpload.ts` from 100MB to 5GB (decimal), leaving headroom under S3's 5,368,709,120-byte single-PUT ceiling, to unblock publishing larger workbooks via the staged upload flow.

## Test plan
- [x] `npx vitest run` on the touched test files (27/27 passing)
- [x] `npx tsc --noEmit` shows no new errors