### PR TITLE
@W-24015251: Push version bump commit before tagging; make tag creation non-fatal

### DIFF
--- a/.github/workflows/auto-version-bump.yml
+++ b/.github/workflows/auto-version-bump.yml
@@ -49,6 +49,11 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add package.json package-lock.json
           git commit -m "chore: bump version to $VERSION [skip ci]"
-          git tag "v$VERSION"
           git push origin main
-          git push origin "v$VERSION"
+
+          if git rev-parse "v$VERSION" >/dev/null 2>&1; then
+            echo "Tag v$VERSION already exists, skipping tag creation"
+          else
+            git tag "v$VERSION"
+            git push origin "v$VERSION"
+          fi


### PR DESCRIPTION
## Summary
- A stale `v4.6.1` tag (from before this workflow existed, pointing at an unrelated old commit) causes `git tag "v$VERSION"` to fail on every merge, and since the step runs under `set -e`, the whole step aborts *before* `git push origin main` runs. Net effect: the bump commit is created in the runner's local checkout but never actually pushed to `main`.
- Reorders the step to push the bump commit to `main` immediately after committing, then only creates/pushes the version tag if it doesn't already exist (logs and skips otherwise instead of failing).

## Test plan
- [ ] Merge and confirm the next push to `main` produces a successful `Auto Version Bump` run that pushes the bump commit to `main` even if the corresponding tag already exists.