### PR TITLE
fix(desktop): match Tableau nested-shelf readback and innermost sort

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "2.67.6",
+  "version": "2.67.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "2.67.6",
+      "version": "2.67.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.7.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "2.67.7",
+  "version": "2.67.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "2.67.7",
+      "version": "2.67.8",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.7.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "2.67.6",
+  "version": "2.67.7",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "2.67.7",
+  "version": "2.67.8",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/src/desktop/guards/commandPolicy.test.ts
+++ b/src/desktop/guards/commandPolicy.test.ts
@@ -9,8 +9,10 @@ describe('commandPolicy', () => {
       reason: 'known-live-failure',
     });
     expect(policy?.fix).toContain('known to fail');
-    expect(policy?.fix).toContain('do not retry');
-    expect(policy?.fix).toContain('cached-document round-trip');
+    expect(policy?.fix).toMatch(/do not retry/i);
+    expect(policy?.fix).toContain('refine-worksheet');
+    expect(policy?.fix).toContain('sort_by_field');
+    expect(policy?.fix).not.toContain('cached-document');
     expect(policy?.params?.required).toEqual(
       new Set(['DimensionToSort', 'Worksheet', 'MeasureName', 'ShelfType']),
     );

--- a/src/desktop/guards/commandPolicy.ts
+++ b/src/desktop/guards/commandPolicy.ts
@@ -13,9 +13,9 @@ const KNOWN_LIVE_FAILURE_REASON = 'known-live-failure';
 const UNVALIDATED_TARGET_REASON = 'unvalidated-target';
 const FILTER_FIX = 'express filters in the NotionalSpec (categoricalFilters/rangeFilters/...)';
 const SORT_FIX =
-  'tabdoc:sort drives a UI dialog and blocks the screen. Use refine-worksheet with operation sort_by_field (sort a dimension by a field/measure), or the cached-document round-trip for nested sorts';
+  'tabdoc:sort drives a UI dialog and blocks the screen. Use refine-worksheet with operation sort_by_field (omit targetField to sort the innermost nested dim, or pass targetField)';
 const SORT_NESTED_FIX =
-  'FIX: tabdoc:sort-nested is known to fail (HTTP 500) on current Desktop builds regardless of parameters — do not retry it. Sort instead via the cached-document round-trip (get-worksheet-xml → read-cached-xml/write-cached-xml to edit the computed-sort → apply-worksheet).';
+  'FIX: tabdoc:sort-nested is known to fail (HTTP 500) on current Desktop builds regardless of parameters. Do not retry it. Use refine-worksheet with operation sort_by_field (omit targetField to sort the innermost nested dim, or pass targetField).';
 const SORT_NESTED_ALLOWED =
   'DimensionToSort Worksheet MeasureName ShelfType Direction ClearSort Dashboard LevelNames MemberValues KeepFieldFilters';
 const SORT_NESTED_REQUIRED = 'DimensionToSort Worksheet MeasureName ShelfType';

--- a/src/desktop/refine/refineWorksheet.test.ts
+++ b/src/desktop/refine/refineWorksheet.test.ts
@@ -614,6 +614,60 @@ describe('planSortByField', () => {
     expect(r.column).toBe('[Superstore].[none:line_item:nk]');
   });
 
+  const nestedGroupCountry = (rows: string): string =>
+    withDeps(
+      "<column caption='Group' datatype='string' name='[Group]' role='dimension' type='nominal' />" +
+        "<column caption='Country' datatype='string' name='[Country]' role='dimension' type='nominal' />" +
+        SALES_COL +
+        "<column-instance column='[Group]' derivation='None' name='[none:Group:nk]' pivot='key' type='nominal' />" +
+        "<column-instance column='[Country]' derivation='None' name='[none:Country:nk]' pivot='key' type='nominal' />" +
+        SALES_CI,
+    )
+      .replace(/<computed-sort[^>]*\/>/, '')
+      .replace('<rows>[Superstore].[none:Region:nk]</rows>', `<rows>${rows}</rows>`);
+
+  it('omitted targetField sorts the innermost pill on a nested same-shelf pair', () => {
+    const r = planSortByField(
+      nestedGroupCountry('[Superstore].[none:Group:nk] / [Superstore].[none:Country:nk]'),
+      { sortByField: 'Sales', direction: 'ASC' },
+    );
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.column).toBe('[Superstore].[none:Country:nk]');
+    expect(r.using).toBe('[Superstore].[sum:Sales:qk]');
+  });
+
+  it('omitted targetField still sorts innermost when Tableau wraps the nested shelf in grouping parens', () => {
+    const r = planSortByField(
+      nestedGroupCountry('([Superstore].[none:Group:nk] / [Superstore].[none:Country:nk])'),
+      { sortByField: 'Sales' },
+    );
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.column).toBe('[Superstore].[none:Country:nk]');
+  });
+
+  it('explicit targetField still sorts an outer nested pill', () => {
+    const r = planSortByField(
+      nestedGroupCountry('[Superstore].[none:Group:nk] / [Superstore].[none:Country:nk]'),
+      { targetField: 'Group', sortByField: 'Sales' },
+    );
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.column).toBe('[Superstore].[none:Group:nk]');
+  });
+
+  it('resolves sortByField from a datasource-qualified column-instance ref', () => {
+    const r = planSortByField(
+      nestedGroupCountry('[Superstore].[none:Group:nk] / [Superstore].[none:Country:nk]'),
+      { sortByField: '[Superstore].[sum:Sales:qk]' },
+    );
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.using).toBe('[Superstore].[sum:Sales:qk]');
+    expect(r.column).toBe('[Superstore].[none:Country:nk]');
+  });
+
   it('refuses (never throws) when targetField is omitted and no axis can be identified', () => {
     // Two categorical axes on shelves → the auto-detect is ambiguous; refuse cleanly.
     const twoAxis = withDeps(
@@ -633,6 +687,9 @@ describe('planSortByField', () => {
     expect(r.ok).toBe(false);
     if (r.ok) return;
     expect(r.reason).toMatch(/more than one categorical axis/i);
+    expect(r.reason).toMatch(/Region/i);
+    expect(r.reason).toMatch(/Category/i);
+    expect(r.reason).toMatch(/targetField/i);
   });
 });
 
@@ -1025,5 +1082,8 @@ describe('planSortByFieldOnCategoricalAxis — anchor_category coexistence (wate
     expect(r.ok).toBe(false);
     if (r.ok) return;
     expect(r.reason).toMatch(/more than one categorical axis/i);
+    expect(r.reason).toMatch(/Region/i);
+    expect(r.reason).toMatch(/Category/i);
+    expect(r.reason).toMatch(/targetField/i);
   });
 });

--- a/src/desktop/refine/refineWorksheet.test.ts
+++ b/src/desktop/refine/refineWorksheet.test.ts
@@ -626,6 +626,65 @@ describe('planSortByField', () => {
       .replace(/<computed-sort[^>]*\/>/, '')
       .replace('<rows>[Superstore].[none:Region:nk]</rows>', `<rows>${rows}</rows>`);
 
+  it('omitted targetField sorts a nested YEAR date-part pill, not the outer plain dim', () => {
+    // Live Desktop (2026-09-04): Rows Region / YEAR(Order Date) sorts YEAR, not Region.
+    // YEAR is ordinal + derivation Year — not nominal/None — and must still be the target.
+    const xml = withDeps(
+      REGION_COL +
+        "<column caption='Order Date' datatype='date' name='[Order Date]' role='dimension' type='ordinal' />" +
+        SALES_COL +
+        REGION_CI +
+        "<column-instance column='[Order Date]' derivation='Year' name='[yr:Order Date:ok]' pivot='key' type='ordinal' />" +
+        SALES_CI,
+    )
+      .replace(/<computed-sort[^>]*\/>/, '')
+      .replace(
+        '<rows>[Superstore].[none:Region:nk]</rows>',
+        '<rows>[Superstore].[none:Region:nk] / [Superstore].[yr:Order Date:ok]</rows>',
+      );
+    const r = planSortByField(xml, { sortByField: 'Sales', direction: 'ASC' });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.column).toBe('[Superstore].[yr:Order Date:ok]');
+    expect(r.using).toBe('[Superstore].[sum:Sales:qk]');
+  });
+
+  it('explicit targetField can name a YEAR date-part CI', () => {
+    const xml = withDeps(
+      REGION_COL +
+        "<column caption='Order Date' datatype='date' name='[Order Date]' role='dimension' type='ordinal' />" +
+        SALES_COL +
+        REGION_CI +
+        "<column-instance column='[Order Date]' derivation='Year' name='[yr:Order Date:ok]' pivot='key' type='ordinal' />" +
+        SALES_CI,
+    )
+      .replace(/<computed-sort[^>]*\/>/, '')
+      .replace(
+        '<rows>[Superstore].[none:Region:nk]</rows>',
+        '<rows>[Superstore].[none:Region:nk] / [Superstore].[yr:Order Date:ok]</rows>',
+      );
+    const r = planSortByField(xml, {
+      targetField: '[yr:Order Date:ok]',
+      sortByField: 'Sales',
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.column).toBe('[Superstore].[yr:Order Date:ok]');
+  });
+
+  it('resolves a decoded P&L qualified sortByField against an XML-escaped datasource name', () => {
+    const xml = BASE.replaceAll('Superstore', 'P&amp;L Data').replace(/<computed-sort[^>]*\/>/, '');
+    const r = planSortByField(xml, {
+      targetField: 'Region',
+      sortByField: '[P&L Data].[sum:Sales:qk]',
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.using).toBe('[P&L Data].[sum:Sales:qk]');
+    expect(r.xml).toContain("using='[P&amp;L Data].[sum:Sales:qk]'");
+    expect(r.xml).not.toContain('P&amp;amp;L');
+  });
+
   it('omitted targetField sorts the innermost pill on a nested same-shelf pair', () => {
     const r = planSortByField(
       nestedGroupCountry('[Superstore].[none:Group:nk] / [Superstore].[none:Country:nk]'),
@@ -1027,10 +1086,11 @@ describe('planSortByFieldOnCategoricalAxis — anchor_category coexistence (wate
     expect(sorted.ok).toBe(true);
     if (!sorted.ok) return;
     // The sort targets the SHELF axis (line_item), never the filter-only anchor (category).
-    // datasourceName() reads the DS name raw from the attribute, so the ref carries the
-    // XML-escaped ampersand ([P&amp;L Data]) — exactly what lands in the <computed-sort>.
-    expect(sorted.column).toBe('[P&amp;L Data].[none:line_item:nk]');
+    // The plan returns logical (decoded) refs; emission escapeXml's once into the node.
+    expect(sorted.column).toBe('[P&L Data].[none:line_item:nk]');
     expect(sorted.column).not.toContain('none:category:nk');
+    expect(sorted.xml).toContain("column='[P&amp;L Data].[none:line_item:nk]'");
+    expect(sorted.xml).not.toContain('P&amp;amp;L');
     expect(confirmSortByFieldApplied(sorted.xml, sorted.column, sorted.using, 'DESC')).toBe(true);
   });
 

--- a/src/desktop/refine/refineWorksheet.ts
+++ b/src/desktop/refine/refineWorksheet.ts
@@ -34,6 +34,7 @@ import { DOMParser } from '@xmldom/xmldom';
 import * as xpath from 'xpath';
 
 import { escapeXml } from '../binder/escape.js';
+import { decodeXmlEntities } from '../xmlElement.js';
 
 export type TopNEnd = 'top' | 'bottom';
 export type SortDirection = 'ASC' | 'DESC';
@@ -240,6 +241,19 @@ function isDimensionCi(ci: ColumnInstance): boolean {
   return !isPseudoFieldCi(ci) && ci.type === 'nominal' && ci.derivation === 'None';
 }
 
+/**
+ * Discrete shelf sort target — Tableau Field::IsDiscrete() (Nominal|Ordinal), minus
+ * measure aggregations (a discrete SUM is ordinal but is a key, not an axis) and
+ * pseudo-fields. YEAR/MONTH date parts are ordinal + Year/Month, so they count.
+ */
+function isDiscreteSortCi(ci: ColumnInstance): boolean {
+  return (
+    !isPseudoFieldCi(ci) &&
+    (ci.type === 'nominal' || ci.type === 'ordinal') &&
+    !Object.prototype.hasOwnProperty.call(AGG_DERIVATIONS, ci.derivation)
+  );
+}
+
 /** A measure CI: quantitative with a canonical aggregation derivation (e.g. [sum:Sales:qk]). */
 function isMeasureCi(ci: ColumnInstance): boolean {
   return (
@@ -255,7 +269,12 @@ function unbracket(value: string): string {
 }
 
 function normalizeCaption(value: string | undefined): string {
-  return (value ?? '').trim().toLocaleLowerCase();
+  return decodeXmlEntities((value ?? '').trim()).toLocaleLowerCase();
+}
+
+/** Logical `[ds].[ci]` from regex-captured XML (which may still contain `&amp;`). */
+function qualifiedCiRef(ds: string, ciName: string): string {
+  return `[${decodeXmlEntities(ds)}].${decodeXmlEntities(ciName)}`;
 }
 
 function fieldCaptionCandidates(
@@ -606,7 +625,10 @@ function planComputedSortByRefs(
   opts: { targetField: string; column: string; using: string; direction: SortDirection },
 ): SortByFieldPlan | RefineRefusal {
   const node = `<computed-sort column='${escapeXml(opts.column)}' direction='${opts.direction}' using='${escapeXml(opts.using)}' />`;
-  const targetSorts = computedSortTargets(xml).filter((sort) => sort.column === opts.column);
+  const targetColumn = decodeXmlEntities(opts.column);
+  const targetSorts = computedSortTargets(xml).filter(
+    (sort) => decodeXmlEntities(sort.column) === targetColumn,
+  );
   if (targetSorts.length > 1) {
     return refuse(`more than one <computed-sort> present for target field "${opts.targetField}".`);
   }
@@ -710,7 +732,7 @@ export function planSortByField(
     columns,
     opts.targetField,
     'target field',
-    isDimensionCi,
+    isDiscreteSortCi,
     ds,
   );
   if (!('name' in target)) return target;
@@ -724,8 +746,8 @@ export function planSortByField(
   );
   if (!('name' in sortBy)) return sortBy;
 
-  const column = `[${ds}].${target.name}`;
-  const using = `[${ds}].${sortBy.name}`;
+  const column = qualifiedCiRef(ds, target.name);
+  const using = qualifiedCiRef(ds, sortBy.name);
   return planComputedSortByRefs(xml, { targetField: opts.targetField, column, using, direction });
 }
 
@@ -765,7 +787,7 @@ export function planSortByFieldOnCategoricalAxis(
   // DS name (e.g. `P&amp;L Data`) is identical on both sides of the comparison.
   const rows = shelfText(xml, 'rows');
   const cols = shelfText(xml, 'cols');
-  const dims = cis.filter(isDimensionCi);
+  const dims = cis.filter(isDiscreteSortCi);
   const rowDims = orderedShelfDims(rows, ds, dims);
   const colDims = orderedShelfDims(cols, ds, dims);
   const columns = parseColumns(xml);
@@ -790,14 +812,14 @@ export function planSortByFieldOnCategoricalAxis(
     ds,
   );
   if (!('name' in sortBy) && !opts.sortByColumnRef) return sortBy;
-  const using = 'name' in sortBy ? `[${ds}].${sortBy.name}` : opts.sortByColumnRef!;
+  const using = 'name' in sortBy ? qualifiedCiRef(ds, sortBy.name) : opts.sortByColumnRef!;
 
   const axisDims = rowDims.length > 0 ? rowDims : colDims;
   const target = axisDims[axisDims.length - 1];
   const targetField = fieldCaptionCandidates(target, columns)[0] ?? target.column;
   return planComputedSortByRefs(xml, {
     targetField,
-    column: `[${ds}].${target.name}`,
+    column: qualifiedCiRef(ds, target.name),
     using,
     direction,
   });

--- a/src/desktop/refine/refineWorksheet.ts
+++ b/src/desktop/refine/refineWorksheet.ts
@@ -278,13 +278,16 @@ function resolveCiByCaption(
   caption: string | undefined,
   kind: 'target field' | 'sort-by field',
   predicate: (ci: ColumnInstance) => boolean,
+  ds?: string,
 ): ColumnInstance | RefineRefusal {
   const wanted = normalizeCaption(caption);
   if (!wanted) return refuse(`${kind} caption is required.`);
 
   const candidates = cis.filter(predicate);
   const matches = candidates.filter((ci) =>
-    fieldCaptionCandidates(ci, columns).some((value) => normalizeCaption(value) === wanted),
+    [...fieldCaptionCandidates(ci, columns), ci.name, ds ? `[${ds}].${ci.name}` : '']
+      .filter(Boolean)
+      .some((value) => normalizeCaption(value) === wanted),
   );
   if (matches.length === 1) return matches[0];
 
@@ -449,6 +452,14 @@ export function planTopN(
 /** The text of a single shelf (`rows`/`cols`) — where placed (bound) pills appear DS-qualified. */
 function shelfText(xml: string, shelf: 'rows' | 'cols'): string {
   return xml.match(new RegExp(`<${shelf}\\b[^>]*>([\\s\\S]*?)</${shelf}>`))?.[1] ?? '';
+}
+
+function orderedShelfDims(shelf: string, ds: string, dims: ColumnInstance[]): ColumnInstance[] {
+  return dims
+    .map((ci) => ({ ci, idx: shelf.indexOf(`[${ds}].${ci.name}`) }))
+    .filter((entry) => entry.idx >= 0)
+    .sort((a, b) => a.idx - b.idx)
+    .map((entry) => entry.ci);
 }
 
 /** True if a value carries any XML-special char that would break a single-quoted attribute. */
@@ -661,14 +672,12 @@ export function planSortDirection(
 }
 
 /**
- * Plan a computed sort for one caption-addressed dimension by one caption-addressed
- * measure. This is the explicit sort primitive for sheets where "flip direction" is not
- * enough: callers name the displayed fields, never Tableau's internal CI refs.
+ * Plan a computed sort for one dimension by one measure. Callers may pass captions,
+ * CI instance names, or datasource-qualified CI refs.
  *
  * `targetField` (the dimension whose axis gets sorted) is optional: when omitted, the
- * dimension is auto-detected from the sheet's single categorical shelf axis via
- * planSortByFieldOnCategoricalAxis — the common case where only the sort-by measure is
- * named. It refuses (never throws) if the axis is absent or ambiguous.
+ * dimension is taken from planSortByFieldOnCategoricalAxis (innermost pill on one
+ * discrete shelf). It refuses (never throws) if the axis is absent or a crosstab.
  */
 export function planSortByField(
   xml: string,
@@ -696,9 +705,23 @@ export function planSortByField(
 
   const cis = parseColumnInstances(xml);
   const columns = parseColumns(xml);
-  const target = resolveCiByCaption(cis, columns, opts.targetField, 'target field', isDimensionCi);
+  const target = resolveCiByCaption(
+    cis,
+    columns,
+    opts.targetField,
+    'target field',
+    isDimensionCi,
+    ds,
+  );
   if (!('name' in target)) return target;
-  const sortBy = resolveCiByCaption(cis, columns, opts.sortByField, 'sort-by field', isMeasureCi);
+  const sortBy = resolveCiByCaption(
+    cis,
+    columns,
+    opts.sortByField,
+    'sort-by field',
+    isMeasureCi,
+    ds,
+  );
   if (!('name' in sortBy)) return sortBy;
 
   const column = `[${ds}].${target.name}`;
@@ -707,7 +730,8 @@ export function planSortByField(
 }
 
 /**
- * Bind-template shorthand: sort the sheet's single categorical axis by a schema field.
+ * Bind-template / omit-targetField sort: nested pills on one discrete shelf sort innermost
+ * (Tableau axis-sort default). Dims on both rows and cols still refuse.
  * If the sort field is not already a worksheet CI, callers may pass its schema column_ref.
  */
 export function planSortByFieldOnCategoricalAxis(
@@ -741,19 +765,35 @@ export function planSortByFieldOnCategoricalAxis(
   // DS name (e.g. `P&amp;L Data`) is identical on both sides of the comparison.
   const rows = shelfText(xml, 'rows');
   const cols = shelfText(xml, 'cols');
-  const dims = cis
-    .filter(isDimensionCi)
-    .filter((ci) => rows.includes(`[${ds}].${ci.name}`) || cols.includes(`[${ds}].${ci.name}`));
-  if (dims.length === 0) return refuse('could not identify a single categorical axis to sort.');
-  if (dims.length > 1)
-    return refuse('more than one categorical axis is present; sort is ambiguous.');
-
+  const dims = cis.filter(isDimensionCi);
+  const rowDims = orderedShelfDims(rows, ds, dims);
+  const colDims = orderedShelfDims(cols, ds, dims);
   const columns = parseColumns(xml);
-  const sortBy = resolveCiByCaption(cis, columns, opts.sortByField, 'sort-by field', isMeasureCi);
+  if (rowDims.length === 0 && colDims.length === 0) {
+    return refuse('could not identify a single categorical axis to sort.');
+  }
+  if (rowDims.length > 0 && colDims.length > 0) {
+    const names = [...rowDims, ...colDims]
+      .map((ci) => fieldCaptionCandidates(ci, columns)[0] ?? unbracket(ci.column))
+      .join(', ');
+    return refuse(
+      `more than one categorical axis is present (${names}); pass targetField to choose one.`,
+    );
+  }
+
+  const sortBy = resolveCiByCaption(
+    cis,
+    columns,
+    opts.sortByField,
+    'sort-by field',
+    isMeasureCi,
+    ds,
+  );
   if (!('name' in sortBy) && !opts.sortByColumnRef) return sortBy;
   const using = 'name' in sortBy ? `[${ds}].${sortBy.name}` : opts.sortByColumnRef!;
 
-  const target = dims[0];
+  const axisDims = rowDims.length > 0 ? rowDims : colDims;
+  const target = axisDims[axisDims.length - 1];
   const targetField = fieldCaptionCandidates(target, columns)[0] ?? target.column;
   return planComputedSortByRefs(xml, {
     targetField,

--- a/src/desktop/validation/readback-verify.test.ts
+++ b/src/desktop/validation/readback-verify.test.ts
@@ -169,6 +169,45 @@ describe('verifyWorksheetReadback', () => {
     );
   });
 
+  it('does not flag Tableau grouping parentheses around nested discrete shelf pills', () => {
+    const group = '[DS].[none:group:nk]';
+    const country = '[DS].[none:country:nk]';
+    const intended = encodedWorksheet().replace(
+      `<rows>${GEO_FIELD}</rows>`,
+      `<rows>${group} / ${country}</rows>`,
+    );
+    const readback = intended.replace(
+      `<rows>${group} / ${country}</rows>`,
+      `<rows>(${group} / ${country})</rows>`,
+    );
+
+    expect(verifyWorksheetReadback(intended, readback).filter((f) => f.kind === 'shelf')).toEqual(
+      [],
+    );
+  });
+
+  it('still flags a nested shelf pill that Tableau actually dropped', () => {
+    const group = '[DS].[none:group:nk]';
+    const country = '[DS].[none:country:nk]';
+    const intended = encodedWorksheet().replace(
+      `<rows>${GEO_FIELD}</rows>`,
+      `<rows>${group} / ${country}</rows>`,
+    );
+    const readback = intended.replace(
+      `<rows>${group} / ${country}</rows>`,
+      `<rows>${group}</rows>`,
+    );
+
+    expect(verifyWorksheetReadback(intended, readback)).toContainEqual({
+      kind: 'shelf',
+      node: 'rows',
+      column: country,
+      intended: country,
+      readback: 'changed',
+      severity: 'error',
+    });
+  });
+
   it('does not flag an authored Automatic mark that Tableau resolved to a concrete class', () => {
     const intended = encodedWorksheet().replace(
       '<mark class="Shape"/>',

--- a/src/desktop/validation/readback-verify.test.ts
+++ b/src/desktop/validation/readback-verify.test.ts
@@ -208,6 +208,71 @@ describe('verifyWorksheetReadback', () => {
     });
   });
 
+  it('flags a grouped readback whose nested pills were reordered', () => {
+    const group = '[DS].[none:group:nk]';
+    const country = '[DS].[none:country:nk]';
+    const intended = encodedWorksheet().replace(
+      `<rows>${GEO_FIELD}</rows>`,
+      `<rows>${group} / ${country}</rows>`,
+    );
+    const readback = intended.replace(
+      `<rows>${group} / ${country}</rows>`,
+      `<rows>(${country} / ${group})</rows>`,
+    );
+
+    const shelfFindings = verifyWorksheetReadback(intended, readback).filter(
+      (f) => f.kind === 'shelf',
+    );
+    expect(shelfFindings.length).toBeGreaterThan(0);
+    expect(shelfFindings).toContainEqual({
+      kind: 'shelf',
+      node: 'rows',
+      column: group,
+      intended: group,
+      readback: 'changed',
+      severity: 'error',
+    });
+  });
+
+  it('flags a grouped readback that dropped a repeated nested pill', () => {
+    const group = '[DS].[none:group:nk]';
+    const country = '[DS].[none:country:nk]';
+    const intended = encodedWorksheet().replace(
+      `<rows>${GEO_FIELD}</rows>`,
+      `<rows>${group} / ${country} / ${group}</rows>`,
+    );
+    const readback = intended.replace(
+      `<rows>${group} / ${country} / ${group}</rows>`,
+      `<rows>(${group} / ${country})</rows>`,
+    );
+
+    expect(verifyWorksheetReadback(intended, readback)).toContainEqual({
+      kind: 'shelf',
+      node: 'rows',
+      column: group,
+      intended: group,
+      readback: 'changed',
+      severity: 'error',
+    });
+  });
+
+  it('does not flag grouping parentheses when a bracketed name contains an unmatched parenthesis', () => {
+    const weird = '[DS].[none:Foo):nk]';
+    const country = '[DS].[none:country:nk]';
+    const intended = encodedWorksheet().replace(
+      `<rows>${GEO_FIELD}</rows>`,
+      `<rows>${weird} / ${country}</rows>`,
+    );
+    const readback = intended.replace(
+      `<rows>${weird} / ${country}</rows>`,
+      `<rows>(${weird} / ${country})</rows>`,
+    );
+
+    expect(verifyWorksheetReadback(intended, readback).filter((f) => f.kind === 'shelf')).toEqual(
+      [],
+    );
+  });
+
   it('does not flag an authored Automatic mark that Tableau resolved to a concrete class', () => {
     const intended = encodedWorksheet().replace(
       '<mark class="Shape"/>',

--- a/src/desktop/validation/readback-verify.ts
+++ b/src/desktop/validation/readback-verify.ts
@@ -6,6 +6,7 @@
  * structures that must survive for the rendered chart to match the authored
  * XML, while tolerating readback-only formatting/style noise.
  */
+import { parseShelfValue } from '../metadata/fields.js';
 import { normalizeArray, parseXML } from '../metadata/parser.js';
 
 export type ReadbackFindingKind = 'encoding' | 'shelf' | 'mark' | 'filter' | 'sort';
@@ -128,10 +129,32 @@ function walkElements(node: unknown, visit: (tag: string, element: XmlRecord) =>
   }
 }
 
+function unwrapGroupingParens(value: string): string {
+  let text = value.trim();
+  while (text.startsWith('(') && text.endsWith(')')) {
+    let depth = 0;
+    let wrapsAll = true;
+    for (let i = 0; i < text.length; i++) {
+      const char = text[i];
+      if (char === '(') depth += 1;
+      else if (char === ')') {
+        depth -= 1;
+        if (depth === 0 && i !== text.length - 1) {
+          wrapsAll = false;
+          break;
+        }
+      }
+    }
+    if (!wrapsAll || depth !== 0) break;
+    text = text.slice(1, -1).trim();
+  }
+  return text;
+}
+
 function shelfValues(value: unknown): string[] {
   return normalizeArray(value)
-    .flatMap((item) => textValue(item).split('/'))
-    .map((item) => item.trim())
+    .flatMap((item) => parseShelfValue(unwrapGroupingParens(textValue(item))))
+    .map((item) => unwrapGroupingParens(item))
     .filter(Boolean);
 }
 

--- a/src/desktop/validation/readback-verify.ts
+++ b/src/desktop/validation/readback-verify.ts
@@ -134,8 +134,21 @@ function unwrapGroupingParens(value: string): string {
   while (text.startsWith('(') && text.endsWith(')')) {
     let depth = 0;
     let wrapsAll = true;
+    let inBracketedName = false;
     for (let i = 0; i < text.length; i++) {
       const char = text[i];
+      if (inBracketedName) {
+        if (char === ']' && text[i + 1] === ']') {
+          i++;
+          continue;
+        }
+        if (char === ']') inBracketedName = false;
+        continue;
+      }
+      if (char === '[') {
+        inBracketedName = true;
+        continue;
+      }
       if (char === '(') depth += 1;
       else if (char === ')') {
         depth -= 1;
@@ -419,14 +432,20 @@ export function verifyWorksheetReadback(
   }
 
   for (const shelf of ['rows', 'cols'] as const) {
-    for (const value of intended.shelves[shelf]) {
-      if (readback.shelves[shelf].includes(value)) continue;
+    const intendedPills = intended.shelves[shelf];
+    const readbackPills = readback.shelves[shelf];
+    const length = Math.max(intendedPills.length, readbackPills.length);
+    for (let i = 0; i < length; i++) {
+      const intendedValue = intendedPills[i];
+      const readbackValue = readbackPills[i];
+      if (intendedValue === readbackValue) continue;
+      const value = intendedValue || readbackValue;
       findings.push({
         kind: 'shelf',
         node: shelf,
         column: value,
         intended: value,
-        readback: readback.shelves[shelf].length > 0 ? 'changed' : 'missing',
+        readback: readbackPills.length > 0 ? 'changed' : 'missing',
         severity: 'error',
       });
     }

--- a/src/server.desktop.test.ts
+++ b/src/server.desktop.test.ts
@@ -271,7 +271,7 @@ describe('desktop tools/list per-tool byte accounting', () => {
     ['add-field', 1396], // ratcheted down 2026-08-12: worksheetName/worksheetFile describes trimmed to fund the sticky edit-buffer nudge while staying under budget
     ['inject-template', 1229], // ratcheted down 2026-08-06 after removing the fork-only output mode; session remains optional
     ['apply-worksheet', 1579], // ratcheted down 2026-08-19: worksheetName inferred from a cached fragment, describe drops the redundant "worksheet"; earlier ratchet 2026-08-12 trimming the worksheetName describe to id-or-name; earlier raise 2026-08-10: direct templatePlan folds an exact single-view build into the existing guarded apply tool; no new tool surface
-    ['refine-worksheet', 1659], // ratcheted down 2026-08-27 while adding the bounded rounded-stack preset; compact prose keeps the enum discoverable without growing the schema
+    ['refine-worksheet', 1656], // ratcheted down with innermost nested-sort omit copy; do not grow
     ['build-worksheets-from-templates', 1150], // raised 2026-08-24: explicit Top-N artifact input keeps ranked executive views bounded before composition
     ['run-dashboard-batch', 1315], // remeasured after preserving explicit replacement safety alongside live chart order, layout roles, and KPI display order
     ['plan-dashboard-creation', 1378], // ratcheted down in the author-set/action/format-labels funding trim (CODA, empty describe stubs); do not grow

--- a/src/tools/desktop/api/executeTableauCommand.test.ts
+++ b/src/tools/desktop/api/executeTableauCommand.test.ts
@@ -5,6 +5,7 @@ import { Err, Ok } from 'ts-results-es';
 
 import * as discoveryModule from '../../../desktop/externalApi/discovery.js';
 import { _resetExternalApiCommandRegistryForTest } from '../../../desktop/externalApi/paramWireRegistry.js';
+import { knownLiveFailureFixFor } from '../../../desktop/guards/commandPolicy.js';
 import { withApplyLock } from '../../../desktop/wrappers/applyMutex.js';
 import { ArgsValidationError, DesktopCommandExecutionError } from '../../../errors/mcpToolError.js';
 import { DesktopMcpServer } from '../../../server.desktop.js';
@@ -16,8 +17,7 @@ import { getExecuteTableauCommandTool } from './executeTableauCommand.js';
 vi.mock('../../../desktop/externalApi/discovery.js');
 
 const SESSION = 'session-1';
-const SORT_NESTED_LIVE_500_FIX =
-  'FIX: tabdoc:sort-nested is known to fail (HTTP 500) on current Desktop builds regardless of parameters — do not retry it. Sort instead via the cached-document round-trip (get-worksheet-xml → read-cached-xml/write-cached-xml to edit the computed-sort → apply-worksheet).';
+const SORT_NESTED_LIVE_500_FIX = knownLiveFailureFixFor('tabdoc:sort-nested')!;
 const TEST_REGISTRY_DIRS: string[] = [];
 
 function makeExtra(
@@ -680,7 +680,7 @@ describe('executeTableauCommandTool', () => {
         'tabdoc:sort drives a UI dialog and blocks the screen',
       );
       expect(result.content[0].text).toContain('refine-worksheet with operation sort_by_field');
-      expect(result.content[0].text).toContain('cached-document round-trip');
+      expect(result.content[0].text).not.toContain('cached-document');
       expect(extra.getExecutor).not.toHaveBeenCalled();
     });
 

--- a/src/tools/desktop/authoring/sheets/refineWorksheet.ts
+++ b/src/tools/desktop/authoring/sheets/refineWorksheet.ts
@@ -101,7 +101,7 @@ function formatValidationErrors(issues: ValidationIssue[]): string {
 }
 
 const paramsSchema = {
-  session: z.string().optional().describe('Desktop session; omit if one.'),
+  session: z.string().optional().describe('Session; omit if one.'),
   worksheetName: z.string().min(1).describe('Sheet name.'),
   operation: z
     .enum(['top_n', 'sort_direction', 'sort_by_field', 'mark_type', 'round_stacked_bar'])
@@ -119,7 +119,7 @@ const paramsSchema = {
     })
     .optional()
     .describe('sort_direction; numeric DESC=largest.'),
-  targetField: z.string().min(1).optional().describe('Axis; omit to detect.'),
+  targetField: z.string().min(1).optional().describe('Omit=innermost nested dim.'),
   sortByField: z.string().min(1).optional().describe('Sort measure.'),
   direction: z.enum(['asc', 'desc']).optional().describe('sort_by_field; numeric desc=largest.'),
   markType: z.enum(TABLEAU_MARK_TYPES).optional().describe('mark_type target.'),


### PR DESCRIPTION
## Decision

RULE WE NOW KEEP: nested discrete shelf pills that Tableau wraps in grouping parentheses are the same pills we wrote, and omitting `targetField` on `sort_by_field` sorts the innermost pill on that one discrete shelf (Tableau axis-sort). Crosstabs (a dim on Rows and a dim on Cols) still require `targetField`.

## Description

- Worksheet readback no longer reports `apply succeeded but Tableau silently dropped` when Desktop canonicalizes `A / B` as `(A / B)`.
- `refine-worksheet` `sort_by_field` without `targetField` sorts the innermost same-shelf dim instead of refusing nested Group/Country as ambiguous.
- `tabdoc:sort` / `tabdoc:sort-nested` hints send nested sorts to `refine-worksheet`, not cache XML.
- `sortByField` accepts a caption, CI name, or `[ds].[ci]` when that measure CI is already declared.

## Motivation and Context

W-23853108 Beat 2 (Group > Country bars, color winners, sort by Position). Color and sort landed, but apply readback lied about dropped row pills, then `sort_by_field` refused nested axes and the agent fell back to XML surgery. `"Axis; omit to detect."` only detected a single dim.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## How Has This Been Tested?

- `src/desktop/validation/readback-verify.test.ts` (grouping parens vs real drop)
- `src/desktop/refine/refineWorksheet.test.ts` (innermost omit, outer `targetField`, crosstab refuse names axes, CI-ref `sortByField`)
- `src/desktop/guards/commandPolicy.test.ts` and `src/tools/desktop/api/executeTableauCommand.test.ts`
- `./scripts/agent-check` green (lint, tsc, vitest, desktop build, lockstep)

## Related Issues

W-23853108

## Checklist

- [x] I have updated the version in the package.json file by using `npm run version`. For example,
      use `npm run version:patch` for a patch version bump.
- [ ] I have made any necessary changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have documented any breaking changes in the PR description. For example, renaming a config
      environment variable or changing its default value.

## Contributor Agreement

By submitting this pull request, I confirm that:

- [x] I have read the [CONTRIBUTING guidelines](../../CONTRIBUTING.md) for this project and followed
      its Contribution Checklist.