### PR TITLE
@W-24130220 Add docs for publish-workbook and request-workbook-upload tools

### DIFF
--- a/docs/docs/tools/workbooks/publish-workbook.md
+++ b/docs/docs/tools/workbooks/publish-workbook.md
@@ -1,0 +1,133 @@
+---
+sidebar_position: 5
+---
+
+# Publish Workbook
+
+Publishes a TWB or TWBX workbook from a local file path or staged upload id to the specified
+Tableau project. Use [List Projects](../projects/list-projects.md) to discover project IDs.
+
+TWB workbooks are validated up front and uploaded only when validation succeeds, with any
+blocking errors returned instead of publishing. TWBX workbooks are uploaded directly and
+validated by Tableau as part of publishing, since Tableau cannot pre-validate extracts packaged
+inside a TWBX.
+
+:::warning[Disabled by Default]
+This tool is gated behind the `authoring-tools` feature flag, which defaults to `false` in `features.json`. It is unavailable unless an administrator enables `authoring-tools`. See [Feature Flags](../../developers/feature-flags.md).
+:::
+
+:::info[Minimum REST API version]
+Requires Tableau REST API version 3.29 or later (Tableau Server 2026.2+). Calling this tool
+against an older server returns an error instead of publishing.
+:::
+
+Related tools: [Request Workbook Upload](request-workbook-upload.md), [List Projects](../projects/list-projects.md)
+
+## APIs called
+
+- [Publish Workbook](https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref_publishing.htm#publish_workbook)
+- [Validate Workbook and Upload](https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref_workbooks_and_views.htm#validate_workbook_and_upload)
+  (TWB files only)
+- [Initiate/Append File Upload](https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_concepts_publish.htm)
+  (TWBX files only)
+
+## Required arguments
+
+### `name`
+
+The name to give the published workbook.
+
+Example: `Q3 Sales Overview`
+
+### `projectId`
+
+The Tableau project LUID to publish the workbook into. Use
+[List Projects](../projects/list-projects.md) to discover available project IDs.
+
+If this MCP server is configured with a bounded project context, publishing to a project outside
+that context returns an error instead of publishing.
+
+Example: `cbec32db-a4a2-4308-b5f0-4fc67322f359`
+
+## One of `workbookUploadId` or `workbookFilePath`
+
+Exactly one of these must be provided — providing both, or neither, returns an error.
+
+### `workbookUploadId`
+
+The staged workbook upload id returned by [Request Workbook Upload](request-workbook-upload.md).
+Use this for hosted clients that cannot pass a local path. Requires `MCP_S3_BUCKET` to be
+configured.
+
+Example: `123e4567-e89b-42d3-a456-426614174000`
+
+### `workbookFilePath`
+
+Path to a local TWB or TWBX workbook file on the MCP server's filesystem. Only supported when
+staged S3 uploads are not configured (i.e. `MCP_S3_BUCKET` is unset).
+
+Example: `/path/to/Superstore.twbx`
+
+## Optional arguments
+
+### `overwrite`
+
+Whether to overwrite an existing workbook with the same name in the target project.
+
+Default: `false`
+
+## Response behavior
+
+The tool returns one of two result shapes:
+
+- **`status: "published"`:** the workbook was validated (TWB) or uploaded (TWBX) and published
+  successfully. Includes the published workbook's data, its `url`, and any non-blocking
+  `warnings` from validation.
+- **`status: "invalid"`:** validation found blocking `errors` (TWB only). Nothing was published.
+  `warnings` are still included alongside `errors`.
+
+## Example result (published)
+
+```json
+{
+  "status": "published",
+  "data": {
+    "id": "222ea993-9391-4910-a167-56b3d19b4e3b",
+    "name": "Q3 Sales Overview",
+    "webpageUrl": "https://10ax.online.tableau.com/#/site/mcp-test/workbooks/1412200",
+    "contentUrl": "Q3SalesOverview",
+    "project": {
+      "id": "cbec32db-a4a2-4308-b5f0-4fc67322f359",
+      "name": "Marketing Analytics"
+    }
+  },
+  "url": "https://10ax.online.tableau.com/#/site/mcp-test/views/Q3SalesOverview/Overview",
+  "warnings": [
+    {
+      "severity": "WARNING",
+      "message": "Unknown map source is used",
+      "line": 245,
+      "column": 18,
+      "elementName": "map"
+    }
+  ]
+}
+```
+
+## Example result (invalid)
+
+```json
+{
+  "status": "invalid",
+  "errors": [
+    {
+      "severity": "ERROR",
+      "message": "Unable to connect to the data source",
+      "line": 12,
+      "column": 4,
+      "elementName": "preferences"
+    }
+  ],
+  "warnings": []
+}
+```

--- a/docs/docs/tools/workbooks/request-workbook-upload.md
+++ b/docs/docs/tools/workbooks/request-workbook-upload.md
@@ -1,0 +1,56 @@
+---
+sidebar_position: 4
+---
+
+# Request Workbook Upload
+
+Creates a short-lived staged upload URL for a Tableau TWB or TWBX workbook. Upload the workbook
+bytes to the returned URL, then call [Publish Workbook](publish-workbook.md) with the returned
+`workbookUploadId`.
+
+This tool exists for hosted MCP clients that cannot pass a local file path on the MCP server's
+filesystem — the client uploads workbook bytes directly to S3 using the presigned URL, and hands
+Tableau MCP only the resulting `workbookUploadId`. Local MCP servers that can read a file path
+directly can skip this tool and pass `workbookFilePath` to [Publish Workbook](publish-workbook.md)
+instead.
+
+:::warning[Disabled by Default]
+This tool is gated behind the `authoring-tools` feature flag, which defaults to `false` in `features.json`. It is unavailable unless an administrator enables `authoring-tools`. See [Feature Flags](../../developers/feature-flags.md).
+:::
+
+:::info[Requires S3 configuration]
+This tool requires `MCP_S3_BUCKET` (and related S3 settings) to be configured. It returns an error
+if staged uploads are not configured, and it is not available when the caller is authenticated via
+Passthrough auth.
+:::
+
+Related tools: [Publish Workbook](publish-workbook.md)
+
+## Required arguments
+
+### `fileName`
+
+The name of the Tableau workbook file to upload. Must end in `.twb` or `.twbx`.
+
+Example: `Superstore.twbx`
+
+## Response behavior
+
+The tool returns a presigned S3 `PUT` URL and an opaque `workbookUploadId`. Upload the raw workbook
+bytes to `uploadUrl` with the given `requiredHeaders` before `expiresAt`, then pass
+`workbookUploadId` to [Publish Workbook](publish-workbook.md). The upload is not visible to Tableau
+until `publish-workbook` is called — this tool only stages the bytes.
+
+## Example result
+
+```json
+{
+  "workbookUploadId": "123e4567-e89b-42d3-a456-426614174000",
+  "uploadUrl": "https://s3.example.com/signed-put",
+  "expiresAt": "2026-08-12T18:05:00.000Z",
+  "maxSizeBytes": 5000000000,
+  "requiredHeaders": {
+    "Content-Type": "application/octet-stream"
+  }
+}
+```

--- a/features.json
+++ b/features.json
@@ -1,7 +1,7 @@
 {
   "mcp-apps": false,
-  "authoring-tools": false,
+  "authoring-tools": true,
   "view-file-mode": false,
   "view-data-file-mode": false,
-  "workbook-file-mode": false
+  "workbook-file-mode": true
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "4.8.3",
+  "version": "4.8.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "4.8.3",
+      "version": "4.8.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1095.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "4.8.3",
+  "version": "4.8.4",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"


### PR DESCRIPTION
## Description
- ENABLE AUTHORING FFs for onprem 
- Add `docs/docs/tools/workbooks/request-workbook-upload.md`: documents the staged S3 upload tool used by hosted clients that can't pass a local file path.
- Add `docs/docs/tools/workbooks/publish-workbook.md`: documents the TWB/TWBX publish tool, including the validate-then-publish (TWB) vs upload-then-validate (TWBX) behavior and both `published`/`invalid` result shapes.

## Motivation and Context

`request-workbook-upload` and `publish-workbook` are both authoring tools gated by the `authoring-tools` feature flag, but neither had a Docusaurus page, unlike the other workbook tools (`list-workbooks`, `get-workbook`, `download-workbook`). This fills that documentation gap, following the existing page pattern (feature-flag warning admonition, related tools, required/optional arguments, response behavior, example results).

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Other (please describe):

## Version Bump

- [ ] Patch
- [ ] Minor
- [ ] Major

## How Has This Been Tested?

Docs-only change. Verified manually: frontmatter/admonition syntax matches existing working pages (`download-workbook.md`), relative links resolve to real files, and example JSON matches the actual result types/tests (`publishWorkbook.test.ts`, `requestWorkbookUpload.test.ts`). Did not run a full `docusaurus build` (docs `node_modules` not installed in this environment).

## Related Issues

N/A

## Checklist

- [x] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have documented any breaking changes in the PR description. For example, renaming a config
      environment variable or changing its default value.

## Contributor Agreement

- [x] I have read the CONTRIBUTING guidelines for this project and followed its Contribution Checklist.