### PR TITLE
Resolve field captions to fieldName for embedded workbook datasource Pulse insights

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "4.7.1",
+  "version": "4.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "4.7.1",
+      "version": "4.7.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1095.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "4.7.1",
+  "version": "4.7.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/src/server/oauth/scopes.test.ts
+++ b/src/server/oauth/scopes.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from 'vitest';
 import * as configModule from '../../config.js';
 import {
   getRequiredApiScopesForTool,
+  getRequiredScopesForTool,
   getSupportedApiScopes,
   getSupportedMcpScopes,
   getSupportedScopes,
@@ -294,6 +295,20 @@ describe('scopes', () => {
 
       expect(scopes).toEqual(['tableau:workbooks:create', 'tableau:file_uploads:create']);
       expect(scopes).not.toContain('tableau:content:read');
+    });
+
+    it('should require content read and viz data service read for generate-pulse-metric-value-insight-bundle', () => {
+      // This tool calls VDS readMetadata and the Datasources REST API
+      // (queryDatasource) to resolve field captions and detect embedded
+      // workbook datasources, so it needs the same API scopes as
+      // generate-insight-cards, which makes the same calls.
+      const apiScopes = getRequiredApiScopesForTool('generate-pulse-metric-value-insight-bundle');
+      expect(apiScopes).toContain('tableau:content:read');
+      expect(apiScopes).toContain('tableau:viz_data_service:read');
+
+      mockGetConfig.mockReturnValue({ oauth: { enforceScopes: true } } as any);
+      const mcpScopes = getRequiredScopesForTool('generate-pulse-metric-value-insight-bundle');
+      expect(mcpScopes).toContain('tableau:mcp:datasource:read');
     });
 
     it('should include tableau:users:update when adminToolsEnabled is true', async () => {

--- a/src/server/oauth/scopes.ts
+++ b/src/server/oauth/scopes.ts
@@ -302,8 +302,13 @@ const toolScopeMap: Record<
     ]),
   },
   'generate-pulse-metric-value-insight-bundle': {
-    mcp: ['tableau:mcp:insight:create'],
-    api: new Set(['tableau:insights:read', 'tableau:mcp_site_settings:read']),
+    mcp: ['tableau:mcp:insight:create', 'tableau:mcp:datasource:read'],
+    api: new Set([
+      'tableau:insights:read',
+      'tableau:content:read',
+      'tableau:viz_data_service:read',
+      'tableau:mcp_site_settings:read',
+    ]),
   },
   'generate-pulse-insight-brief': {
     mcp: ['tableau:mcp:insight:create'],

--- a/src/tools/web/pulse/generateMetricValueInsightBundle/generatePulseMetricValueInsightBundleTool.test.ts
+++ b/src/tools/web/pulse/generateMetricValueInsightBundle/generatePulseMetricValueInsightBundleTool.test.ts
@@ -1,4 +1,5 @@
 import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { AxiosError } from 'axios';
 import { Err, Ok } from 'ts-results-es';
 
 import {
@@ -229,6 +230,31 @@ describe('getGeneratePulseMetricValueInsightBundleTool', () => {
     expect(result.isError).toBe(false);
   });
 
+  it('forwards the request unchanged when readMetadata throws instead of returning Err', async () => {
+    // readMetadata only returns Err for a 404 ('feature-disabled'); any other
+    // failure (auth, 5xx, network) throws instead.
+    mocks.mockReadMetadata.mockRejectedValue(
+      new AxiosError('Internal Server Error', 'ERR_BAD_RESPONSE', undefined, undefined, {
+        status: 500,
+        statusText: 'Internal Server Error',
+        data: {},
+        headers: {},
+        config: {} as any,
+      }),
+    );
+    mocks.mockGeneratePulseMetricValueInsightBundle.mockResolvedValue(
+      new Ok(mockBundleRequestResponse),
+    );
+
+    const result = await getToolResult();
+
+    expect(mocks.mockGeneratePulseMetricValueInsightBundle).toHaveBeenCalledWith(
+      bundleRequest,
+      'ban',
+    );
+    expect(result.isError).toBe(false);
+  });
+
   it('sets id_type to DATASOURCE_ID_TYPE_WORKBOOK_DATASOURCE when queryDatasource returns an embedded contentUrl', async () => {
     // Pulse must always call HBI directly (never a cached query result) for
     // embedded workbook datasources. Callers can't be relied on to set
@@ -257,8 +283,43 @@ describe('getGeneratePulseMetricValueInsightBundleTool', () => {
     expect(result.isError).toBe(false);
   });
 
-  it('sets id_type to DATASOURCE_ID_TYPE_WORKBOOK_DATASOURCE when queryDatasource does not recognize the LUID at all', async () => {
-    mocks.mockQueryDatasource.mockRejectedValue(new Error('not found'));
+  it('sets id_type to DATASOURCE_ID_TYPE_WORKBOOK_DATASOURCE when queryDatasource does not recognize the LUID at all (404)', async () => {
+    mocks.mockQueryDatasource.mockRejectedValue(
+      new AxiosError('Not Found', 'ERR_BAD_REQUEST', undefined, undefined, {
+        status: 404,
+        statusText: 'Not Found',
+        data: {},
+        headers: {},
+        config: {} as any,
+      }),
+    );
+    mocks.mockGeneratePulseMetricValueInsightBundle.mockResolvedValue(
+      new Ok(mockBundleRequestResponse),
+    );
+
+    const result = await getToolResult();
+
+    const [sentRequest] = mocks.mockGeneratePulseMetricValueInsightBundle.mock.calls[0];
+    expect(sentRequest.bundle_request.input.metric.definition.datasource).toEqual({
+      id: 'A6FC3C9F-4F40-4906-8DB0-AC70C5FB5A11',
+      id_type: 'DATASOURCE_ID_TYPE_WORKBOOK_DATASOURCE',
+    });
+    expect(result.isError).toBe(false);
+  });
+
+  it('defaults to DATASOURCE_ID_TYPE_WORKBOOK_DATASOURCE (and logs) when queryDatasource fails for a non-404 reason', async () => {
+    // A published/embedded lookup that fails for an operational reason (auth,
+    // 5xx, network) can't be distinguished from a genuinely unknown LUID, so
+    // it defaults the same way as a 404 — but this case is logged separately.
+    mocks.mockQueryDatasource.mockRejectedValue(
+      new AxiosError('Internal Server Error', 'ERR_BAD_RESPONSE', undefined, undefined, {
+        status: 500,
+        statusText: 'Internal Server Error',
+        data: {},
+        headers: {},
+        config: {} as any,
+      }),
+    );
     mocks.mockGeneratePulseMetricValueInsightBundle.mockResolvedValue(
       new Ok(mockBundleRequestResponse),
     );

--- a/src/tools/web/pulse/generateMetricValueInsightBundle/generatePulseMetricValueInsightBundleTool.test.ts
+++ b/src/tools/web/pulse/generateMetricValueInsightBundle/generatePulseMetricValueInsightBundleTool.test.ts
@@ -1,5 +1,5 @@
 import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
-import { Ok } from 'ts-results-es';
+import { Err, Ok } from 'ts-results-es';
 
 import {
   PulseDisabledError,
@@ -19,13 +19,22 @@ import { getGeneratePulseMetricValueInsightBundleTool } from './generatePulseMet
 const { resetResourceAccessCheckerSingleton } = resourceAccessCheckerExportedForTesting;
 const mocks = vi.hoisted(() => ({
   mockGeneratePulseMetricValueInsightBundle: vi.fn(),
+  mockReadMetadata: vi.fn(),
+  mockQueryDatasource: vi.fn(),
 }));
 
 vi.mock('../../../../restApiInstance.js', () => ({
   useRestApi: vi.fn().mockImplementation(async ({ callback }) =>
     callback({
+      siteId: 'site-id',
       pulseMethods: {
         generatePulseMetricValueInsightBundle: mocks.mockGeneratePulseMetricValueInsightBundle,
+      },
+      vizqlDataServiceMethods: {
+        readMetadata: mocks.mockReadMetadata,
+      },
+      datasourcesMethods: {
+        queryDatasource: mocks.mockQueryDatasource,
       },
     }),
   ),
@@ -120,6 +129,8 @@ describe('getGeneratePulseMetricValueInsightBundleTool', () => {
     vi.unstubAllEnvs();
     stubDefaultEnvVars();
     resetResourceAccessCheckerSingleton();
+    mocks.mockReadMetadata.mockResolvedValue(new Ok({ data: [] }));
+    mocks.mockQueryDatasource.mockResolvedValue({ name: 'Some Datasource' });
   });
 
   afterEach(() => {
@@ -173,6 +184,88 @@ describe('getGeneratePulseMetricValueInsightBundleTool', () => {
       expect(parsedValue).toEqual(mockBundleRequestResponse);
     },
   );
+
+  it('resolves field captions to fieldName using VDS metadata before calling Pulse', async () => {
+    // The Insight Service validates `field` against HBI metadata's fieldName,
+    // not fieldCaption. Callers build bundleRequest from captions (all
+    // getDatasourceMetadata exposes), so a calc field's caption must be
+    // resolved to its fieldName before the request reaches Pulse.
+    mocks.mockReadMetadata.mockResolvedValue(
+      new Ok({
+        data: [
+          { fieldCaption: 'Sales', fieldName: 'Calculation_0013913069531140' },
+          { fieldCaption: 'Order Date', fieldName: 'Order Date' },
+        ],
+      }),
+    );
+    mocks.mockGeneratePulseMetricValueInsightBundle.mockResolvedValue(
+      new Ok(mockBundleRequestResponse),
+    );
+
+    const result = await getToolResult();
+
+    expect(mocks.mockReadMetadata).toHaveBeenCalledWith({
+      datasource: { datasourceLuid: 'A6FC3C9F-4F40-4906-8DB0-AC70C5FB5A11' },
+    });
+    const [sentRequest] = mocks.mockGeneratePulseMetricValueInsightBundle.mock.calls[0];
+    const basicSpec = sentRequest.bundle_request.input.metric.definition.basic_specification;
+    expect(basicSpec.measure.field).toBe('Calculation_0013913069531140');
+    expect(basicSpec.time_dimension.field).toBe('Order Date');
+    expect(result.isError).toBe(false);
+  });
+
+  it('forwards the request unchanged when metadata cannot be read', async () => {
+    mocks.mockReadMetadata.mockResolvedValue(new Err('boom'));
+    mocks.mockGeneratePulseMetricValueInsightBundle.mockResolvedValue(
+      new Ok(mockBundleRequestResponse),
+    );
+
+    const result = await getToolResult();
+
+    expect(mocks.mockGeneratePulseMetricValueInsightBundle).toHaveBeenCalledWith(
+      bundleRequest,
+      'ban',
+    );
+    expect(result.isError).toBe(false);
+  });
+
+  it('sets id_type to DATASOURCE_ID_TYPE_WORKBOOK_DATASOURCE when the datasource is not a published datasource', async () => {
+    // Pulse must always call HBI directly (never a cached query result) for
+    // embedded workbook datasources. Callers can't be relied on to set
+    // id_type themselves, so the tool detects it: queryDatasource (the
+    // published Datasources REST API) doesn't recognize an embedded LUID.
+    mocks.mockQueryDatasource.mockRejectedValue(new Error('not found'));
+    mocks.mockGeneratePulseMetricValueInsightBundle.mockResolvedValue(
+      new Ok(mockBundleRequestResponse),
+    );
+
+    const result = await getToolResult();
+
+    expect(mocks.mockQueryDatasource).toHaveBeenCalledWith({
+      siteId: 'site-id',
+      datasourceId: 'A6FC3C9F-4F40-4906-8DB0-AC70C5FB5A11',
+    });
+    const [sentRequest] = mocks.mockGeneratePulseMetricValueInsightBundle.mock.calls[0];
+    expect(sentRequest.bundle_request.input.metric.definition.datasource).toEqual({
+      id: 'A6FC3C9F-4F40-4906-8DB0-AC70C5FB5A11',
+      id_type: 'DATASOURCE_ID_TYPE_WORKBOOK_DATASOURCE',
+    });
+    expect(result.isError).toBe(false);
+  });
+
+  it('leaves id_type unset when the datasource resolves as a published datasource', async () => {
+    mocks.mockGeneratePulseMetricValueInsightBundle.mockResolvedValue(
+      new Ok(mockBundleRequestResponse),
+    );
+
+    const result = await getToolResult();
+
+    const [sentRequest] = mocks.mockGeneratePulseMetricValueInsightBundle.mock.calls[0];
+    expect(sentRequest.bundle_request.input.metric.definition.datasource).toEqual({
+      id: 'A6FC3C9F-4F40-4906-8DB0-AC70C5FB5A11',
+    });
+    expect(result.isError).toBe(false);
+  });
 
   it('should have correct tool properties', () => {
     const tool = getGeneratePulseMetricValueInsightBundleTool(new WebMcpServer());

--- a/src/tools/web/pulse/generateMetricValueInsightBundle/generatePulseMetricValueInsightBundleTool.test.ts
+++ b/src/tools/web/pulse/generateMetricValueInsightBundle/generatePulseMetricValueInsightBundleTool.test.ts
@@ -229,12 +229,16 @@ describe('getGeneratePulseMetricValueInsightBundleTool', () => {
     expect(result.isError).toBe(false);
   });
 
-  it('sets id_type to DATASOURCE_ID_TYPE_WORKBOOK_DATASOURCE when the datasource is not a published datasource', async () => {
+  it('sets id_type to DATASOURCE_ID_TYPE_WORKBOOK_DATASOURCE when queryDatasource returns an embedded contentUrl', async () => {
     // Pulse must always call HBI directly (never a cached query result) for
     // embedded workbook datasources. Callers can't be relied on to set
-    // id_type themselves, so the tool detects it: queryDatasource (the
-    // published Datasources REST API) doesn't recognize an embedded LUID.
-    mocks.mockQueryDatasource.mockRejectedValue(new Error('not found'));
+    // id_type themselves, so the tool detects it: the Datasources REST API
+    // resolves embedded/workbook datasource LUIDs too, but marks them with a
+    // contentUrl of the form '$embedded$_<workbookLuid>' instead of 404ing.
+    mocks.mockQueryDatasource.mockResolvedValue({
+      name: 'SalesCloud',
+      contentUrl: '$embedded$_857cae8f-aaee-4e7a-ad78-851b465b5121',
+    });
     mocks.mockGeneratePulseMetricValueInsightBundle.mockResolvedValue(
       new Ok(mockBundleRequestResponse),
     );
@@ -245,6 +249,22 @@ describe('getGeneratePulseMetricValueInsightBundleTool', () => {
       siteId: 'site-id',
       datasourceId: 'A6FC3C9F-4F40-4906-8DB0-AC70C5FB5A11',
     });
+    const [sentRequest] = mocks.mockGeneratePulseMetricValueInsightBundle.mock.calls[0];
+    expect(sentRequest.bundle_request.input.metric.definition.datasource).toEqual({
+      id: 'A6FC3C9F-4F40-4906-8DB0-AC70C5FB5A11',
+      id_type: 'DATASOURCE_ID_TYPE_WORKBOOK_DATASOURCE',
+    });
+    expect(result.isError).toBe(false);
+  });
+
+  it('sets id_type to DATASOURCE_ID_TYPE_WORKBOOK_DATASOURCE when queryDatasource does not recognize the LUID at all', async () => {
+    mocks.mockQueryDatasource.mockRejectedValue(new Error('not found'));
+    mocks.mockGeneratePulseMetricValueInsightBundle.mockResolvedValue(
+      new Ok(mockBundleRequestResponse),
+    );
+
+    const result = await getToolResult();
+
     const [sentRequest] = mocks.mockGeneratePulseMetricValueInsightBundle.mock.calls[0];
     expect(sentRequest.bundle_request.input.metric.definition.datasource).toEqual({
       id: 'A6FC3C9F-4F40-4906-8DB0-AC70C5FB5A11',

--- a/src/tools/web/pulse/generateMetricValueInsightBundle/generatePulseMetricValueInsightBundleTool.ts
+++ b/src/tools/web/pulse/generateMetricValueInsightBundle/generatePulseMetricValueInsightBundleTool.ts
@@ -279,18 +279,23 @@ async function resolveBundleRequestFieldNames(
   };
 }
 
-// Published datasources resolve via the Datasources REST API; embedded
-// workbook datasources don't exist there, so a failed lookup identifies one.
+// The Datasources REST API returns an entry for embedded/workbook datasources
+// too (it doesn't 404), but marks them with a contentUrl of the form
+// '$embedded$_<workbookLuid>' instead of a normal published contentUrl. A
+// LUID the API doesn't recognize at all is treated the same way, since
+// Pulse's HBI-direct, uncached path is the safer default for an unknown ID.
 async function resolveDatasourceIdType(
   restApi: RestApi,
   datasourceLuid: string,
 ): Promise<'DATASOURCE_ID_TYPE_WORKBOOK_DATASOURCE' | undefined> {
   try {
-    await restApi.datasourcesMethods.queryDatasource({
+    const datasource = await restApi.datasourcesMethods.queryDatasource({
       siteId: restApi.siteId,
       datasourceId: datasourceLuid,
     });
-    return undefined;
+    return datasource.contentUrl?.startsWith('$embedded$')
+      ? 'DATASOURCE_ID_TYPE_WORKBOOK_DATASOURCE'
+      : undefined;
   } catch {
     return 'DATASOURCE_ID_TYPE_WORKBOOK_DATASOURCE';
   }

--- a/src/tools/web/pulse/generateMetricValueInsightBundle/generatePulseMetricValueInsightBundleTool.ts
+++ b/src/tools/web/pulse/generateMetricValueInsightBundle/generatePulseMetricValueInsightBundleTool.ts
@@ -14,6 +14,12 @@ import {
 import { WebMcpServer } from '../../../../server.web.js';
 import { isAxiosError } from '../../../../utils/axios.js';
 import { WebTool } from '../../tool.js';
+import {
+  applyFieldNameResolution,
+  buildFieldNameByCaption,
+  resolveIdTypeFromContentUrl,
+  WorkbookDatasourceIdType,
+} from '../resolveBundleRequestFieldNames.js';
 import { validateBundleRequest } from '../validatePulsePayload.js';
 
 const paramsSchema = {
@@ -233,66 +239,11 @@ async function resolveBundleRequestFieldNames(
     resolveDatasourceIdType(restApi, datasourceLuid),
   ]);
 
-  const fieldNameByCaption = new Map<string, string>();
-  if (metadataResult.isOk()) {
-    for (const field of metadataResult.value.data ?? []) {
-      if (typeof field.fieldCaption === 'string' && typeof field.fieldName === 'string') {
-        fieldNameByCaption.set(field.fieldCaption, field.fieldName);
-      }
-    }
-  }
-  const toFieldName = (caption: string): string => fieldNameByCaption.get(caption) ?? caption;
+  const fieldNameByCaption = metadataResult.isOk()
+    ? buildFieldNameByCaption(metadataResult.value.data ?? [])
+    : new Map<string, string>();
 
-  const metric = bundleRequest.bundle_request.input.metric;
-  const basicSpecification = metric.definition.basic_specification;
-
-  return {
-    ...bundleRequest,
-    bundle_request: {
-      ...bundleRequest.bundle_request,
-      input: {
-        ...bundleRequest.bundle_request.input,
-        metric: {
-          ...metric,
-          definition: {
-            ...metric.definition,
-            datasource: {
-              ...datasource,
-              ...(idType ? { id_type: idType } : {}),
-            },
-            basic_specification: {
-              ...basicSpecification,
-              measure: {
-                ...basicSpecification.measure,
-                field: toFieldName(basicSpecification.measure.field),
-              },
-              time_dimension: {
-                ...basicSpecification.time_dimension,
-                field: toFieldName(basicSpecification.time_dimension.field),
-              },
-              filters: basicSpecification.filters.map((filter) => ({
-                ...filter,
-                field: toFieldName(filter.field),
-              })),
-            },
-          },
-          metric_specification: {
-            ...metric.metric_specification,
-            filters: metric.metric_specification.filters?.map((filter) => ({
-              ...filter,
-              field: toFieldName(filter.field),
-            })),
-          },
-          extension_options: metric.extension_options
-            ? {
-                ...metric.extension_options,
-                allowed_dimensions: metric.extension_options.allowed_dimensions?.map(toFieldName),
-              }
-            : metric.extension_options,
-        },
-      },
-    },
-  };
+  return applyFieldNameResolution(bundleRequest, fieldNameByCaption, idType);
 }
 
 // The Datasources REST API returns an entry for embedded/workbook datasources
@@ -306,15 +257,13 @@ async function resolveBundleRequestFieldNames(
 async function resolveDatasourceIdType(
   restApi: RestApi,
   datasourceLuid: string,
-): Promise<'DATASOURCE_ID_TYPE_WORKBOOK_DATASOURCE' | undefined> {
+): Promise<WorkbookDatasourceIdType | undefined> {
   try {
     const datasource = await restApi.datasourcesMethods.queryDatasource({
       siteId: restApi.siteId,
       datasourceId: datasourceLuid,
     });
-    return datasource.contentUrl?.startsWith('$embedded$')
-      ? 'DATASOURCE_ID_TYPE_WORKBOOK_DATASOURCE'
-      : undefined;
+    return resolveIdTypeFromContentUrl(datasource.contentUrl);
   } catch (error) {
     const isNotFound = isAxiosError(error) && error.response?.status === 404;
     if (!isNotFound) {

--- a/src/tools/web/pulse/generateMetricValueInsightBundle/generatePulseMetricValueInsightBundleTool.ts
+++ b/src/tools/web/pulse/generateMetricValueInsightBundle/generatePulseMetricValueInsightBundleTool.ts
@@ -3,6 +3,7 @@ import z from 'zod';
 
 import { ArgsValidationError, DatasourceNotAllowedError } from '../../../../errors/mcpToolError.js';
 import { useRestApi } from '../../../../restApiInstance.js';
+import { RestApi } from '../../../../sdks/tableau/restApi.js';
 import {
   pulseBundleRequestSchema,
   PulseBundleResponse,
@@ -32,9 +33,7 @@ Generate an insight bundle for the current aggregated value for Pulse Metric usi
     - time_zone: 'UTC'
     - language: 'LANGUAGE_EN_US'
     - locale: 'LOCALE_EN_US'
-    - The \`datasource\` field under \`metric.definition\` requires an \`id\` (datasource LUID) and accepts an optional \`id_type\`:
-      - Omit \`id_type\` for standard published datasources (default behavior).
-      - Use \`'DATASOURCE_ID_TYPE_WORKBOOK_DATASOURCE'\` when the metric is based on an embedded workbook datasource rather than a published datasource.
+    - The \`datasource\` field under \`metric.definition\` requires an \`id\` (datasource LUID). An optional \`id_type\` may also be set, but it does not need to be — this tool automatically detects embedded workbook datasources and sets \`id_type\` accordingly.
 - \`bundleType\` (optional): The type of bundle to generate.  The default is 'ban'.
   - 'ban' - Return a basic insight bundle with the current aggregated value for the Pulse Metric, period over period change, and the highest ranked insight for each filterable dimension of the metric.
   - 'springboard' - Return a springboard insight bundle with the current value, period over period change, and the highest ranked insight for the metric.
@@ -171,7 +170,7 @@ Generate an insight bundle for the current aggregated value for Pulse Metric usi
             jwtScopes: generatePulseMetricValueInsightBundleTool.requiredApiScopes,
             callback: async (restApi) =>
               await restApi.pulseMethods.generatePulseMetricValueInsightBundle(
-                bundleRequest,
+                await resolveBundleRequestFieldNames(restApi, bundleRequest),
                 bundleType ?? 'ban',
               ),
           });
@@ -190,3 +189,109 @@ Generate an insight bundle for the current aggregated value for Pulse Metric usi
 
   return generatePulseMetricValueInsightBundleTool;
 };
+
+// The Insight Service validates every `field` string against HBI metadata's
+// fieldName, not fieldCaption. Callers build bundleRequest from field captions
+// (that's all getDatasourceMetadata exposes), so a calculated field's caption
+// (e.g. "Amount_Billions") 400s while its underlying fieldName (e.g.
+// "Calculation_00...") succeeds. VDS readMetadata returns both, so resolve
+// caption -> fieldName here before forwarding to Pulse. Best-effort: if
+// metadata can't be read, forward the request unchanged rather than blocking
+// the call — this is a caption/fieldName workaround, not a hard dependency.
+//
+// Separately, Pulse must always call HBI directly (never a cached query
+// result) for embedded/workbook datasources, which requires
+// id_type: 'DATASOURCE_ID_TYPE_WORKBOOK_DATASOURCE' on the request. Callers
+// can't be relied on to set this themselves, so determine it here: a LUID
+// that queryDatasource (the published Datasources REST API) doesn't
+// recognize is an embedded workbook datasource.
+async function resolveBundleRequestFieldNames(
+  restApi: RestApi,
+  bundleRequest: z.infer<typeof pulseBundleRequestSchema>,
+): Promise<z.infer<typeof pulseBundleRequestSchema>> {
+  const datasource = bundleRequest.bundle_request.input.metric.definition.datasource;
+  const datasourceLuid = datasource.id;
+
+  const [metadataResult, idType] = await Promise.all([
+    restApi.vizqlDataServiceMethods.readMetadata({ datasource: { datasourceLuid } }),
+    resolveDatasourceIdType(restApi, datasourceLuid),
+  ]);
+
+  const fieldNameByCaption = new Map<string, string>();
+  if (metadataResult.isOk()) {
+    for (const field of metadataResult.value.data ?? []) {
+      if (typeof field.fieldCaption === 'string' && typeof field.fieldName === 'string') {
+        fieldNameByCaption.set(field.fieldCaption, field.fieldName);
+      }
+    }
+  }
+  const toFieldName = (caption: string): string => fieldNameByCaption.get(caption) ?? caption;
+
+  const metric = bundleRequest.bundle_request.input.metric;
+  const basicSpecification = metric.definition.basic_specification;
+
+  return {
+    ...bundleRequest,
+    bundle_request: {
+      ...bundleRequest.bundle_request,
+      input: {
+        ...bundleRequest.bundle_request.input,
+        metric: {
+          ...metric,
+          definition: {
+            ...metric.definition,
+            datasource: {
+              ...datasource,
+              ...(idType ? { id_type: idType } : {}),
+            },
+            basic_specification: {
+              ...basicSpecification,
+              measure: {
+                ...basicSpecification.measure,
+                field: toFieldName(basicSpecification.measure.field),
+              },
+              time_dimension: {
+                ...basicSpecification.time_dimension,
+                field: toFieldName(basicSpecification.time_dimension.field),
+              },
+              filters: basicSpecification.filters.map((filter) => ({
+                ...filter,
+                field: toFieldName(filter.field),
+              })),
+            },
+          },
+          metric_specification: {
+            ...metric.metric_specification,
+            filters: metric.metric_specification.filters?.map((filter) => ({
+              ...filter,
+              field: toFieldName(filter.field),
+            })),
+          },
+          extension_options: metric.extension_options
+            ? {
+                ...metric.extension_options,
+                allowed_dimensions: metric.extension_options.allowed_dimensions?.map(toFieldName),
+              }
+            : metric.extension_options,
+        },
+      },
+    },
+  };
+}
+
+// Published datasources resolve via the Datasources REST API; embedded
+// workbook datasources don't exist there, so a failed lookup identifies one.
+async function resolveDatasourceIdType(
+  restApi: RestApi,
+  datasourceLuid: string,
+): Promise<'DATASOURCE_ID_TYPE_WORKBOOK_DATASOURCE' | undefined> {
+  try {
+    await restApi.datasourcesMethods.queryDatasource({
+      siteId: restApi.siteId,
+      datasourceId: datasourceLuid,
+    });
+    return undefined;
+  } catch {
+    return 'DATASOURCE_ID_TYPE_WORKBOOK_DATASOURCE';
+  }
+}

--- a/src/tools/web/pulse/generateMetricValueInsightBundle/generatePulseMetricValueInsightBundleTool.ts
+++ b/src/tools/web/pulse/generateMetricValueInsightBundle/generatePulseMetricValueInsightBundleTool.ts
@@ -1,7 +1,9 @@
 import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { Err } from 'ts-results-es';
 import z from 'zod';
 
 import { ArgsValidationError, DatasourceNotAllowedError } from '../../../../errors/mcpToolError.js';
+import { log } from '../../../../logging/logger.js';
 import { useRestApi } from '../../../../restApiInstance.js';
 import { RestApi } from '../../../../sdks/tableau/restApi.js';
 import {
@@ -10,6 +12,7 @@ import {
   pulseInsightBundleTypeEnum,
 } from '../../../../sdks/tableau/types/pulse.js';
 import { WebMcpServer } from '../../../../server.web.js';
+import { isAxiosError } from '../../../../utils/axios.js';
 import { WebTool } from '../../tool.js';
 import { validateBundleRequest } from '../validatePulsePayload.js';
 
@@ -213,7 +216,20 @@ async function resolveBundleRequestFieldNames(
   const datasourceLuid = datasource.id;
 
   const [metadataResult, idType] = await Promise.all([
-    restApi.vizqlDataServiceMethods.readMetadata({ datasource: { datasourceLuid } }),
+    // readMetadata only returns Err for a 404 ('feature-disabled'); any other
+    // failure (auth, 5xx, network) throws. Catch it here too so a metadata
+    // outage forwards the request unchanged instead of failing the whole call.
+    restApi.vizqlDataServiceMethods
+      .readMetadata({ datasource: { datasourceLuid } })
+      .catch((error): Err<'feature-disabled'> => {
+        log({
+          message: `readMetadata failed for datasource ${datasourceLuid}; forwarding field captions unchanged`,
+          level: 'warning',
+          logger: 'pulse',
+          data: error,
+        });
+        return Err('feature-disabled');
+      }),
     resolveDatasourceIdType(restApi, datasourceLuid),
   ]);
 
@@ -282,8 +298,11 @@ async function resolveBundleRequestFieldNames(
 // The Datasources REST API returns an entry for embedded/workbook datasources
 // too (it doesn't 404), but marks them with a contentUrl of the form
 // '$embedded$_<workbookLuid>' instead of a normal published contentUrl. A
-// LUID the API doesn't recognize at all is treated the same way, since
-// Pulse's HBI-direct, uncached path is the safer default for an unknown ID.
+// LUID the API genuinely doesn't recognize (404) is treated the same way,
+// since Pulse's HBI-direct, uncached path is the safer default for an
+// unknown ID. Any other failure (auth, 5xx, network) can't distinguish
+// published from embedded either, so it defaults the same way, but is logged
+// separately since it's an operational problem rather than an expected case.
 async function resolveDatasourceIdType(
   restApi: RestApi,
   datasourceLuid: string,
@@ -296,7 +315,16 @@ async function resolveDatasourceIdType(
     return datasource.contentUrl?.startsWith('$embedded$')
       ? 'DATASOURCE_ID_TYPE_WORKBOOK_DATASOURCE'
       : undefined;
-  } catch {
+  } catch (error) {
+    const isNotFound = isAxiosError(error) && error.response?.status === 404;
+    if (!isNotFound) {
+      log({
+        message: `queryDatasource failed for datasource ${datasourceLuid} with a non-404 error; defaulting to DATASOURCE_ID_TYPE_WORKBOOK_DATASOURCE since published/embedded status could not be verified`,
+        level: 'warning',
+        logger: 'pulse',
+        data: error,
+      });
+    }
     return 'DATASOURCE_ID_TYPE_WORKBOOK_DATASOURCE';
   }
 }

--- a/src/tools/web/pulse/insights/generateInsightCardsTool.test.ts
+++ b/src/tools/web/pulse/insights/generateInsightCardsTool.test.ts
@@ -391,6 +391,122 @@ describe('getGenerateInsightCardsTool', () => {
     expect(req.definition.basic_specification.filters).toEqual([]);
   });
 
+  it('resolves field captions to fieldName using VDS metadata before calling Pulse', async () => {
+    // Same caption/fieldName mismatch handled in generatePulseMetricValueInsightBundleTool:
+    // the Insight Service validates `field` against HBI metadata's fieldName, not
+    // fieldCaption, so a calculated field's caption must be resolved before the
+    // request reaches Pulse. See resolveBundleRequestFieldNames.ts.
+    mocks.mockListDatasources.mockResolvedValue({
+      datasources: [{ id: 'ds-luid', name: 'GUS Work', contentUrl: 'GUS-Work' }],
+    });
+    mocks.mockReadMetadata.mockResolvedValue(
+      Ok({
+        data: [
+          { fieldCaption: 'Created Date', fieldName: 'Created Date', dataType: 'DATE' },
+          {
+            fieldCaption: 'Cases',
+            fieldName: 'Calculation_0013913069531140',
+            dataType: 'INTEGER',
+          },
+        ],
+      }),
+    );
+    mocks.mockGenerateBundle.mockResolvedValue(
+      Ok({
+        bundle_response: {
+          result: {
+            insight_groups: [
+              {
+                type: 'ban',
+                summaries: [],
+                insights: [
+                  {
+                    insight_type: 'popc',
+                    result: {
+                      type: 'popc',
+                      version: 1,
+                      question: '',
+                      score: 1,
+                      markup: 'Cases are up 12%',
+                      facts: { formatted_current_value: '2.2K', delta_percent: 12 },
+                    },
+                  },
+                ],
+              },
+            ],
+            has_errors: false,
+            characterization: 'CHARACTERIZATION_UNSPECIFIED',
+          },
+        },
+      }),
+    );
+
+    const result = await getToolResult();
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+    const parsed = JSON.parse(result.content[0].text);
+    const req = parsed.cards[0].briefConfig.args.bundleRequest.bundle_request.input.metric;
+    expect(req.definition.basic_specification.measure.field).toBe('Calculation_0013913069531140');
+    expect(req.definition.basic_specification.time_dimension.field).toBe('Created Date');
+  });
+
+  it('sets id_type to DATASOURCE_ID_TYPE_WORKBOOK_DATASOURCE for an embedded workbook datasource', async () => {
+    // resolveDatasource resolves { luid } input via queryDatasource, whose
+    // contentUrl for an embedded/workbook datasource is '$embedded$_<workbookLuid>'.
+    // Pulse must always call HBI directly (id_type set) for those.
+    mocks.mockQueryDatasource.mockResolvedValue({
+      name: 'SalesCloud',
+      contentUrl: '$embedded$_857cae8f-aaee-4e7a-ad78-851b465b5121',
+    });
+    mocks.mockReadMetadata.mockResolvedValue(
+      Ok({
+        data: [
+          { fieldCaption: 'Created Date', dataType: 'DATE' },
+          { fieldCaption: 'Cases', dataType: 'INTEGER' },
+        ],
+      }),
+    );
+    mocks.mockGenerateBundle.mockResolvedValue(
+      Ok({
+        bundle_response: {
+          result: {
+            insight_groups: [
+              {
+                type: 'ban',
+                summaries: [],
+                insights: [
+                  {
+                    insight_type: 'popc',
+                    result: {
+                      type: 'popc',
+                      version: 1,
+                      question: '',
+                      score: 1,
+                      markup: 'Cases are up 12%',
+                      facts: { formatted_current_value: '2.2K', delta_percent: 12 },
+                    },
+                  },
+                ],
+              },
+            ],
+            has_errors: false,
+            characterization: 'CHARACTERIZATION_UNSPECIFIED',
+          },
+        },
+      }),
+    );
+
+    const result = await getToolResult({ datasource: { luid: 'ds-luid' } });
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+    const parsed = JSON.parse(result.content[0].text);
+    const req = parsed.cards[0].briefConfig.args.bundleRequest.bundle_request.input.metric;
+    expect(req.definition.datasource).toEqual({
+      id: 'ds-luid',
+      id_type: 'DATASOURCE_ID_TYPE_WORKBOOK_DATASOURCE',
+    });
+  });
+
   it('parses delta direction from markup when facts omit percentage', async () => {
     mocks.mockListDatasources.mockResolvedValue({
       datasources: [{ id: 'ds-luid', name: 'GUS Work', contentUrl: 'GUS-Work' }],

--- a/src/tools/web/pulse/insights/generateInsightCardsTool.ts
+++ b/src/tools/web/pulse/insights/generateInsightCardsTool.ts
@@ -18,6 +18,11 @@ import { getVizqlDataServiceDisabledError } from '../../getVizqlDataServiceDisab
 import { resourceAccessChecker } from '../../resourceAccessChecker.js';
 import { WebTool } from '../../tool.js';
 import { TableauWebRequestHandlerExtra } from '../../toolContext.js';
+import {
+  applyFieldNameResolution,
+  buildFieldNameByCaption,
+  resolveIdTypeFromContentUrl,
+} from '../resolveBundleRequestFieldNames.js';
 import { buildInsightBundleRequest } from './requestBuilder.js';
 import { runInsightBundle } from './runInsightBundle.js';
 
@@ -290,18 +295,31 @@ export const getGenerateInsightCardsTool = (server: WebMcpServer): WebTool<typeo
               const activeDimensions = breakdownDimension ? [breakdownDimension] : allDimensions;
               const primaryDimension = activeDimensions[0] ?? null;
 
+              // Reuse the metadata and contentUrl already fetched above (via
+              // readMetadata / resolveDatasource) rather than re-fetching them
+              // per bundle request — this datasource is the same for every
+              // measure in this call. See resolveBundleRequestFieldNames.ts for
+              // why captions need resolving to fieldNames and why embedded
+              // workbook datasources need id_type set.
+              const fieldNameByCaption = buildFieldNameByCaption(metadataFields);
+              const idType = resolveIdTypeFromContentUrl(resolved.contentUrl);
+
               const cards: InsightCard[] = [];
               const bundleErrors: Array<{ measure: string; error: string }> = [];
               let firstBundleError: McpToolError | null = null;
               for (const measure of selectedMeasures) {
-                const request = buildInsightBundleRequest({
-                  datasourceLuid: resolved.luid,
-                  datasourceName: resolved.name,
-                  measure,
-                  timeField: selectedTimeField,
-                  allowedDimensions: activeDimensions,
-                  filters,
-                });
+                const request = applyFieldNameResolution(
+                  buildInsightBundleRequest({
+                    datasourceLuid: resolved.luid,
+                    datasourceName: resolved.name,
+                    measure,
+                    timeField: selectedTimeField,
+                    allowedDimensions: activeDimensions,
+                    filters,
+                  }),
+                  fieldNameByCaption,
+                  idType,
+                );
                 const bundle = await runInsightBundle({
                   extra,
                   request,

--- a/src/tools/web/pulse/resolveBundleRequestFieldNames.test.ts
+++ b/src/tools/web/pulse/resolveBundleRequestFieldNames.test.ts
@@ -1,0 +1,118 @@
+import {
+  applyFieldNameResolution,
+  buildFieldNameByCaption,
+  resolveIdTypeFromContentUrl,
+} from './resolveBundleRequestFieldNames.js';
+
+describe('resolveBundleRequestFieldNames', () => {
+  describe('buildFieldNameByCaption', () => {
+    it('maps caption to fieldName, skipping fields missing either', () => {
+      const map = buildFieldNameByCaption([
+        { fieldCaption: 'Sales', fieldName: 'Calculation_123' },
+        { fieldCaption: 'Order Date', fieldName: 'Order Date' },
+        { fieldCaption: 'Missing Field Name' },
+        { fieldName: 'Missing Caption' },
+      ]);
+
+      expect(map.get('Sales')).toBe('Calculation_123');
+      expect(map.get('Order Date')).toBe('Order Date');
+      expect(map.size).toBe(2);
+    });
+  });
+
+  describe('resolveIdTypeFromContentUrl', () => {
+    it('returns the workbook datasource id_type for an embedded contentUrl', () => {
+      expect(resolveIdTypeFromContentUrl('$embedded$_857cae8f-aaee-4e7a-ad78')).toBe(
+        'DATASOURCE_ID_TYPE_WORKBOOK_DATASOURCE',
+      );
+    });
+
+    it('returns undefined for a published contentUrl', () => {
+      expect(resolveIdTypeFromContentUrl('SalesCloud')).toBeUndefined();
+    });
+
+    it('returns undefined when contentUrl is undefined', () => {
+      expect(resolveIdTypeFromContentUrl(undefined)).toBeUndefined();
+    });
+  });
+
+  describe('applyFieldNameResolution', () => {
+    const baseRequest = {
+      bundle_request: {
+        version: 1 as const,
+        options: {
+          output_format: 'OUTPUT_FORMAT_HTML' as const,
+          time_zone: 'UTC',
+          language: 'LANGUAGE_EN_US' as const,
+          locale: 'LOCALE_EN_US' as const,
+        },
+        input: {
+          metadata: { name: 'Metric' },
+          metric: {
+            definition: {
+              datasource: { id: 'ds-luid' },
+              basic_specification: {
+                measure: { field: 'Sales', aggregation: 'AGGREGATION_SUM' as const },
+                time_dimension: { field: 'Order Date' },
+                filters: [{ field: 'Region', operator: 'OPERATOR_EQUAL' as const }],
+              },
+              is_running_total: false,
+            },
+            metric_specification: {
+              filters: [{ field: 'Segment', operator: 'OPERATOR_EQUAL' as const }],
+              measurement_period: {
+                granularity: 'GRANULARITY_BY_MONTH' as const,
+                range: 'RANGE_LAST_COMPLETE' as const,
+              },
+              comparison: { comparison: 'TIME_COMPARISON_PREVIOUS_PERIOD' as const },
+            },
+            extension_options: {
+              allowed_dimensions: ['Region'],
+              allowed_granularities: [],
+              offset_from_today: 0,
+            },
+          },
+        },
+      },
+    };
+
+    it('rewrites measure, time_dimension, filters, and allowed_dimensions to fieldNames', () => {
+      const fieldNameByCaption = new Map([
+        ['Sales', 'Calculation_123'],
+        ['Region', 'Calculation_456'],
+      ]);
+
+      const result = applyFieldNameResolution(baseRequest as any, fieldNameByCaption);
+      const metric = result.bundle_request.input.metric;
+
+      expect(metric.definition.basic_specification.measure.field).toBe('Calculation_123');
+      // Not in the map -> forwarded unchanged rather than dropped.
+      expect(metric.definition.basic_specification.time_dimension.field).toBe('Order Date');
+      expect(metric.definition.basic_specification.filters[0].field).toBe('Calculation_456');
+      expect(metric.metric_specification.filters?.[0].field).toBe('Segment');
+      expect(metric.extension_options?.allowed_dimensions).toEqual(['Calculation_456']);
+      expect(metric.definition.datasource).toEqual({ id: 'ds-luid' });
+    });
+
+    it('sets id_type when provided', () => {
+      const result = applyFieldNameResolution(
+        baseRequest as any,
+        new Map(),
+        'DATASOURCE_ID_TYPE_WORKBOOK_DATASOURCE',
+      );
+
+      expect(result.bundle_request.input.metric.definition.datasource).toEqual({
+        id: 'ds-luid',
+        id_type: 'DATASOURCE_ID_TYPE_WORKBOOK_DATASOURCE',
+      });
+    });
+
+    it('leaves datasource unchanged when idType is undefined', () => {
+      const result = applyFieldNameResolution(baseRequest as any, new Map());
+
+      expect(result.bundle_request.input.metric.definition.datasource).toEqual({
+        id: 'ds-luid',
+      });
+    });
+  });
+});

--- a/src/tools/web/pulse/resolveBundleRequestFieldNames.ts
+++ b/src/tools/web/pulse/resolveBundleRequestFieldNames.ts
@@ -1,0 +1,102 @@
+import { z } from 'zod';
+
+import { pulseBundleRequestSchema } from '../../../sdks/tableau/types/pulse.js';
+
+export type PulseBundleRequest = z.infer<typeof pulseBundleRequestSchema>;
+
+export type WorkbookDatasourceIdType = 'DATASOURCE_ID_TYPE_WORKBOOK_DATASOURCE';
+
+// The Insight Service validates every `field` string against HBI metadata's
+// fieldName, not fieldCaption. Callers build requests from field captions
+// (that's all getDatasourceMetadata / VDS readMetadata expose to a human-
+// readable caller), so a calculated field's caption (e.g. "Amount_Billions")
+// 400s while its underlying fieldName (e.g. "Calculation_00...") succeeds.
+export function buildFieldNameByCaption(
+  metadataFields: ReadonlyArray<Record<string, unknown>>,
+): Map<string, string> {
+  const fieldNameByCaption = new Map<string, string>();
+  for (const field of metadataFields) {
+    if (typeof field.fieldCaption === 'string' && typeof field.fieldName === 'string') {
+      fieldNameByCaption.set(field.fieldCaption, field.fieldName);
+    }
+  }
+  return fieldNameByCaption;
+}
+
+// The Datasources REST API returns an entry for embedded/workbook datasources
+// too (it doesn't 404), but marks them with a contentUrl of the form
+// '$embedded$_<workbookLuid>' instead of a normal published contentUrl. Pulse
+// must always call HBI directly (never a cached query result) for those, which
+// requires id_type: 'DATASOURCE_ID_TYPE_WORKBOOK_DATASOURCE' on the request.
+export function resolveIdTypeFromContentUrl(
+  contentUrl: string | undefined,
+): WorkbookDatasourceIdType | undefined {
+  return contentUrl?.startsWith('$embedded$')
+    ? 'DATASOURCE_ID_TYPE_WORKBOOK_DATASOURCE'
+    : undefined;
+}
+
+// Rewrites a bundle request's field captions to fieldNames using an
+// already-resolved caption->fieldName map, and sets id_type when the caller
+// determined the datasource is an embedded workbook datasource. Pure
+// transform: callers are responsible for fetching metadata / resolving
+// id_type (including best-effort fallback when those lookups fail).
+export function applyFieldNameResolution(
+  bundleRequest: PulseBundleRequest,
+  fieldNameByCaption: ReadonlyMap<string, string>,
+  idType?: WorkbookDatasourceIdType,
+): PulseBundleRequest {
+  const toFieldName = (caption: string): string => fieldNameByCaption.get(caption) ?? caption;
+
+  const datasource = bundleRequest.bundle_request.input.metric.definition.datasource;
+  const metric = bundleRequest.bundle_request.input.metric;
+  const basicSpecification = metric.definition.basic_specification;
+
+  return {
+    ...bundleRequest,
+    bundle_request: {
+      ...bundleRequest.bundle_request,
+      input: {
+        ...bundleRequest.bundle_request.input,
+        metric: {
+          ...metric,
+          definition: {
+            ...metric.definition,
+            datasource: {
+              ...datasource,
+              ...(idType ? { id_type: idType } : {}),
+            },
+            basic_specification: {
+              ...basicSpecification,
+              measure: {
+                ...basicSpecification.measure,
+                field: toFieldName(basicSpecification.measure.field),
+              },
+              time_dimension: {
+                ...basicSpecification.time_dimension,
+                field: toFieldName(basicSpecification.time_dimension.field),
+              },
+              filters: basicSpecification.filters.map((filter) => ({
+                ...filter,
+                field: toFieldName(filter.field),
+              })),
+            },
+          },
+          metric_specification: {
+            ...metric.metric_specification,
+            filters: metric.metric_specification.filters?.map((filter) => ({
+              ...filter,
+              field: toFieldName(filter.field),
+            })),
+          },
+          extension_options: metric.extension_options
+            ? {
+                ...metric.extension_options,
+                allowed_dimensions: metric.extension_options.allowed_dimensions?.map(toFieldName),
+              }
+            : metric.extension_options,
+        },
+      },
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- The Pulse Insight Service validates the `field` on `generate-pulse-metric-value-insight-bundle` requests against HBI metadata's `fieldName`, not `fieldCaption`. Since `get-datasource-metadata` only exposes captions, calculated fields built from their caption (e.g. `Amount_Billions`) 400 while the underlying `fieldName` (e.g. `Calculation_0013913069531140`) succeeds. This resolves caption -> fieldName via VDS `readMetadata` before forwarding the request to Pulse.
- Also auto-detects embedded workbook datasources and sets `id_type: 'DATASOURCE_ID_TYPE_WORKBOOK_DATASOURCE'` on the request, so Pulse always calls HBI directly instead of a cached query result for embedded datasources. Detection uses `queryDatasource` (the published Datasources REST API): it resolves embedded/workbook datasource LUIDs too, but marks them with a `contentUrl` of the form `$embedded$_<workbookLuid>` instead of a normal published contentUrl; a LUID it can't resolve at all is treated the same way, since the HBI-direct/uncached path is the safer default for an unknown ID.

Both behaviors were confirmed with Sanaz Arabzadeh Esfarjani on the Pulse Insights team.

## Test plan
- [x] `npx vitest run` — all unit tests pass
- [x] `npx tsc --noEmit -p .` clean
- [x] `npx eslint` clean
- [x] New unit tests cover: caption -> fieldName resolution, forwarding the request unchanged when metadata can't be read, `id_type` set when `queryDatasource` returns an embedded `contentUrl`, `id_type` set when `queryDatasource` doesn't recognize the LUID at all, `id_type` left unset for a published datasource
- [x] Manually verified end-to-end against a real Tableau site with an embedded/workbook datasource containing a calculated field — see comment below for details

🤖 Generated with [Claude Code](https://claude.com/claude-code)
