### PR TITLE
@W-23752441: correct docs referencing removed get-stale-content-report tool

### DIFF
--- a/docs/docs/configuration/mcp-config/env-vars.md
+++ b/docs/docs/configuration/mcp-config/env-vars.md
@@ -497,7 +497,7 @@ TTL (in minutes) for caches used by admin-only tools. Affects:
 
 - Admin role lookups (`assertAdmin`)
 - Admin Insights dataset LUID resolution
-- Project ID → name resolution used by `get-stale-content-report`
+- Project ID → name resolution used by `query-admin-insights` (`kind: "stale-content"`)
 
 - Default: `5`
 - Minimum: `1`

--- a/docs/docs/configuration/mcp-config/request-overrides.md
+++ b/docs/docs/configuration/mcp-config/request-overrides.md
@@ -160,7 +160,7 @@ Overrides whether Metadata API requests are disabled.
 
 ### [`STALE_CONTENT_MIN_AGE_DAYS`](env-vars.md#stale_content_min_age_days)
 
-Overrides the default threshold (in days) used by the `get-stale-content-report` tool to flag stale workbooks and published datasources. Override value must be an integer in the range `1`–`3650`. Empty string reverts to the default (`90`).
+Overrides the default threshold (in days) used by the `query-admin-insights` tool (`kind: "stale-content"`) to flag stale workbooks and published datasources. Override value must be an integer in the range `1`–`3650`. Empty string reverts to the default (`90`).
 
 | Restriction Type | Behavior |
 |---|---|

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -126,7 +126,7 @@ Prompts orchestrate multiple tools into a guided admin workflow. They are gated 
 
 | **Prompt**                                                                    | **Description**                                                                                                          |
 | ----------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
-| [stale-content-cleanup-inform](prompts/stale-content-cleanup-inform.md)       | Admin-only. Read-only. Generates a stale-content report by calling `get-stale-content-report`.                          |
+| [stale-content-cleanup-inform](prompts/stale-content-cleanup-inform.md)       | Admin-only. Read-only. Generates a stale-content report by calling `query-admin-insights` with `kind: "stale-content"`. |
 | [stale-content-cleanup-apply](prompts/stale-content-cleanup-apply.md)         | Admin-only. Destructive. Tags stale content, reports owners to notify, and — after a required human-confirmation break — deletes approved items to the recycle bin. |
 | [job-optimization-inform](prompts/job-optimization-inform.md)                 | Admin-only. Read-only. Analyzes Admin Insights job performance and surfaces optimization signals.                       |
 | [extract-optimization-apply](prompts/extract-optimization-apply.md)           | Admin-only. Destructive. Applies schedule downgrades and deletions to extract refresh tasks after a required human-confirmation break; defaults to a dry-run report. |


### PR DESCRIPTION
[Akash's agent]

## Summary

The `get-stale-content-report` tool was **removed** and consolidated into `query-admin-insights` with `kind: "stale-content"`. Three docs still named the removed tool and misled readers; this corrects them to point at the current tool.

| File | Context | Now references |
|---|---|---|
| `docs/docs/intro.md` | Prompt list — `stale-content-cleanup-inform` row | `query-admin-insights` with `kind: "stale-content"` |
| `docs/docs/configuration/mcp-config/request-overrides.md` | `STALE_CONTENT_MIN_AGE_DAYS` override | `query-admin-insights` tool (`kind: "stale-content"`) |
| `docs/docs/configuration/mcp-config/env-vars.md` | `ADMIN_GATE_CACHE_TTL_MINUTES` cache note | `query-admin-insights` (`kind: "stale-content"`) |

Wording mirrors the already-correct dedicated page `docs/docs/tools/admin-insights/query-admin-insights.md` and the adjacent `STALE_CONTENT_MAX_ROWS` section.

## Why

This resolves the **documentation** root cause behind bug W-23752441. Functional behavior was verified correct during triage — the alleged "stale-content requires an explicit project" behavior is **not a bug**: `projectIds` is already optional and defaults to whole-site scope. This PR only corrects docs that referenced the removed `get-stale-content-report` tool, which was the likely source of the reported confusion.

## Testing

- `rg get-stale-content-report` across the repo → **0** remaining references.
- Docs-only change (no `src/**` touched) → `Version Bump Check` CI skips; no version bump required.
- Docusaurus build is exercised by the `Test deployment` CI workflow (`npm ci && npm run build` over `docs/`). No new links were introduced — the edits are inline-code spans that already build elsewhere in these same files.

## Type of change

- [x] Documentation only
