### PR TITLE
chore: bump version to 2.67.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "2.67.3",
+  "version": "2.67.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "2.67.3",
+      "version": "2.67.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.7.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "2.67.3",
+  "version": "2.67.4",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"


### PR DESCRIPTION
## Summary
- bump the MCP package version from 2.67.3 to 2.67.4
- allow the internal publishing pipeline to create new immutable Desktop MCP artifacts

## Context
The pipeline for PR #858 rebuilt the fixed MCP at version 2.67.3, but publishing skipped because the 2.67.3 Artifactory artifacts already existed. A new version is required so the KPI fixes can be published and then bundled by tab-agent-south.

## Testing
- version-only change
- git diff --check