### PR TITLE
@W-23757365: admin instructions nudge — don't gate admin-tool use on user restating admin status

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "4.8.1",
+  "version": "4.8.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "4.8.1",
+      "version": "4.8.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1095.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "4.8.1",
+  "version": "4.8.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/src/server.web.test.ts
+++ b/src/server.web.test.ts
@@ -155,6 +155,9 @@ describe('server', () => {
     // so a future edit that drops the rendering guidance can't silently pass.
     expect(instructions).toContain('present them as Markdown tables');
     expect(instructions).toContain('to a chat or Slack surface');
+    // Admin-invocation nudge: the model must not gate admin-tool use on the user restating admin
+    // status — the per-call assertAdmin gate authorizes each call and cleanly rejects non-admins.
+    expect(instructions).toContain('Do not require the user to state or re-confirm admin status');
 
     // The clause belongs to the admin block specifically: it must be appended after the base
     // guidance and after the admin lead-in, never spliced into the base sentence.
@@ -183,6 +186,10 @@ describe('server', () => {
     // stayed out of the base instructions).
     expect(instructions).not.toContain('present them as Markdown tables');
     expect(instructions).not.toContain('Markdown tables');
+    // The admin-invocation nudge is part of the admin-only block and must also be absent.
+    expect(instructions).not.toContain(
+      'Do not require the user to state or re-confirm admin status',
+    );
   });
 
   it('should not register disabled tools', async () => {

--- a/src/server.web.ts
+++ b/src/server.web.ts
@@ -55,6 +55,8 @@ const ADMIN_INSTRUCTIONS =
   'job/extract optimization, user-license reclamation) and the query-admin-insights tool ' +
   '(e.g. stale-content, job-performance, ts-users) for supporting data — even when the user asks broadly ' +
   'rather than naming a specific tool. ' +
+  'Do not require the user to state or re-confirm admin status before using these tools — invoke them ' +
+  'whenever the task warrants; the server authorizes each call and cleanly rejects non-admins. ' +
   'When rendering admin/list results (users, admin-insights, etc.) to a chat or Slack surface, present ' +
   'them as Markdown tables.';
 


### PR DESCRIPTION
## What
Adds one sentence to `ADMIN_INSTRUCTIONS` (the server `initialize` instructions string, advertised only when `ADMIN_TOOLS_ENABLED` is set):

> Do not require the user to state or re-confirm admin status before using these tools — invoke them whenever the task warrants; the server authorizes each call and cleanly rejects non-admins.

## Why
W-23757365: the client's own system-prompt persona makes the model assume it is *not* talking to an admin, so it won't invoke admin tools unless the user re-states their admin role each session. The only server-side lever over model behavior is the `initialize` instructions string. Authorization is already enforced per-call by `assertAdmin` (`src/tools/web/adminGate.ts`), which cleanly rejects non-admins — so the model never needs the user to prove admin status; it can just invoke, and the server decides.

Deliberately **not** worded "if you can see this tool the user IS an admin" — on `main`, admin-tool registration is gated only by `ADMIN_TOOLS_ENABLED`, not by role, so visibility != admin identity. The truthful, always-correct nudge is "just invoke; the server authorizes each call."

## Notes
- Doc/instructions-only; no code or gating change.
- ~30 words, appended once to the handshake instructions — no per-tool description bloat.
- Server-side nudge is best-effort; a strong client persona may still override it. Client-side education may be needed as a follow-up for full closure.

## Tests
- `src/server.web.test.ts`: assert the phrase is present when the flag is on, absent when off (mirrors sibling Markdown-tables assertions).
- Unit 22/22 · lint · build all green.
- Patch bump 4.8.1 → 4.8.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)