### PR TITLE
@W-23757359: Surface connected Tableau server + site in MCP instructions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "4.5.8",
+  "version": "4.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "4.5.8",
+      "version": "4.7.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1095.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "4.5.8",
+  "version": "4.7.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/src/server.web.test.ts
+++ b/src/server.web.test.ts
@@ -167,6 +167,102 @@ describe('server', () => {
     expect(instructions).not.toContain('Markdown tables');
   });
 
+  it('should name the connected server and site in instructions when SERVER and SITE_NAME are set', () => {
+    vi.mocked(McpServer).mockClear();
+    vi.stubEnv('SERVER', 'https://10ax.online.tableau.com');
+    vi.stubEnv('SITE_NAME', 'admin-insights');
+    new WebMcpServer();
+    const instructions = getConstructedInstructions();
+
+    expect(instructions).toBeTruthy();
+    expect(instructions).toContain(
+      'This server is connected to Tableau server https://10ax.online.tableau.com (site: admin-insights).',
+    );
+  });
+
+  it('should fall back to the "Default" site label when SITE_NAME is empty but SERVER is set', () => {
+    vi.mocked(McpServer).mockClear();
+    vi.stubEnv('SERVER', 'https://10ax.online.tableau.com');
+    vi.stubEnv('SITE_NAME', '');
+    new WebMcpServer();
+    const instructions = getConstructedInstructions();
+
+    expect(instructions).toContain(
+      'This server is connected to Tableau server https://10ax.online.tableau.com (site: Default).',
+    );
+  });
+
+  it('should omit the connection clause entirely when SERVER is unset', () => {
+    vi.mocked(McpServer).mockClear();
+    vi.stubEnv('SERVER', undefined);
+    vi.stubEnv('SITE_NAME', 'tc25');
+    new WebMcpServer();
+    const instructions = getConstructedInstructions();
+
+    // Base guidance is still present...
+    expect(instructions).toContain('Tableau MCP exposes tools');
+    // ...but no static connection clause: hosted/multi-tenant OAuth resolves the site per-user at sign-in.
+    expect(instructions).not.toContain('This server is connected to Tableau server');
+    expect(instructions).not.toContain('(site:');
+  });
+
+  it('should not leak an unresolved ${user_config.*} template verbatim into the connection clause', () => {
+    vi.mocked(McpServer).mockClear();
+    // The Claude MCP Bundle leaves this placeholder verbatim when the user configures no site name.
+    vi.stubEnv('SERVER', 'https://10ax.online.tableau.com');
+    vi.stubEnv('SITE_NAME', '${user_config.site_name}');
+    new WebMcpServer();
+    const instructions = getConstructedInstructions();
+
+    // The sanitizer blanks the placeholder, so the site falls back to "Default" and the raw template
+    // never reaches the model-facing instructions.
+    expect(instructions).not.toContain('${user_config.site_name}');
+    expect(instructions).toContain(
+      'This server is connected to Tableau server https://10ax.online.tableau.com (site: Default).',
+    );
+  });
+
+  it('should defer the site to sign-in when OAuth site-locking is off (OAUTH_LOCK_SITE=false)', () => {
+    vi.mocked(McpServer).mockClear();
+    vi.stubEnv('SERVER', 'https://10ay.online.tableau.com');
+    vi.stubEnv('SITE_NAME', 'strawberrysugar10ay');
+    vi.stubEnv('OAUTH_LOCK_SITE', 'false');
+    new WebMcpServer();
+    const instructions = getConstructedInstructions();
+
+    // The pod is still named, but the now non-authoritative static SITE_NAME is suppressed rather than
+    // asserted — under lock-off each user signs in to their own site.
+    expect(instructions).toContain(
+      'This server is connected to Tableau server https://10ay.online.tableau.com (site: determined per user at sign-in).',
+    );
+    expect(instructions).not.toContain('strawberrysugar10ay');
+  });
+
+  it('should name the static site when OAuth site-locking is on (OAUTH_LOCK_SITE=true)', () => {
+    vi.mocked(McpServer).mockClear();
+    vi.stubEnv('SERVER', 'https://10ay.online.tableau.com');
+    vi.stubEnv('SITE_NAME', 'strawberrysugar10ay');
+    vi.stubEnv('OAUTH_LOCK_SITE', 'true');
+    new WebMcpServer();
+    const instructions = getConstructedInstructions();
+
+    expect(instructions).toContain(
+      'This server is connected to Tableau server https://10ay.online.tableau.com (site: strawberrysugar10ay).',
+    );
+  });
+
+  it('should defer the site to sign-in under passthrough auth (ENABLE_PASSTHROUGH_AUTH=true)', () => {
+    vi.mocked(McpServer).mockClear();
+    vi.stubEnv('SERVER', 'https://10ay.online.tableau.com');
+    vi.stubEnv('SITE_NAME', 'strawberrysugar10ay');
+    vi.stubEnv('ENABLE_PASSTHROUGH_AUTH', 'true');
+    new WebMcpServer();
+    const instructions = getConstructedInstructions();
+
+    expect(instructions).toContain('(site: determined per user at sign-in)');
+    expect(instructions).not.toContain('strawberrysugar10ay');
+  });
+
   it('should not register disabled tools', async () => {
     const server = getServer();
     await server.registerTools();

--- a/src/server.web.ts
+++ b/src/server.web.ts
@@ -15,6 +15,7 @@ import { join } from 'path';
 
 import pkg from '../package.json';
 import { getConfig } from './config.js';
+import { removeClaudeMcpBundleUserConfigTemplates } from './config.shared.js';
 import { ServiceUnavailableError } from './errors/mcpToolError.js';
 import { getFeatureGate } from './features/init.js';
 import { getTableauServerInfo } from './getTableauServerInfo.js';
@@ -57,11 +58,13 @@ const ADMIN_INSTRUCTIONS =
  * Single source of truth for the web server's `initialize` instructions string. Returns the base
  * guidance, with the admin/site-health guidance appended only when ADMIN_TOOLS_ENABLED is set.
  *
- * ADMIN_TOOLS_ENABLED is read straight from env (matching Config's exact semantics in config.ts:
- * `ADMIN_TOOLS_ENABLED === 'true'`) rather than via getConfig(). The instructions string depends
- * ONLY on this flag, and it is composed at handshake/registration-independent construction time —
- * eagerly building the full Config here would newly require SERVER to be set and would consume test
- * getConfig() mocks. Direct env read keeps composition side-effect-free.
+ * All inputs are read straight from env rather than via getConfig(): ADMIN_TOOLS_ENABLED (matching Config's
+ * exact semantics in config.ts, `ADMIN_TOOLS_ENABLED === 'true'`); SERVER/SITE_NAME through
+ * removeClaudeMcpBundleUserConfigTemplates so an unreplaced Claude-Bundle `${user_config.*}` template is
+ * blanked rather than leaked; and OAUTH_LOCK_SITE / ENABLE_PASSTHROUGH_AUTH, which decide whether the site
+ * is statically pinned. Composed at handshake/registration-independent construction time — eagerly building
+ * the full Config here would newly require SERVER to be set and would consume test getConfig() mocks. Direct
+ * env reads keep composition side-effect-free.
  *
  * Both the default/web path (WebMcpServer constructs its own McpServer) and the combined path
  * (index.combined.ts supplies a pre-built McpServer) MUST feed instructions through this function.
@@ -71,7 +74,30 @@ const ADMIN_INSTRUCTIONS =
  */
 export function buildWebInstructions(): string {
   const adminToolsEnabled = process.env.ADMIN_TOOLS_ENABLED === 'true';
-  return adminToolsEnabled ? `${BASE_INSTRUCTIONS} ${ADMIN_INSTRUCTIONS}` : BASE_INSTRUCTIONS;
+  const instructions = adminToolsEnabled
+    ? `${BASE_INSTRUCTIONS} ${ADMIN_INSTRUCTIONS}`
+    : BASE_INSTRUCTIONS;
+
+  // Connection clause: name the single Tableau instance this process is bound to so a client/model can tell
+  // which one it maps to. SERVER (the pod) is printed verbatim (no URL reparse, matching the operator's
+  // configured value); the whole clause is omitted when SERVER is unset (hosted/multi-tenant OAuth).
+  const { SERVER: server, SITE_NAME: siteName } = removeClaudeMcpBundleUserConfigTemplates(
+    process.env,
+  );
+  if (!server) {
+    return instructions;
+  }
+
+  // The SERVER (pod) is fixed, but the SITE is only statically pinned when every session binds to one site.
+  // Two opt-in modes float the site per connecting user, so a static SITE_NAME would misstate the live
+  // connection: OAuth with site-locking off (OAUTH_LOCK_SITE=false — mirrors Config's default
+  // `lockSite: oauthLockSite !== 'false'`) and passthrough auth (ENABLE_PASSTHROUGH_AUTH=true, where each
+  // request carries its own site). In those modes name the pod but defer the site to sign-in rather than
+  // assert a stale value.
+  const siteFloatsPerUser =
+    process.env.OAUTH_LOCK_SITE === 'false' || process.env.ENABLE_PASSTHROUGH_AUTH === 'true';
+  const site = siteFloatsPerUser ? 'determined per user at sign-in' : siteName || 'Default';
+  return `${instructions} This server is connected to Tableau server ${server} (site: ${site}).`;
 }
 
 export class WebMcpServer extends Server {


### PR DESCRIPTION
[Akash's agent]

## Summary

A `tableau-mcp` process is bound to exactly one `(server, site)` pair, but today it surfaces the configured `SERVER` / `SITE_NAME` **nowhere** a client or model can read: `serverName` is a static literal, `buildWebInstructions()` never mentions them, and no tool/resource/serverInfo carries them. When an admin runs several instances (one per site), there is no way to tell which instance maps to which Tableau site.

This extends the merged server-instructions work (`#840`, `@W-23757364`) by appending a third, always-safe clause to `buildWebInstructions()` naming the connected host + site, so the connection identity is discoverable in the MCP `initialize` instructions that the host injects into every session.

## Fix

`src/server.web.ts` — `buildWebInstructions()` now appends:

> `This server is connected to Tableau server <SERVER> (site: <SITE_NAME>).`

Design decisions (all verified against current code):

- **Raw env, not `getConfig()`.** `SERVER`/`SITE_NAME` (and the site-pinning flags below) are read straight from `process.env` — the same rationale already documented for `ADMIN_TOOLS_ENABLED` in this function: eagerly building `Config` here would newly require `SERVER` and would consume test `getConfig()` mocks.
- **Sanitized.** Values pass through `removeClaudeMcpBundleUserConfigTemplates` so an unreplaced Claude-Bundle placeholder (e.g. `${user_config.site_name}`) is blanked instead of leaking verbatim into model-facing text.
- **`SERVER` printed verbatim** — no `new URL(server).hostname` reparse. Keeps this deliberately validation-free path exception-free and matches the operator's own configured value.
- **Site label defaults to `Default`** when `SITE_NAME` is empty (mirrors `src/server/oauth/callback.ts:129`).
- **Clause omitted entirely when `SERVER` is unset** (hosted `mcp.tableau.com` / pure multi-tenant OAuth) — avoids advertising a misleading static site.
- **The site is named only when it is statically pinned.** When it floats per connecting user — OAuth with `OAUTH_LOCK_SITE=false`, or passthrough auth (`ENABLE_PASSTHROUGH_AUTH=true`) — the clause names the pod but defers the site: `(site: determined per user at sign-in)`, rather than assert a stale static `SITE_NAME`. (Addresses PR review — thanks @Alon-ST-DATA.)

The change lives solely in the shared `buildWebInstructions()` builder, so it flows through **both** entry points (the default `WebMcpServer` path and the combined `src/index.combined.ts` path) and stays covered by the lockstep `invariant` in `src/server.ts`.

The bug title also stresses "naming". I evaluated enriching the MCP `serverInfo` `title` with the site, but **deliberately skipped** it: the `name` is asserted as a stable literal and clients may key on it, and a dynamic `title` would have to be threaded through three separate construction sites that would otherwise drift — disproportionate risk once the instructions clause already delivers the identity to the model.

## Testing

- **Unit** (`src/server.web.test.ts`): instructions name `SERVER` + `SITE_NAME` when both set; site falls back to `Default` when empty; clause omitted when `SERVER` unset; unresolved `${user_config.*}` template does not leak; **site deferred under `OAUTH_LOCK_SITE=false` and under passthrough**; static site named when site-locking is on.
- Full pre-commit checklist green: `npm run build` (all variants incl. combined), `npx tsc --noEmit`, `npm run lint`, `npm test` (2844 unit tests).

## Known limitation

This fix stops the server from asserting a **wrong** site — under the per-user modes (OAuth `OAUTH_LOCK_SITE=false`, passthrough) it now defers rather than printing a stale `SITE_NAME`. What it does **not** do is *resolve and display the actual live signed-in site* in those modes: `buildWebInstructions()` runs once at construction with no request context, so it can't name a per-user site. Doing that would require threading `tableauAuthInfo` through the handshake / per-request instruction composition — a separate, larger follow-up. This PR is correct for the common single-site deployment and safe (defers, never lies) in the dynamic modes.

## Risk

**Low.** Additive, single-function change to a string builder; no behavior change when `SERVER` is unset, and existing base/admin instructions tests use substring assertions that are unaffected. Version bumped to `4.7.2`.
