### PR TITLE
fix(desktop): quote string filter members

### DIFF
--- a/src/desktop/refine/roundStackedBar.test.ts
+++ b/src/desktop/refine/roundStackedBar.test.ts
@@ -379,6 +379,25 @@ describe('planRoundStackedBar', () => {
     );
   });
 
+  it('decodes Tableau-escaped backslashes in a quoted categorical filter member', () => {
+    const source = worksheet({
+      extraColumnInstances:
+        "<column caption='Region' datatype='string' name='[Region]' role='dimension' type='nominal' /><column-instance column='[Region]' derivation='None' name='[none:Region:nk]' pivot='key' type='nominal' />",
+      filter: `<filter class='categorical' column='[${INTERNAL_DS}].[none:Region:nk]'>
+        <groupfilter function='union' user:ui-enumeration='inclusive'>
+          <groupfilter function='member' level='[none:Region:nk]' member='&quot;Path\\\\Name&quot;' />
+        </groupfilter>
+      </filter>`,
+      slices: `<slices><column>[${INTERNAL_DS}].[none:Region:nk]</column></slices>`,
+    });
+
+    const result = planRoundStackedBar(source, { preset: 'subtle' });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.semanticContract.filter?.member).toBe('Path\\Name');
+  });
+
   it('preserves backslash sequences in an unquoted categorical filter member', () => {
     const source = worksheet({
       extraColumnInstances:

--- a/src/desktop/refine/roundStackedBar.ts
+++ b/src/desktop/refine/roundStackedBar.ts
@@ -570,10 +570,7 @@ function readFilter(
   }
 
   const encodedMember = members[0].getAttribute('member') ?? '';
-  const member =
-    encodedMember.startsWith('"') && encodedMember.endsWith('"')
-      ? encodedMember.slice(1, -1).replaceAll('\\"', '"')
-      : encodedMember;
+  const member = decodeTableauFilterMember(encodedMember);
   return {
     ok: true,
     allowedColumn: filterInstance.column,
@@ -584,6 +581,30 @@ function readFilter(
       member,
     },
   };
+}
+
+/**
+ * Decode the quoted string-literal form Tableau uses for categorical filter members.
+ * The binder escapes both backslashes and quotes before wrapping the member in quotes,
+ * so decode them together in one pass to preserve adjacent escape sequences correctly.
+ * Legacy unquoted members are returned unchanged.
+ */
+function decodeTableauFilterMember(encodedMember: string): string {
+  if (!encodedMember.startsWith('"') || !encodedMember.endsWith('"')) return encodedMember;
+
+  const literal = encodedMember.slice(1, -1);
+  let decoded = '';
+  for (let index = 0; index < literal.length; index += 1) {
+    const current = literal[index];
+    const next = literal[index + 1];
+    if (current === '\\' && (next === '\\' || next === '"')) {
+      decoded += next;
+      index += 1;
+    } else {
+      decoded += current;
+    }
+  }
+  return decoded;
 }
 
 function baseNodes(parsed: ParsedXml):

--- a/src/tools/desktop/authoring/binder/bindTemplate.test.ts
+++ b/src/tools/desktop/authoring/binder/bindTemplate.test.ts
@@ -4679,7 +4679,13 @@ describe('bindTemplateTool auto_apply gate', () => {
         ...boundM7TopNContextFilterResult,
         args: {
           ...boundM7TopNContextFilterResult.args,
-          filters: [{ field: 'Region', values: ['East'], context: true }],
+          filters: [
+            {
+              field: 'Region',
+              values: ['Archive - DLM', 'FIREInfra', 'MCIS - Operations Team'],
+              context: true,
+            },
+          ],
         },
       } as BinderResult,
       inject: { ok: true, xml: INJECTED_M7_RANKING_XML },
@@ -4692,7 +4698,13 @@ describe('bindTemplateTool auto_apply gate', () => {
       proposal: {
         ...sampleProposal,
         top_n: 10,
-        filters: [{ field: 'Region', values: ['East'], context: true }],
+        filters: [
+          {
+            field: 'Region',
+            values: ['Archive - DLM', 'FIREInfra', 'MCIS - Operations Team'],
+            context: true,
+          },
+        ],
       },
       auto_apply: true,
       getExecutor,
@@ -4704,10 +4716,47 @@ describe('bindTemplateTool auto_apply gate', () => {
       "<filter class='categorical' column='[M7].[none:region:nk]' context='true'>",
     );
     expect(xml).toContain(
-      "<groupfilter function='member' level='[none:region:nk]' member='East' user:ui-enumeration='inclusive' user:ui-marker='enumerate' />",
+      "<groupfilter function='member' level='[none:region:nk]' member='&quot;Archive - DLM&quot;' user:ui-enumeration='inclusive' user:ui-marker='enumerate' />",
     );
+    expect(xml).toContain("member='&quot;FIREInfra&quot;'");
+    expect(xml).toContain("member='&quot;MCIS - Operations Team&quot;'");
     // top-N unaffected.
     expect(xml).toMatch(/function='end'\s+end='top'\s+count='10'/);
+  });
+
+  it('m7: leaves non-string categorical members unquoted', async () => {
+    const integerRegionWorkbook = M7_WORKBOOK_XML.replace(
+      "<column caption='Region' name='[region]' role='dimension' type='nominal' datatype='string' />",
+      "<column caption='Region' name='[region]' role='dimension' type='ordinal' datatype='integer' />",
+    );
+    const { applyWorkbookDocument, getExecutor } = setupAutoApplyMocks({
+      bind: {
+        ...boundM7TopNContextFilterResult,
+        args: {
+          ...boundM7TopNContextFilterResult.args,
+          filters: [{ field: 'Region', values: ['42'], context: true }],
+        },
+      } as BinderResult,
+      inject: { ok: true, xml: INJECTED_M7_RANKING_XML },
+      workbookReads: [integerRegionWorkbook],
+    });
+
+    const result = await getToolResult({
+      session: '1',
+      ask: 'top 10 products by sales in region 42',
+      proposal: {
+        ...sampleProposal,
+        top_n: 10,
+        filters: [{ field: 'Region', values: ['42'], context: true }],
+      },
+      auto_apply: true,
+      getExecutor,
+    });
+
+    expect(result.isError).toBe(false);
+    const xml = appliedXml(applyWorkbookDocument);
+    expect(xml).toContain("member='42'");
+    expect(xml).not.toContain("member='&quot;42&quot;'");
   });
 
   it('preserves two proposal filters, both slices and shown dropdown cards without losing the grouping shelf', async () => {
@@ -4738,7 +4787,7 @@ describe('bindTemplateTool auto_apply gate', () => {
       "<filter class='categorical' column='[M7].[none:region:nk]' context='true'>",
     );
     expect(xml).toContain("<filter class='categorical' column='[M7].[none:segment:nk]'>");
-    expect(xml).toContain("member='Consumer'");
+    expect(xml).toContain("member='&quot;Consumer&quot;'");
     expect(xml).toContain('<column>[M7].[none:region:nk]</column>');
     expect(xml).toContain('<column>[M7].[none:segment:nk]</column>');
     expect(xml).toContain("<card mode='dropdown' param='[M7].[none:region:nk]' type='filter' />");

--- a/src/tools/desktop/authoring/binder/bindTemplate.test.ts
+++ b/src/tools/desktop/authoring/binder/bindTemplate.test.ts
@@ -4759,6 +4759,41 @@ describe('bindTemplateTool auto_apply gate', () => {
     expect(xml).not.toContain("member='&quot;42&quot;'");
   });
 
+  it('m7: escapes special characters in string categorical members', async () => {
+    const values = ["O'Brien", 'A "quoted" member', 'Path\\Name', 'A&B <Team>', ''];
+    const { applyWorkbookDocument, getExecutor } = setupAutoApplyMocks({
+      bind: {
+        ...boundM7TopNContextFilterResult,
+        args: {
+          ...boundM7TopNContextFilterResult.args,
+          filters: [{ field: 'Region', values, context: true }],
+        },
+      } as BinderResult,
+      inject: { ok: true, xml: INJECTED_M7_RANKING_XML },
+      workbookReads: [M7_WORKBOOK_XML],
+    });
+
+    const result = await getToolResult({
+      session: '1',
+      ask: 'top 10 products by sales for exact region members',
+      proposal: {
+        ...sampleProposal,
+        top_n: 10,
+        filters: [{ field: 'Region', values, context: true }],
+      },
+      auto_apply: true,
+      getExecutor,
+    });
+
+    expect(result.isError).toBe(false);
+    const xml = appliedXml(applyWorkbookDocument);
+    expect(xml).toContain("member='&quot;O&apos;Brien&quot;'");
+    expect(xml).toContain("member='&quot;A \\&quot;quoted\\&quot; member&quot;'");
+    expect(xml).toContain("member='&quot;Path\\\\Name&quot;'");
+    expect(xml).toContain("member='&quot;A&amp;B &lt;Team&gt;&quot;'");
+    expect(xml).toContain("member='&quot;&quot;'");
+  });
+
   it('preserves two proposal filters, both slices and shown dropdown cards without losing the grouping shelf', async () => {
     const { applyWorkbookDocument, getExecutor } = setupAutoApplyMocks({
       bind: boundM7TwoFilterResult,

--- a/src/tools/desktop/authoring/binder/bindTemplate.ts
+++ b/src/tools/desktop/authoring/binder/bindTemplate.ts
@@ -1855,6 +1855,7 @@ function ensureFilterColumnDependency(
 function buildInteractiveFilterNode(p: {
   columnRef: string;
   level: string;
+  datatype: string;
   context: boolean;
   values?: string[];
 }): string {
@@ -1864,7 +1865,7 @@ function buildInteractiveFilterNode(p: {
     const members = p.values
       .map(
         (v) =>
-          `<groupfilter function='member' level='${level}' member='${escapeXmlAttribute(v)}' user:ui-enumeration='inclusive' user:ui-marker='enumerate' />`,
+          `<groupfilter function='member' level='${level}' member='${serializeFilterMember(v, p.datatype)}' user:ui-enumeration='inclusive' user:ui-marker='enumerate' />`,
       )
       .join('');
     return (
@@ -1878,6 +1879,18 @@ function buildInteractiveFilterNode(p: {
     `<groupfilter function='level-members' level='${level}' user:ui-enumeration='all' />` +
     '</filter>'
   );
+}
+
+/**
+ * Tableau stores string members as quoted literals inside the XML attribute
+ * (`member='&quot;East&quot;'`). Raw strings are accepted at document dispatch but
+ * Desktop silently drops the filter during persistence. Non-string members use
+ * Tableau's unquoted representation (for example, a discrete year is `2026`).
+ */
+function serializeFilterMember(value: string, datatype: string): string {
+  if (datatype.trim().toLowerCase() !== 'string') return escapeXmlAttribute(value);
+  const tableauString = `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+  return escapeXmlAttribute(tableauString);
 }
 
 /**
@@ -2069,6 +2082,7 @@ function applyProposalSplices({
       const filterNode = buildInteractiveFilterNode({
         columnRef: declared.columnRef,
         level: declared.level,
+        datatype: resolved.field.datatype,
         context: filter.context === true,
         values: filter.values,
       });


### PR DESCRIPTION
## Summary

- serialize string categorical filter members as quoted Tableau literals before XML escaping
- preserve existing unquoted serialization for non-string members
- add regression coverage using the exact member names from the live Story Points detractor failure

## Why

Tableau can accept the worksheet apply while silently dropping categorical filters whose string members are emitted as raw values. The worksheet then renders without the requested driver/detractor member restriction, and post-apply verification correctly reports that the filter did not persist.

## Testing

- `npm test -- --run src/tools/desktop/authoring/binder/bindTemplate.test.ts` — 196 passed
- `npm run lint` — passed
- `npm run build:desktop:dirty` — passed
- live Tableau Desktop smoke: **Top detractors — Story Points** applied with `verification: "passed"`
- workbook readback confirmed all three quoted member nodes and the filter slice persisted

The repository-wide local test run entered environment-dependent timeout cases and was stopped; the PR pipeline remains the canonical full-suite gate.
