### PR TITLE
@W-24061219: Gate MCP-Apps tool registration on client capability and exclude claude.ai

### DIFF
--- a/.work/specs/W-24061219-mcp-apps-client-capability-gate.md
+++ b/.work/specs/W-24061219-mcp-apps-client-capability-gate.md
@@ -1,0 +1,89 @@
+# W-24061219: Gate MCP-Apps tool registration on client capability
+
+## Source
+
+- Ticket: GUS W-24061219 (https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002jTxXKYA0/view)
+- Slack:
+- Google Docs/Drive:
+- Owner: Jaehun Song
+- Date: 2026-08-28 (round 1) — 2026-08-31 (hideWhenUnsupported follow-up)
+- Related PRs/issues: https://github.com/tableau/tableau-mcp/pull/861
+
+## Intent
+
+Don't hand a client an interactive MCP-Apps tool it has no way to render. Today,
+app-tool vs. plain-tool registration depends solely on the server-side `mcp-apps`
+feature flag — it ignores what the connecting client actually advertised. Clients that
+don't support MCP-Apps rendering should transparently get the plain-tool fallback (or,
+for `render-interactive-viz` specifically, no tool at all — a degraded plain-tool
+fallback isn't a useful experience for that one).
+
+## Problem
+
+- `WebMcpServer.registerTools` (`src/server.web.ts`) branched only on `mcpAppsEnabled && tool.app`. Any client connecting with the flag on got app tools regardless of its own SEP-1724 `extensions["io.modelcontextprotocol/ui"]` capability.
+- claude.ai (OAuth/HTTP) advertises the UI capability but has a broken MCP-Apps renderer, so it needed an explicit deny-list entry independent of capability detection.
+- `render-interactive-viz` specifically has no useful plain-tool fallback (rendering a viz without an interactive embed isn't the same feature) — needed a way to disappear entirely for unsupported clients instead of degrading.
+
+## Acceptance criteria
+
+- [x] Client capability (`extensions["io.modelcontextprotocol/ui"]` at `initialize`, checked via `clientSupportsMcpApps`) gates app-tool registration, ANDed with the existing `mcp-apps` feature flag.
+- [x] claude.ai (`getClientDisplayName(clientId) === 'Claude'`) is force-excluded from app-tool registration regardless of advertised capability.
+- [x] Unsupported/unknown clients safely fall back to plain-tool registration (default-safe).
+- [x] `capabilities`/`clientId` threaded end-to-end for the HTTP stateful-session path (`Server`, `WebMcpServer`, `Session`, `express.ts`), mirroring the existing `clientInfo` pattern.
+- [x] Stateless-HTTP-mode limitation (capabilities only present on the literal `initialize` body, so live detection never activates for real per-request traffic in that mode) is explicitly documented, not silently left as a gap.
+- [x] `render-interactive-viz` is hidden entirely (no tool, no resource) — not just downgraded to plain — for clients that fail the app-tool gate, via a new opt-in `AppDetails.hideWhenUnsupported` field.
+- [x] Other app tools (`update-cloud-extract-refresh-task`, `delete-content`) are unaffected — they keep falling back to plain tools as before.
+
+## Non-goals
+
+- Do not implement the `oninitialized`-based post-registration upgrade path (removing and re-registering tools after handshake via `listChanged`) — separate, larger change.
+- Do not attempt capability detection for stdio or stateless-HTTP transports beyond the documented safe-default fallback.
+- Do not change `getAppConfig()` itself to carry `hideWhenUnsupported` — it's a generic lookup shared by multiple tools; the flag is set per-call-site via object spread instead.
+- Do not modify `getClientDisplayName`/`clientDisplayName.ts` — reused as-is.
+
+## Constraints
+
+- Compatibility: default behavior for unknown/absent capability must remain today's plain-tool registration — no client that currently works should regress.
+- Performance: capability check is a pure in-memory lookup on already-parsed `initialize` data; no new I/O.
+- Security/privacy: `clientId` is attacker-influenceable but used only for host-based display-name matching; worst case of a mismatch is an unwanted plain-tool downgrade, not a privilege or exposure issue.
+- UX/API behavior: no plain-tool fallback should ever silently look broken — either it renders correctly as a plain tool, or (for `render-interactive-viz`) it's absent from the tool list entirely.
+- Rollout: gated behind the existing `mcp-apps` feature flag; no independent flag for the capability gate itself.
+
+## Risk classification
+
+low
+
+Reason: additive/defensive gating on top of an already-flagged feature; default-safe fallback preserves current behavior for every client that doesn't advertise the new capability signal. Went through 3 rounds of dual-reviewer + synthesis review before landing (see plan doc), including a dedicated round for the `hideWhenUnsupported` follow-up.
+
+## Test plan
+
+- Unit: `src/server.web.test.ts` (capable client → app tool; missing/lacking capability → plain; flag off → plain; claude.ai clientId → plain despite otherwise qualifying; non-Claude known client (Cursor) → app tool; `hideWhenUnsupported` cases — absent entirely when ungated, still registers as app tool when capable). `src/server/mcpUiCapability.test.ts` (new — `clientSupportsMcpApps` unit tests). `src/tools/web/renderInteractiveViz/renderInteractiveViz.test.ts` (asserts `tool.app?.hideWhenUnsupported === true`).
+- Integration: n/a beyond the above — no separate integration harness for tool registration.
+- E2E/manual: connect a UI-capable client, a plain client, and a simulated claude.ai `client_id` via MCP Inspector with custom `initialize` capabilities payloads; confirm registration behavior for each.
+- Regression: `npx vitest run` full suite (177 files / 2845 tests passing at last check); `npm run build` (default + MCP Apps + tracing bundles).
+
+## Implementation notes
+
+See `plans/gate-mcp-apps-registration-by-client-capability.md` for the full design writeup
+(registration timing, gate composition, threading, and the `hideWhenUnsupported` follow-up).
+
+## Open questions / conflicts
+
+- None open. Package.json version on the branch briefly diverged to an unexpected `4.6.0`
+  from a merge-conflict resolution (branch had bumped to 4.8.0, main was at 4.5.8) — flagged
+  for the PR author to confirm the intended version before merge, not a design conflict.
+
+## Final evidence
+
+- Files changed: `src/server.web.ts`, `src/server.ts`, `src/server/express.ts`,
+  `src/sessions.ts`, `src/server/mcpUiCapability.ts` (new), `src/tools/web/tool.ts`,
+  `src/tools/web/renderInteractiveViz/renderInteractiveViz.ts`, plus test files for each,
+  `docs/docs/configuration/mcp-config/env-vars.md`.
+- Checks run: `npx vitest run` (177 files / 2845 tests, exit 0), `npm run build` (exit 0).
+- Review result: 3 rounds dual-reviewer + synthesis for the base gate, canonical
+  `VERDICT: PASS` each round; separate dual-reviewer + synthesis round for
+  `hideWhenUnsupported`, canonical `VERDICT: PASS`.
+- Security result: no new trust boundary; `clientId` misuse worst-case is a UX downgrade, not
+  an access-control issue.
+- Remaining risks: stateless-HTTP-mode app-tool activation gap is a known, documented,
+  accepted limitation — not a defect to track further unless product requirements change.

--- a/.work/specs/W-24064643-mcp-apps-stateless-multi-instance-session-store.md
+++ b/.work/specs/W-24064643-mcp-apps-stateless-multi-instance-session-store.md
@@ -1,0 +1,114 @@
+# W-24064643: Fix MCP-Apps client-capability detection under DISABLE_SESSION_MANAGEMENT / multi-instance deployments
+
+## Source
+
+- Ticket: GUS W-24064643 (https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002jW0dUYAS/view)
+- Slack:
+- Google Docs/Drive:
+- Owner: Jaehun Song
+- Date: 2026-09-01
+- Related PRs/issues: follow-up from W-24061219 / https://github.com/tableau/tableau-mcp/pull/861
+
+## Intent
+
+MCP-Apps client-capability gating (W-24061219) should give correct app-tool-vs-plain-tool
+decisions for every client, in every supported deployment topology — not just the
+single-instance, sticky-session default. Operators running `DISABLE_SESSION_MANAGEMENT=true`
+or a horizontally-scaled fleet without guaranteed sticky routing should get the same correct
+behavior as the default single-instance stateful deployment.
+
+## Problem
+
+`src/sessions.ts`'s in-process `{ [sessionId]: Session }` map (holding the live transport) means
+the capability decision made at a client's `initialize` request is only visible to later
+`tools/list`/`tools/call` requests if they're served by the *same process*:
+- In stateless mode (`DISABLE_SESSION_MANAGEMENT=true`), every request — including
+  `tools/list`/`tools/call` — spins up a brand-new server with `capabilities = undefined`
+  (only the literal `initialize` request body carries that field), so MCP-Apps tools always
+  fall back to plain tools, regardless of client support. Currently documented as an accepted
+  limitation, not fixed.
+- In the default stateful path, a client's follow-up request landing on a different
+  instance/pod than the one that handled its `initialize` (no sticky routing guaranteed) won't
+  find its session at all — a general session-continuity bug, not specific to MCP-Apps.
+
+## Acceptance criteria
+
+- [ ] Session metadata (`clientInfo`, `capabilities`, `clientId`) is persisted in a shared
+      external store (Redis or DynamoDB), not an in-process object, keyed by `sessionId`.
+- [ ] A request for an existing `sessionId` landing on an instance that didn't handle that
+      session's `initialize` locally can still reconstruct a `WebMcpServer` with the correct
+      stored capabilities and register tools correctly.
+- [ ] Existing single-instance behavior (today's tests in `src/server.web.test.ts` /
+      `src/server/mcpUiCapability.test.ts`) continues to pass unchanged.
+- [ ] Scope decision documented: whether this fix extends into the `DISABLE_SESSION_MANAGEMENT`
+      branch in the same change, or lands stateful-path-only with stateless mode's limitation
+      still documented as-is pending a follow-up.
+
+## Non-goals
+
+- Do not persist or share the live `StreamableHTTPServerTransport` object itself across
+  instances — it's inherently a local, in-flight HTTP streaming connection.
+- Do not change the client-capability gating *logic* itself (`clientSupportsMcpApps`,
+  `isKnownIncompatibleClient` in `src/server.web.ts`) — this is purely about making the
+  *inputs* to that logic (capabilities, clientId) reliably available regardless of which
+  instance serves a given request.
+- Do not require sticky-session load-balancer configuration as the fix — that's the status quo
+  being replaced, not the target state.
+
+## Constraints
+
+- Compatibility: default (stateful) behavior for single-instance deployments must not regress.
+- Performance: session lookup moves from an in-memory hash lookup to a network call per
+  session-bearing request — evaluate latency impact; consider caching within a request's
+  lifetime if needed, but do not cache stale capabilities across requests (capabilities don't
+  change mid-session, so caching for the life of a session is safe if scoped correctly).
+- Security/privacy: session records contain `clientInfo`/`capabilities`/`clientId` — no
+  Tableau credentials or tokens; confirm the chosen store's access controls are appropriate for
+  this data (likely low sensitivity, but verify against existing DynamoDB feature-gate table
+  precedent for the org's baseline expectations).
+- UX/API behavior: no observable change for well-behaved clients; the fix is transparent.
+- Rollout: needs the chosen store (Redis/DynamoDB) provisioned before this can go live in any
+  environment — infra dependency, similar to the Gater Feature Gates DynamoDB rollout.
+
+## Risk classification
+
+medium
+
+Reason: touches shared session-handling infrastructure (not just tool-registration logic),
+introduces a new external dependency (Redis/DynamoDB) and its provisioning/ops burden, and has
+a scope decision (whether to also fix stateless mode) that affects blast radius.
+
+## Test plan
+
+- Unit: extend/add `src/sessions.test.ts` — round-trip create/lookup through the store
+  abstraction (mocked store client), confirm no live transport is ever persisted.
+- Integration: simulate two "instances" sharing one store; `initialize` against instance A,
+  `tools/list`/`tools/call` with that session ID against instance B; assert correct app-tool
+  registration on B.
+- E2E/manual: exercise via MCP Inspector against a multi-instance local setup if feasible, or a
+  staging deployment once the store is provisioned.
+- Regression: `npx vitest run` (full suite), `npm run build`.
+
+## Implementation notes
+
+Full design in `plans/fix-mcp-apps-capability-detection-stateless-multi-instance.md`. Consider
+reusing the DynamoDB DAO pattern already established for feature gates (see Gater Feature Gates
+workstream in the work brain) if DynamoDB is the chosen store, for consistency with existing
+ops tooling.
+
+## Open questions / conflicts
+
+- Redis vs. DynamoDB — depends on what's already provisioned/supported for this service; not
+  yet decided.
+- Whether to fix `DISABLE_SESSION_MANAGEMENT` mode in the same change or as a further follow-up
+  (see Non-goals/scope note above).
+
+## Final evidence
+
+Filled in by agent at the end:
+
+- Files changed:
+- Checks run:
+- Review result:
+- Security result:
+- Remaining risks:

--- a/docs/docs/configuration/mcp-config/env-vars.md
+++ b/docs/docs/configuration/mcp-config/env-vars.md
@@ -330,6 +330,9 @@ information about the client's identity, capabilities, and protocol version comp
   clients to provide that session ID in the `mcp-session-id` header for subsequent requests.
 - Set this to `true` if you are using the HTTP transport and your client does not support or need
   session management.
+- MCP-Apps interactive tool rendering requires session management to detect client capabilities.
+  When `true`, app tools always fall back to plain tool registration, regardless of what the
+  connecting client supports.
 
 <hr />
 

--- a/docs/docs/configuration/mcp-config/env-vars.md
+++ b/docs/docs/configuration/mcp-config/env-vars.md
@@ -331,8 +331,9 @@ information about the client's identity, capabilities, and protocol version comp
 - Set this to `true` if you are using the HTTP transport and your client does not support or need
   session management.
 - MCP-Apps interactive tool rendering requires session management to detect client capabilities.
-  When `true`, app tools always fall back to plain tool registration, regardless of what the
-  connecting client supports.
+  When `true`, app tools fall back to plain tool registration, regardless of what the connecting
+  client supports — except tools that opt out of the plain-tool fallback entirely (via
+  `hideWhenUnsupported`), which are omitted from registration altogether in this mode.
 
 <hr />
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -60,7 +60,8 @@ export default [
       'build/**',
       'docs/.docusaurus/**',
       'docs/build/**',
-      '.claude/worktrees/**',
+      '.claude/**',
+      '.worktrees/**',
     ],
   },
   {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -55,7 +55,13 @@ export default [
     },
   },
   {
-    ignores: ['node_modules/**', 'build/**', 'docs/.docusaurus/**', 'docs/build/**'],
+    ignores: [
+      'node_modules/**',
+      'build/**',
+      'docs/.docusaurus/**',
+      'docs/build/**',
+      '.claude/worktrees/**',
+    ],
   },
   {
     plugins: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "4.7.1",
+  "version": "4.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "4.7.1",
+      "version": "4.8.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1095.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "4.7.1",
+  "version": "4.8.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/plans/fix-mcp-apps-capability-detection-stateless-multi-instance.md
+++ b/plans/fix-mcp-apps-capability-detection-stateless-multi-instance.md
@@ -1,0 +1,104 @@
+# Fix MCP-Apps client-capability detection under `DISABLE_SESSION_MANAGEMENT` / multi-instance deployments
+
+## Context
+
+`gate-mcp-apps-registration-by-client-capability.md` (W-24061219, PR #861) added live
+client-capability gating for MCP-Apps tool registration, but only makes correct decisions when
+the same server instance that processed a client's `initialize` handshake also serves that
+client's later `tools/list`/`tools/call` requests.
+
+`src/sessions.ts` stores sessions in a plain in-process object:
+
+```ts
+const sessions: { [sessionId: string]: Session } = {};
+```
+
+This holds the live `StreamableHTTPServerTransport` itself, keyed by `sessionId`, entirely in
+one process's memory. Two consequences:
+
+1. **`DISABLE_SESSION_MANAGEMENT=true` (stateless mode)** — `src/server/express.ts`'s
+   `createMcpServer` builds a brand-new `WebMcpServer` on every single HTTP request and tears
+   it down on `res.on('close')`. `capabilities` is only populated when the request is itself
+   the literal `initialize` request (`isInitializeRequest(req.body) ? req.body.params.capabilities
+   : undefined`). Since `initialize`, `tools/list`, and `tools/call` are three separate HTTP
+   requests, only the (immediately-discarded) `initialize`-handling server instance ever sees
+   real capabilities — the instances that actually serve `tools/list`/`tools/call` always get
+   `capabilities = undefined`, so MCP-Apps tools always fall back to plain tools regardless of
+   what the client actually supports. This was documented as a known, accepted limitation in
+   round 2/3 review of W-24061219 (`docs/docs/configuration/mcp-config/env-vars.md`) rather than
+   fixed, since fixing it was out of scope for that PR.
+
+2. **Horizontal scaling, even in the default stateful path** — the in-process `sessions` map
+   only exists on the pod/instance that handled a given client's `initialize` request. If a load
+   balancer doesn't guarantee sticky routing per session, a later `tools/list`/`tools/call`
+   request for that same `sessionId` can land on a *different* instance, whose `sessions` map
+   never had that entry — breaking session continuity generally, not just MCP-Apps gating.
+
+## Design
+
+Replace the in-memory `sessions` map with a shared external store (Redis or DynamoDB — pick
+based on what's already provisioned/operationally supported for this service; DynamoDB
+precedent already exists for feature gates, see the Gater Feature Gates workstream), keyed by
+`sessionId`, holding only the metadata needed to reconstruct correct behavior:
+
+```ts
+type SessionRecord = {
+  clientInfo: ClientInfo;
+  capabilities: ClientCapabilitiesWithUiExtension;
+  clientId: string | undefined;
+};
+```
+
+**Do not** try to persist the live `StreamableHTTPServerTransport` itself — an open HTTP
+streaming connection is inherently local to the process handling it and can't be
+serialized/shared. Instead:
+
+- On `initialize` (no `sessionId`, `isInitializeRequest(req.body)` true): write the
+  `SessionRecord` to the shared store keyed by the newly-generated `sessionId`, same as today's
+  `createSession` but persisting to the external store instead of the local object.
+- On a later request with a `sessionId` header: look up the `SessionRecord` from the shared
+  store. If the local process doesn't have a live transport for that `sessionId` (e.g. it never
+  saw the `initialize` locally, or its own local transport was evicted/restarted), reconstruct a
+  fresh `WebMcpServer({ clientInfo, capabilities, clientId })` using the stored record and
+  connect a new transport — `registerTools()` will then correctly gate app-tool vs. plain-tool
+  registration using the real, persisted capabilities, regardless of which instance handles the
+  request.
+- This closes both gaps from Context: capabilities survive across requests/instances (fixing
+  stateless-mode gating), and session continuity no longer depends on sticky routing (fixing the
+  general multi-instance gap).
+
+**Scope question to resolve during implementation:** whether `DISABLE_SESSION_MANAGEMENT`
+should remain a separate mode once a shared store exists (the transport still needs to be
+initiated per-request in a stateless deployment, but capabilities would no longer need to be
+`undefined` on non-initialize requests — the shared store lookup could apply there too), or
+whether this fix is scoped to the stateful path only and stateless mode keeps its documented
+limitation. Recommend starting with the stateful/session-map path only (directly fixes the
+sticky-routing gap) and revisiting whether to extend the same store lookup into the stateless
+branch as a follow-up, to keep this change reviewable.
+
+## Critical files
+
+- `src/sessions.ts` — swap the in-process map for a shared-store-backed implementation
+- `src/server/express.ts` — session lookup/creation call sites (~lines 130-165)
+- `src/server.web.ts` / `src/server.ts` — no expected changes; `capabilities`/`clientId` are
+  already threaded through the constructor from W-24061219
+- New: whatever client module wraps the chosen store (Redis client or DynamoDB DAO, mirroring
+  the Gater Feature Gates DynamoDB DAO precedent if DynamoDB is chosen)
+
+## Verification
+
+- Unit: extend `src/sessions.test.ts` (or add one if it doesn't exist) to cover create/lookup
+  round-tripping through the shared-store abstraction (mock the store client).
+- Integration/manual: simulate two "instances" locally (two processes pointed at the same
+  store) — `initialize` against instance A, then send `tools/list`/`tools/call` with that
+  session ID against instance B; confirm correct app-tool registration on B without ever having
+  locally seen the `initialize` request.
+- Full suite: `npx vitest run`, `npm run build`.
+- This is infra/session-layer, not tool-registration logic — still goes through the standard
+  dual-reviewer + synthesis gate per repo convention (touches shared session-handling, not a
+  mechanical mirror).
+
+## Status
+
+Not started. Tracked as GUS **W-24064643** (epic: `[TMCP] MCP Apps extension for Chat GPT app
+launch Part 2`, team: AX Integrations Essentials), filed as a follow-up to W-24061219 / PR #861.

--- a/plans/gate-mcp-apps-registration-by-client-capability.md
+++ b/plans/gate-mcp-apps-registration-by-client-capability.md
@@ -1,0 +1,141 @@
+# Gate MCP-Apps tool registration on client capability + known-incompatible clients, not just the feature flag
+
+## Context
+
+tableau-mcp's `WebMcpServer.registerTools` (`src/server.web.ts`) decided whether to
+register a tool as an interactive "MCP App" (`_registerAppTool`, using
+`@modelcontextprotocol/ext-apps`) or as a plain tool (`_registerTool`), based solely on the
+server-side `mcp-apps` feature flag:
+
+```ts
+if (mcpAppsEnabled && tool.app) {
+  await this._registerAppTool(tool, toolCallback);
+} else {
+  await this._registerTool(tool, toolCallback);
+}
+```
+
+There was no check of whether the **connecting client** actually supports rendering MCP Apps.
+If the flag is on, every client — including ones with no MCP-Apps UI support — got an app
+tool it couldn't render. The MCP protocol has a real mechanism for this: during the
+`initialize` handshake, a capable client advertises
+`ClientCapabilities.extensions["io.modelcontextprotocol/ui"] = { mimeTypes: [...] }` (must
+include `"text/html;profile=mcp-app"`). `@modelcontextprotocol/ext-apps` (already a repo
+dependency) exposes `getUiCapability(clientCapabilities)` to read this. This plan added
+client-capability as a second, orthogonal gate next to the feature flag, defaulting to the
+safe (plain-tool) fallback whenever the client's support is unknown or absent.
+
+Separately, there's a known rendering bug specific to **claude.ai** connecting over
+OAuth/HTTP: even when it correctly advertises the UI capability, its MCP-Apps renderer is
+broken, so it needs to be force-disabled regardless of what it declares. This repo already
+had the exact mapping needed for this: `getClientDisplayName(clientId)`
+(`src/telemetry/clientDisplayName.ts`) maps an OAuth `client_id` (a CIMD URL) to a friendly
+name via a host lookup table, and `'claude.ai' → 'Claude'` is already in that table.
+
+## Design
+
+### 1. Registration timing
+
+`registerTools()` runs before `mcpServer.connect(transport)` at every call site (stdio,
+combined, desktop, and both HTTP branches in `express.ts`). For the **stateful HTTP session
+path** — the realistic path for any real MCP-Apps client — `express.ts` already parses the
+raw `initialize` request body synchronously and pulls `req.body.params.clientInfo` out of it
+before `WebMcpServer` is constructed. `req.body.params.capabilities` sits right next to it.
+So no lifecycle change was needed for this path — `capabilities` threads through the same
+dual-path pattern `clientInfo` already used.
+
+**Scope shipped:** the HTTP stateful-session path (Tier 1) — the case that matters, since
+MCP-Apps clients connect over HTTP. For stdio and stateless-HTTP, default to "unsupported" →
+plain tool (safe by construction). The `oninitialized`-based post-registration upgrade
+(`RegisteredTool.remove()` + re-registration + `listChanged`) was explicitly **not**
+implemented — materially separate change, not needed to close the actual gap.
+
+**Known, documented limitation (accepted in round 2 review):** in stateless HTTP mode
+(`DISABLE_SESSION_MANAGEMENT=true`), a fresh server/transport is created and torn down per
+request, and `capabilities` is only ever present on the literal `initialize` request body —
+so live capability detection never activates app tools for real tool-call traffic in that
+mode; it always safely falls back to plain tools. Documented in a code comment
+(`src/server/express.ts`) and `docs/docs/configuration/mcp-config/env-vars.md`
+(`DISABLE_SESSION_MANAGEMENT`) rather than left as a silent gap. The claude.ai exclusion is
+unaffected since it's keyed on `clientId`, available on every request.
+
+### 2. Composing with existing gates
+
+`tool.disabled` (`_getToolsToRegister`) decides whether a tool is registered *at all* —
+untouched by this change. `clientSupportsMcpApps` and `isKnownIncompatibleClient` are ANDed
+onto the existing app/plain branch:
+
+```ts
+if (mcpAppsEnabled && tool.app && supportsMcpApps && !isKnownIncompatibleClient) {
+  await this._registerAppTool(tool, toolCallback);
+} else if (tool.app?.hideWhenUnsupported) {
+  continue;
+} else {
+  await this._registerTool(tool, toolCallback);
+}
+```
+
+`isKnownIncompatibleClient` is `getClientDisplayName(this.clientId) === 'Claude'` — reusing
+the existing telemetry mapping rather than a new claude.ai string constant.
+
+### 3. New helper module
+
+`src/server/mcpUiCapability.ts` exports:
+- `ClientCapabilitiesWithUiExtension` — the SEP-1724-pending widened type
+  (`ClientCapabilities & { extensions?: Record<string, unknown> }`), a single greppable seam
+  to delete once the SDK core type absorbs `extensions`.
+- `clientSupportsMcpApps(capabilities): boolean` — wraps `getUiCapability` from
+  `@modelcontextprotocol/ext-apps/server` and checks
+  `uiCap?.mimeTypes?.includes(RESOURCE_MIME_TYPE)`.
+
+No new module for the claude.ai check — it reuses `getClientDisplayName`.
+
+### 4. Threading capabilities and clientId end-to-end
+
+Mirrors the existing `clientInfo` pattern for both new values across `src/server.ts`,
+`src/sessions.ts`, `src/server/express.ts`, and `src/server.web.ts` (constructor + gating
+computation in `registerTools`).
+
+### 5. Follow-up: app-only tools (`hideWhenUnsupported`)
+
+After the base gate shipped, a follow-up request asked for `render-interactive-viz`
+specifically to be **hidden entirely** — not fall back to a plain tool — for clients that
+can't render MCP Apps (the plain-tool fallback for a viz-rendering tool isn't a useful
+degraded experience). Added an opt-in `hideWhenUnsupported?: boolean` field to `AppDetails`
+(`src/tools/web/tool.ts`), set only at the `render-interactive-viz` call site via object
+spread (`{ ...getAppConfig('render-interactive-viz'), hideWhenUnsupported: true }`) rather
+than inside `getAppConfig` itself, since `getAppConfig` is a generic lookup shared by
+`update-cloud-extract-refresh-task` and `delete-content`, which must keep falling back to
+plain tools. The registration loop's `else if (tool.app?.hideWhenUnsupported) continue;`
+branch (see §2) implements the "hide, don't fall back" behavior; other app tools are
+unaffected since their `AppDetails` never set the field.
+
+## Critical files
+- `src/server.web.ts` — main gating logic
+- `src/server.ts` — base `Server` class, `capabilities`/`clientId` alongside `clientInfo`
+- `src/server/express.ts` — threads `req.body.params.capabilities` and `req.auth?.clientId`
+- `src/sessions.ts` — `capabilities`/`clientId` on `Session`/`createSession`
+- `src/server/mcpUiCapability.ts` (new) — `clientSupportsMcpApps` helper + widened type
+- `src/telemetry/clientDisplayName.ts` — reused as-is
+- `src/tools/web/tool.ts` — `AppDetails.hideWhenUnsupported`
+- `src/tools/web/renderInteractiveViz/renderInteractiveViz.ts` — opts into `hideWhenUnsupported`
+- `src/server.web.test.ts`, `src/server/mcpUiCapability.test.ts`,
+  `src/tools/web/renderInteractiveViz/renderInteractiveViz.test.ts`
+
+## Verification
+- `npx vitest run` (full suite) — 177 files / 2845 tests passing at last check.
+- `npm run build` — default + MCP Apps + tracing bundles.
+- Manual: connect a UI-capable client with the flag on → app tools register; connect a plain
+  client (no extension) with the flag on → plain-tool fallback; simulate `client_id` of
+  `https://claude.ai/...` with the flag on and UI capability present → still falls back to
+  plain despite otherwise qualifying; `render-interactive-viz` specifically → absent entirely
+  (no tool, no resource) for any client that fails the app-tool gate.
+- Went through 3 rounds of dual-reviewer + synthesis review (round 1: fixed stateless-branch
+  threading regression; round 2: confirmed/accepted the stateless-mode limitation; round 3:
+  documented it), plus a separate dual-reviewer + synthesis round for the `hideWhenUnsupported`
+  follow-up. All rounds: canonical `VERDICT: PASS`.
+
+## Status
+
+Shipped. PR: https://github.com/tableau/tableau-mcp/pull/861
+(`feat/mcp-apps-client-capability-gate-v2` → `main`, GUS: W-24061219).

--- a/src/server.ts
+++ b/src/server.ts
@@ -2,6 +2,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { InitializeRequest } from '@modelcontextprotocol/sdk/types.js';
 
 import { TableauAuthInfo } from './server/oauth/schemas.js';
+import { ClientCapabilitiesWithUiExtension } from './server/mcpUiCapability.js';
 import invariant from './utils/invariant.js';
 
 export type ClientInfo = InitializeRequest['params']['clientInfo'];
@@ -21,19 +22,34 @@ export abstract class Server {
   // With stdio transport, we can use the getClientVersion() method to get the client info.
   private readonly _clientInfo: ClientInfo | undefined;
 
+  // Client-advertised capabilities and OAuth `client_id`, threaded in per-request on both HTTP
+  // branches (session-managed and stateless) the same way `clientInfo` is (see note above).
+  // `capabilities` falls back to the SDK's populated value for stdio; `clientId` has no stdio
+  // equivalent (no OAuth handshake), so it is simply undefined there.
+  private readonly _capabilities: ClientCapabilitiesWithUiExtension | undefined;
+  readonly clientId: string | undefined;
+
   get clientInfo(): ClientInfo | undefined {
     return this._clientInfo ?? this.mcpServer.server.getClientVersion();
+  }
+
+  get capabilities(): ClientCapabilitiesWithUiExtension | undefined {
+    return this._capabilities ?? this.mcpServer.server.getClientCapabilities();
   }
 
   constructor({
     mcpServer,
     clientInfo,
+    capabilities,
+    clientId,
     serverName,
     serverVersion,
     instructions,
   }: {
     mcpServer?: McpServer;
     clientInfo?: ClientInfo;
+    capabilities?: ClientCapabilitiesWithUiExtension;
+    clientId?: string;
     serverName: string;
     serverVersion: string;
     // Optional server-level instructions surfaced in the MCP `initialize` result. Composed by
@@ -82,6 +98,8 @@ export abstract class Server {
     this.name = serverName;
     this.version = serverVersion;
     this._clientInfo = clientInfo;
+    this._capabilities = capabilities;
+    this.clientId = clientId;
   }
 
   get userAgent(): string {

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,8 +1,8 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { InitializeRequest } from '@modelcontextprotocol/sdk/types.js';
 
-import { TableauAuthInfo } from './server/oauth/schemas.js';
 import { ClientCapabilitiesWithUiExtension } from './server/mcpUiCapability.js';
+import { TableauAuthInfo } from './server/oauth/schemas.js';
 import invariant from './utils/invariant.js';
 
 export type ClientInfo = InitializeRequest['params']['clientInfo'];

--- a/src/server.web.test.ts
+++ b/src/server.web.test.ts
@@ -74,7 +74,7 @@ describe('server', () => {
     return server;
   }
 
-  function createMockAppTool(): WebTool<any> {
+  function createMockAppTool(opts?: { hideWhenUnsupported?: boolean }): WebTool<any> {
     return {
       name: 'mock-app-tool' as WebToolName,
       server: {} as any,
@@ -97,6 +97,7 @@ describe('server', () => {
         name: 'test-app',
         resourceUri: 'tableau://app/test',
         htmlPath: '<html><body>Test App UI</body></html>',
+        ...(opts?.hideWhenUnsupported ? { hideWhenUnsupported: true } : {}),
       },
     };
   }
@@ -529,5 +530,71 @@ describe('server', () => {
       expect.any(Function),
     );
     expect(mocks.mockRegisterAppResource).toHaveBeenCalled();
+  });
+
+  it('should not register a hideWhenUnsupported app tool at all when the client lacks MCP-Apps support', async () => {
+    mocks.mockFeatureGate.isFeatureEnabled.mockReturnValue(true);
+
+    // Flag on, but no UI capability advertised. A hideWhenUnsupported tool skips the plain-tool
+    // fallback entirely, so it must be absent from registration (neither app nor plain).
+    const server = getServer();
+    const mockAppTool = createMockAppTool({ hideWhenUnsupported: true });
+    vi.spyOn(webToolFactories, 'map').mockReturnValueOnce([mockAppTool]);
+
+    await server.registerTools();
+
+    expect(server.mcpServer.registerTool).not.toHaveBeenCalledWith(
+      'mock-app-tool',
+      expect.anything(),
+      expect.anything(),
+    );
+    expect(mocks.mockRegisterAppTool).not.toHaveBeenCalled();
+    expect(mocks.mockRegisterAppResource).not.toHaveBeenCalled();
+  });
+
+  it('should not register a hideWhenUnsupported app tool for the known-incompatible client (claude.ai)', async () => {
+    mocks.mockFeatureGate.isFeatureEnabled.mockReturnValue(true);
+
+    // UI-capable but claude.ai → app path is blocked; hideWhenUnsupported means no plain fallback either.
+    const server = getServer({
+      capabilities: uiCapableClientCapabilities,
+      clientId: 'https://claude.ai/some/cimd',
+    });
+    const mockAppTool = createMockAppTool({ hideWhenUnsupported: true });
+    vi.spyOn(webToolFactories, 'map').mockReturnValueOnce([mockAppTool]);
+
+    await server.registerTools();
+
+    expect(server.mcpServer.registerTool).not.toHaveBeenCalledWith(
+      'mock-app-tool',
+      expect.anything(),
+      expect.anything(),
+    );
+    expect(mocks.mockRegisterAppTool).not.toHaveBeenCalled();
+    expect(mocks.mockRegisterAppResource).not.toHaveBeenCalled();
+  });
+
+  it('should still register a hideWhenUnsupported app tool as an app tool when the client supports MCP Apps', async () => {
+    mocks.mockFeatureGate.isFeatureEnabled.mockReturnValue(true);
+
+    // hideWhenUnsupported only changes the fallback; the happy path still registers it as an app tool.
+    const server = getServer({ capabilities: uiCapableClientCapabilities });
+    const mockAppTool = createMockAppTool({ hideWhenUnsupported: true });
+    vi.spyOn(webToolFactories, 'map').mockReturnValueOnce([mockAppTool]);
+
+    await server.registerTools();
+
+    expect(mocks.mockRegisterAppTool).toHaveBeenCalledWith(
+      server.mcpServer,
+      'mock-app-tool',
+      expect.any(Object),
+      expect.any(Function),
+    );
+    expect(mocks.mockRegisterAppResource).toHaveBeenCalled();
+    expect(server.mcpServer.registerTool).not.toHaveBeenCalledWith(
+      'mock-app-tool',
+      expect.anything(),
+      expect.anything(),
+    );
   });
 });

--- a/src/server.web.test.ts
+++ b/src/server.web.test.ts
@@ -2,6 +2,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
 import { ServiceUnavailableError } from './errors/mcpToolError.js';
 import { serverName, WebMcpServer } from './server.web.js';
+import { ClientCapabilitiesWithUiExtension } from './server/mcpUiCapability.js';
 import { stubDefaultEnvVars, testProductVersion } from './testShared.js';
 import { exportedForTesting } from './tools/web/datasources/listDatasources.js';
 import { getQueryDatasourceTool } from './tools/web/queryDatasource/queryDatasource.js';
@@ -22,11 +23,21 @@ const mocks = vi.hoisted(() => ({
   mockReadFile: vi.fn(),
 }));
 
+const UI_EXTENSION_ID = 'io.modelcontextprotocol/ui';
+
 vi.mock('@modelcontextprotocol/ext-apps/server', () => ({
   registerAppTool: mocks.mockRegisterAppTool,
   registerAppResource: mocks.mockRegisterAppResource,
   RESOURCE_MIME_TYPE: 'text/html',
+  // Mirror ext-apps' real getUiCapability: return the SEP-1724 UI extension object, if present.
+  getUiCapability: (capabilities: { extensions?: Record<string, unknown> } | undefined) =>
+    capabilities?.extensions?.[UI_EXTENSION_ID],
 }));
+
+// Client capabilities advertising MCP-Apps rendering support (uses the mocked RESOURCE_MIME_TYPE).
+const uiCapableClientCapabilities: ClientCapabilitiesWithUiExtension = {
+  extensions: { [UI_EXTENSION_ID]: { mimeTypes: ['text/html'] } },
+};
 
 vi.mock('./features/init.js', () => ({
   getFeatureGate: vi.fn(() => mocks.mockFeatureGate),
@@ -51,8 +62,14 @@ describe('server', () => {
   });
 
   // Helper functions
-  function getServer(): WebMcpServer {
-    const server = new WebMcpServer();
+  function getServer(opts?: {
+    capabilities?: ClientCapabilitiesWithUiExtension;
+    clientId?: string;
+  }): WebMcpServer {
+    const server = new WebMcpServer({
+      capabilities: opts?.capabilities,
+      clientId: opts?.clientId,
+    });
     server.mcpServer.registerTool = vi.fn();
     return server;
   }
@@ -323,7 +340,8 @@ describe('server', () => {
 
     mocks.mockFeatureGate.isFeatureEnabled.mockReturnValue(true);
 
-    const server = getServer();
+    // Flag on + client advertises the UI capability + a non-Claude clientId → app tool registers.
+    const server = getServer({ capabilities: uiCapableClientCapabilities });
     const mockAppTool = createMockAppTool();
     vi.spyOn(webToolFactories, 'map').mockReturnValueOnce([mockAppTool]);
 
@@ -431,5 +449,85 @@ describe('server', () => {
     // Should NOT register as app tool
     expect(mocks.mockRegisterAppTool).not.toHaveBeenCalled();
     expect(mocks.mockRegisterAppResource).not.toHaveBeenCalled();
+  });
+
+  it('should register as standard tool when client capabilities lack the UI extension', async () => {
+    mocks.mockFeatureGate.isFeatureEnabled.mockReturnValue(true);
+
+    // Flag on, but no client capabilities advertised → falls back to plain tool.
+    const server = getServer();
+    const mockAppTool = createMockAppTool();
+    vi.spyOn(webToolFactories, 'map').mockReturnValueOnce([mockAppTool]);
+
+    await server.registerTools();
+
+    expect(server.mcpServer.registerTool).toHaveBeenCalledWith(
+      'mock-app-tool',
+      expect.any(Object),
+      expect.any(Function),
+    );
+    expect(mocks.mockRegisterAppTool).not.toHaveBeenCalled();
+    expect(mocks.mockRegisterAppResource).not.toHaveBeenCalled();
+  });
+
+  it('should register as standard tool when flag is off even if client is UI-capable', async () => {
+    mocks.mockFeatureGate.isFeatureEnabled.mockReturnValue(false);
+
+    const server = getServer({ capabilities: uiCapableClientCapabilities });
+    const mockAppTool = createMockAppTool();
+    vi.spyOn(webToolFactories, 'map').mockReturnValueOnce([mockAppTool]);
+
+    await server.registerTools();
+
+    expect(server.mcpServer.registerTool).toHaveBeenCalledWith(
+      'mock-app-tool',
+      expect.any(Object),
+      expect.any(Function),
+    );
+    expect(mocks.mockRegisterAppTool).not.toHaveBeenCalled();
+    expect(mocks.mockRegisterAppResource).not.toHaveBeenCalled();
+  });
+
+  it('should register as standard tool for a known-incompatible client (claude.ai) despite UI support', async () => {
+    mocks.mockFeatureGate.isFeatureEnabled.mockReturnValue(true);
+
+    // Flag on + UI-capable, but clientId resolves to 'Claude' via getClientDisplayName → plain tool.
+    const server = getServer({
+      capabilities: uiCapableClientCapabilities,
+      clientId: 'https://claude.ai/some/cimd',
+    });
+    const mockAppTool = createMockAppTool();
+    vi.spyOn(webToolFactories, 'map').mockReturnValueOnce([mockAppTool]);
+
+    await server.registerTools();
+
+    expect(server.mcpServer.registerTool).toHaveBeenCalledWith(
+      'mock-app-tool',
+      expect.any(Object),
+      expect.any(Function),
+    );
+    expect(mocks.mockRegisterAppTool).not.toHaveBeenCalled();
+    expect(mocks.mockRegisterAppResource).not.toHaveBeenCalled();
+  });
+
+  it('should register app tool for a non-Claude known client (Cursor) that is UI-capable', async () => {
+    mocks.mockFeatureGate.isFeatureEnabled.mockReturnValue(true);
+
+    const server = getServer({
+      capabilities: uiCapableClientCapabilities,
+      clientId: 'https://cursor.com/some/cimd',
+    });
+    const mockAppTool = createMockAppTool();
+    vi.spyOn(webToolFactories, 'map').mockReturnValueOnce([mockAppTool]);
+
+    await server.registerTools();
+
+    expect(mocks.mockRegisterAppTool).toHaveBeenCalledWith(
+      server.mcpServer,
+      'mock-app-tool',
+      expect.any(Object),
+      expect.any(Function),
+    );
+    expect(mocks.mockRegisterAppResource).toHaveBeenCalled();
   });
 });

--- a/src/server.web.ts
+++ b/src/server.web.ts
@@ -170,6 +170,8 @@ export class WebMcpServer extends Server {
 
       if (mcpAppsEnabled && tool.app && supportsMcpApps && !isKnownIncompatibleClient) {
         await this._registerAppTool(tool, toolCallback);
+      } else if (tool.app?.hideWhenUnsupported) {
+        continue;
       } else {
         await this._registerTool(tool, toolCallback);
       }

--- a/src/server.web.ts
+++ b/src/server.web.ts
@@ -20,9 +20,14 @@ import { getFeatureGate } from './features/init.js';
 import { getTableauServerInfo } from './getTableauServerInfo.js';
 import { registerPrompts } from './prompts/index.js';
 import { ClientInfo, Server } from './server.js';
+import {
+  ClientCapabilitiesWithUiExtension,
+  clientSupportsMcpApps,
+} from './server/mcpUiCapability.js';
 import { getTableauAuthInfo } from './server/oauth/getTableauAuthInfo.js';
 import { TableauAuthInfo } from './server/oauth/schemas.js';
 import { getRequestOverridesFromHeader, X_TABLEAU_MCP_CONFIG_HEADER } from './server/requestUtils';
+import { getClientDisplayName } from './telemetry/clientDisplayName.js';
 import { WebTool } from './tools/web/tool.js';
 import { TableauWebRequestHandlerExtra } from './tools/web/toolContext.js';
 import { webToolFactories } from './tools/web/tools.js';
@@ -73,10 +78,22 @@ export function buildWebInstructions(): string {
 }
 
 export class WebMcpServer extends Server {
-  constructor({ mcpServer, clientInfo }: { mcpServer?: McpServer; clientInfo?: ClientInfo } = {}) {
+  constructor({
+    mcpServer,
+    clientInfo,
+    capabilities,
+    clientId,
+  }: {
+    mcpServer?: McpServer;
+    clientInfo?: ClientInfo;
+    capabilities?: ClientCapabilitiesWithUiExtension;
+    clientId?: string;
+  } = {}) {
     super({
       mcpServer,
       clientInfo,
+      capabilities,
+      clientId,
       serverName,
       serverVersion,
       instructions: buildWebInstructions(),
@@ -87,6 +104,15 @@ export class WebMcpServer extends Server {
     const config = getConfig();
 
     const mcpAppsEnabled = await getFeatureGate().isFeatureEnabled('mcp-apps');
+
+    // App tools are only rendered by clients that advertise the SEP-1724 UI capability during the
+    // `initialize` handshake; default to the plain-tool fallback when support is unknown/absent.
+    const supportsMcpApps = clientSupportsMcpApps(this.capabilities);
+
+    // claude.ai over OAuth/HTTP advertises the UI capability but its MCP-Apps renderer is broken,
+    // so force the plain-tool fallback for it regardless of what it declares. Reuses the existing
+    // telemetry client_id → display-name mapping; undefined clientId (e.g. stdio) is never 'Claude'.
+    const isKnownIncompatibleClient = getClientDisplayName(this.clientId) === 'Claude';
 
     for (const tool of await this._getToolsToRegister(tableauAuthInfo)) {
       const toolCallback: ToolCallback<typeof tool.paramsSchema> = async (
@@ -142,7 +168,7 @@ export class WebMcpServer extends Server {
         return tableauToolCallback(args, tableauRequestHandlerExtra);
       };
 
-      if (mcpAppsEnabled && tool.app) {
+      if (mcpAppsEnabled && tool.app && supportsMcpApps && !isKnownIncompatibleClient) {
         await this._registerAppTool(tool, toolCallback);
       } else {
         await this._registerTool(tool, toolCallback);

--- a/src/server/express.ts
+++ b/src/server/express.ts
@@ -128,19 +128,6 @@ export async function startExpressServer({
       let transport: StreamableHTTPServerTransport;
 
       if (config.disableSessionManagement) {
-        // Stateless mode re-registers tools on every request (not just `initialize`), so client
-        // capabilities are only present on the `initialize` request itself — subsequent requests
-        // legitimately have none, which safe-defaults to plain-tool registration. `clientId` comes
-        // from the OAuth Bearer token and is available on every authenticated request.
-        //
-        // Known, accepted limitation (not a bug): because a fresh server/transport is built and torn
-        // down per request with no cross-request state, `capabilities` is `undefined` on every
-        // `tools/call` / `tools/list` request. So MCP-Apps client-capability detection — and therefore
-        // rendering tools as interactive app tools — never actually activates for real tool-call
-        // traffic under `DISABLE_SESSION_MANAGEMENT=true`; app tools always fall back to plain tool
-        // registration regardless of what the client declared at its own `initialize`. Session
-        // management is required for MCP-Apps rendering. `clientId`-based checks (e.g. the claude.ai
-        // exclusion) are unaffected, since `clientId` is available on every request.
         const capabilities = isInitializeRequest(req.body)
           ? req.body.params.capabilities
           : undefined;

--- a/src/server/express.ts
+++ b/src/server/express.ts
@@ -128,7 +128,24 @@ export async function startExpressServer({
       let transport: StreamableHTTPServerTransport;
 
       if (config.disableSessionManagement) {
-        const server = new WebMcpServer();
+        // Stateless mode re-registers tools on every request (not just `initialize`), so client
+        // capabilities are only present on the `initialize` request itself — subsequent requests
+        // legitimately have none, which safe-defaults to plain-tool registration. `clientId` comes
+        // from the OAuth Bearer token and is available on every authenticated request.
+        //
+        // Known, accepted limitation (not a bug): because a fresh server/transport is built and torn
+        // down per request with no cross-request state, `capabilities` is `undefined` on every
+        // `tools/call` / `tools/list` request. So MCP-Apps client-capability detection — and therefore
+        // rendering tools as interactive app tools — never actually activates for real tool-call
+        // traffic under `DISABLE_SESSION_MANAGEMENT=true`; app tools always fall back to plain tool
+        // registration regardless of what the client declared at its own `initialize`. Session
+        // management is required for MCP-Apps rendering. `clientId`-based checks (e.g. the claude.ai
+        // exclusion) are unaffected, since `clientId` is available on every request.
+        const capabilities = isInitializeRequest(req.body)
+          ? req.body.params.capabilities
+          : undefined;
+        const clientId = req.auth?.clientId;
+        const server = new WebMcpServer({ capabilities, clientId });
         transport = new StreamableHTTPServerTransport({
           sessionIdGenerator: undefined,
         });
@@ -147,9 +164,11 @@ export async function startExpressServer({
           transport = session.transport;
         } else if (!sessionId && isInitializeRequest(req.body)) {
           const clientInfo = req.body.params.clientInfo;
-          transport = createSession({ clientInfo });
+          const capabilities = req.body.params.capabilities;
+          const clientId = req.auth?.clientId;
+          transport = createSession({ clientInfo, capabilities, clientId });
 
-          const server = new WebMcpServer({ clientInfo });
+          const server = new WebMcpServer({ clientInfo, capabilities, clientId });
           await connect(server, transport, logLevel, getTableauAuthInfo(req.auth));
         } else {
           log({

--- a/src/server/mcpUiCapability.test.ts
+++ b/src/server/mcpUiCapability.test.ts
@@ -1,0 +1,43 @@
+import { RESOURCE_MIME_TYPE } from '@modelcontextprotocol/ext-apps/server';
+import { describe, expect, it } from 'vitest';
+
+import { ClientCapabilitiesWithUiExtension, clientSupportsMcpApps } from './mcpUiCapability.js';
+
+const UI_EXTENSION_ID = 'io.modelcontextprotocol/ui';
+
+describe('clientSupportsMcpApps', () => {
+  it('returns false when capabilities are undefined', () => {
+    expect(clientSupportsMcpApps(undefined)).toBe(false);
+  });
+
+  it('returns false when the extensions field is absent', () => {
+    expect(clientSupportsMcpApps({})).toBe(false);
+  });
+
+  it('returns false when the UI extension is present but has no matching mimeTypes', () => {
+    const capabilities: ClientCapabilitiesWithUiExtension = {
+      extensions: {
+        [UI_EXTENSION_ID]: { mimeTypes: ['text/plain'] },
+      },
+    };
+    expect(clientSupportsMcpApps(capabilities)).toBe(false);
+  });
+
+  it('returns false when the UI extension is present but mimeTypes is missing', () => {
+    const capabilities: ClientCapabilitiesWithUiExtension = {
+      extensions: {
+        [UI_EXTENSION_ID]: {},
+      },
+    };
+    expect(clientSupportsMcpApps(capabilities)).toBe(false);
+  });
+
+  it('returns true when the UI extension advertises the MCP Apps MIME type', () => {
+    const capabilities: ClientCapabilitiesWithUiExtension = {
+      extensions: {
+        [UI_EXTENSION_ID]: { mimeTypes: [RESOURCE_MIME_TYPE] },
+      },
+    };
+    expect(clientSupportsMcpApps(capabilities)).toBe(true);
+  });
+});

--- a/src/server/mcpUiCapability.ts
+++ b/src/server/mcpUiCapability.ts
@@ -1,0 +1,25 @@
+import { getUiCapability, RESOURCE_MIME_TYPE } from '@modelcontextprotocol/ext-apps/server';
+import { ClientCapabilities } from '@modelcontextprotocol/sdk/types.js';
+
+/**
+ * `ClientCapabilities` widened with the `extensions` field where a client advertises MCP Apps
+ * support during the `initialize` handshake (`extensions["io.modelcontextprotocol/ui"]`). The
+ * SDK's `ClientCapabilities` does not yet model `extensions` (pending SEP-1724); once it does,
+ * this alias can collapse to `ClientCapabilities` directly.
+ */
+export type ClientCapabilitiesWithUiExtension = ClientCapabilities & {
+  extensions?: Record<string, unknown>;
+};
+
+/**
+ * Whether the connecting client advertised that it can render MCP Apps. Reads the SEP-1724 UI
+ * capability via ext-apps' `getUiCapability` and requires the MCP Apps MIME type to be present.
+ * Returns `false` when capabilities are missing or the UI extension is absent — the safe default
+ * that falls back to plain (non-app) tool registration.
+ */
+export function clientSupportsMcpApps(
+  capabilities: ClientCapabilitiesWithUiExtension | undefined,
+): boolean {
+  const uiCap = getUiCapability(capabilities);
+  return uiCap?.mimeTypes?.includes(RESOURCE_MIME_TYPE) ?? false;
+}

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -3,23 +3,30 @@ import { randomUUID } from 'crypto';
 
 import { log } from './logging/logger.js';
 import { ClientInfo } from './server.js';
+import { ClientCapabilitiesWithUiExtension } from './server/mcpUiCapability.js';
 
 export type Session = {
   transport: StreamableHTTPServerTransport;
   clientInfo: ClientInfo;
+  capabilities: ClientCapabilitiesWithUiExtension;
+  clientId: string | undefined;
 };
 
 const sessions: { [sessionId: string]: Session } = {};
 
 export const createSession = ({
   clientInfo,
+  capabilities,
+  clientId,
 }: {
   clientInfo: ClientInfo;
+  capabilities: ClientCapabilitiesWithUiExtension;
+  clientId: string | undefined;
 }): StreamableHTTPServerTransport => {
   const transport = new StreamableHTTPServerTransport({
     sessionIdGenerator: () => randomUUID(),
     onsessioninitialized: (sessionId) => {
-      sessions[sessionId] = { transport, clientInfo };
+      sessions[sessionId] = { transport, clientInfo, capabilities, clientId };
       log({ message: `Session created: ${sessionId}`, level: 'debug', logger: 'session' });
     },
   });

--- a/src/testSetup.ts
+++ b/src/testSetup.ts
@@ -15,6 +15,7 @@ vi.mock('@modelcontextprotocol/sdk/server/mcp.js', async (importOriginal) => {
           version: '1.0.0',
           name: 'test-client',
         }),
+        getClientCapabilities: vi.fn().mockReturnValue(undefined),
       },
       registerTool: vi.fn(),
       connect: vi.fn(),

--- a/src/tools/web/renderInteractiveViz/renderInteractiveViz.test.ts
+++ b/src/tools/web/renderInteractiveViz/renderInteractiveViz.test.ts
@@ -71,6 +71,8 @@ describe('renderInteractiveVizTool', () => {
       objectType: expect.any(Object),
     });
     expect(tool.app?.resourceUri).toBe('ui://render-interactive-viz/mcp-app.html');
+    // Opts out of the plain-tool fallback so the tool is hidden from clients that can't render it.
+    expect(tool.app?.hideWhenUnsupported).toBe(true);
   });
 
   describe('disabled property', () => {

--- a/src/tools/web/renderInteractiveViz/renderInteractiveViz.ts
+++ b/src/tools/web/renderInteractiveViz/renderInteractiveViz.ts
@@ -41,7 +41,7 @@ export const getRenderInteractiveVizTool = (server: WebMcpServer): WebTool<typeo
       idempotentHint: true,
       openWorldHint: false,
     },
-    app: getAppConfig('render-interactive-viz'),
+    app: { ...getAppConfig('render-interactive-viz'), hideWhenUnsupported: true },
     disabled: new Provider(
       async () =>
         !(await getFeatureGate().isFeatureEnabled('mcp-apps')) ||

--- a/src/tools/web/tool.ts
+++ b/src/tools/web/tool.ts
@@ -32,6 +32,8 @@ export type AppDetails = {
   name: string;
   resourceUri: string;
   htmlPath: string;
+  // Skip the plain-tool fallback entirely when the client can't render the app.
+  hideWhenUnsupported?: boolean;
 };
 
 /**


### PR DESCRIPTION
## Description
- Gate MCP-Apps tool registration on whether the connecting client actually advertised the SEP-1724 UI capability at `initialize`, instead of relying solely on the `mcp-apps` feature flag.
- Exclude claude.ai (OAuth/HTTP) from app-tool registration even when it advertises the capability, due to a known incompatibility in its MCP-Apps renderer. Reuses the existing `getClientDisplayName` telemetry host mapping — no new client identity logic.
- Threads `capabilities`/`clientId` end-to-end (`Server`, `WebMcpServer`, `Session`, both HTTP branches in `express.ts`) mirroring the existing `clientInfo` pattern.
- New `src/server/mcpUiCapability.ts` helper (`clientSupportsMcpApps`) with its own unit tests.

## Motivation and Context
Previously, any client got an interactive "app tool" whenever the `mcp-apps` flag was on, even if it had no way to render one — and claude.ai specifically advertises the capability but has a broken renderer for it. This adds a second, orthogonal gate (live client capability) plus an explicit deny-list entry for the one known-incompatible client, defaulting safely to plain-tool registration whenever support is unknown/absent.

**Known, documented limitation:** in stateless HTTP mode (`DISABLE_SESSION_MANAGEMENT=true`), a fresh server/transport is created and torn down on every request, and per the MCP spec `capabilities` is only ever present on the literal `initialize` request body — so app-tool activation via live capability detection never fires for real tool-call traffic in that mode (it always safely falls back to plain tools). This is called out explicitly in a code comment (`src/server/express.ts`) and in the `DISABLE_SESSION_MANAGEMENT` docs page, rather than silently left as an unexplained gap. The claude.ai exclusion is unaffected, since it's keyed on `clientId` (available on every request, not just `initialize`).

This change went through 3 rounds of independent dual-reviewer + synthesis review:
- **Round 1** found and fixed a regression where the stateless HTTP branch wasn't threading `capabilities`/`clientId` at all.
- **Round 2** found the deeper structural limitation described above (capabilities are only available on `initialize`, so app tools can never activate for real requests in stateless mode) and confirmed it isn't fixable by more parameter threading.
- **Round 3** confirmed the fix (documenting the limitation rather than engineering around it) — canonical `VERDICT: PASS`.

GUS: W-24061219

## Type of Change
- [x] New feature
- [x] Documentation update

## How Has This Been Tested?
- `npx vitest run` — 177 files / 2842 tests passing, including 5 new tests for `mcpUiCapability.ts` and 5 new/updated cases in `server.web.test.ts` covering: capable client registers app tool, missing/lacking capability falls back to plain, flag off falls back to plain, claude.ai clientId falls back to plain despite otherwise qualifying, and a non-Claude known client (Cursor) still registers as an app tool.
- `npm run build` passing (default + MCP Apps + tracing bundles).

## Related Issues
GUS: W-24061219 (https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002jTxXKYA0/view)

## Checklist
- [ ] I have updated the version in the package.json file by using `npm run version`.
- [x] I have made any necessary changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have documented any breaking changes in the PR description (none — this is additive; stateless-mode limitation is a documented pre-existing constraint, not a behavior change for any currently-working case)

## Contributor Agreement
- [x] I have read the CONTRIBUTING guidelines for this project and followed its Contribution Checklist.
