### PR TITLE
@W-23870893: Expand allData coverage

### DIFF
--- a/src/sdks/tableau/methods/viewAllData.test.ts
+++ b/src/sdks/tableau/methods/viewAllData.test.ts
@@ -35,6 +35,75 @@ const multipartBody = Buffer.from(
 );
 
 describe('parseViewAllData', () => {
+  it('parses a single successful sheet', () => {
+    const body = Buffer.from(
+      [
+        `--${boundary}`,
+        'Content-Disposition: form-data; name="Sales_payload"',
+        'Content-Type: text/csv; charset=utf-8',
+        'X-Tableau-Sheet-Name: Sales',
+        'X-Tableau-Sheet-Status: 200',
+        '',
+        'Region,Sales',
+        'West,100',
+        `--${boundary}--`,
+        '',
+      ].join('\r\n'),
+    );
+
+    expect(parseViewAllData(body, `multipart/form-data; boundary=${boundary}`)).toEqual([
+      {
+        sheetName: 'Sales',
+        status: 'OK',
+        errorDetail: undefined,
+        columns: ['Region', 'Sales'],
+        rows: [['West', '100']],
+      },
+    ]);
+  });
+
+  it('preserves successful sheets in multipart response order', () => {
+    const body = Buffer.from(
+      [
+        `--${boundary}`,
+        'Content-Disposition: form-data; name="Sales_payload"',
+        'Content-Type: text/csv; charset=utf-8',
+        'X-Tableau-Sheet-Name: Sales',
+        'X-Tableau-Sheet-Status: 200',
+        '',
+        'Region',
+        'West',
+        `--${boundary}`,
+        'Content-Disposition: form-data; name="Profit_payload"',
+        'Content-Type: text/csv; charset=utf-8',
+        'X-Tableau-Sheet-Name: Profit',
+        'X-Tableau-Sheet-Status: 200',
+        '',
+        'Region',
+        'East',
+        `--${boundary}--`,
+        '',
+      ].join('\r\n'),
+    );
+
+    expect(parseViewAllData(body, `multipart/form-data; boundary=${boundary}`)).toEqual([
+      {
+        sheetName: 'Sales',
+        status: 'OK',
+        errorDetail: undefined,
+        columns: ['Region'],
+        rows: [['West']],
+      },
+      {
+        sheetName: 'Profit',
+        status: 'OK',
+        errorDetail: undefined,
+        columns: ['Region'],
+        rows: [['East']],
+      },
+    ]);
+  });
+
   it('preserves sheet order, headers, and CSV cells', () => {
     const sheets = parseViewAllData(multipartBody, `multipart/form-data; boundary=${boundary}`);
 

--- a/src/server/oauth/scopes.test.ts
+++ b/src/server/oauth/scopes.test.ts
@@ -296,6 +296,14 @@ describe('scopes', () => {
       expect(scopes).not.toContain('tableau:content:read');
     });
 
+    it('should require all view-data API scopes for get-view-data', () => {
+      expect(getRequiredApiScopesForTool('get-view-data')).toEqual([
+        'tableau:views:download',
+        'tableau:content:read',
+        'tableau:mcp_site_settings:read',
+      ]);
+    });
+
     it('should include tableau:users:update when adminToolsEnabled is true', async () => {
       mockGetConfig.mockReturnValue({
         adminToolsEnabled: true,

--- a/src/tools/web/toolName.test.ts
+++ b/src/tools/web/toolName.test.ts
@@ -33,6 +33,10 @@ describe('WebToolName', () => {
     }
   });
 
+  it('should group get-view-data with the view tools', () => {
+    expect(webToolGroups.view).toContain('get-view-data');
+  });
+
   it('should not allow a tool group to have the same name as a tool', () => {
     for (const group of webToolGroupNames) {
       expect(isWebToolName(group), `Group ${group} is the same as a tool name`).toBe(false);

--- a/src/tools/web/views/getViewData.test.ts
+++ b/src/tools/web/views/getViewData.test.ts
@@ -1,4 +1,5 @@
 import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { AxiosError } from 'axios';
 
 import { RestApi } from '../../../sdks/tableau/restApi.js';
 import { WebMcpServer } from '../../../server.web.js';
@@ -230,6 +231,21 @@ describe('getViewDataTool', () => {
         errorDetail: 'Sheet could not be rendered',
       },
     ]);
+  });
+
+  it.each([403, 404])('returns an allData %i error to the caller', async (status) => {
+    RestApi.version = '3.30';
+    RestApi.versionIsAtLeast = vi.fn().mockReturnValue(true);
+    const error = new AxiosError(`Request failed with status code ${status}`);
+    error.response = { status } as AxiosError['response'];
+    mocks.mockGetViewAllData.mockRejectedValue(error);
+
+    const result = await getToolResult({ viewId: mockView.id });
+
+    expect(result.isError).toBe(true);
+    invariant(result.content[0].type === 'text');
+    expect(result.content[0].text).toContain(`Request failed with status code ${status}`);
+    expect(mocks.mockQueryViewData).not.toHaveBeenCalled();
   });
 
   it('should handle API errors gracefully', async () => {


### PR DESCRIPTION
## Description

Adds follow-up test coverage for `get-view-data` allData handling. The tests cover successful multipart parsing, response ordering, 403/404 propagation, tool grouping, and required API scopes.

## Motivation and Context

W-23870893 tracks confidence gaps remaining after the allData migration in #831. This coverage protects the API 3.30+ allData contract while retaining the legacy behavior on earlier REST API versions.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Other (please describe): Test coverage

## Version Bump

Version is bumped automatically after merge. Select the bump this PR needs (defaults to Patch if none selected):

- [x] Patch
- [ ] Minor
- [ ] Major

## How Has This Been Tested?

- `scripts/agent-check`
  - lint passed
  - `tsc --noEmit` passed
  - 176 unit-test files and 2,846 tests passed

## Related Issues

- W-23870893
- #831

## Checklist

- [x] I have made any necessary changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have documented any breaking changes in the PR description. For example, renaming a config environment variable or changing its default value.

## Contributor Agreement

By submitting this pull request, I confirm that:

- [x] I have read the [CONTRIBUTING guidelines](../../CONTRIBUTING.md) for this project and followed its Contribution Checklist.