### PR TITLE
@W-21254846: Implement Pulse registration conditions and unmet-condition instructions

### DIFF
--- a/src/restApiInstance.ts
+++ b/src/restApiInstance.ts
@@ -29,6 +29,7 @@ type JwtScopes =
   | 'tableau:insight_metrics:read'
   | 'tableau:metric_subscriptions:read'
   | 'tableau:insights:read'
+  | 'tableau:entitlements:read'
   | 'tableau:views:download'
   | 'tableau:views:embed'
   | 'tableau:insight_brief:create'

--- a/src/sdks/tableau/apis/pulseApi.ts
+++ b/src/sdks/tableau/apis/pulseApi.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 import {
   pulseBundleRequestSchema,
   pulseBundleResponseSchema,
+  pulseEntitlementSchema,
   pulseInsightBriefRequestSchema,
   pulseInsightBriefResponseSchema,
   pulseInsightBundleTypeEnum,
@@ -165,7 +166,20 @@ const generatePulseInsightBriefRestEndpoint = makeEndpoint({
   response: pulseInsightBriefResponseSchema,
 });
 
+const getPulseEntitlementsRestEndpoint = makeEndpoint({
+  method: 'get',
+  path: '/pulse/entitlements',
+  alias: 'getPulseEntitlements',
+  description:
+    "Returns the Pulse feature entitlements for the caller's site. An entitlement reported as " +
+    'enabled means the corresponding Pulse premium feature is available. Tableau Cloud only.',
+  response: z.object({
+    entitlements: z.array(pulseEntitlementSchema).optional(),
+  }),
+});
+
 const pulseApi = makeApi([
+  getPulseEntitlementsRestEndpoint,
   generatePulseMetricValueInsightBundleRestEndpoint,
   generatePulseInsightBriefRestEndpoint,
   listAllPulseMetricDefinitionsRestEndpoint,

--- a/src/sdks/tableau/methods/pulseMethods.ts
+++ b/src/sdks/tableau/methods/pulseMethods.ts
@@ -17,6 +17,7 @@ import { PulsePagination } from '../types/pagination.js';
 import {
   pulseBundleRequestSchema,
   PulseBundleResponse,
+  PulseEntitlement,
   pulseInsightBriefRequestSchema,
   PulseInsightBriefResponse,
   PulseInsightBundleType,
@@ -38,6 +39,28 @@ export default class PulseMethods extends AuthenticatedMethods<typeof pulseApis>
   constructor(baseUrl: string, creds: RestApiCredentials, axiosConfig: AxiosRequestConfig) {
     super(new Zodios(baseUrl, pulseApis, { axiosConfig }), creds);
   }
+
+  /**
+   * Returns the Pulse feature entitlements for the caller's site, used to decide whether Pulse
+   * premium features (AI-powered insights) are available.
+   *
+   * The service returns every known entitlement type with a boolean, and substitutes an all-false
+   * response when its own upstream lookup fails, so a missing type is equivalent to disabled.
+   *
+   * Required scopes: `tableau:entitlements:read`
+   *
+   * Tableau Cloud only; on Tableau Server this surfaces as {@link PulseNotAvailableError}.
+   *
+   * @link https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref_pulse.htm#MetricQueryService_GetEntitlements
+   */
+  getPulseEntitlements = async (): Promise<PulseResult<PulseEntitlement[]>> => {
+    return await guardAgainstPulseDisabled(async () => {
+      const response = await this._apiClient.getPulseEntitlements({
+        ...this.authHeader,
+      });
+      return response.entitlements ?? [];
+    });
+  };
 
   /**
    * Returns a list of all published Pulse Metric Definitions.

--- a/src/sdks/tableau/types/pulse.ts
+++ b/src/sdks/tableau/types/pulse.ts
@@ -484,6 +484,30 @@ export type PulseInsightBriefResponse = z.infer<typeof pulseInsightBriefResponse
 export const pulseInsightBundleTypeEnum = ['ban', 'springboard', 'basic', 'detail'] as const;
 export type PulseInsightBundleType = (typeof pulseInsightBundleTypeEnum)[number];
 
+/**
+ * The Pulse premium entitlement that gates AI-powered insights, i.e. the one whose absence
+ * produces {@link PulseInsightsDisabledError} ("requires Tableau+").
+ *
+ * `ENTITLEMENT_TYPE_PULSE_PREMIUM_GAI` is a sibling that gates generative-AI features
+ * specifically. Distinguishing the two is a possible refinement; today a single coarse
+ * "premium" signal maps to the insights entitlement.
+ */
+export const PULSE_PREMIUM_INSIGHTS_ENTITLEMENT = 'ENTITLEMENT_TYPE_PULSE_PREMIUM_INSIGHTS';
+
+/**
+ * One Pulse feature entitlement for a site.
+ *
+ * `entitlement_type` is deliberately a bare string rather than an enum: the service owns the
+ * enum and adding a member must not fail schema validation here, since a validation error at
+ * registration time would fail closed and hide otherwise-entitled tools.
+ */
+export const pulseEntitlementSchema = z.object({
+  entitlement_type: z.string().optional(),
+  enabled: z.boolean().optional(),
+});
+
+export type PulseEntitlement = z.infer<typeof pulseEntitlementSchema>;
+
 export const pulseMetricDefinitionViewEnum = [
   'DEFINITION_VIEW_BASIC',
   'DEFINITION_VIEW_FULL',

--- a/src/server.web.test.ts
+++ b/src/server.web.test.ts
@@ -25,6 +25,7 @@ const mocks = vi.hoisted(() => ({
   mockReadFile: vi.fn(),
   mockGetCurrentUserSiteRole: vi.fn(),
   mockAssertAdmin: vi.fn(),
+  mockCheckRegistrationConditions: vi.fn(),
 }));
 
 vi.mock('@modelcontextprotocol/ext-apps/server', () => ({
@@ -46,6 +47,16 @@ vi.mock('./tools/web/adminGate.js', () => ({
   assertAdmin: mocks.mockAssertAdmin,
 }));
 
+// Only the capability probe is stubbed — the real `getUnmetConditionInstructions` is kept so the
+// instructions assertions below verify the copy users actually receive.
+vi.mock('./tools/web/registrationConditions.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./tools/web/registrationConditions.js')>();
+  return {
+    ...actual,
+    checkRegistrationConditions: mocks.mockCheckRegistrationConditions,
+  };
+});
+
 // Auto-mock the telemetry logger so the registration-time warning is captured as a spy call.
 vi.mock('./logging/logger.js');
 
@@ -59,6 +70,9 @@ describe('server', () => {
     mocks.mockReadFile.mockClear();
     mocks.mockGetCurrentUserSiteRole.mockReset().mockResolvedValue('SiteAdministratorCreator');
     mocks.mockAssertAdmin.mockReset();
+    mocks.mockCheckRegistrationConditions
+      .mockReset()
+      .mockResolvedValue({ registrationConditionsMet: true });
     (logger.log as MockedFunction<typeof logger.log>).mockClear();
   });
 
@@ -635,6 +649,10 @@ describe('server', () => {
 
   it('logs a telemetry warning naming the tools omitted for unmet conditions and the failing condition', async () => {
     mocks.mockFeatureGate.isFeatureEnabled.mockImplementation(enforceRegistrationConditions);
+    mocks.mockCheckRegistrationConditions.mockResolvedValue({
+      registrationConditionsMet: false,
+      failingCondition: 'RequiresPulse',
+    });
 
     const server = getServer();
     const mockConditionalTool = createMockConditionalTool();
@@ -642,7 +660,6 @@ describe('server', () => {
 
     await server.registerTools();
 
-    // The Pulse capability is not yet implemented, so `RequiresPulse` fails closed and the tool is hidden.
     expect(server.mcpServer.registerTool).not.toHaveBeenCalledWith(
       'mock-conditional-tool',
       expect.anything(),
@@ -653,6 +670,24 @@ describe('server', () => {
     // Names the omitted tool and the condition it failed, so operators can see what was hidden and why.
     expect(warnings[0].message).toContain('mock-conditional-tool');
     expect(warnings[0].message).toContain('RequiresPulse');
+  });
+
+  it('registers a conditional tool when its conditions are met', async () => {
+    mocks.mockFeatureGate.isFeatureEnabled.mockImplementation(enforceRegistrationConditions);
+    mocks.mockCheckRegistrationConditions.mockResolvedValue({ registrationConditionsMet: true });
+
+    const server = getServer();
+    const mockConditionalTool = createMockConditionalTool();
+    vi.spyOn(webToolFactories, 'map').mockReturnValueOnce([mockConditionalTool]);
+
+    await server.registerTools();
+
+    expect(server.mcpServer.registerTool).toHaveBeenCalledWith(
+      'mock-conditional-tool',
+      expect.anything(),
+      expect.any(Function),
+    );
+    expect(getWarningLogs()).toHaveLength(0);
   });
 
   it('does not check conditions or warn when enforce-registration-conditions is off', async () => {
@@ -670,7 +705,40 @@ describe('server', () => {
       expect.anything(),
       expect.any(Function),
     );
+    expect(mocks.mockCheckRegistrationConditions).not.toHaveBeenCalled();
     expect(getWarningLogs()).toHaveLength(0);
+  });
+
+  it('explains in the connect instructions why Pulse tools were omitted', async () => {
+    mocks.mockFeatureGate.isFeatureEnabled.mockImplementation(enforceRegistrationConditions);
+    mocks.mockCheckRegistrationConditions.mockResolvedValue({
+      registrationConditionsMet: false,
+      failingCondition: 'RequiresPulse',
+    });
+
+    const server = getServer();
+    vi.spyOn(webToolFactories, 'map').mockReturnValueOnce([createMockConditionalTool()]);
+
+    await server.registerTools();
+
+    // Without this the caller just sees a short tool list and no reason for it.
+    const instructions = getInstructions(server);
+    expect(instructions).toContain('Pulse is not enabled');
+    expect(instructions).toContain(
+      'https://help.tableau.com/current/online/en-us/pulse_set_up.htm',
+    );
+  });
+
+  it('does not mention Pulse in the connect instructions when conditions are met', async () => {
+    mocks.mockFeatureGate.isFeatureEnabled.mockImplementation(enforceRegistrationConditions);
+    mocks.mockCheckRegistrationConditions.mockResolvedValue({ registrationConditionsMet: true });
+
+    const server = getServer();
+    vi.spyOn(webToolFactories, 'map').mockReturnValueOnce([createMockConditionalTool()]);
+
+    await server.registerTools();
+
+    expect(getInstructions(server)).not.toContain('Pulse is not enabled');
   });
 
   it('should register as standard tool when mcp-apps feature flag is disabled', async () => {

--- a/src/server.web.test.ts
+++ b/src/server.web.test.ts
@@ -723,7 +723,7 @@ describe('server', () => {
 
     // Without this the caller just sees a short tool list and no reason for it.
     const instructions = getInstructions(server);
-    expect(instructions).toContain('Pulse is not enabled');
+    expect(instructions).toContain('Pulse is not available');
     expect(instructions).toContain(
       'https://help.tableau.com/current/online/en-us/pulse_set_up.htm',
     );
@@ -738,7 +738,7 @@ describe('server', () => {
 
     await server.registerTools();
 
-    expect(getInstructions(server)).not.toContain('Pulse is not enabled');
+    expect(getInstructions(server)).not.toContain('Pulse is not available');
   });
 
   it('should register as standard tool when mcp-apps feature flag is disabled', async () => {

--- a/src/server.web.ts
+++ b/src/server.web.ts
@@ -29,6 +29,7 @@ import { getRequestOverridesFromHeader, X_TABLEAU_MCP_CONFIG_HEADER } from './se
 import { getCurrentUserSiteRole } from './tools/web/adminGate.js';
 import {
   checkRegistrationConditions,
+  getUnmetConditionInstructions,
   RegistrationCondition,
   RegistrationContext,
 } from './tools/web/registrationConditions.js';
@@ -279,6 +280,8 @@ export class WebMcpServer extends Server {
         (total, toolNames) => total + toolNames.length,
         0,
       );
+      // Telemetry: registration runs before the transport connects, so client notifications aren't
+      // available — the process logger (stderr/file, honors LOG_LEVEL) is the only sink here.
       log({
         level: 'warning',
         logger: 'server',
@@ -287,7 +290,11 @@ export class WebMcpServer extends Server {
           `conditions were not met — ${omittedByCondition}.`,
       });
 
-      // TODO: for each condition append intialization message that explains that some features are unavailable.
+      // Client-facing counterpart: one explanation per distinct unmet condition, so a Pulse-less
+      // site is told that Pulse is off and why, rather than silently receiving a shorter tool list.
+      for (const condition of toolsOmittedFromUnmetConditions.keys()) {
+        this.appendInstructions(getUnmetConditionInstructions(condition));
+      }
     }
 
     return toolsToRegister;

--- a/src/server/oauth/scopes.ts
+++ b/src/server/oauth/scopes.ts
@@ -44,6 +44,7 @@ export type TableauApiScope =
   | 'tableau:insight_metrics:read'
   | 'tableau:metric_subscriptions:read'
   | 'tableau:insights:read'
+  | 'tableau:entitlements:read'
   | 'tableau:insight_brief:create'
   | 'tableau:mcp_site_settings:read'
   | 'tableau:tasks:read'

--- a/src/tools/web/pulse/generateInsightBrief/generatePulseInsightBriefTool.ts
+++ b/src/tools/web/pulse/generateInsightBrief/generatePulseInsightBriefTool.ts
@@ -20,6 +20,7 @@ export const getGeneratePulseInsightBriefTool = (
   const generatePulseInsightBriefTool = new WebTool({
     server,
     name: 'generate-pulse-insight-brief',
+    registrationConditions: ['RequiresPulse', 'RequiresPulsePremium'],
     description: `
 Generate a concise insight brief for Pulse Metrics using Tableau REST API. This endpoint provides AI-powered conversational insights based on natural language questions about your metrics.
 

--- a/src/tools/web/pulse/generateMetricValueInsightBundle/generatePulseMetricValueInsightBundleTool.ts
+++ b/src/tools/web/pulse/generateMetricValueInsightBundle/generatePulseMetricValueInsightBundleTool.ts
@@ -23,6 +23,7 @@ export const getGeneratePulseMetricValueInsightBundleTool = (
   const generatePulseMetricValueInsightBundleTool = new WebTool({
     server,
     name: 'generate-pulse-metric-value-insight-bundle',
+    registrationConditions: ['RequiresPulse', 'RequiresPulsePremium'],
     description: `
 Generate an insight bundle for the current aggregated value for Pulse Metric using Tableau REST API.  You need the full information of the Pulse Metric and Pulse Metric Definition to use this tool.
 

--- a/src/tools/web/pulse/insights/generateInsightCardsTool.ts
+++ b/src/tools/web/pulse/insights/generateInsightCardsTool.ts
@@ -151,6 +151,7 @@ export const getGenerateInsightCardsTool = (server: WebMcpServer): WebTool<typeo
   const tool = new WebTool({
     server,
     name: 'generate-insight-cards',
+    registrationConditions: ['RequiresPulse', 'RequiresPulsePremium'],
     description: 'Generate deterministic insights for a published datasource.',
     // Gated off by default (INSIGHTS_TOOLS_ENABLED) so it's never frontloaded
     // onto the default surface / into hosts like Slackbot; set the env var to

--- a/src/tools/web/pulse/listAllMetricDefinitions/listAllPulseMetricDefinitions.ts
+++ b/src/tools/web/pulse/listAllMetricDefinitions/listAllPulseMetricDefinitions.ts
@@ -24,6 +24,7 @@ export const getListAllPulseMetricDefinitionsTool = (
   const listAllPulseMetricDefinitionsTool = new WebTool({
     server,
     name: 'list-all-pulse-metric-definitions',
+    registrationConditions: ['RequiresPulse'],
     description: `
 Retrieves a list of all published Pulse Metric Definitions using the Tableau REST API.  Use this tool when a user requests to list all Tableau Pulse Metric Definitions on the current site.
 

--- a/src/tools/web/pulse/listMetricDefinitionsFromDefinitionIds/listPulseMetricDefinitionsFromDefinitionIds.ts
+++ b/src/tools/web/pulse/listMetricDefinitionsFromDefinitionIds/listPulseMetricDefinitionsFromDefinitionIds.ts
@@ -18,6 +18,7 @@ export const getListPulseMetricDefinitionsFromDefinitionIdsTool = (
   const listPulseMetricDefinitionsFromDefinitionIdsTool = new WebTool({
     server,
     name: 'list-pulse-metric-definitions-from-definition-ids',
+    registrationConditions: ['RequiresPulse'],
     description: `
 Retrieves a list of specific Pulse Metric Definitions using the Tableau REST API from a list of metric definition IDs.  Use this tool when a user requests information about specific Pulse Metric Definitions on the current site.
 

--- a/src/tools/web/pulse/listMetricSubscriptions/listPulseMetricSubscriptions.ts
+++ b/src/tools/web/pulse/listMetricSubscriptions/listPulseMetricSubscriptions.ts
@@ -17,6 +17,7 @@ export const getListPulseMetricSubscriptionsTool = (
   const listPulseMetricSubscriptionsTool = new WebTool({
     server,
     name: toolName,
+    registrationConditions: ['RequiresPulse'],
     description: `
 Retrieves a list of published Pulse Metric Subscriptions for the current user using the Tableau REST API.  Use this tool when a user requests to list Tableau Pulse Metric Subscriptions for the current user.
 

--- a/src/tools/web/pulse/listMetricsFromMetricDefinitionId/listPulseMetricsFromMetricDefinitionId.ts
+++ b/src/tools/web/pulse/listMetricsFromMetricDefinitionId/listPulseMetricsFromMetricDefinitionId.ts
@@ -17,6 +17,7 @@ export const getListPulseMetricsFromMetricDefinitionIdTool = (
   const listPulseMetricsFromMetricDefinitionIdTool = new WebTool({
     server,
     name: 'list-pulse-metrics-from-metric-definition-id',
+    registrationConditions: ['RequiresPulse'],
     description: `
 Retrieves a list of published Pulse Metrics from a Pulse Metric Definition using the Tableau REST API.  Use this tool when a user requests to list Tableau Pulse Metrics for a specific Pulse Metric Definition on the current site.
 

--- a/src/tools/web/pulse/listMetricsFromMetricIds/listPulseMetricsFromMetricIds.ts
+++ b/src/tools/web/pulse/listMetricsFromMetricIds/listPulseMetricsFromMetricIds.ts
@@ -16,6 +16,7 @@ export const getListPulseMetricsFromMetricIdsTool = (
   const listPulseMetricsFromMetricIdsTool = new WebTool({
     server,
     name: 'list-pulse-metrics-from-metric-ids',
+    registrationConditions: ['RequiresPulse'],
     description: `
 Retrieves a list of published Pulse Metrics from a list of metric IDs using the Tableau REST API.  Use this tool when a user requests to list Tableau Pulse Metrics for a list of metric IDs on the current site.
 

--- a/src/tools/web/registrationConditions.test.ts
+++ b/src/tools/web/registrationConditions.test.ts
@@ -1,82 +1,431 @@
+import { AxiosError, AxiosResponse } from 'axios';
+import { Ok } from 'ts-results-es';
+
+import {
+  PulseDisabledError,
+  PulseInsightsApiError,
+  PulseNotAvailableError,
+} from '../../errors/mcpToolError.js';
 import { RestApiArgs } from '../../restApiInstance.js';
+import { PULSE_PREMIUM_INSIGHTS_ENTITLEMENT } from '../../sdks/tableau/types/pulse.js';
 import {
   checkRegistrationConditions,
+  getUnmetConditionInstructions,
+  MAX_PULSE_PROBE_ATTEMPTS,
   RegistrationCondition,
   RegistrationContext,
 } from './registrationConditions.js';
 
+const mocks = vi.hoisted(() => ({
+  useRestApi: vi.fn(),
+}));
+
+vi.mock('../../restApiInstance.js', () => ({
+  useRestApi: mocks.useRestApi,
+}));
+
+// The Pulse probe is reached through the mocked useRestApi, so a minimal stub is sufficient here.
+const restApiArgs = {} as unknown as RestApiArgs;
+
+/** A successful `listAllPulseMetricDefinitions` page. An empty site still means Pulse is enabled. */
+function pulseDefinitionsPage(definitionCount = 0): Ok<unknown> {
+  return new Ok({
+    pagination: { next_page_token: undefined, offset: 0, total_available: definitionCount },
+    definitions: Array.from({ length: definitionCount }, (_, i) => ({
+      metadata: { name: `m${i}` },
+    })),
+  });
+}
+
+/** An entitlements response built from `{ entitlementType: enabled }` pairs. */
+function entitlements(enabledByType: Record<string, boolean>): Ok<unknown> {
+  return new Ok(
+    Object.entries(enabledByType).map(([entitlement_type, enabled]) => ({
+      entitlement_type,
+      enabled,
+    })),
+  );
+}
+
+/** Stubs the two probe calls, each with an `Ok` or an `Err`. */
+function stubPulseProbe(definitionsResult: unknown, entitlementsResult?: unknown): void {
+  mocks.useRestApi.mockImplementation(async ({ callback }: { callback: (api: any) => unknown }) =>
+    callback({
+      pulseMethods: {
+        listAllPulseMetricDefinitions: vi.fn().mockResolvedValue(definitionsResult),
+        getPulseEntitlements: vi.fn().mockResolvedValue(entitlementsResult),
+      },
+    }),
+  );
+}
+
+// The probe retries with real backoff delays. Fake timers keep the retry-path tests fast: schedule
+// the call, drain all pending timers/microtasks, then await the settled result.
+async function resolveWithFakeTimers<T>(op: () => Promise<T>): Promise<T> {
+  vi.useFakeTimers();
+  try {
+    const pending = op();
+    await vi.runAllTimersAsync();
+    return await pending;
+  } finally {
+    vi.useRealTimers();
+  }
+}
+
 describe('checkRegistrationConditions', () => {
-  // restApiArgs is only consulted by the (not-yet-implemented) capability lookups; the decision
-  // logic under test reads/writes `context`, so a minimal stub is sufficient here.
-  const restApiArgs = {} as unknown as RestApiArgs;
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
 
-  it('is met when there are no conditions to satisfy', async () => {
-    const context: RegistrationContext = {};
-    await expect(checkRegistrationConditions([], context, restApiArgs)).resolves.toEqual({
-      registrationConditionsMet: true,
+  describe('decision logic', () => {
+    it('is met when there are no conditions to satisfy', async () => {
+      const context: RegistrationContext = {};
+      await expect(checkRegistrationConditions([], context, restApiArgs)).resolves.toEqual({
+        registrationConditionsMet: true,
+      });
+      expect(mocks.useRestApi).not.toHaveBeenCalled();
+    });
+
+    it('is met when a required capability is already satisfied in context', async () => {
+      // Pre-populated context models a capability resolved earlier in the same registration pass.
+      const context: RegistrationContext = { isPulseEnabled: true };
+      await expect(
+        checkRegistrationConditions(['RequiresPulse'], context, restApiArgs),
+      ).resolves.toEqual({ registrationConditionsMet: true });
+    });
+
+    it('reports the failing condition when a required capability is disabled in context (fail-closed)', async () => {
+      const context: RegistrationContext = { isPulseEnabled: false };
+      await expect(
+        checkRegistrationConditions(['RequiresPulse'], context, restApiArgs),
+      ).resolves.toEqual({ registrationConditionsMet: false, failingCondition: 'RequiresPulse' });
+    });
+
+    it('does not re-resolve a capability already present in context (memoized across tools)', async () => {
+      const context: RegistrationContext = { hasPulsePremium: true };
+      await expect(
+        checkRegistrationConditions(['RequiresPulsePremium'], context, restApiArgs),
+      ).resolves.toEqual({ registrationConditionsMet: true });
+      expect(mocks.useRestApi).not.toHaveBeenCalled();
+    });
+
+    it('requires every condition — one unmet condition hides the tool and names it', async () => {
+      const context: RegistrationContext = { isPulseEnabled: true, hasPulsePremium: false };
+      await expect(
+        checkRegistrationConditions(
+          ['RequiresPulse', 'RequiresPulsePremium'],
+          context,
+          restApiArgs,
+        ),
+      ).resolves.toEqual({
+        registrationConditionsMet: false,
+        failingCondition: 'RequiresPulsePremium',
+      });
+    });
+
+    it('is met when every condition is satisfied', async () => {
+      const context: RegistrationContext = { isPulseEnabled: true, hasPulsePremium: true };
+      await expect(
+        checkRegistrationConditions(
+          ['RequiresPulse', 'RequiresPulsePremium'],
+          context,
+          restApiArgs,
+        ),
+      ).resolves.toEqual({ registrationConditionsMet: true });
+    });
+
+    it('fails closed with MissingConditionCheck on an unrecognized condition', async () => {
+      // Only reachable via an unsound cast (the union type excludes it), but the runtime guard must
+      // hide the tool rather than expose it, and flag it as a missing check.
+      const context: RegistrationContext = {};
+      await expect(
+        checkRegistrationConditions(['Nonsense' as RegistrationCondition], context, restApiArgs),
+      ).resolves.toEqual({
+        registrationConditionsMet: false,
+        failingCondition: 'MissingConditionCheck',
+      });
     });
   });
 
-  it('is met when a required capability is already satisfied in context', async () => {
-    // Pre-populated context models a capability resolved earlier in the same registration pass.
-    const context: RegistrationContext = { isPulseEnabled: true };
-    await expect(
-      checkRegistrationConditions(['RequiresPulse'], context, restApiArgs),
-    ).resolves.toEqual({ registrationConditionsMet: true });
-  });
+  describe('RequiresPulse — Pulse enablement scenarios', () => {
+    it('is met when the site has Pulse enabled and published definitions', async () => {
+      stubPulseProbe(pulseDefinitionsPage(3));
+      const context: RegistrationContext = {};
 
-  it('reports the failing condition when a required capability is disabled in context (fail-closed)', async () => {
-    const context: RegistrationContext = { isPulseEnabled: false };
-    await expect(
-      checkRegistrationConditions(['RequiresPulse'], context, restApiArgs),
-    ).resolves.toEqual({ registrationConditionsMet: false, failingCondition: 'RequiresPulse' });
-  });
+      await expect(
+        checkRegistrationConditions(['RequiresPulse'], context, restApiArgs),
+      ).resolves.toEqual({ registrationConditionsMet: true });
+      expect(context.isPulseEnabled).toBe(true);
+    });
 
-  it('does not re-resolve a capability already present in context (memoized across tools)', async () => {
-    // If the `=== undefined` guard were missing, the lookup would overwrite this with the
-    // not-yet-implemented default (false). Getting "met" back proves the re-fetch is short-circuited.
-    const context: RegistrationContext = { hasPulsePremium: true };
-    await expect(
-      checkRegistrationConditions(['RequiresPulsePremium'], context, restApiArgs),
-    ).resolves.toEqual({ registrationConditionsMet: true });
-  });
+    it('is met when Pulse is enabled but the site has no definitions yet', async () => {
+      // Availability is about whether the request cleared the site-settings interceptor, not about
+      // whether anyone has authored a metric — a brand new Pulse site must still get the tools.
+      stubPulseProbe(pulseDefinitionsPage(0));
+      const context: RegistrationContext = {};
 
-  it('requires every condition — one unmet condition hides the tool and names it', async () => {
-    const context: RegistrationContext = { isPulseEnabled: true, hasPulsePremium: false };
-    await expect(
-      checkRegistrationConditions(['RequiresPulse', 'RequiresPulsePremium'], context, restApiArgs),
-    ).resolves.toEqual({
-      registrationConditionsMet: false,
-      failingCondition: 'RequiresPulsePremium',
+      await expect(
+        checkRegistrationConditions(['RequiresPulse'], context, restApiArgs),
+      ).resolves.toEqual({ registrationConditionsMet: true });
+      expect(context.isPulseEnabled).toBe(true);
+    });
+
+    it('is unmet when Pulse is disabled for the site', async () => {
+      stubPulseProbe(new PulseDisabledError().toErr());
+      const context: RegistrationContext = {};
+
+      await expect(
+        checkRegistrationConditions(['RequiresPulse'], context, restApiArgs),
+      ).resolves.toEqual({ registrationConditionsMet: false, failingCondition: 'RequiresPulse' });
+      expect(context.isPulseEnabled).toBe(false);
+    });
+
+    it('does not retry when Pulse is disabled — the answer is deterministic', async () => {
+      stubPulseProbe(new PulseDisabledError().toErr());
+
+      await checkRegistrationConditions(['RequiresPulse'], {}, restApiArgs);
+
+      expect(mocks.useRestApi).toHaveBeenCalledTimes(1);
+    });
+
+    it('is unmet when Pulse is not available on the deployment (Tableau Server)', async () => {
+      stubPulseProbe(new PulseNotAvailableError().toErr());
+      const context: RegistrationContext = {};
+
+      await expect(
+        checkRegistrationConditions(['RequiresPulse'], context, restApiArgs),
+      ).resolves.toEqual({ registrationConditionsMet: false, failingCondition: 'RequiresPulse' });
+      expect(mocks.useRestApi).toHaveBeenCalledTimes(1);
+    });
+
+    it('resolves the capability once and reuses it for every tool declaring the condition', async () => {
+      stubPulseProbe(pulseDefinitionsPage(1));
+      const context: RegistrationContext = {};
+
+      await checkRegistrationConditions(['RequiresPulse'], context, restApiArgs);
+      await checkRegistrationConditions(['RequiresPulse'], context, restApiArgs);
+      await checkRegistrationConditions(['RequiresPulse'], context, restApiArgs);
+
+      expect(mocks.useRestApi).toHaveBeenCalledTimes(1);
+    });
+
+    it('retries an indeterminate failure and is met once a retry succeeds', async () => {
+      mocks.useRestApi
+        .mockRejectedValueOnce(new Error('transient 1'))
+        .mockRejectedValueOnce(new Error('transient 2'))
+        .mockImplementationOnce(
+          async ({ callback }: { callback: (api: any) => unknown }) =>
+            await callback({
+              pulseMethods: {
+                listAllPulseMetricDefinitions: vi.fn().mockResolvedValue(pulseDefinitionsPage(2)),
+              },
+            }),
+        );
+
+      const result = await resolveWithFakeTimers(() =>
+        checkRegistrationConditions(['RequiresPulse'], {}, restApiArgs),
+      );
+
+      expect(result).toEqual({ registrationConditionsMet: true });
+      expect(mocks.useRestApi).toHaveBeenCalledTimes(MAX_PULSE_PROBE_ATTEMPTS);
+    });
+
+    it('fails closed after exhausting retries when every attempt fails', async () => {
+      mocks.useRestApi.mockRejectedValue(new Error('network down'));
+      const context: RegistrationContext = {};
+
+      const result = await resolveWithFakeTimers(() =>
+        checkRegistrationConditions(['RequiresPulse'], context, restApiArgs),
+      );
+
+      expect(result).toEqual({
+        registrationConditionsMet: false,
+        failingCondition: 'RequiresPulse',
+      });
+      expect(mocks.useRestApi).toHaveBeenCalledTimes(MAX_PULSE_PROBE_ATTEMPTS);
+      // Memoized so the failure is not re-probed for every remaining Pulse tool.
+      expect(context.isPulseEnabled).toBe(false);
+    });
+
+    it('does not retry a 4xx transport error (deterministic — retrying cannot help)', async () => {
+      const forbidden = new AxiosError('Forbidden', 'ERR_BAD_REQUEST', undefined, undefined, {
+        status: 403,
+      } as AxiosResponse);
+      mocks.useRestApi.mockRejectedValue(forbidden);
+
+      await expect(
+        checkRegistrationConditions(['RequiresPulse'], {}, restApiArgs),
+      ).resolves.toEqual({ registrationConditionsMet: false, failingCondition: 'RequiresPulse' });
+      expect(mocks.useRestApi).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not retry a 4xx Pulse API error', async () => {
+      stubPulseProbe(new PulseInsightsApiError('bad request', 400).toErr());
+
+      await expect(
+        checkRegistrationConditions(['RequiresPulse'], {}, restApiArgs),
+      ).resolves.toEqual({ registrationConditionsMet: false, failingCondition: 'RequiresPulse' });
+      expect(mocks.useRestApi).toHaveBeenCalledTimes(1);
+    });
+
+    it('retries a 5xx Pulse API error before failing closed', async () => {
+      stubPulseProbe(new PulseInsightsApiError('upstream down', 503).toErr());
+
+      const result = await resolveWithFakeTimers(() =>
+        checkRegistrationConditions(['RequiresPulse'], {}, restApiArgs),
+      );
+
+      expect(result).toEqual({
+        registrationConditionsMet: false,
+        failingCondition: 'RequiresPulse',
+      });
+      expect(mocks.useRestApi).toHaveBeenCalledTimes(MAX_PULSE_PROBE_ATTEMPTS);
     });
   });
 
-  it('is met when every condition is satisfied', async () => {
-    const context: RegistrationContext = { isPulseEnabled: true, hasPulsePremium: true };
-    await expect(
-      checkRegistrationConditions(['RequiresPulse', 'RequiresPulsePremium'], context, restApiArgs),
-    ).resolves.toEqual({ registrationConditionsMet: true });
-  });
+  describe('RequiresPulsePremium', () => {
+    it('is unmet without a second probe when Pulse itself is disabled', async () => {
+      // Premium is a superset of base Pulse, so a Pulse-less site short-circuits on the base probe.
+      stubPulseProbe(new PulseDisabledError().toErr());
+      const context: RegistrationContext = {};
 
-  it('fails closed with MissingConditionCheck on an unrecognized condition', async () => {
-    // Only reachable via an unsound cast (the union type excludes it), but the runtime guard must
-    // hide the tool rather than expose it, and flag it as a missing check.
-    const context: RegistrationContext = {};
-    await expect(
-      checkRegistrationConditions(['Nonsense' as RegistrationCondition], context, restApiArgs),
-    ).resolves.toEqual({
-      registrationConditionsMet: false,
-      failingCondition: 'MissingConditionCheck',
+      await expect(
+        checkRegistrationConditions(['RequiresPulsePremium'], context, restApiArgs),
+      ).resolves.toEqual({
+        registrationConditionsMet: false,
+        failingCondition: 'RequiresPulsePremium',
+      });
+      expect(mocks.useRestApi).toHaveBeenCalledTimes(1);
+      expect(context.isPulseEnabled).toBe(false);
+    });
+
+    it('is met when the site has the premium insights entitlement enabled', async () => {
+      stubPulseProbe(
+        pulseDefinitionsPage(1),
+        entitlements({ [PULSE_PREMIUM_INSIGHTS_ENTITLEMENT]: true }),
+      );
+      const context: RegistrationContext = {};
+
+      await expect(
+        checkRegistrationConditions(['RequiresPulsePremium'], context, restApiArgs),
+      ).resolves.toEqual({ registrationConditionsMet: true });
+      expect(context.hasPulsePremium).toBe(true);
+    });
+
+    it('is unmet when the premium insights entitlement is reported disabled', async () => {
+      stubPulseProbe(
+        pulseDefinitionsPage(1),
+        entitlements({ [PULSE_PREMIUM_INSIGHTS_ENTITLEMENT]: false }),
+      );
+      const context: RegistrationContext = {};
+
+      await expect(
+        checkRegistrationConditions(['RequiresPulsePremium'], context, restApiArgs),
+      ).resolves.toEqual({
+        registrationConditionsMet: false,
+        failingCondition: 'RequiresPulsePremium',
+      });
+      expect(context.hasPulsePremium).toBe(false);
+    });
+
+    it('is unmet when the entitlement is absent from the response entirely', async () => {
+      // The service normally returns every type, but a missing type must read as disabled rather
+      // than as permission to register.
+      stubPulseProbe(pulseDefinitionsPage(1), entitlements({}));
+
+      await expect(
+        checkRegistrationConditions(['RequiresPulsePremium'], {}, restApiArgs),
+      ).resolves.toEqual({
+        registrationConditionsMet: false,
+        failingCondition: 'RequiresPulsePremium',
+      });
+    });
+
+    it('does not treat a different premium entitlement as the insights entitlement', async () => {
+      stubPulseProbe(
+        pulseDefinitionsPage(1),
+        entitlements({
+          ENTITLEMENT_TYPE_PULSE_PREMIUM_CONSUMPTION: true,
+          ENTITLEMENT_TYPE_PULSE_PREMIUM_SCALE: true,
+          [PULSE_PREMIUM_INSIGHTS_ENTITLEMENT]: false,
+        }),
+      );
+
+      await expect(
+        checkRegistrationConditions(['RequiresPulsePremium'], {}, restApiArgs),
+      ).resolves.toEqual({
+        registrationConditionsMet: false,
+        failingCondition: 'RequiresPulsePremium',
+      });
+    });
+
+    it('reuses an already-resolved base Pulse capability and probes only entitlements', async () => {
+      stubPulseProbe(
+        pulseDefinitionsPage(1),
+        entitlements({ [PULSE_PREMIUM_INSIGHTS_ENTITLEMENT]: true }),
+      );
+      const context: RegistrationContext = { isPulseEnabled: true };
+
+      await checkRegistrationConditions(['RequiresPulsePremium'], context, restApiArgs);
+
+      expect(mocks.useRestApi).toHaveBeenCalledTimes(1);
+    });
+
+    it('costs one probe per capability when a tool declares both conditions', async () => {
+      stubPulseProbe(
+        pulseDefinitionsPage(1),
+        entitlements({ [PULSE_PREMIUM_INSIGHTS_ENTITLEMENT]: true }),
+      );
+
+      await expect(
+        checkRegistrationConditions(['RequiresPulse', 'RequiresPulsePremium'], {}, restApiArgs),
+      ).resolves.toEqual({ registrationConditionsMet: true });
+      // One Pulse probe plus one entitlements probe — the base capability is not re-resolved.
+      expect(mocks.useRestApi).toHaveBeenCalledTimes(2);
+    });
+
+    it('fails closed when the entitlements lookup keeps failing', async () => {
+      // Notably the case where the deployment has not granted `tableau:entitlements:read`.
+      stubPulseProbe(
+        pulseDefinitionsPage(1),
+        new PulseInsightsApiError('upstream down', 503).toErr(),
+      );
+      const context: RegistrationContext = {};
+
+      const result = await resolveWithFakeTimers(() =>
+        checkRegistrationConditions(['RequiresPulsePremium'], context, restApiArgs),
+      );
+
+      expect(result).toEqual({
+        registrationConditionsMet: false,
+        failingCondition: 'RequiresPulsePremium',
+      });
+      expect(context.hasPulsePremium).toBe(false);
     });
   });
+});
 
-  it('is fail-closed until a capability lookup is implemented, memoizing the unresolved result', async () => {
-    // The Pulse lookups are not yet implemented (near-term roadmap); until then an unresolved
-    // capability resolves to "unavailable" and is memoized so it is looked up at most once per pass.
-    const context: RegistrationContext = {};
-    await expect(
-      checkRegistrationConditions(['RequiresPulse'], context, restApiArgs),
-    ).resolves.toEqual({ registrationConditionsMet: false, failingCondition: 'RequiresPulse' });
-    expect(context.isPulseEnabled).toBe(false);
+describe('getUnmetConditionInstructions', () => {
+  it('explains that Pulse is not enabled and how to enable it', async () => {
+    const message = getUnmetConditionInstructions('RequiresPulse');
+
+    expect(message).toContain('Pulse');
+    expect(message).toContain('not enabled');
+    // The client-facing copy must point somewhere actionable rather than just stating the failure.
+    expect(message).toContain('https://help.tableau.com/current/online/en-us/pulse_set_up.htm');
+  });
+
+  it('explains that AI insights require the Tableau+ entitlement', async () => {
+    const message = getUnmetConditionInstructions('RequiresPulsePremium');
+
+    expect(message).toContain('Tableau+');
+    expect(message).toContain('insight');
+  });
+
+  it('describes a missing condition check as a server-side defect, not a permissions problem', async () => {
+    const message = getUnmetConditionInstructions('MissingConditionCheck');
+
+    expect(message).toContain('server-side defect');
+    expect(message).not.toContain('Tableau+');
   });
 });

--- a/src/tools/web/registrationConditions.test.ts
+++ b/src/tools/web/registrationConditions.test.ts
@@ -406,12 +406,12 @@ describe('checkRegistrationConditions', () => {
 });
 
 describe('getUnmetConditionInstructions', () => {
-  it('explains that Pulse is not enabled and how to enable it', async () => {
+  it('explains that Pulse is not available and points at Cloud setup guidance', async () => {
     const message = getUnmetConditionInstructions('RequiresPulse');
 
-    expect(message).toContain('Pulse');
-    expect(message).toContain('not enabled');
-    // The client-facing copy must point somewhere actionable rather than just stating the failure.
+    // Kept generic — Pulse can be unavailable for site, user, or Server reasons.
+    expect(message).toContain('Pulse is not available');
+    expect(message).not.toContain('not enabled for this site');
     expect(message).toContain('https://help.tableau.com/current/online/en-us/pulse_set_up.htm');
   });
 
@@ -422,10 +422,11 @@ describe('getUnmetConditionInstructions', () => {
     expect(message).toContain('insight');
   });
 
-  it('describes a missing condition check as a server-side defect, not a permissions problem', async () => {
+  it('describes a missing condition check as an unimplemented check, without a reconnect suggestion', async () => {
     const message = getUnmetConditionInstructions('MissingConditionCheck');
 
-    expect(message).toContain('server-side defect');
+    expect(message).toContain('not implemented');
+    expect(message).not.toContain('Disconnect and reconnect');
     expect(message).not.toContain('Tableau+');
   });
 });

--- a/src/tools/web/registrationConditions.ts
+++ b/src/tools/web/registrationConditions.ts
@@ -1,4 +1,13 @@
-import { RestApiArgs } from '../../restApiInstance.js';
+import { isAxiosError } from 'axios';
+
+import {
+  McpToolError,
+  PulseDisabledError,
+  PulseNotAvailableError,
+} from '../../errors/mcpToolError.js';
+import { RestApiArgs, useRestApi } from '../../restApiInstance.js';
+import { PULSE_PREMIUM_INSIGHTS_ENTITLEMENT } from '../../sdks/tableau/types/pulse.js';
+import { retry } from '../../utils/retry.js';
 
 /**
  * A capability a tool can require at registration time to be verified by {@link checkRegistrationConditions}.
@@ -55,7 +64,7 @@ export async function checkRegistrationConditions(
       }
       case 'RequiresPulsePremium': {
         if (context.hasPulsePremium === undefined) {
-          context.hasPulsePremium = await checkPulsePremium(restApiArgs);
+          context.hasPulsePremium = await checkPulsePremium(restApiArgs, context);
         }
         if (!context.hasPulsePremium) {
           return { registrationConditionsMet: false, failingCondition: 'RequiresPulsePremium' };
@@ -75,23 +84,180 @@ export async function checkRegistrationConditions(
 }
 
 /**
- * Whether Pulse is enabled for the caller's site.
+ * Client-facing explanation for each condition, appended to the initialize instructions when that
+ * condition hid at least one tool. Registration runs before the transport connects, so the
+ * instructions are the only channel that reaches the user — without this the caller just sees a
+ * short tool list with no explanation.
  *
- * TODO(pulse): implement the Tableau REST lookup (near-term roadmap). Model it on
- * {@link getCurrentUserSiteRole} — fetch via `useRestApi(restApiArgs)` and fail closed on error.
- * Until then this returns `false`, so any tool declaring `RequiresPulse` is hidden rather than
- * exposed.
+ * Typed as a total `Record` so adding a {@link RegistrationCondition} without user-facing copy is
+ * a compile error rather than a silent omission.
  */
-async function checkPulseEnabled(_restApiArgs: RestApiArgs): Promise<boolean> {
-  return false;
+const UNMET_CONDITION_INSTRUCTIONS: Record<RegistrationCondition, string> = {
+  RequiresPulse:
+    'NOTE: Tableau Pulse tools were omitted from this session because Pulse is not enabled for ' +
+    'this site. Pulse is available on Tableau Cloud and must be turned on by a site ' +
+    'administrator — see https://help.tableau.com/current/online/en-us/pulse_set_up.htm. Do not ' +
+    'offer Pulse metrics or insights; if the user asks for them, explain that Pulse is not ' +
+    'enabled and suggest they contact their Tableau administrator.',
+  RequiresPulsePremium:
+    'NOTE: AI-powered Tableau Pulse insight tools were omitted from this session because this ' +
+    'site does not have the Tableau+ entitlement those insights require. Basic Pulse metric ' +
+    'tools may still be available. Do not offer AI-generated Pulse insights or briefs; if the ' +
+    'user asks for them, explain that the feature requires Tableau+.',
+  MissingConditionCheck:
+    'WARNING: Some tools were omitted from this session because a required capability check ' +
+    'could not be evaluated. This is a server-side defect rather than a permissions or licensing ' +
+    'problem. Disconnect and reconnect to retry; if it persists, report it to your Tableau ' +
+    'administrator.',
+};
+
+/** The client-facing explanation to surface when `condition` hid one or more tools. */
+export function getUnmetConditionInstructions(condition: RegistrationCondition): string {
+  return UNMET_CONDITION_INSTRUCTIONS[condition];
+}
+
+/** Total number of Pulse probe attempts (1 initial + {@link MAX_PULSE_PROBE_ATTEMPTS}-1 retries). */
+export const MAX_PULSE_PROBE_ATTEMPTS = 3;
+
+/**
+ * Whether a failed capability probe is worth retrying.
+ *
+ * A 4xx is a deterministic answer ("not allowed", "not found") that retrying cannot change, so we
+ * fail fast rather than delaying registration for every caller on a Pulse-less site. Mirrors the
+ * retry predicate in {@link getCurrentUserSiteRole}, but also understands {@link McpToolError},
+ * which is what the Pulse methods return rather than a raw `AxiosError`.
+ */
+function isRetryableProbeError(error: unknown): boolean {
+  if (error instanceof McpToolError) {
+    return !(error.statusCode >= 400 && error.statusCode < 500);
+  }
+
+  if (isAxiosError(error)) {
+    const status = error.response?.status;
+    if (status !== undefined && status >= 400 && status < 500) {
+      return false;
+    }
+  }
+
+  return true;
 }
 
 /**
- * Whether the caller's site has the Pulse premium entitlement.
+ * Whether Pulse is enabled for the caller's site.
  *
- * TODO(pulse): implement the entitlement lookup (near-term roadmap). Returns `false` until then, so
- * `RequiresPulsePremium` is fail-closed.
+ * There is no endpoint that reports Pulse availability directly, so this probes the cheapest Pulse
+ * read there is — a single-item page of metric definitions — and classifies the outcome. What
+ * matters is only whether the request cleared the site-settings interceptor, not what came back: a
+ * site with zero definitions is still Pulse-enabled.
+ *
+ * Fail-closed: an indeterminate outcome (transient API error, exhausted retries, failed sign-in)
+ * returns `false`, so a tool declaring `RequiresPulse` is hidden rather than exposed.
  */
-async function checkPulsePremium(_restApiArgs: RestApiArgs): Promise<boolean> {
-  return false;
+async function checkPulseEnabled(restApiArgs: RestApiArgs): Promise<boolean> {
+  try {
+    return await retry(
+      () =>
+        useRestApi({
+          ...restApiArgs,
+          jwtScopes: ['tableau:insight_definitions_metrics:read'],
+          callback: async (restApi) => {
+            const result = await restApi.pulseMethods.listAllPulseMetricDefinitions(
+              undefined,
+              undefined,
+              1,
+            );
+
+            if (result.isOk()) {
+              return true;
+            }
+
+            // Both of these are definitive "Pulse is not usable here" answers rather than
+            // failures: the site setting is off, or this is Tableau Server, where Pulse
+            // does not exist. Returning resolves the probe, so no retry is attempted.
+            if (
+              result.error instanceof PulseDisabledError ||
+              result.error instanceof PulseNotAvailableError
+            ) {
+              return false;
+            }
+
+            // Anything else is indeterminate. Throw so `retry` can attempt again; exhausting
+            // retries falls through to the fail-closed catch below.
+            throw result.error;
+          },
+        }),
+      {
+        maxRetries: MAX_PULSE_PROBE_ATTEMPTS - 1,
+        retryIf: isRetryableProbeError,
+      },
+    );
+  } catch {
+    // Retries exhausted or a non-retryable error was thrown — fail closed.
+    return false;
+  }
+}
+
+/**
+ * Whether the caller's site has the Pulse premium (Tableau+) entitlement for AI-powered insights.
+ *
+ * Premium is a superset of base Pulse, so this short-circuits on the base probe first — memoized
+ * via `context`, so a tool declaring both conditions costs one Pulse probe, not two.
+ *
+ * Reads the site's entitlements directly. The service returns every known entitlement type with a
+ * boolean and substitutes an all-false response when its own upstream lookup fails, so a missing
+ * or absent entitlement is treated as disabled.
+ *
+ * Note on scopes: this requests `tableau:entitlements:read`, and a Connected App rejects a JWT
+ * mint that asks for a scope it has not granted. A deployment that enables
+ * `enforce-registration-conditions` must therefore grant that scope, or the probe fails closed and
+ * hides the premium tools. That is why the condition is only consulted for tools that declare it.
+ */
+async function checkPulsePremium(
+  restApiArgs: RestApiArgs,
+  context: RegistrationContext,
+): Promise<boolean> {
+  if (context.isPulseEnabled === undefined) {
+    context.isPulseEnabled = await checkPulseEnabled(restApiArgs);
+  }
+
+  if (!context.isPulseEnabled) {
+    return false;
+  }
+
+  try {
+    return await retry(
+      () =>
+        useRestApi({
+          ...restApiArgs,
+          jwtScopes: ['tableau:entitlements:read'],
+          callback: async (restApi) => {
+            const result = await restApi.pulseMethods.getPulseEntitlements();
+
+            if (result.isOk()) {
+              return result.value.some(
+                (entitlement) =>
+                  entitlement.entitlement_type === PULSE_PREMIUM_INSIGHTS_ENTITLEMENT &&
+                  entitlement.enabled === true,
+              );
+            }
+
+            if (
+              result.error instanceof PulseDisabledError ||
+              result.error instanceof PulseNotAvailableError
+            ) {
+              return false;
+            }
+
+            throw result.error;
+          },
+        }),
+      {
+        maxRetries: MAX_PULSE_PROBE_ATTEMPTS - 1,
+        retryIf: isRetryableProbeError,
+      },
+    );
+  } catch {
+    // Retries exhausted or a non-retryable error was thrown — fail closed.
+    return false;
+  }
 }

--- a/src/tools/web/registrationConditions.ts
+++ b/src/tools/web/registrationConditions.ts
@@ -93,22 +93,24 @@ export async function checkRegistrationConditions(
  * a compile error rather than a silent omission.
  */
 const UNMET_CONDITION_INSTRUCTIONS: Record<RegistrationCondition, string> = {
+  // Kept generic: Pulse can be unavailable for several reasons (Tableau Server, site setting
+  // off, or a user-level preference), and the probe cannot distinguish them cleanly enough to
+  // name a single cause here.
   RequiresPulse:
-    'NOTE: Tableau Pulse tools were omitted from this session because Pulse is not enabled for ' +
-    'this site. Pulse is available on Tableau Cloud and must be turned on by a site ' +
-    'administrator — see https://help.tableau.com/current/online/en-us/pulse_set_up.htm. Do not ' +
-    'offer Pulse metrics or insights; if the user asks for them, explain that Pulse is not ' +
-    'enabled and suggest they contact their Tableau administrator.',
+    'NOTE: Tableau Pulse tools were omitted from this session because Pulse is not available. ' +
+    'Do not offer Pulse metrics or insights; if the user asks for them, explain that Pulse is ' +
+    'not available and suggest they contact their Tableau administrator. For setup guidance ' +
+    'on Tableau Cloud, see https://help.tableau.com/current/online/en-us/pulse_set_up.htm.',
   RequiresPulsePremium:
     'NOTE: AI-powered Tableau Pulse insight tools were omitted from this session because this ' +
     'site does not have the Tableau+ entitlement those insights require. Basic Pulse metric ' +
     'tools may still be available. Do not offer AI-generated Pulse insights or briefs; if the ' +
     'user asks for them, explain that the feature requires Tableau+.',
+  // Developer-facing only: reached when a RegistrationCondition is declared on a tool but has
+  // no corresponding case in checkRegistrationConditions. Reconnecting cannot help.
   MissingConditionCheck:
-    'WARNING: Some tools were omitted from this session because a required capability check ' +
-    'could not be evaluated. This is a server-side defect rather than a permissions or licensing ' +
-    'problem. Disconnect and reconnect to retry; if it persists, report it to your Tableau ' +
-    'administrator.',
+    'WARNING: Some tools were omitted from this session because a required registration ' +
+    'condition check is not implemented.',
 };
 
 /** The client-facing explanation to surface when `condition` hid one or more tools. */


### PR DESCRIPTION
## Description

Builds on #871, which added the `registrationConditions` tool property and the omission logic for
`RequiresPulse` / `RequiresPulsePremium`. That PR left three things open: how to actually check the
conditions, declaring them on the Pulse tools, and an initialization message explaining why Pulse
was unavailable. This adds all three, plus tests for the Pulse enablement scenarios.

### 1. Capability checks (`src/tools/web/registrationConditions.ts`)

**`RequiresPulse`** — there is no endpoint that reports Pulse availability directly, so
`checkPulseEnabled` probes the cheapest Pulse read available (a one-item page of metric
definitions) and classifies the outcome:

| Outcome | Result |
| --- | --- |
| `Ok` | enabled — including an empty page, since a brand-new Pulse site has no definitions yet |
| `PulseDisabledError` | disabled (site setting off), not retried |
| `PulseNotAvailableError` | disabled (Tableau Server), not retried |
| anything else | retried, then fails closed |

The two Pulse-specific errors are definitive answers rather than failures, so retrying them would
just delay registration for every caller on a Pulse-less site. The retry predicate mirrors
`getCurrentUserSiteRole` but also understands `McpToolError`, which is what the Pulse methods
return instead of a raw `AxiosError`.

**`RequiresPulsePremium`** — reads `GET /api/-/pulse/entitlements` and requires
`ENTITLEMENT_TYPE_PULSE_PREMIUM_INSIGHTS` to be enabled. That is the entitlement whose absence
produces `PulseInsightsDisabledError` ("requires Tableau+"). It short-circuits on the memoized
base-Pulse probe first, since premium is a superset of base Pulse — so a tool declaring both
conditions costs one probe per capability, not two.

The entitlements endpoint was not in the SDK yet, so this also adds the Zodios endpoint, the
response schema, `getPulseEntitlements`, and the `tableau:entitlements:read` scope.

### 2. Tool declarations

All eight Pulse-backed tools declare `RequiresPulse`. That includes `generate-insight-cards`, which
isn't named like a Pulse tool but routes through `generatePulseMetricValueInsightBundle`. The three
AI-insight tools (`generate-pulse-insight-brief`, `generate-pulse-metric-value-insight-bundle`,
`generate-insight-cards`) additionally declare `RequiresPulsePremium`.

### 3. Initialization message (`src/server.web.ts`)

Replaces the `TODO` with one explanation per distinct unmet condition, appended to the initialize
instructions. Registration runs before the transport connects, so the instructions are the only
channel that reaches the user — without this a Pulse-less site just gets a shorter tool list and no
reason for it. The copy is a total `Record<RegistrationCondition, string>`, so adding a condition
without user-facing copy is a compile error rather than a silent omission.

## Motivation and Context

Continues the goal from #871: register only the tools that are actually usable for a given site, and
tell the user when something was withheld and why.

## Notes for reviewers

Two deliberate decisions worth a look:

- **`entitlement_type` is a bare string, not a Zod enum.** The service owns that enum, and a
  validation error here happens at registration time — it would fail closed and hide tools from
  entitled customers. Forward compatibility is worth more than strictness in this specific spot.
- **The premium probe requests `tableau:entitlements:read`.** Per the existing notes in `scopes.ts`,
  a Connected App rejects a JWT mint that asks for an un-granted scope, so any deployment turning
  on `enforce-registration-conditions` must grant that scope or the premium tools will fail closed.
  Everything stays behind that default-off flag, so there is no change in behavior until it is
  enabled — but it should be called out in the rollout notes.

One open question: `ENTITLEMENT_TYPE_PULSE_PREMIUM_GAI` is a sibling entitlement that gates
generative-AI features specifically. Mapping the single coarse `RequiresPulsePremium` condition to
`PULSE_PREMIUM_INSIGHTS` covers the insight-bundle tools cleanly, but the conversational insight
brief is arguably GAI. Splitting the condition is a reasonable follow-up if that distinction matters
in practice.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## How Has This Been Tested?

Unit tests. `registrationConditions.test.ts` covers the enablement scenarios end to end: Pulse
enabled with and without definitions, disabled by site setting, unavailable on Tableau Server,
retry-then-succeed, exhausted retries, 4xx not retried, 5xx retried, memoization across tools, and
for premium — entitlement enabled, disabled, absent from the response, a different premium
entitlement not being mistaken for it, and the short-circuit when base Pulse is off.
`server.web.test.ts` covers registration and the initialize instructions in both directions.

Full unit suite: 2895 passing. `tsc --noEmit` and `eslint` clean over the changed files.

## Related Issues

Stacked on #871. Work item: @W-21254846

## Checklist

- [ ] I have updated the version in the package.json file by using `npm run version`. Not bumped
      deliberately — the base branch is still at 4.8.0, and bumping in a stacked PR would just
      conflict. Worth a single bump when the stack lands.
- [x] I have made any necessary changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have documented any breaking changes in the PR description
