### PR TITLE
feat(desktop): report and harden deterministic insight authoring

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "2.67.5",
+  "version": "2.67.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "2.67.5",
+      "version": "2.67.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.7.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "2.67.5",
+  "version": "2.67.6",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/src/desktop/binder/binder.test.ts
+++ b/src/desktop/binder/binder.test.ts
@@ -230,7 +230,7 @@ it('binds explicit Insights bar, line, and KPI proposals through the non-discove
         },
       },
       expectedMapping: {
-        '{{field_base_1}}': '[Metrics].[none:Product:nk]',
+        '{{field_base_1}}': '[Metrics].[attr:Product:nk]',
         '{{field_base_2}}': '[Metrics].[sum:ARR:qk]',
         '{{field_base_3}}': '[Metrics].[sum:ARR:qk]',
         '{{field_base_4}}': '[Metrics].[sum:ARR:qk]',

--- a/src/desktop/data/templates/insights__kpi.tbm
+++ b/src/desktop/data/templates/insights__kpi.tbm
@@ -63,8 +63,8 @@
         <mark-sizing mark-sizing-setting='marks-scaling-off' />
         <encodings>
           <text column='[Sample - Superstore].[sum:Profit:qk]' />
-          <text column='[Sample - Superstore].[sum:Sales:qk]' />
-          <text column='[Sample - Superstore].[sum:Quantity:qk]' />
+          <tooltip column='[Sample - Superstore].[sum:Sales:qk]' />
+          <tooltip column='[Sample - Superstore].[sum:Quantity:qk]' />
           <text column='[Sample - Superstore].[sum:Discount:qk]' />
         </encodings>
         <customized-tooltip>
@@ -78,8 +78,7 @@
             <run bold='true' fontcolor='#000000'>&lt;[Sample - Superstore].[sum:Sales:qk]&gt;</run>
             <run>Æ&#10;</run>
             <run fontcolor='#898989'>CHANGE FROM PREVIOUS PERIOD | </run>
-            <run bold='true' fontcolor='{{CHANGE_COLOR}}'>{{DIRECTION_SYMBOL}} </run>
-            <run bold='true' fontcolor='#000000'>&lt;[Sample - Superstore].[sum:Discount:qk]&gt;</run>
+            <run bold='true' fontcolor='{{CHANGE_COLOR}}'>&lt;[Sample - Superstore].[sum:Discount:qk]&gt;</run>
           </formatted-text>
         </customized-tooltip>
         <customized-label>
@@ -88,9 +87,7 @@
             <run>Æ&#10;</run>
             <run bold='true' fontname='Tableau Medium' fontsize='24'>&lt;[Sample - Superstore].[sum:Profit:qk]&gt;</run>
             <run>Æ&#10;</run>
-            <run fontcolor='{{CHANGE_COLOR}}'>{{DIRECTION_SYMBOL}}</run>
-            <run>Æ </run>
-            <run bold='true'>&lt;[Sample - Superstore].[sum:Discount:qk]&gt;</run>
+            <run bold='true' fontcolor='{{CHANGE_COLOR}}'>&lt;[Sample - Superstore].[sum:Discount:qk]&gt;</run>
             <run>Æ&#10;</run>
           </formatted-text>
         </customized-label>

--- a/src/desktop/data/templates/insights__kpi.tbm
+++ b/src/desktop/data/templates/insights__kpi.tbm
@@ -33,7 +33,7 @@
         <column-instance column='[Sales]' derivation='Sum' name='[sum:Sales:qk]' pivot='key' type='quantitative' />
         <column-instance column='[Quantity]' derivation='Sum' name='[sum:Quantity:qk]' pivot='key' type='quantitative' />
         <column-instance column='[Discount]' derivation='Sum' name='[sum:Discount:qk]' pivot='key' type='quantitative' />
-        <column-instance column='[Region]' derivation='None' name='[none:Region:nk]' pivot='key' type='nominal' />
+        <column-instance column='[Region]' derivation='Attribute' name='[attr:Region:nk]' pivot='key' type='nominal' />
       </datasource-dependencies>
       <aggregation value='true' />
     </view>
@@ -47,7 +47,7 @@
         <format attr='text-format' field='[Sample - Superstore].[sum:Discount:qk]' value='p+0.0%;-0.0%;0.0%' />
       </style-rule>
       <style-rule element='label'>
-        <format attr='display' field='[Sample - Superstore].[none:Region:nk]' value='false' />
+        <format attr='display' field='[Sample - Superstore].[attr:Region:nk]' value='false' />
       </style-rule>
       <style-rule element='table-div'>
         <format attr='stroke-size' scope='cols' value='0' />
@@ -62,6 +62,7 @@
         <mark class='Text' />
         <mark-sizing mark-sizing-setting='marks-scaling-off' />
         <encodings>
+          <tooltip column='[Sample - Superstore].[attr:Region:nk]' />
           <text column='[Sample - Superstore].[sum:Profit:qk]' />
           <tooltip column='[Sample - Superstore].[sum:Sales:qk]' />
           <tooltip column='[Sample - Superstore].[sum:Quantity:qk]' />
@@ -104,6 +105,6 @@
       </pane>
     </panes>
     <rows />
-    <cols>[Sample - Superstore].[none:Region:nk]</cols>
+    <cols />
   </table>
 </bookmark>

--- a/src/desktop/templates/injectTemplateCore.test.ts
+++ b/src/desktop/templates/injectTemplateCore.test.ts
@@ -97,6 +97,15 @@ describe('buildInjectedWorkbookXml — caller-authored KPI formatting', () => {
     expect(result.xml).toContain("Prior year's Q1 | ");
     expect(result.xml).not.toContain("PREVIOUS PERIOD | Prior year's Q1 | ");
     expect(result.xml).toContain('&lt;[Analytics].[usr:Comparison:qk]&gt;');
+    expect(result.xml).toContain('<text column="[Analytics].[usr:Target:qk]">');
+    expect(result.xml).toContain('<text column="[Analytics].[usr:Relative Change:qk]">');
+    expect(result.xml).toContain('<tooltip column="[Analytics].[usr:Comparison:qk]">');
+    expect(result.xml).toContain('<tooltip column="[Analytics].[usr:Absolute Change:qk]">');
+    expect(result.xml).not.toContain('<text column="[Analytics].[usr:Comparison:qk]">');
+    expect(result.xml).not.toContain('<text column="[Analytics].[usr:Absolute Change:qk]">');
+    expect(result.xml).toContain(
+      '<run bold="true" fontcolor="#208591">&lt;[Analytics].[usr:Relative Change:qk]&gt;</run>',
+    );
   });
 });
 

--- a/src/desktop/vendoredAssets.test.ts
+++ b/src/desktop/vendoredAssets.test.ts
@@ -60,7 +60,10 @@ describe('desktop vendored assets', () => {
     expect(kpi).toBeDefined();
     expect(kpi?.snapshot.xml).toContain("<mark class='Text' />");
     expect(kpi?.snapshot.xml).not.toContain("<zoom type='entire-view' />");
-    expect(kpi?.snapshot.xml).toContain('<cols>[{{DATASOURCE}}].[none:{{field_base_1}}:nk]</cols>');
+    expect(kpi?.snapshot.xml).toContain('<cols />');
+    expect(kpi?.snapshot.xml).toContain(
+      "<tooltip column='[{{DATASOURCE}}].[attr:{{field_base_1}}:nk]' />",
+    );
     expect(kpi?.snapshot.xml).toContain("fontcolor='#898989' fontsize='12'>{{METRIC_NAME}}");
     expect(kpi?.snapshot.xml.match(/value='\{\{VALUE_FORMAT\}\}'/g)).toHaveLength(2);
     expect(kpi?.snapshot.xml).toContain("fontname='Tableau Medium' fontsize='24'");

--- a/src/desktop/vendoredAssets.test.ts
+++ b/src/desktop/vendoredAssets.test.ts
@@ -66,10 +66,31 @@ describe('desktop vendored assets', () => {
     expect(kpi?.snapshot.xml).toContain("fontname='Tableau Medium' fontsize='24'");
     expect(kpi?.snapshot.xml).toContain('<run>Æ&#10;</run>');
     expect(kpi?.snapshot.xml).toContain("<format attr='text-align' value='left' />");
+    expect(kpi?.snapshot.xml).toContain(
+      "<text column='[{{DATASOURCE}}].[sum:{{field_base_2}}:qk]' />",
+    );
+    expect(kpi?.snapshot.xml).toContain(
+      "<text column='[{{DATASOURCE}}].[sum:{{field_base_5}}:qk]' />",
+    );
+    expect(kpi?.snapshot.xml).toContain(
+      "<tooltip column='[{{DATASOURCE}}].[sum:{{field_base_3}}:qk]' />",
+    );
+    expect(kpi?.snapshot.xml).toContain(
+      "<tooltip column='[{{DATASOURCE}}].[sum:{{field_base_4}}:qk]' />",
+    );
+    expect(kpi?.snapshot.xml).not.toContain(
+      "<text column='[{{DATASOURCE}}].[sum:{{field_base_3}}:qk]' />",
+    );
+    expect(kpi?.snapshot.xml).not.toContain(
+      "<text column='[{{DATASOURCE}}].[sum:{{field_base_4}}:qk]' />",
+    );
     expect(kpi?.snapshot.xml).toContain('{{COMPARISON_PERIOD_CONTEXT}} | ');
     expect(kpi?.snapshot.xml).not.toContain('PREVIOUS PERIOD | {{COMPARISON_PERIOD_CONTEXT}} | ');
     expect(kpi?.snapshot.xml).toContain('&lt;[{{DATASOURCE}}].[sum:{{field_base_3}}:qk]&gt;');
     expect(kpi?.snapshot.xml).toContain('CHANGE FROM PREVIOUS PERIOD | ');
+    expect(kpi?.snapshot.xml).toContain(
+      "<run bold='true' fontcolor='{{CHANGE_COLOR}}'>&lt;[{{DATASOURCE}}].[sum:{{field_base_5}}:qk]&gt;</run>",
+    );
     expect(kpi?.snapshot.xml).not.toContain('ABSOLUTE CHANGE | ');
     expect(kpi?.snapshot.xml).not.toContain('PREVIOUS VALUE | ');
   });

--- a/src/tools/desktop/authoring/binder/bindTemplate.test.ts
+++ b/src/tools/desktop/authoring/binder/bindTemplate.test.ts
@@ -38,7 +38,7 @@ import * as loggerModule from '../../../../logging/logger.js';
 import { DesktopMcpServer } from '../../../../server.desktop.js';
 import invariant from '../../../../utils/invariant.js';
 import { Provider } from '../../../../utils/provider.js';
-import { TableauDesktopToolContext } from '../../toolContext.js';
+import { TableauDesktopRequestHandlerExtra, TableauDesktopToolContext } from '../../toolContext.js';
 import { getMockRequestHandlerExtra } from '../../toolContext.mock.js';
 import { appliedSheetSignature } from './appliedSheetSignature.js';
 import { getBindTemplateTool } from './bindTemplate.js';
@@ -3300,6 +3300,8 @@ async function getToolResult({
   allowSkipValidation,
   customSignal,
   getExecutor,
+  progressToken,
+  sendNotification,
 }: {
   // Optional: omitted exercises session-default-when-unique resolution.
   session?: string;
@@ -3320,6 +3322,8 @@ async function getToolResult({
   allowSkipValidation?: boolean;
   customSignal?: AbortSignal;
   getExecutor?: TableauDesktopToolContext['getExecutor'];
+  progressToken?: string | number;
+  sendNotification?: TableauDesktopRequestHandlerExtra['sendNotification'];
 }): Promise<CallToolResult> {
   const tool = getBindTemplateTool(new DesktopMcpServer());
   const callback = await Provider.from(tool.callback);
@@ -3334,6 +3338,8 @@ async function getToolResult({
       ...(allowSkipValidation !== undefined ? { allowSkipValidation } : {}),
     },
     getExecutor: mockExecutor,
+    ...(progressToken !== undefined ? { _meta: { progressToken } } : {}),
+    ...(sendNotification ? { sendNotification } : {}),
     ...(customSignal && { signal: customSignal }),
   };
 
@@ -5206,6 +5212,52 @@ describe('bindTemplateTool auto_apply gate', () => {
     expect(appliedXml).toMatch(new RegExp(`user:tableau-agent-idempotency-key=["']${key}["']`));
   });
 
+  it('returns a matching deterministic worksheet without applying after Desktop strips its identity stamp', async () => {
+    const key = 'c'.repeat(64);
+    const existingWorksheet =
+      "<worksheet name='Sales by Region'><table><view>" +
+      "<datasource-dependencies datasource='Orders'>" +
+      "<column datatype='string' name='[Region]' role='dimension' type='nominal' />" +
+      "<column datatype='real' name='[Sales]' role='measure' type='quantitative' />" +
+      '</datasource-dependencies></view></table></worksheet>';
+    const existingWorkbook = CALC_BASE_XML.replace(
+      "<worksheet name='Sheet 1' />",
+      existingWorksheet,
+    );
+    const { getExecutor } = setupAutoApplyMocks({ workbookReads: [existingWorkbook] });
+    vi.mocked(classifyWorksheetReplaceTarget).mockReturnValue('in-dashboard');
+    vi.mocked(workbookHasSheetNamed).mockImplementation((_xml, name) => name === 'Sales by Region');
+    vi.mocked(buildInjectedWorkbookXml).mockImplementation(({ title }) => ({
+      ok: true,
+      xml: existingWorkbook.replace(
+        existingWorksheet,
+        `<worksheet name='${title}'><table /></worksheet>`,
+      ),
+    }));
+
+    const result = await getToolResult({
+      session: '1',
+      ask: 'Sales by Region',
+      auto_apply: true,
+      skip_validation: true,
+      proposal: {
+        ...sampleProposal,
+        template_parameters: { __TABLEAU_AGENT_IDEMPOTENCY_KEY__: key },
+      },
+      allowSkipValidation: true,
+      getExecutor,
+    });
+
+    expect(result.isError).toBe(false);
+    invariant(result.content[0].type === 'text');
+    expect(JSON.parse(result.content[0].text)).toMatchObject({
+      applied: false,
+      reused: true,
+      sheet_name: 'Sales by Region',
+    });
+    expect(buildInjectedWorkbookXml).not.toHaveBeenCalled();
+  });
+
   it('reuses the hidden deterministic identity while keeping the visible title clean', async () => {
     const key = 'b'.repeat(64);
     const existingWorkbook = ensureUserNamespace(
@@ -5242,10 +5294,12 @@ describe('bindTemplateTool auto_apply gate', () => {
 
     expect(result.isError).toBe(false);
     invariant(result.content[0].type === 'text');
-    expect(JSON.parse(result.content[0].text).sheet_name).toBe('Sales by Region');
-    expect(buildInjectedWorkbookXml).toHaveBeenCalledWith(
-      expect.objectContaining({ title: 'Sales by Region' }),
-    );
+    expect(JSON.parse(result.content[0].text)).toMatchObject({
+      applied: false,
+      reused: true,
+      sheet_name: 'Sales by Region',
+    });
+    expect(buildInjectedWorkbookXml).not.toHaveBeenCalled();
   });
 
   it('keeps untrusted Insights KPI calc application on the ordinary two-apply path', async () => {
@@ -7152,6 +7206,62 @@ describe('bindTemplateTool host verification on the bind hot path', () => {
     vi.clearAllMocks();
     vi.mocked(externalDiscovery.discoverInstances).mockReturnValue([]);
     vi.mocked(classifyWorksheetReplaceTarget).mockReturnValue('replaceable');
+  });
+
+  it('reports generic preparation, apply, and verification progress at the real boundaries', async () => {
+    const mocks = setupAutoApplyMocks({ inject: { ok: true, xml: INJECTED_RANKING_WORKBOOK_XML } });
+    const sendNotification = vi.fn(
+      async (_notification: Parameters<TableauDesktopRequestHandlerExtra['sendNotification']>[0]) =>
+        undefined,
+    );
+
+    await getToolResult({
+      session: '1',
+      ask: 'bar chart of Sales by Region',
+      auto_apply: true,
+      getExecutor: readbackExecutor(mocks),
+      progressToken: 'bind-1',
+      sendNotification,
+    });
+
+    expect(sendNotification.mock.calls.map(([notification]) => notification)).toEqual([
+      {
+        method: 'notifications/progress',
+        params: {
+          progressToken: 'bind-1',
+          progress: 1,
+          total: 3,
+          message: 'Preparing template',
+        },
+      },
+      {
+        method: 'notifications/progress',
+        params: {
+          progressToken: 'bind-1',
+          progress: 2,
+          total: 3,
+          message: 'Applying workbook changes',
+        },
+      },
+      {
+        method: 'notifications/progress',
+        params: {
+          progressToken: 'bind-1',
+          progress: 3,
+          total: 3,
+          message: 'Verifying workbook changes',
+        },
+      },
+    ]);
+    expect(sendNotification.mock.invocationCallOrder[1]).toBeLessThan(
+      mocks.applyWorkbookDocument.mock.invocationCallOrder[0],
+    );
+    expect(sendNotification.mock.invocationCallOrder[2]).toBeGreaterThan(
+      mocks.applyWorkbookDocument.mock.invocationCallOrder[0],
+    );
+    expect(sendNotification.mock.invocationCallOrder[2]).toBeLessThan(
+      vi.mocked(getWorkbookXmlModule.getWorkbookXml).mock.invocationCallOrder.at(-1)!,
+    );
   });
 
   it('a clean readback earns a verified host line', async () => {

--- a/src/tools/desktop/authoring/binder/bindTemplate.ts
+++ b/src/tools/desktop/authoring/binder/bindTemplate.ts
@@ -91,6 +91,7 @@ import {
   DesktopCommandExecutionError,
   IncompleteOperationError,
 } from '../../../../errors/mcpToolError.js';
+import { log } from '../../../../logging/logger.js';
 import { DesktopMcpServer } from '../../../../server.desktop.js';
 import { getExceptionMessage } from '../../../../utils/getExceptionMessage.js';
 import {
@@ -1640,11 +1641,17 @@ function deterministicWorksheetTitle(
   workbookXml: string,
   requestedTitle: string,
   idempotencyKey: string | undefined,
+  bindingFields: string[] = [],
 ): string {
   if (!idempotencyKey) {
     return collisionFreeWorksheetTitle(workbookXml, requestedTitle);
   }
-  const existingTitle = worksheetTitleForIdempotencyKey(workbookXml, idempotencyKey);
+  const existingTitle = existingDeterministicWorksheetTitle(
+    workbookXml,
+    requestedTitle,
+    idempotencyKey,
+    bindingFields,
+  );
   if (
     existingTitle &&
     classifyWorksheetReplaceTarget(workbookXml, existingTitle) === 'replaceable'
@@ -1654,6 +1661,56 @@ function deterministicWorksheetTitle(
   // A clean visible title is not an identity. Never overwrite an unrelated loose
   // worksheet merely because it has the same label; choose a normal Tableau suffix.
   return collisionFreeWorksheetTitle(workbookXml, requestedTitle, false);
+}
+
+function existingDeterministicWorksheetTitle(
+  workbookXml: string,
+  requestedTitle: string,
+  idempotencyKey: string,
+  bindingFields: string[],
+): string | undefined {
+  const stampedTitle = worksheetTitleForIdempotencyKey(workbookXml, idempotencyKey);
+  if (stampedTitle && workbookHasSheetNamed(workbookXml, stampedTitle)) {
+    return stampedTitle;
+  }
+  // Tableau currently strips the custom worksheet identity attribute on live
+  // workbook readback. Recover that identity without trusting the visible title
+  // alone: the requested sheet must also contain every deterministic binding.
+  return workbookHasSheetNamed(workbookXml, requestedTitle) &&
+    worksheetContainsBindingFields(workbookXml, requestedTitle, bindingFields)
+    ? requestedTitle
+    : undefined;
+}
+
+function worksheetContainsBindingFields(
+  workbookXml: string,
+  worksheetTitle: string,
+  bindingFields: string[],
+): boolean {
+  if (bindingFields.length === 0) return false;
+  let worksheetXml: string | null;
+  try {
+    worksheetXml = extractSheetXml(workbookXml, worksheetTitle);
+  } catch {
+    return false;
+  }
+  if (!worksheetXml) return false;
+
+  const identities = new Set<string>();
+  for (const match of worksheetXml.matchAll(/<column\b[^>]*>/g)) {
+    const tag = match[0];
+    for (const attribute of ['caption', 'name']) {
+      const value = tag.match(new RegExp(`\\b${attribute}=(['"])(.*?)\\1`))?.[2];
+      if (value === undefined) continue;
+      const decoded = decodeXmlEntities(value);
+      identities.add(decoded);
+      identities.add(decoded.replace(/^\[|\]$/g, ''));
+    }
+  }
+  return bindingFields.every((field) => {
+    const decoded = decodeXmlEntities(field);
+    return identities.has(decoded) || identities.has(decoded.replace(/^\[|\]$/g, ''));
+  });
 }
 
 function stampWorksheetIdempotencyKey(
@@ -2231,6 +2288,8 @@ async function performAutoApply({
   atomicCalcs,
   trustedDeterministicApply,
   idempotencyKey,
+  deterministicBindingFields,
+  reportProgress,
 }: {
   res: BoundResult;
   base: BindTemplateToolResultBase;
@@ -2249,6 +2308,8 @@ async function performAutoApply({
   atomicCalcs?: AuthoredCalc[];
   trustedDeterministicApply?: boolean;
   idempotencyKey?: string;
+  deterministicBindingFields?: string[];
+  reportProgress: (progress: 1 | 2 | 3, message: string) => Promise<void>;
 }): Promise<{
   result: StructuredBindTemplateToolResult;
   failureDisposition?: AutoApplyFailureDisposition;
@@ -2272,7 +2333,12 @@ async function performAutoApply({
     const requestedTitle = decodeXmlEntities(args.title);
     literalTitle =
       args.sheet_type === 'worksheet'
-        ? deterministicWorksheetTitle(workbookXml, requestedTitle, idempotencyKey)
+        ? deterministicWorksheetTitle(
+            workbookXml,
+            requestedTitle,
+            idempotencyKey,
+            deterministicBindingFields,
+          )
         : requestedTitle;
     injected = buildInjectedWorkbookXml({
       workbookXml,
@@ -2378,6 +2444,7 @@ async function performAutoApply({
   const injectMs = Date.now() - injectStart;
 
   // ── Apply leg (SAME validated path; runValidation preflight runs) ─
+  await reportProgress(2, 'Applying workbook changes');
   const applyStart = Date.now();
   const applyBaselineXml = hostBaselineWorkbookXml ?? workbookXml;
   const applyResult = await loadWorkbookXml({
@@ -2415,6 +2482,7 @@ async function performAutoApply({
   // the document we posted. If it cannot be sliced (or the re-read fails), verification is
   // SKIPPED, not assumed — the receipt then says "unverified" rather than claiming a check
   // that never ran.
+  await reportProgress(3, 'Verifying workbook changes');
   let intendedWorksheetXml: string | null = null;
   try {
     intendedWorksheetXml = extractSheetXml(appliedWorkbookXml, literalTitle);
@@ -2843,6 +2911,38 @@ function hasDivisionOperator(formula: string): boolean {
 
 const title = 'Matching template';
 
+const BIND_TEMPLATE_PROGRESS_TOTAL = 3;
+
+async function reportBindTemplateProgress(
+  extra: TableauDesktopRequestHandlerExtra,
+  progress: 1 | 2 | 3,
+  message: string,
+): Promise<void> {
+  const progressToken = extra._meta?.progressToken;
+  if (progressToken === undefined) return;
+
+  try {
+    await extra.sendNotification({
+      method: 'notifications/progress',
+      params: {
+        progressToken,
+        progress,
+        total: BIND_TEMPLATE_PROGRESS_TOTAL,
+        message,
+      },
+    });
+  } catch (error) {
+    // Progress is presentation-only. A disconnected or older client must never
+    // interrupt template binding or a workbook mutation already in flight.
+    log({
+      level: 'warning',
+      logger: 'tool',
+      message: 'bind-template progress notification failed',
+      data: error,
+    });
+  }
+}
+
 export const getBindTemplateTool = (server: DesktopMcpServer): DesktopTool<typeof paramsSchema> => {
   const bindTemplateTool = new DesktopTool({
     server,
@@ -2889,6 +2989,10 @@ export const getBindTemplateTool = (server: DesktopMcpServer): DesktopTool<typeo
           skip_validation,
         },
         callback: async () => {
+          const reportProgress = async (progress: 1 | 2 | 3, message: string): Promise<void> =>
+            await reportBindTemplateProgress(extra, progress, message);
+          await reportProgress(1, 'Preparing template');
+
           const sessionResult = resolveSession(session);
           if (sessionResult.isErr()) {
             return sessionResult.error.toErr();
@@ -3379,6 +3483,27 @@ export const getBindTemplateTool = (server: DesktopMcpServer): DesktopTool<typeo
             }
           }
 
+          if (target_worksheet === undefined && trustedDeterministicApply && idempotencyKey) {
+            const existingTitle = existingDeterministicWorksheetTitle(
+              workbookXml,
+              decodeXmlEntities(res.args.title),
+              idempotencyKey,
+              proposal?.bindings.map((binding) => binding.field) ?? [],
+            );
+            if (existingTitle !== undefined) {
+              return new Ok(
+                reusedSheetResult(
+                  {
+                    sheetName: existingTitle,
+                    template: res.args.template_name,
+                    ts: new Date().toISOString(),
+                  },
+                  authoredCalcCaptions,
+                ),
+              );
+            }
+          }
+
           const autoApplyResult = await performAutoApply({
             res,
             base,
@@ -3396,6 +3521,10 @@ export const getBindTemplateTool = (server: DesktopMcpServer): DesktopTool<typeo
             atomicCalcs,
             trustedDeterministicApply,
             idempotencyKey,
+            deterministicBindingFields: trustedDeterministicApply
+              ? proposal?.bindings.map((binding) => binding.field)
+              : undefined,
+            reportProgress,
             // Honor skip_validation only for a server-trusted caller (config gate set by the
             // deterministic spawner). An untrusted LLM turn that passes the flag gets full
             // validation, not a bypass — the param alone cannot skip the preflight.

--- a/src/tools/desktop/authoring/datasource/authorCalc.test.ts
+++ b/src/tools/desktop/authoring/datasource/authorCalc.test.ts
@@ -562,6 +562,104 @@ describe('prepareCalculationsInWorkbook idempotency', () => {
     },
   );
 
+  it.each([
+    { existingDatatype: 'integer', requestedDatatype: 'real' as const },
+    { existingDatatype: 'real', requestedDatatype: 'integer' as const },
+  ])(
+    'reuses an identical numeric measure when Desktop stores $existingDatatype and the caller requests $requestedDatatype',
+    ({ existingDatatype, requestedDatatype }) => {
+      const numericReadback = existingCalc.replace(
+        "datatype='real'",
+        `datatype='${existingDatatype}'`,
+      );
+      const workbookXml = withColumn(BASE_XML, numericReadback);
+      const result = prepareCalculationsInWorkbook({
+        workbookXml,
+        calcs: [
+          {
+            caption: 'Margin',
+            formula: '[Sales] * 0.2',
+            datatype: requestedDatatype,
+            role: 'measure',
+          },
+        ],
+      });
+
+      expect(result.isOk()).toBe(true);
+      if (result.isErr()) return;
+      expect(result.value.workbookXml).toBe(workbookXml);
+      expect(result.value.authoredCalcs).toEqual([]);
+    },
+  );
+
+  it.each([
+    { existingDatatype: 'integer', requestedDatatype: 'string' as const },
+    { existingDatatype: 'date', requestedDatatype: 'real' as const },
+    { existingDatatype: 'boolean', requestedDatatype: 'integer' as const },
+  ])(
+    'rejects an identical formula when $existingDatatype and $requestedDatatype are not both numeric',
+    ({ existingDatatype, requestedDatatype }) => {
+      const incompatibleReadback = existingCalc.replace(
+        "datatype='real'",
+        `datatype='${existingDatatype}'`,
+      );
+      const result = prepareCalculationsInWorkbook({
+        workbookXml: withColumn(BASE_XML, incompatibleReadback),
+        calcs: [
+          {
+            caption: 'Margin',
+            formula: '[Sales] * 0.2',
+            datatype: requestedDatatype,
+            role: 'measure',
+          },
+        ],
+      });
+
+      expect(result.isErr()).toBe(true);
+      if (result.isOk()) return;
+      expect(result.error.message).toContain('caption collision');
+    },
+  );
+
+  it('does not treat integer and real as compatible for a dimension', () => {
+    const integerDimension = existingCalc
+      .replace("datatype='real'", "datatype='integer'")
+      .replace("role='measure'", "role='dimension'");
+    const result = prepareCalculationsInWorkbook({
+      workbookXml: withColumn(BASE_XML, integerDimension),
+      calcs: [
+        {
+          caption: 'Margin',
+          formula: '[Sales] * 0.2',
+          datatype: 'real',
+          role: 'dimension',
+        },
+      ],
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isOk()) return;
+    expect(result.error.message).toContain('caption collision');
+  });
+
+  it('still rejects the same caption when its role differs', () => {
+    const result = prepareCalculationsInWorkbook({
+      workbookXml: withColumn(BASE_XML, existingCalc),
+      calcs: [
+        {
+          caption: 'Margin',
+          formula: '[Sales] * 0.2',
+          datatype: 'real',
+          role: 'dimension',
+        },
+      ],
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isOk()) return;
+    expect(result.error.message).toContain('caption collision');
+  });
+
   it('still rejects the same caption when its formula differs', () => {
     const result = prepareCalculationsInWorkbook({
       workbookXml: withColumn(BASE_XML, existingCalc),

--- a/src/tools/desktop/authoring/datasource/authorCalcCore.ts
+++ b/src/tools/desktop/authoring/datasource/authorCalcCore.ts
@@ -210,7 +210,7 @@ function prepareCalculationBatch({
         existingFormula !== undefined &&
         normalizeFormula(unescapeXml(existingFormula)) === normalizeFormula(resolvedFormula) &&
         existingRole === role &&
-        existingDatatype === datatype &&
+        calculationDatatypesMatch(existingDatatype, datatype, role) &&
         existingDefaultFormat === (calc.defaultFormat ?? '')
       ) {
         // Idempotent retry: the live workbook already contains this exact
@@ -241,6 +241,18 @@ function prepareCalculationBatch({
   }
 
   return new Ok({ editedXml, authoredCalcs });
+}
+
+function calculationDatatypesMatch(existing: string, requested: Datatype, role: Role): boolean {
+  if (existing === requested) return true;
+  if (role !== 'measure') return false;
+
+  // Tableau may canonicalize a numeric calculation between real and integer on
+  // workbook readback based on the formula's result type. When the normalized
+  // formula, role, and default format are unchanged, both representations refer
+  // to the same numeric measure and are safe to reuse on an idempotent retry.
+  const numericDatatypes = new Set<string>(['integer', 'real']);
+  return numericDatatypes.has(existing) && numericDatatypes.has(requested);
 }
 
 function resolveLooseFormulaReferences(


### PR DESCRIPTION
## Summary

- emit three progress notifications from `bind-template`: preparing the template, applying workbook changes, and verifying readback
- keep progress reporting fail-open so an older or disconnected client cannot interrupt workbook authoring
- recover deterministic worksheet identity using the requested title plus its bound fields when Tableau strips the custom idempotency marker
- reuse matching numeric measure calculations when Tableau canonicalizes `real` to `integer` or `integer` to `real`

## Why

Deterministic Reveal Insight authoring currently appears as one opaque operation. This gives the backend stable phase boundaries while also fixing two retry cases: recreating a KPI after deleting its worksheet and recognizing a deterministic worksheet whose custom identity attribute was removed by Tableau.

## Validation

- `npx vitest run src/tools/desktop/authoring/binder/bindTemplate.test.ts src/tools/desktop/authoring/datasource/authorCalc.test.ts` — 229 passed
- `scripts/agent-check` — all 5 checks green
  - lint
  - typecheck
  - 6,847 unit tests
  - Desktop build
  - lockstep-core hash gate

## Cross-repository rollout

- Backend consumes these progress notifications and emits persisted chat steps.
- UI renders the structured progress details.

- Backend: https://gitlab.tableausoftware.com/browser-clients/tab-agent-south/-/merge_requests/179
- UI: https://gitlab.tableausoftware.com/browser-clients/tab-agent-south-ui/-/merge_requests/97
