### PR TITLE
@W-23752441: guard docs against removed/renamed tool names

### DIFF
--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -27,6 +27,10 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+      - name: Verify docs tool-name guard logic
+        run: npm run test:guard
+      - name: Check docs for removed tool-name references
+        run: npm run check:tool-names
       - name: Test build website
         run: npm run build
       - name: Upload artifacts

--- a/docs/package.json
+++ b/docs/package.json
@@ -12,7 +12,9 @@
     "serve": "docusaurus serve --port 3000 --dir build/tableau-mcp",
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",
-    "typecheck": "tsc"
+    "typecheck": "tsc",
+    "check:tool-names": "node scripts/check-removed-tool-names.mjs",
+    "test:guard": "node --test scripts/check-removed-tool-names.test.mjs"
   },
   "dependencies": {
     "@docusaurus/core": "^3.9.0",

--- a/docs/scripts/check-removed-tool-names.mjs
+++ b/docs/scripts/check-removed-tool-names.mjs
@@ -1,0 +1,131 @@
+// Docs ↔ tool-registry consistency guard.
+//
+// When a Tableau MCP tool is removed or renamed, its old kebab-case name must
+// not linger in the published docs: a stale name misleads readers into calling
+// a tool that no longer exists. This has happened before — the docs kept naming
+// the removed `get-stale-content-report` tool after it was folded into
+// `query-admin-insights` (with `kind: "stale-content"`).
+//
+// This guard fails when any deny-listed (removed/renamed) tool name appears as a
+// standalone token under docs/docs. It is deliberately a deny-list of REMOVED
+// names rather than an allow-list diff against the live registry: a registry
+// diff would false-positive on legitimate kebab tokens such as the
+// query-admin-insights `kind` values (stale-content, ts-events, ts-users,
+// site-content, job-performance) and REST operation ids.
+//
+// Scope: only files under docs/docs (the Docusaurus content root) are scanned.
+//
+// To extend: when you remove or rename a tool, add its old name to
+// REMOVED_TOOL_NAMES below.
+
+import { readdirSync, readFileSync } from 'node:fs';
+import { join, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export const REMOVED_TOOL_NAMES = [
+  // Consolidated into `query-admin-insights` (kind: "stale-content"); the
+  // standalone tool was removed in PR #860.
+  'get-stale-content-report',
+];
+
+const DOC_EXTENSIONS = ['.md', '.mdx'];
+
+/** Recursively collect files with a docs extension under `rootDir`. */
+function collectDocFiles(rootDir) {
+  const files = [];
+  for (const entry of readdirSync(rootDir, { withFileTypes: true })) {
+    if (entry.isDirectory()) {
+      // Skip dependency/tooling dirs that could contain unrelated markdown.
+      if (entry.name === 'node_modules' || entry.name.startsWith('.')) {
+        continue;
+      }
+      files.push(...collectDocFiles(join(rootDir, entry.name)));
+    } else if (DOC_EXTENSIONS.some((ext) => entry.name.endsWith(ext))) {
+      files.push(join(rootDir, entry.name));
+    }
+  }
+  return files;
+}
+
+/**
+ * Build a matcher that hits `name` only as a standalone kebab token, so a longer
+ * identifier that merely contains a removed name (hypothetically
+ * `get-stale-content-report-v2`) does not trigger a false positive.
+ */
+function tokenRegex(name) {
+  const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return new RegExp(`(?<![A-Za-z0-9-])${escaped}(?![A-Za-z0-9-])`);
+}
+
+const MATCHERS = REMOVED_TOOL_NAMES.map((name) => ({ name, re: tokenRegex(name) }));
+
+/**
+ * Scan every doc file under `rootDir` for references to removed tool names.
+ * @returns {{ filesScanned: number, violations: Array<{file:string,line:number,name:string,snippet:string}> }}
+ */
+export function findRemovedToolNameReferences(rootDir) {
+  const files = collectDocFiles(rootDir);
+  const violations = [];
+  for (const file of files) {
+    const lines = readFileSync(file, 'utf8').split('\n');
+    lines.forEach((text, i) => {
+      for (const { name, re } of MATCHERS) {
+        if (re.test(text)) {
+          violations.push({ file, line: i + 1, name, snippet: text.trim() });
+        }
+      }
+    });
+  }
+  return { filesScanned: files.length, violations };
+}
+
+// Default docs root: <repo>/docs/docs, resolved relative to this script so the
+// guard works regardless of the current working directory.
+export const DEFAULT_DOCS_ROOT = fileURLToPath(new URL('../docs', import.meta.url));
+
+function main() {
+  // Optional positional arg overrides the docs root (used by the tests to point
+  // the CLI at fixtures); defaults to the real docs/docs tree.
+  const rootArg = process.argv[2];
+  const rootDir = rootArg ? resolve(process.cwd(), rootArg) : DEFAULT_DOCS_ROOT;
+
+  const { filesScanned, violations } = findRemovedToolNameReferences(rootDir);
+
+  // A guard that scans nothing must never pass: zero files means the docs root
+  // moved or was mis-resolved, not that the docs are clean.
+  if (filesScanned === 0) {
+    console.error(
+      `✖ docs tool-name guard scanned 0 doc files under ${rootDir}. ` +
+        'The docs root may have moved; refusing to pass vacuously.',
+    );
+    process.exit(1);
+  }
+
+  if (violations.length > 0) {
+    console.error('✖ Docs reference removed/renamed tool names:\n');
+    for (const v of violations) {
+      console.error(`  ${relative(process.cwd(), v.file)}:${v.line}  ->  "${v.name}"`);
+      console.error(`      ${v.snippet}`);
+    }
+    console.error(
+      `\n${violations.length} reference(s) found. These tools were removed or renamed; ` +
+        'update the docs to the current tool name (e.g. "get-stale-content-report" -> ' +
+        '"query-admin-insights" with kind: "stale-content").',
+    );
+    console.error(
+      '\nIf a name flagged here is in fact still a live tool, remove it from ' +
+        'REMOVED_TOOL_NAMES in docs/scripts/check-removed-tool-names.mjs.',
+    );
+    process.exit(1);
+  }
+
+  console.log(
+    `✓ docs tool-name guard: no removed tool names in ${filesScanned} doc file(s) ` +
+      `(deny-list: ${REMOVED_TOOL_NAMES.join(', ')}).`,
+  );
+}
+
+// Run as a CLI only when invoked directly (not when imported by the test).
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/docs/scripts/check-removed-tool-names.test.mjs
+++ b/docs/scripts/check-removed-tool-names.test.mjs
@@ -1,0 +1,140 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import {
+  DEFAULT_DOCS_ROOT,
+  findRemovedToolNameReferences,
+  REMOVED_TOOL_NAMES,
+} from './check-removed-tool-names.mjs';
+
+const SCRIPT = fileURLToPath(new URL('./check-removed-tool-names.mjs', import.meta.url));
+
+/** Create a temp docs tree from a { relativePath: contents } map. */
+function makeDocsTree(files) {
+  const root = mkdtempSync(join(tmpdir(), 'docs-guard-'));
+  for (const [rel, contents] of Object.entries(files)) {
+    const full = join(root, rel);
+    mkdirSync(dirname(full), { recursive: true });
+    writeFileSync(full, contents);
+  }
+  return root;
+}
+
+function withDocsTree(files, fn) {
+  const root = makeDocsTree(files);
+  try {
+    return fn(root);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+/** Run the guard CLI against `rootDir`; returns the spawn result. */
+function runGuardCli(rootDir) {
+  return spawnSync(process.execPath, [SCRIPT, rootDir], { encoding: 'utf8' });
+}
+
+test('deny-list is non-empty and includes the seed name', () => {
+  assert.ok(REMOVED_TOOL_NAMES.length > 0);
+  assert.ok(REMOVED_TOOL_NAMES.includes('get-stale-content-report'));
+});
+
+test('passes when no removed tool names are present', () => {
+  withDocsTree(
+    {
+      'intro.md': 'Use the `query-admin-insights` tool with `kind: "stale-content"`.',
+      'nested/config.md': 'See query-datasource and get-datasource-metadata.',
+    },
+    (root) => {
+      const { violations, filesScanned } = findRemovedToolNameReferences(root);
+      assert.equal(violations.length, 0);
+      assert.equal(filesScanned, 2);
+    },
+  );
+});
+
+test('flags a removed tool name in prose and inside backticks (.md and .mdx)', () => {
+  withDocsTree(
+    {
+      'intro.md': 'Call the `get-stale-content-report` tool to find stale content.',
+      'guide/usage.mdx': 'The get-stale-content-report output lists workbooks.',
+    },
+    (root) => {
+      const { violations } = findRemovedToolNameReferences(root);
+      assert.equal(violations.length, 2);
+      assert.ok(violations.every((v) => v.name === 'get-stale-content-report'));
+      assert.deepEqual(
+        violations.map((v) => v.line).sort(),
+        [1, 1],
+      );
+    },
+  );
+});
+
+test('does not false-positive on kind values or longer identifiers', () => {
+  withDocsTree(
+    {
+      'kinds.md': [
+        '- `stale-content`',
+        '- `ts-events`',
+        '- `ts-users`',
+        '- `site-content`',
+        '- `job-performance`',
+        'A hypothetical `get-stale-content-report-v2` token must not match.',
+      ].join('\n'),
+    },
+    (root) => {
+      const { violations } = findRemovedToolNameReferences(root);
+      assert.equal(violations.length, 0);
+    },
+  );
+});
+
+test('skips node_modules and dot-directories', () => {
+  withDocsTree(
+    {
+      'intro.md': 'Clean doc referencing `query-admin-insights`.',
+      'node_modules/pkg/README.md': 'Third-party `get-stale-content-report` mention.',
+      '.cache/leftover.md': 'Stale `get-stale-content-report` build artifact.',
+    },
+    (root) => {
+      const { violations, filesScanned } = findRemovedToolNameReferences(root);
+      assert.equal(filesScanned, 1);
+      assert.equal(violations.length, 0);
+    },
+  );
+});
+
+test('default docs root resolves to the real docs and scans files (wiring)', () => {
+  const { filesScanned } = findRemovedToolNameReferences(DEFAULT_DOCS_ROOT);
+  assert.ok(filesScanned > 0, 'expected DEFAULT_DOCS_ROOT to resolve to a non-empty docs tree');
+});
+
+test('CLI exits 0 on the real docs tree (default root)', () => {
+  const result = spawnSync(process.execPath, [SCRIPT], { encoding: 'utf8' });
+  assert.equal(result.status, 0, result.stderr);
+});
+
+test('CLI exits 1 when a removed tool name is present', () => {
+  withDocsTree(
+    { 'intro.md': 'Use the `get-stale-content-report` tool.' },
+    (root) => {
+      const result = runGuardCli(root);
+      assert.equal(result.status, 1);
+      assert.match(result.stderr, /get-stale-content-report/);
+    },
+  );
+});
+
+test('CLI exits 1 when it scans zero doc files (never passes vacuously)', () => {
+  withDocsTree({}, (root) => {
+    const result = runGuardCli(root);
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /0 doc files/);
+  });
+});

--- a/docs/scripts/check-removed-tool-names.test.mjs
+++ b/docs/scripts/check-removed-tool-names.test.mjs
@@ -68,10 +68,7 @@ test('flags a removed tool name in prose and inside backticks (.md and .mdx)', (
       const { violations } = findRemovedToolNameReferences(root);
       assert.equal(violations.length, 2);
       assert.ok(violations.every((v) => v.name === 'get-stale-content-report'));
-      assert.deepEqual(
-        violations.map((v) => v.line).sort(),
-        [1, 1],
-      );
+      assert.deepEqual(violations.map((v) => v.line).sort(), [1, 1]);
     },
   );
 });
@@ -121,14 +118,11 @@ test('CLI exits 0 on the real docs tree (default root)', () => {
 });
 
 test('CLI exits 1 when a removed tool name is present', () => {
-  withDocsTree(
-    { 'intro.md': 'Use the `get-stale-content-report` tool.' },
-    (root) => {
-      const result = runGuardCli(root);
-      assert.equal(result.status, 1);
-      assert.match(result.stderr, /get-stale-content-report/);
-    },
-  );
+  withDocsTree({ 'intro.md': 'Use the `get-stale-content-report` tool.' }, (root) => {
+    const result = runGuardCli(root);
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /get-stale-content-report/);
+  });
 });
 
 test('CLI exits 1 when it scans zero doc files (never passes vacuously)', () => {

--- a/docs/scripts/check-removed-tool-names.test.mjs
+++ b/docs/scripts/check-removed-tool-names.test.mjs
@@ -58,17 +58,21 @@ test('passes when no removed tool names are present', () => {
   );
 });
 
-test('flags a removed tool name in prose and inside backticks (.md and .mdx)', () => {
+test('flags a removed tool name in prose and backticks, with accurate line numbers (.md and .mdx)', () => {
   withDocsTree(
     {
-      'intro.md': 'Call the `get-stale-content-report` tool to find stale content.',
+      // Removed name on line 3 (not line 1) so the reported line number is actually exercised.
+      'intro.md': '# Intro\n\nCall the `get-stale-content-report` tool to find stale content.',
       'guide/usage.mdx': 'The get-stale-content-report output lists workbooks.',
     },
     (root) => {
       const { violations } = findRemovedToolNameReferences(root);
       assert.equal(violations.length, 2);
       assert.ok(violations.every((v) => v.name === 'get-stale-content-report'));
-      assert.deepEqual(violations.map((v) => v.line).sort(), [1, 1]);
+      const intro = violations.find((v) => v.file.endsWith('intro.md'));
+      const usage = violations.find((v) => v.file.endsWith('usage.mdx'));
+      assert.equal(intro.line, 3);
+      assert.equal(usage.line, 1);
     },
   );
 });

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -46,6 +46,15 @@ export default [
     },
   },
   {
+    // Standalone Node CLI scripts (plain JS): the TS return-type rule is
+    // inapplicable to .mjs, and a CLI legitimately writes to stdout.
+    files: ['docs/scripts/**/*.mjs'],
+    rules: {
+      'no-console': 'off',
+      '@typescript-eslint/explicit-function-return-type': 'off',
+    },
+  },
+  {
     languageOptions: {
       ecmaVersion: 'latest',
       sourceType: 'module',


### PR DESCRIPTION
[Akash's agent]

## Summary

Adds a docs↔tool-registry consistency guard that fails CI when a **removed or renamed tool name** reappears anywhere under `docs/docs`. Follow-up hardening suggested during review of #860.

## Why

The root cause behind the doc drift fixed in #860 was that the removed `get-stale-content-report` tool — consolidated into `query-admin-insights` (`kind: "stale-content"`) — kept being named in three docs long after it was gone. Nothing guarded the docs against referencing tools that no longer exist, so the stale name sat undetected: a valid-*looking* kebab token inside an inline-code span that the Docusaurus build has no reason to fail on.

## What

A small, zero-dependency Node guard:

- **Deny-list of removed names**, seeded with `get-stale-content-report`. Deliberately a deny-list of *removed* names, **not** an allow-list diff against the live tool registry — a registry diff would false-positive on legitimate kebab tokens such as the `query-admin-insights` `kind` values (`stale-content`, `ts-events`, `ts-users`, `site-content`, `job-performance`) and REST operation ids.
- **Token-precise match** — a removed name is caught wherever it appears as a standalone token (backticked or in prose), but a longer identifier that merely contains it is not flagged.
- Prints `file:line` + the offending line and **exits non-zero** on any hit; also **refuses to pass if it ever scans zero files**, so a future docs-root move can't silently neuter the guard.

### Files

| File | Purpose |
|---|---|
| `docs/scripts/check-removed-tool-names.mjs` | The guard (zero deps). |
| `docs/scripts/check-removed-tool-names.test.mjs` | `node:test` suite — logic + CLI exit codes. |
| `docs/package.json` | `check:tool-names` + `test:guard` scripts. |
| `.github/workflows/test-deploy.yml` | Runs both in the existing docs CI job. |

> **⚠️ Docs-only by design:** the guard lives under `docs/`, never `src/`, so this PR does not trip `version-bump-check` (which only fires on `src/**`) — no version bump required.

## Testing

- `npm run test:guard` → **9/9 pass** (logic, `.md`/`.mdx`, false-positive guards on `kind` values, CLI exit 0/1, zero-file floor).
- `npm run check:tool-names` → clean on current docs (scans **74** `.md`/`.mdx` files).
- Verified the failure path: injecting `get-stale-content-report` into a doc makes the guard exit 1 with the file/line; reverted.
- This check **would have failed before #860 and passes now.**
