### PR TITLE
feat(desktop): report Tableau Desktop blocking state

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableau/mcp-server",
-  "version": "2.68.6",
+  "version": "2.68.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableau/mcp-server",
-      "version": "2.68.6",
+      "version": "2.68.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.7.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tableau/mcp-server",
   "description": "Helping agents see and understand data.",
-  "version": "2.68.6",
+  "version": "2.68.7",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tableau/tableau-mcp.git"

--- a/resources/desktop/knowledge/_index.md
+++ b/resources/desktop/knowledge/_index.md
@@ -97,8 +97,9 @@ Entries show the tactics slug and, where one exists, its strategy companion.
 ### "Something went wrong / governance / tooling"
 - Recovering from a failed apply (MCP) → `tactics/workflow/recovery` · general troubleshooting: `strategy/workflow/troubleshooting-workbooks`
 - Blocking Desktop error dialogs (10-code catalog, prevention guards, exact
-  `get-active-dialogs` → one `invoke-dialog-action` action when intent is unambiguous,
-  otherwise human fallback) → `tactics/workflow/errors-as-modals`
+  `get-desktop-state` → fresh `get-active-dialogs` → one `invoke-dialog-action` action
+  when intent is unambiguous → fresh `get-desktop-state` verification, otherwise human fallback)
+  → `tactics/workflow/errors-as-modals`
 - Field/datasource "not found" after a user change = stale cache (refresh with a live `session` first, don't declare Tableau unreachable); honor the `HOST VERIFICATION` receipt before claiming success → `tactics/workflow/failure-recovery-honesty`
 - Python helper templates → `tactics/workflow/python-helpers` · tool-selection strategy: `strategy/workflow/automation-tool-selection`
 - Template injection workflow → `tactics/workflow/templates`

--- a/resources/desktop/knowledge/tactics/workflow/errors-as-modals.md
+++ b/resources/desktop/knowledge/tactics/workflow/errors-as-modals.md
@@ -1,99 +1,115 @@
 # Errors That Arrive as Blocking Modals
 
-Tableau Desktop can report an authoring failure in a modal dialog instead of through
-the Agent API response. The modal owns Desktop's single UI thread, so later `/v0`
-calls wait behind it even when the call that opened it appeared to complete.
+Tableau Desktop can report an authoring failure in a modal dialog instead of through the Agent API
+response. The modal owns Desktop's single UI thread, so later `/v0` calls wait behind it even when
+the call that opened it appeared to complete.
 
 - Tags: blocking-dialog, modal, error-code, unattended-authoring, apply-failure, prevention
-- Relevant user prompts/search terms: "Tableau is stuck after apply", "blocking modal",
-  "error code 47BF7751", "Qualified Name Parse Error", "filter limit greater than zero",
-  "internal error after action apply"
+- Relevant user prompts/search terms: "Tableau is stuck after apply", "blocking modal", "error code
+  47BF7751", "Qualified Name Parse Error", "filter limit greater than zero", "internal error after
+  action apply"
 
 ## When to Use
 
-Read this before unattended workbook applies, action authoring, Top-N/filter emission,
-or sheet navigation. Use it again when Desktop stops answering after a write or raw
-command and a human-visible error dialog may be open.
+Read this before unattended workbook applies, action authoring, Top-N/filter emission, or sheet
+navigation. Use it again when Desktop stops answering after a write or raw command and a
+human-visible error dialog may be open.
 
-Two dedicated dialog routes remain usable while a modal blocks ordinary UI-thread
-operations: `get-active-dialogs` reads `GET /v0/app/dialogs`, and `invoke-dialog-action`
-calls `POST /v0/app:invokeDialogAction`. Do not send other `/v0` calls while an
-actionable modal is open, and do not search for a synthetic Cancel/Escape command.
+Three dedicated state/dialog routes remain usable while a modal blocks ordinary UI-thread
+operations: `get-desktop-state` reads a bounded `GET /v0/app/state` snapshot, `get-active-dialogs`
+reads fresh actionable context from `GET /v0/app/dialogs`, and `invoke-dialog-action` calls
+`POST /v0/app:invokeDialogAction`. Do not send other `/v0` calls while an actionable modal is open,
+and do not search for a synthetic Cancel/Escape command.
 
 ## Best Practices
 
-1. Validate names and payload invariants before dispatch. In particular, resolve
-   sheet names against a fresh worksheet/dashboard inventory, require filter limits
-   of at least 1, and resolve action targets to the correct Tableau object type.
-2. Prefer guarded authoring tools over raw `tabdoc:` commands. The `activate-sheet`
-   tool fresh-reads the workbook and refuses an unknown target before navigation.
-3. When a modal is suspected, call `get-active-dialogs`. Choose a dialog only by
-   copying its exact returned `objectName`, `title`, and `className`, and choose only
-   an exact action returned for that dialog. Call `invoke-dialog-action` once only
-   when the task or explicit user intent makes that action unambiguous. Never guess,
-   and never assume an action such as Cancel is inherently safe.
-4. Do not retry the operation that opened the dialog until its cause is understood
-   and corrected. If `invoke-dialog-action` returns **action-invoked-dialog-remains**, the
-   action was already invoked: do not retry it or the originating operation.
-5. Ask the user to handle the dialog when either dedicated tool is missing or
-   version-gated, the returned identity or intended action is ambiguous, or no
-   returned action is clearly safe. Follow the escalation ladder in
-   `expertise://tableau/tactics/workflow/recovery` for diagnosis and human handoff.
-6. Preserve evidence that distinguishes triggers: input encoding, delimiter,
-   filename, target object type, command arguments, Desktop build, and whether reads
-   still worked before the apply.
-7. Keep UNKNOWN triggers unknown. A shared error code does not prove that two
-   operations have the same cause.
+1. Validate names and payload invariants before dispatch. In particular, resolve sheet names against
+   a fresh worksheet/dashboard inventory, require filter limits of at least 1, and resolve action
+   targets to the correct Tableau object type.
+2. Prefer guarded authoring tools over raw `tabdoc:` commands. The `activate-sheet` tool fresh-reads
+   the workbook and refuses an unknown target before navigation.
+3. When Desktop may be blocked, call `get-desktop-state` first. Treat `state: IDLE` as authoritative
+   only because the endpoint requires a complete empty UI snapshot. `state: BLOCKED` reports the
+   strongest observed `blockedBy` cause plus all native `activeActivities`;
+   `uiSnapshotAvailable: false` means window evidence was not captured, not that no dialog exists.
+   Apply the cause-specific rule before doing anything else:
+   - For a named activity (`LOADING`, `QUERYING`, `EXTRACT_REFRESH`, `DOWNLOADING`, or
+     `SERVER_COMMUNICATION`) or `PROGRESS_DIALOG`, do not retry the originating operation. Use
+     bounded backoff of 1 second, then 2 seconds, then 4 seconds, calling `get-desktop-state` after
+     each delay. Stop after those three rechecks and report the still-active cause instead of
+     polling indefinitely.
+   - For `MODAL_LOOP`, stop automated work and report the cause and returned window evidence. Do not
+     click, issue ordinary API calls, or retry the originating operation.
+   - For `UI_UNRESPONSIVE`, retry only the state read after 1 second and then 2 seconds. If it
+     remains unresponsive after those two rechecks, stop and hand off to the user.
+4. When `blockingWindows` reports a modal, call `get-active-dialogs` for fresh action context. A
+   window from the state read can be correlated by the same `objectName`, `title`, and `className`,
+   but only the fresh dialog result authorizes an action. Copy its exact identity and one exact
+   returned action. Call `invoke-dialog-action` once only when the task or explicit user intent
+   makes that action unambiguous. Never guess, and never assume an action such as Cancel is
+   inherently safe.
+5. After an action result, call `get-desktop-state` again. Continue ordinary work only after it
+   returns `IDLE`; if it remains `BLOCKED`, reason from the new evidence and do not replay the old
+   action context.
+6. Do not retry the operation that opened the dialog until its cause is understood and corrected. If
+   `invoke-dialog-action` returns **action-invoked-dialog-remains**, the action was already invoked:
+   do not retry it or the originating operation.
+7. Ask the user to handle the dialog when a required dedicated tool is missing or version-gated, the
+   returned identity or intended action is ambiguous, or no returned action is clearly safe. Follow
+   the escalation ladder in `expertise://tableau/tactics/workflow/recovery` for diagnosis and human
+   handoff.
+8. Preserve evidence that distinguishes triggers: input encoding, delimiter, filename, target object
+   type, command arguments, Desktop build, and whether reads still worked before the apply.
+9. Keep UNKNOWN triggers unknown. A shared error code does not prove that two operations have the
+   same cause.
 
 ### Known blocking-dialog catalog
 
-| Code | Verified trigger | Guard / avoidance |
-| --- | --- | --- |
-| `5F1F5407` | **Qualified Name Parse Error.** Apply against a datasource built from a UTF-16LE, tab-delimited CSV whose filename contains parentheses. Reads and calculation authoring work; only apply fails. Reproduced twice in two fresh instances on build `0000.26.0724.1117`. | Re-encode the file as UTF-8 comma-delimited data and use a plain filename before building/applying the datasource. That combination fixed both reproductions. |
-| `AC6CC624` | **"The filter limit must be greater than zero."** A filter/Top-N payload emits a limit less than or equal to 0. | Never emit a limit below 1. Validate this invariant before dispatch. |
-| `CDEAC1A9` | **Internal error.** An `<edit-parameter-action>` targets a SET instead of a parameter. | A set action must be authored as `<edit-group-action>` with a resolved, datasource-qualified `'target-group'`. Use `<edit-parameter-action>` only for a parameter target. |
-| `47BF7751` | Raw `tabdoc:goto-sheet` names a worksheet/dashboard that does not exist. | Validate the exact, case-sensitive name against the live worksheet/dashboard inventory, or use `activate-sheet`, which performs that validation first. |
-| `CEED3E34` | **Receipted from session evidence; not newly reproduced:** invalid calculation derivation strings during a Gantt build opened a blocking modal. | Use only canonical Tableau derivation strings and run the registered invalid-derivation-string preflight before apply. |
-| `F1E7F185` | **Receipted from session evidence; not newly reproduced:** a new-worksheet name was passed as the literal value `'new-worksheet'`, opening a blocking modal. | Pass the actual requested worksheet name and reject `'new-worksheet'` when it appears literally in the value position. |
-| `2F8B7E6C`, `44A7CD32`, `60283812`, `87193686` | **UNKNOWN.** Observed but not characterized by repository or supplied evidence. | **UNKNOWN.** Capture the failing operation and payload; do not infer a trigger or retry recipe. |
+| Code                                           | Verified trigger                                                                                                                                                                                                                                                       | Guard / avoidance                                                                                                                                                         |
+| ---------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `5F1F5407`                                     | **Qualified Name Parse Error.** Apply against a datasource built from a UTF-16LE, tab-delimited CSV whose filename contains parentheses. Reads and calculation authoring work; only apply fails. Reproduced twice in two fresh instances on build `0000.26.0724.1117`. | Re-encode the file as UTF-8 comma-delimited data and use a plain filename before building/applying the datasource. That combination fixed both reproductions.             |
+| `AC6CC624`                                     | **"The filter limit must be greater than zero."** A filter/Top-N payload emits a limit less than or equal to 0.                                                                                                                                                        | Never emit a limit below 1. Validate this invariant before dispatch.                                                                                                      |
+| `CDEAC1A9`                                     | **Internal error.** An `<edit-parameter-action>` targets a SET instead of a parameter.                                                                                                                                                                                 | A set action must be authored as `<edit-group-action>` with a resolved, datasource-qualified `'target-group'`. Use `<edit-parameter-action>` only for a parameter target. |
+| `47BF7751`                                     | Raw `tabdoc:goto-sheet` names a worksheet/dashboard that does not exist.                                                                                                                                                                                               | Validate the exact, case-sensitive name against the live worksheet/dashboard inventory, or use `activate-sheet`, which performs that validation first.                    |
+| `CEED3E34`                                     | **Receipted from session evidence; not newly reproduced:** invalid calculation derivation strings during a Gantt build opened a blocking modal.                                                                                                                        | Use only canonical Tableau derivation strings and run the registered invalid-derivation-string preflight before apply.                                                    |
+| `F1E7F185`                                     | **Receipted from session evidence; not newly reproduced:** a new-worksheet name was passed as the literal value `'new-worksheet'`, opening a blocking modal.                                                                                                           | Pass the actual requested worksheet name and reject `'new-worksheet'` when it appears literally in the value position.                                                    |
+| `2F8B7E6C`, `44A7CD32`, `60283812`, `87193686` | **UNKNOWN.** Observed but not characterized by repository or supplied evidence.                                                                                                                                                                                        | **UNKNOWN.** Capture the failing operation and payload; do not infer a trigger or retry recipe.                                                                           |
 
-Automated enforcement for the below-1 limit and set-action requirements is in
-flight; do not treat either as landed enforcement on this branch.
+Automated enforcement for the below-1 limit and set-action requirements is in flight; do not treat
+either as landed enforcement on this branch.
 
 ## Common Mistakes
 
-1. **Trusting a completed API response as proof that Desktop is usable.** The UI can
-   be blocked by a modal after the originating call returns.
-2. **Trying an ordinary command to close or work around the modal.** Ordinary calls
-   queue behind the blocked UI thread. Use only `get-active-dialogs` followed, when
-   the exact choice is safe and unambiguous, by one `invoke-dialog-action` call.
-3. **Retrying an apply unchanged.** A repeated trigger can open the same modal again
-   after the dialog is cleared. Correct the datasource, limit, action type, or sheet
-   name before retrying.
-4. **Assuming Cancel is safe or retrying an action.** Action meaning depends on the
-   dialog and task context. Never guess from its label or semantic kind, and never call
-   `invoke-dialog-action` again after **action-invoked-dialog-remains**.
-5. **Treating every Qualified Name Parse Error as the CSV case.** `5F1F5407` is
-   verified for the specific encoding/delimiter/filename combination above; other
-   qualified-name failures can have different causes.
+1. **Trusting a completed API response as proof that Desktop is usable.** The UI can be blocked by a
+   modal after the originating call returns.
+2. **Trying an ordinary command to close or work around the modal.** Ordinary calls queue behind the
+   blocked UI thread. Use `get-desktop-state`, then `get-active-dialogs` when it reports an
+   actionable modal, followed, when the exact choice is safe and unambiguous, by one
+   `invoke-dialog-action` call and a fresh `get-desktop-state` verification.
+3. **Retrying an apply unchanged.** A repeated trigger can open the same modal again after the
+   dialog is cleared. Correct the datasource, limit, action type, or sheet name before retrying.
+4. **Assuming Cancel is safe or retrying an action.** Action meaning depends on the dialog and task
+   context. Never guess from its label or semantic kind, and never call `invoke-dialog-action` again
+   after **action-invoked-dialog-remains**.
+5. **Treating every Qualified Name Parse Error as the CSV case.** `5F1F5407` is verified for the
+   specific encoding/delimiter/filename combination above; other qualified-name failures can have
+   different causes.
 6. **Using `<edit-parameter-action>` for a set.** A SET is not a parameter. Use
    `<edit-group-action>` with a datasource-qualified `'target-group'`.
-7. **Inventing explanations for uncatalogued codes.** Four codes remain UNKNOWN.
-   Record evidence rather than turning correlation into a guard rule.
+7. **Inventing explanations for uncatalogued codes.** Four codes remain UNKNOWN. Record evidence
+   rather than turning correlation into a guard rule.
 
 ## Implementation
 
-The shipped command reference flags 18 commands with
-`opens_blocking_dialog: true`. That count is a floor, not the true number:
-`expertise://tableau/tactics/data/dialog-command-misclassification` documents 16
-additional known false negatives, making the known blocking set at least 34. The
-reference's command-name fields contain no Dismiss/Cancel/Escape/CloseDialog/
-CloseModal operation. Dialog recovery is instead provided by the authenticated,
-non-command routes behind `get-active-dialogs` and `invoke-dialog-action`; these are the
-only External Client API routes intended for use while an actionable modal blocks
-ordinary UI-thread operations. The command policy separately refuses raw
-`tabdoc:goto-sheet` because its target cannot be validated at that boundary and
-redirects callers to `activate-sheet`.
+The shipped command reference flags 18 commands with `opens_blocking_dialog: true`. That count is a
+floor, not the true number: `expertise://tableau/tactics/data/dialog-command-misclassification`
+documents 16 additional known false negatives, making the known blocking set at least 34. The
+reference's command-name fields contain no Dismiss/Cancel/Escape/CloseDialog/ CloseModal operation.
+State detection and dialog recovery are instead provided by the authenticated, non-command routes
+behind `get-desktop-state`, `get-active-dialogs`, and `invoke-dialog-action`; these are the only
+External Client API routes intended for state/decision handling while an actionable modal blocks
+ordinary UI-thread operations. The command policy separately refuses raw `tabdoc:goto-sheet` because
+its target cannot be validated at that boundary and redirects callers to `activate-sheet`.
 
 ### Confirmed-working navigation pattern
 
@@ -105,10 +121,9 @@ After obtaining an exact live inventory name, call `activate-sheet` with that na
 }
 ```
 
-Repository unit coverage confirms that this path fresh-reads the workbook, checks
-the exact case-sensitive worksheet/dashboard name, and only then dispatches
-navigation. For an absent name it returns the available sheets and dispatches
-nothing.
+Repository unit coverage confirms that this path fresh-reads the workbook, checks the exact
+case-sensitive worksheet/dashboard name, and only then dispatches navigation. For an absent name it
+returns the available sheets and dispatches nothing.
 
 ### What does NOT work
 
@@ -117,33 +132,31 @@ tabdoc:goto-sheet
   Sheet: "name that is not in the live inventory"
 ```
 
-That raw call can produce blocking error `47BF7751`. Calling another `/v0` operation,
-guessing a dialog-close command or label, or blindly retrying does not recover the
-session. Use the two dedicated dialog tools under the exact-choice rules above, or
-ask the user to dismiss the modal when a safe choice cannot be established.
+That raw call can produce blocking error `47BF7751`. Calling another `/v0` operation, guessing a
+dialog-close command or label, or blindly retrying does not recover the session. Use the dedicated
+state-and-dialog workflow under the exact-choice rules above, or ask the user to dismiss the modal
+when a safe choice cannot be established.
 
 ## Related Knowledge
 
-- `expertise://tableau/tactics/data/dialog-command-misclassification` — the 16 known false negatives omitted by the reference's blocking-dialog flag.
-- `expertise://tableau/tactics/workflow/recovery` — the escalation ladder for safe
-  dedicated-tool recovery, out-of-band diagnosis, and human handoff while ordinary
-  `/v0` calls must stop.
+- `expertise://tableau/tactics/data/dialog-command-misclassification` — the 16 known false negatives
+  omitted by the reference's blocking-dialog flag.
+- `expertise://tableau/tactics/workflow/recovery` — the escalation ladder for safe dedicated-tool
+  recovery, out-of-band diagnosis, and human handoff while ordinary `/v0` calls must stop.
 
 ## Source and Confidence
 
-- Command-reference evidence: 18 entries are flagged
-  `opens_blocking_dialog: true`; this is a floor. The misclassification catalog
-  documents 16 additional known false negatives, so the known count is at least 34.
-- Repository enforcement evidence: guarded sheet activation and raw
-  `tabdoc:goto-sheet` refusal are covered by unit tests.
-- External Client API evidence: dedicated authenticated dialog discovery and action
-  routes support exact compare-and-act recovery without using the blocked command
+- Command-reference evidence: 18 entries are flagged `opens_blocking_dialog: true`; this is a floor.
+  The misclassification catalog documents 16 additional known false negatives, so the known count is
+  at least 34.
+- Repository enforcement evidence: guarded sheet activation and raw `tabdoc:goto-sheet` refusal are
+  covered by unit tests.
+- External Client API evidence: dedicated authenticated state, dialog discovery, and action routes
+  support detect-classify and exact compare-and-act recovery without using the blocked command
   queue.
-- Known-verified reproduction notes: `5F1F5407`, `AC6CC624`, and `CDEAC1A9` trigger
-  and avoidance details.
-- Receipted session evidence, not newly reproduced here: `CEED3E34` invalid
-  derivation strings during a Gantt build; `F1E7F185` literal `'new-worksheet'`
-  value.
-- UNKNOWN: triggers and code-specific guards for `2F8B7E6C`, `44A7CD32`,
-  `60283812`, and `87193686`.
+- Known-verified reproduction notes: `5F1F5407`, `AC6CC624`, and `CDEAC1A9` trigger and avoidance
+  details.
+- Receipted session evidence, not newly reproduced here: `CEED3E34` invalid derivation strings
+  during a Gantt build; `F1E7F185` literal `'new-worksheet'` value.
+- UNKNOWN: triggers and code-specific guards for `2F8B7E6C`, `44A7CD32`, `60283812`, and `87193686`.
 - Last reviewed: 2026-09-04

--- a/resources/desktop/knowledge/tactics/workflow/recovery.md
+++ b/resources/desktop/knowledge/tactics/workflow/recovery.md
@@ -2,142 +2,221 @@
 
 ## Scope Check
 
-
 - Primary audience: Tableau agent / SE authoring XML
 - Authoring outcome improved: troubleshoot
-- In-scope reason: Recovery guidance helps Claude detect apply failures, distinguish real errors from Data-pane metadata lag, use undo or rollback snapshots, and verify post-apply state correctly.
+- In-scope reason: Recovery guidance helps Claude detect apply failures, distinguish real errors
+  from Data-pane metadata lag, use undo or rollback snapshots, and verify post-apply state
+  correctly.
 - Out-of-scope risk: none
-- Tags: recovery, undo, rollback, apply-failure, snapshot, error-dialog, logs, data-pane-warning, metadata-resolution, post-apply-verification, silent-failure, apply-history
-- Relevant user prompts/search terms: "how do I recover from a failed apply", "workbook changes silently dropped", "Tableau shows error dialog after apply", "undo the most recent apply", "rollback to prior known-good state", "where are Tableau Desktop logs", "Data pane shows invalid datasources warning", "apply succeeded but Data pane not updated", "force metadata catch-up after apply", "post-apply verification with list-available-fields"
+- Tags: recovery, undo, rollback, apply-failure, snapshot, error-dialog, logs, data-pane-warning,
+  metadata-resolution, post-apply-verification, silent-failure, apply-history
+- Relevant user prompts/search terms: "how do I recover from a failed apply", "workbook changes
+  silently dropped", "Tableau shows error dialog after apply", "undo the most recent apply",
+  "rollback to prior known-good state", "where are Tableau Desktop logs", "Data pane shows invalid
+  datasources warning", "apply succeeded but Data pane not updated", "force metadata catch-up after
+  apply", "post-apply verification with list-available-fields"
 
 ## When to Use
 
-After an `apply-workbook` or `apply-worksheet` call fails, silently drops changes, or leaves Tableau Desktop in an error state. For file-based workbook document applies, the MCP server handles the required XML→JSON conversion automatically.
+After an `apply-workbook` or `apply-worksheet` call fails, silently drops changes, or leaves Tableau
+Desktop in an error state. For file-based workbook document applies, the MCP server handles the
+required XML→JSON conversion automatically.
 
 ## Best Practices
 
 ### Apply history is automatic (not pre-apply protection)
 
-The MCP server automatically saves the XML from every **successful** `apply-workbook` call. Snapshots are stored at:
+The MCP server automatically saves the XML from every **successful** `apply-workbook` call.
+Snapshots are stored at:
 
 ```
 /tmp/tableau-mcp-rollback/<session-id>/workbook-<timestamp>.xml
 ```
 
-The server keeps the last 5 snapshots per session. These are **post-apply** snapshots — they contain the state that was just successfully applied, not the state before that apply. Key limitations:
+The server keeps the last 5 snapshots per session. These are **post-apply** snapshots — they contain
+the state that was just successfully applied, not the state before that apply. Key limitations:
 
-- They **cannot** protect against a hard crash during the current apply (the crash prevents the snapshot from being saved)
+- They **cannot** protect against a hard crash during the current apply (the crash prevents the
+  snapshot from being saved)
 - They **cannot** restore state if no prior successful apply occurred in the session
 - They are useful for rolling back to a known-good state from N applies ago
 
-For reversing the **most recent** apply, use `tabdoc:undo` instead — it is faster and does not require a file apply.
+For reversing the **most recent** apply, use `tabdoc:undo` instead — it is faster and does not
+require a file apply.
 
 ### Detect failures
 
-The Agent API may report `status: "completed"` even when Tableau shows a GUI error dialog. Use this escalation ladder:
+The Agent API may report `status: "completed"` even when Tableau shows a GUI error dialog. Use this
+escalation ladder:
 
-1. **Inspect a suspected modal with the dedicated dialog tools.** Call
-   `get-active-dialogs`, which uses `GET /v0/app/dialogs`. While an actionable modal
-   is open, ordinary UI-thread `/v0` operations remain blocked; only that route and
-   `POST /v0/app:invokeDialogAction` behind `invoke-dialog-action` are intended for use. Copy
-   the exact returned `objectName`, `title`, and `className`, and choose only an exact
-   action returned for that dialog. If the task or explicit user intent
-   makes that choice unambiguous, call `invoke-dialog-action` once. Never guess, never
-   assume Cancel is safe, and never blindly retry the originating operation. A
-   **action-invoked-dialog-remains** result confirms a side effect, so do not retry the
-   dialog action or originating operation. Ask the user to handle the dialog if
-   either tool is missing or version-gated, the identity or intent is ambiguous, or
-   no action is clearly safe.
+1. **Detect and classify the blocking state.** Call `get-desktop-state`, which uses the bounded
+   `GET /v0/app/state` route. It distinguishes native activities from modal and progress windows.
+   Treat `uiSnapshotAvailable: false` as incomplete window evidence, never as proof that no dialog
+   exists. If the result is `BLOCKED` without an actionable modal, reason from `blockedBy` and
+   `activeActivities`; do not invent a dialog action. Apply these bounded cause-specific rules:
+   - For a named activity (`LOADING`, `QUERYING`, `EXTRACT_REFRESH`, `DOWNLOADING`, or
+     `SERVER_COMMUNICATION`) or `PROGRESS_DIALOG`, do not retry the originating operation. Back off
+     for 1 second, then 2 seconds, then 4 seconds and re-run `get-desktop-state` after each delay.
+     Stop after those three rechecks and report the still-active cause rather than polling
+     indefinitely.
+   - For `MODAL_LOOP`, stop automated work and report the cause and returned window evidence. Do not
+     click or send ordinary API calls.
+   - For `UI_UNRESPONSIVE`, retry only `get-desktop-state` after 1 second and then 2 seconds. If it
+     remains unresponsive after those two rechecks, stop and hand off to the user.
 
-2. **Verify via ordinary MCP tools only after no actionable modal remains.** Use
-   worksheet-list readback or `activate-sheet` to confirm the expected sheets exist.
-   Raw `tabdoc:goto-sheet` is refused at the execute boundary because a bad sheet
-   value can open a blocking Desktop dialog. If a sheet you just added is missing,
-   the apply was silently rejected. Diagnose and correct the original cause before
-   retrying the apply.
+2. **Inspect an actionable modal with fresh dialog context.** When the state snapshot includes
+   `blockingWindows`, call `get-active-dialogs`, which uses `GET /v0/app/dialogs`. While an
+   actionable modal is open, ordinary UI-thread `/v0` operations remain blocked; only the dedicated
+   state/dialog routes are intended for use. Correlate the state window by exact `objectName`,
+   `title`, and `className`, but copy the identity and action from this fresh dialog result. If the
+   task or explicit user intent makes the choice unambiguous, call `invoke-dialog-action` once.
+   Never guess, never assume Cancel is safe, and never blindly retry the originating operation. An
+   **action-invoked-dialog-remains** result confirms a side effect, so do not retry the dialog
+   action or originating operation. Ask the user to handle the dialog if a required tool is missing
+   or version-gated, the identity or intent is ambiguous, or no action is clearly safe.
 
-3. **Check MCP server logs.** Look for `exec_command_failed`, `fetch failed`, or
-   `Command timed out` entries. These indicate the apply never reached Tableau or was
-   rejected at the API level.
+3. **Verify with a new state snapshot.** After any dialog action, discard the old action context and
+   call `get-desktop-state` again. Resume ordinary MCP calls only after it returns `IDLE`; otherwise
+   reason from the newly reported cause and content.
 
-4. **Check Tableau Desktop logs.** The session manager resolves the Tableau repository path on session create (via `tabdoc:get-app-config` with `app-config-enum: "repository-dir"`). The logs directory is at `<repositoryDir>/Logs/`. Key files:
-   - `log.txt` — main application log (most recent; look for `InformationBox` entries or `Command failed` warnings)
+4. **Verify via ordinary MCP tools only after no actionable modal remains.** Use worksheet-list
+   readback or `activate-sheet` to confirm the expected sheets exist. Raw `tabdoc:goto-sheet` is
+   refused at the execute boundary because a bad sheet value can open a blocking Desktop dialog. If
+   a sheet you just added is missing, the apply was silently rejected. Diagnose and correct the
+   original cause before retrying the apply.
+
+5. **Check MCP server logs.** Look for `exec_command_failed`, `fetch failed`, or `Command timed out`
+   entries. These indicate the apply never reached Tableau or was rejected at the API level.
+
+6. **Check Tableau Desktop logs.** The session manager resolves the Tableau repository path on
+   session create (via `tabdoc:get-app-config` with `app-config-enum: "repository-dir"`). The logs
+   directory is at `<repositoryDir>/Logs/`. Key files:
+   - `log.txt` — main application log (most recent; look for `InformationBox` entries or
+     `Command failed` warnings)
    - `log_1.txt` through `log_N.txt` — rotated logs (check if multiple instances are running)
 
-   Search for `"not in a recognizable format"`, `CommandSystemInputsException`, or `Command failed` near the timestamp of the apply attempt. If multiple Tableau Desktop instances are open, each writes to its own set of log files — check the most recent files first and match the PID from your session.
+   Search for `"not in a recognizable format"`, `CommandSystemInputsException`, or `Command failed`
+   near the timestamp of the apply attempt. If multiple Tableau Desktop instances are open, each
+   writes to its own set of log files — check the most recent files first and match the PID from
+   your session.
 
-5. **Check the screen (if screen-vision MCP is configured).** Use `get_window_list` to look for Tableau dialog windows — Qt-based modal dialogs are reported to the OS window manager. If a dialog is found, capture it to understand the error.
+7. **Check the screen (if screen-vision MCP is configured).** Use `get_window_list` to look for
+   Tableau dialog windows — Qt-based modal dialogs are reported to the OS window manager. If a
+   dialog is found, capture it to understand the error.
 
-6. **Ask the user.** If the dedicated dialog tools cannot establish a safe,
-   unambiguous action, ask the user to dismiss the modal and describe what they see.
-   This conservative fallback is always valid.
+8. **Ask the user.** If the dedicated dialog tools cannot establish a safe, unambiguous action, ask
+   the user to dismiss the modal and describe what they see. This conservative fallback is always
+   valid.
 
 ### Diagnose external-API write failures by error class before retrying
 
-Calibrated live via `execute-tableau-command` (2026-07-19): different failure shapes mean different things, so classify before retrying blindly.
+Calibrated live via `execute-tableau-command` (2026-07-19): different failure shapes mean different
+things, so classify before retrying blindly.
 
-- **HTTP 404 `command-not-found`** — the command name is wrong. Fix the name (see `expertise://tableau/tactics/workflow/execute-command-crash-risk` — never guess a command name); do not retry the same call.
-- **HTTP 400 `invalid-request-body`** — the request envelope shape is wrong, not the underlying intent. Check the parameter contract before changing approach.
-- **HTTP 500 on a write whose payload has a documented contract** (a fabricated or forbidden field/parameter) — the payload violates that contract. Re-read the relevant authoring module and rebuild the payload; one corrected retry is cheaper than abandoning the approach on the first 500.
-- **`{"type":"unknown","error":{}}` on writes while reads still succeed** — the app is dying or modally blocked, not your command. Stop retrying. Check once whether reads still answer; if reads fail too, the Desktop process is gone — tell the user the connection is down rather than pretending to build.
+- **HTTP 404 `command-not-found`** — the command name is wrong. Fix the name (see
+  `expertise://tableau/tactics/workflow/execute-command-crash-risk` — never guess a command name);
+  do not retry the same call.
+- **HTTP 400 `invalid-request-body`** — the request envelope shape is wrong, not the underlying
+  intent. Check the parameter contract before changing approach.
+- **HTTP 500 on a write whose payload has a documented contract** (a fabricated or forbidden
+  field/parameter) — the payload violates that contract. Re-read the relevant authoring module and
+  rebuild the payload; one corrected retry is cheaper than abandoning the approach on the first 500.
+- **`{"type":"unknown","error":{}}` on writes while reads still succeed** — the app is dying or
+  modally blocked, not your command. Stop retrying. Check once whether reads still answer; if reads
+  fail too, the Desktop process is gone — tell the user the connection is down rather than
+  pretending to build.
 
 ### Distinguish a real failure from a Data-pane warning lag
 
-Not every "invalid" warning visible to the user means the apply actually failed. Tableau's Data pane is backed by a metadata-resolution service that runs asynchronously from the apply call. A short "invalid datasources" flash can appear in the Data pane after an apply that:
+Not every "invalid" warning visible to the user means the apply actually failed. Tableau's Data pane
+is backed by a metadata-resolution service that runs asynchronously from the apply call. A short
+"invalid datasources" flash can appear in the Data pane after an apply that:
 
-- **Introduces a multi-level calc dependency chain** (e.g. a calc that references a calc that references a calc — 3+ levels deep). Tableau has to walk and resolve the whole chain before the Data pane reflects green.
-- **Bumps a `document-format-change-manifest` feature marker** (e.g. `ObjectModelRelationshipPerfOptions`, `SetMembershipControl`). These markers can fire the metadata service to re-evaluate against a newly-enabled evaluation mode.
-- **Adds many calc fields simultaneously** on a datasource that also has a complex `<object-graph>` (native multi-table model) — the relationship graph + calc graph have to be reconciled together.
+- **Introduces a multi-level calc dependency chain** (e.g. a calc that references a calc that
+  references a calc — 3+ levels deep). Tableau has to walk and resolve the whole chain before the
+  Data pane reflects green.
+- **Bumps a `document-format-change-manifest` feature marker** (e.g.
+  `ObjectModelRelationshipPerfOptions`, `SetMembershipControl`). These markers can fire the metadata
+  service to re-evaluate against a newly-enabled evaluation mode.
+- **Adds many calc fields simultaneously** on a datasource that also has a complex `<object-graph>`
+  (native multi-table model) — the relationship graph + calc graph have to be reconciled together.
 
-In every case the Agent API apply call has *already* returned success before the warning appears in the UI.
+In every case the Agent API apply call has _already_ returned success before the warning appears in
+the UI.
 
 **Authoritative check (not the Data pane):**
+
 ```
 list-available-fields workbook_file=<post-apply snapshot>
 ```
-If the new fields appear in the returned list with correct `type`/`role`, the apply succeeded. The Data pane will catch up on the next view evaluation.
+
+If the new fields appear in the returned list with correct `type`/`role`, the apply succeeded. The
+Data pane will catch up on the next view evaluation.
 
 **Force the catch-up (don't rollback):**
+
 ```
 activate-sheet
   sheetName: "<any worksheet>"
 ```
-Switching to any worksheet triggers a full view-context evaluation that completes the metadata resolution. The warning clears.
 
-**Do NOT** reach for `tabdoc:undo` or a snapshot rollback on the strength of a Data-pane warning alone. Verify via `list-available-fields` first; if the fields are there and typed correctly, the apply is real and the UI just needs a nudge.
+Switching to any worksheet triggers a full view-context evaluation that completes the metadata
+resolution. The warning clears.
+
+**Do NOT** reach for `tabdoc:undo` or a snapshot rollback on the strength of a Data-pane warning
+alone. Verify via `list-available-fields` first; if the fields are there and typed correctly, the
+apply is real and the UI just needs a nudge.
 
 ### Recover from a bad state
 
 **Undo the most recent apply (preferred for same-apply errors):**
-- `tabdoc:undo` reverses the last action. Chain multiple calls for multi-step undo. Re-fetch the workbook afterward to confirm the restored state.
+
+- `tabdoc:undo` reverses the last action. Chain multiple calls for multi-step undo. Re-fetch the
+  workbook afterward to confirm the restored state.
 - This works even if no prior snapshot exists in the session.
 
 **Rollback to a prior known-good state (for multi-step rollback):**
-1. Find the most recent snapshot in `/tmp/tableau-mcp-rollback/<session-id>/` — these contain previously-applied XML, not the state before the current apply
-2. Apply the chosen snapshot via `apply-workbook` with `mode=file` and `workbook_file` pointing to the snapshot
+
+1. Find the most recent snapshot in `/tmp/tableau-mcp-rollback/<session-id>/` — these contain
+   previously-applied XML, not the state before the current apply
+2. Apply the chosen snapshot via `apply-workbook` with `mode=file` and `workbook_file` pointing to
+   the snapshot
 3. Verify recovery with worksheet-list readback
 
-**Nuclear option — open a fresh instance:**
-If Tableau Desktop is stuck (commands time out, no dialog action can be chosen safely, or the workbook is corrupted):
+**Nuclear option — open a fresh instance:** If Tableau Desktop is stuck (commands time out, no
+dialog action can be chosen safely, or the workbook is corrupted):
+
 1. Save the most recent working snapshot to a `.twb` file in a known location
-2. Use `execute_tableau_command` with `tabui:open-workbook` on the backup file, OR ask the user to open it manually
-3. If `list-instances` is absent from the tool list, the session is pinned to the launching Desktop; open the backup in that Desktop, or restart the MCP session against the fresh Desktop
+2. Use `execute_tableau_command` with `tabui:open-workbook` on the backup file, OR ask the user to
+   open it manually
+3. If `list-instances` is absent from the tool list, the session is pinned to the launching Desktop;
+   open the backup in that Desktop, or restart the MCP session against the fresh Desktop
 4. Otherwise, after the new instance is running, call `list-instances` to discover its session ID
 5. Switch to the new session and continue work
 
 ## Common Mistakes
 
-1. **Reaching for rollback snapshots when `tabdoc:undo` is faster.** For same-apply errors, `tabdoc:undo` is immediate and doesn't require a file apply. Reserve snapshots for multi-step rollback to a state from N applies ago.
-2. **Trusting `status: "completed"` from the Agent API.** Always verify with a follow-up tool call. The API reports success even when Tableau's UI shows an error dialog.
-3. **Searching the wrong log file.** Multiple Tableau instances write to separate log files. Match the PID from your session to find the right log.
-4. **Retrying the same malformed XML.** If an apply fails, re-fetching the workbook first (`get-workbook-xml`) gives you a clean baseline. Never retry with the same modified XML without diagnosing why it failed.
-5. **Spiraling through alternatives.** Cap recovery attempts at 3. After that, report the error to the user — they can see Tableau and may spot the issue faster.
+1. **Reaching for rollback snapshots when `tabdoc:undo` is faster.** For same-apply errors,
+   `tabdoc:undo` is immediate and doesn't require a file apply. Reserve snapshots for multi-step
+   rollback to a state from N applies ago.
+2. **Trusting `status: "completed"` from the Agent API.** Always verify with a follow-up tool call.
+   The API reports success even when Tableau's UI shows an error dialog.
+3. **Searching the wrong log file.** Multiple Tableau instances write to separate log files. Match
+   the PID from your session to find the right log.
+4. **Retrying the same malformed XML.** If an apply fails, re-fetching the workbook first
+   (`get-workbook-xml`) gives you a clean baseline. Never retry with the same modified XML without
+   diagnosing why it failed.
+5. **Spiraling through alternatives.** Cap recovery attempts at 3. After that, report the error to
+   the user — they can see Tableau and may spot the issue faster.
 
 ## Implementation
 
 ### Apply history snapshot management
 
-Implemented in `src/server/tools/shared-helpers.ts` (`saveRollbackSnapshot`). Called automatically after every successful `loadWorkbookXml` call. Saves the successfully-applied XML to `/tmp/tableau-mcp-rollback/<session-id>/workbook-<timestamp>.xml` and prunes to 5 snapshots per session. These are post-apply snapshots — not pre-apply state captures.
+Implemented in `src/server/tools/shared-helpers.ts` (`saveRollbackSnapshot`). Called automatically
+after every successful `loadWorkbookXml` call. Saves the successfully-applied XML to
+`/tmp/tableau-mcp-rollback/<session-id>/workbook-<timestamp>.xml` and prunes to 5 snapshots per
+session. These are post-apply snapshots — not pre-apply state captures.
 
 ### Tableau Desktop log search (pseudo-code)
 
@@ -157,7 +236,7 @@ const logPath = `${logsDir}/log.txt`;
 // After every apply, verify:
 const sheets = await listWorksheets(sessionId);
 if (!sheets.includes(expectedNewSheet)) {
-  log("ERROR", "Apply was silently rejected — expected sheet not found");
+  log('ERROR', 'Apply was silently rejected — expected sheet not found');
   // Trigger recovery escalation
 }
 ```
@@ -165,7 +244,8 @@ if (!sheets.includes(expectedNewSheet)) {
 ## Source and Confidence
 
 - Source/evidence type: SME-authored reference
-- Source: MCP rollback-snapshot design plus Tableau Desktop log-search and post-apply verification patterns; no customer data
+- Source: MCP rollback-snapshot design plus Tableau Desktop log-search and post-apply verification
+  patterns; no customer data
 - Customer-identifying details removed: yes
 - Confidence: SME-reviewed
 - Last reviewed: 2026-09-04

--- a/src/desktop/externalApi/__fixtures__/externalClientApi-openapi.json
+++ b/src/desktop/externalApi/__fixtures__/externalClientApi-openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Tableau External Client API",
-    "version": "0.2.13",
+    "version": "0.2.14",
     "description": "Loopback HTTP interface for reading and authoring the open Tableau Desktop document. Clients authenticate with the bearer token published in the per-user discovery file."
   },
   "servers": [
@@ -98,6 +98,26 @@
             "description": "Returns the current visible modal dialogs that require a user decision. Actions and dialog identity fields are exact values for a subsequent POST /v0/app:invokeDialogAction request. Self-clearing progress windows are excluded.",
             "content": {
               "application/json": { "schema": { "$ref": "#/components/schemas/DialogList" } }
+            }
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "421": { "$ref": "#/components/responses/MisdirectedRequest" },
+          "500": { "$ref": "#/components/responses/ServerError" },
+          "503": { "$ref": "#/components/responses/ServiceUnavailable" }
+        }
+      }
+    },
+    "/v0/app/state": {
+      "get": {
+        "summary": "Get application blocking state",
+        "description": "Returns one bounded app-wide snapshot of Desktop activity, modal state, and visible blocking content without dispatching a command. state is IDLE only after a complete UI snapshot observes no blocking signal. blockedBy precedence is MODAL_DIALOG, the first active native activity in canonical order, PROGRESS_DIALOG, MODAL_LOOP, then UI_UNRESPONSIVE. Window arrays are not attributed to an operation.",
+        "operationId": "getAppState",
+        "responses": {
+          "200": {
+            "description": "Returns one bounded app-wide snapshot of Desktop activity, modal state, and visible blocking content without dispatching a command. state is IDLE only after a complete UI snapshot observes no blocking signal. blockedBy precedence is MODAL_DIALOG, the first active native activity in canonical order, PROGRESS_DIALOG, MODAL_LOOP, then UI_UNRESPONSIVE. Window arrays are not attributed to an operation.",
+            "content": {
+              "application/json": { "schema": { "$ref": "#/components/schemas/AppState" } }
             }
           },
           "400": { "$ref": "#/components/responses/BadRequest" },
@@ -2861,6 +2881,59 @@
         "required": ["dialogs"],
         "properties": {
           "dialogs": { "type": "array", "items": { "$ref": "#/components/schemas/WindowInfo" } }
+        }
+      },
+      "AppState": {
+        "type": "object",
+        "description": "One app-wide point-in-time snapshot of Desktop activity and modal state. Window arrays are not attributed to an operation. When state is BLOCKED, blockedBy reports the strongest observed signal in precedence order: MODAL_DIALOG, the first active activity in canonical order, PROGRESS_DIALOG, MODAL_LOOP, then UI_UNRESPONSIVE.",
+        "required": ["state", "uiSnapshotAvailable", "activeActivities"],
+        "properties": {
+          "state": {
+            "type": "string",
+            "description": "IDLE only after a complete UI snapshot observes no activity, modal loop, or modal window; otherwise BLOCKED.",
+            "x-extensible-enum": ["IDLE", "BLOCKED"]
+          },
+          "blockedBy": {
+            "type": "string",
+            "description": "Present when state is BLOCKED and identifies the strongest observed signal.",
+            "x-extensible-enum": [
+              "MODAL_DIALOG",
+              "LOADING",
+              "QUERYING",
+              "EXTRACT_REFRESH",
+              "DOWNLOADING",
+              "SERVER_COMMUNICATION",
+              "PROGRESS_DIALOG",
+              "MODAL_LOOP",
+              "UI_UNRESPONSIVE"
+            ]
+          },
+          "uiSnapshotAvailable": {
+            "type": "boolean",
+            "description": "Whether modal-loop and window evidence was captured within the bounded UI probe interval. A false value never produces IDLE and window arrays are omitted."
+          },
+          "activeActivities": {
+            "type": "array",
+            "description": "All active native activities in canonical order: LOADING, QUERYING, EXTRACT_REFRESH, DOWNLOADING, SERVER_COMMUNICATION.",
+            "items": {
+              "type": "string",
+              "x-extensible-enum": [
+                "LOADING",
+                "QUERYING",
+                "EXTRACT_REFRESH",
+                "DOWNLOADING",
+                "SERVER_COMMUNICATION"
+              ]
+            }
+          },
+          "blockingWindows": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/WindowInfo" }
+          },
+          "progressWindows": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/WindowInfo" }
+          }
         }
       },
       "InvokeDialogActionRequest": {

--- a/src/desktop/externalApi/discovery.test.ts
+++ b/src/desktop/externalApi/discovery.test.ts
@@ -54,6 +54,47 @@ describe('discoverInstances', () => {
     ]);
   });
 
+  it.each(['http://127.0.0.1:1', 'http://127.0.0.1:51000', 'http://127.0.0.1:65535'])(
+    'accepts the exact producer loopback origin %s',
+    (baseUrl) => {
+      const instances = discoverInstances({
+        discoveryDir: '/discovery',
+        readDir: () => ['12345.json'],
+        readFile: () => validFile({ baseUrl }),
+        isPidAlive: () => true,
+      });
+
+      expect(instances).toHaveLength(1);
+      expect(instances[0].baseUrl).toBe(baseUrl);
+    },
+  );
+
+  it.each([
+    'https://127.0.0.1:51000',
+    'http://localhost:51000',
+    'http://127.0.0.2:51000',
+    'http://[::1]:51000',
+    'http://127.0.0.1',
+    'http://127.0.0.1:0',
+    'http://127.0.0.1:65536',
+    'http://user@127.0.0.1:51000',
+    'http://127.0.0.1:51000/',
+    'http://127.0.0.1:51000/v0',
+    'http://127.0.0.1:51000?target=elsewhere',
+    'http://127.0.0.1:51000#fragment',
+  ])('rejects a discovery origin outside the exact producer form: %s', (baseUrl) => {
+    const readFile = vi.fn(() => validFile({ baseUrl }));
+    const instances = discoverInstances({
+      discoveryDir: '/discovery',
+      readDir: () => ['12345.json'],
+      readFile,
+      isPidAlive: () => true,
+    });
+
+    expect(readFile).toHaveBeenCalledOnce();
+    expect(instances).toEqual([]);
+  });
+
   it('skips entries whose pid is dead', () => {
     const instances = discoverInstances({
       discoveryDir: '/discovery',

--- a/src/desktop/externalApi/executor.mock.ts
+++ b/src/desktop/externalApi/executor.mock.ts
@@ -29,6 +29,15 @@ export function makeExecutorMock(
     getActiveDialogs: vi
       .fn<ExternalApiToolExecutor['getActiveDialogs']>()
       .mockResolvedValue(Ok({ dialogs: [] })),
+    getDesktopState: vi.fn<ExternalApiToolExecutor['getDesktopState']>().mockResolvedValue(
+      Ok({
+        state: 'IDLE',
+        uiSnapshotAvailable: true,
+        activeActivities: [],
+        blockingWindows: [],
+        progressWindows: [],
+      }),
+    ),
     invokeDialogAction: vi
       .fn<ExternalApiToolExecutor['invokeDialogAction']>()
       .mockResolvedValue(Ok({ outcome: 'no-active-dialog', dialogs: [] })),

--- a/src/desktop/externalApi/externalApiContract.test.ts
+++ b/src/desktop/externalApi/externalApiContract.test.ts
@@ -10,6 +10,7 @@ import {
   dashboardListSchema,
   datasourceItemSchema,
   datasourceListSchema,
+  desktopStateSchema,
   dialogActionSchema,
   dialogIdentitySchema,
   dialogListSchema,
@@ -53,10 +54,10 @@ import {
  * `Operation`/`OperationList` with `progressWindows`, documents `UnprocessableContent` (422)
  * on the document-replace routes, and adds individual datasource metadata and document
  * GET/POST contracts on top of the 0.2.8 surface.
- * The worksheet `:refreshNow` path and `info.version` 0.2.13 were projected from
+ * The worksheet `:refreshNow` path was projected from
  * monolith PR #64791 at commit 364d19f2e624c1859afebc34367e15c1e4b95e99 because no live
- * 0.2.13 capture was available. The dialog contract was generated from the monolith production
- * registry and canonical-JSON compared on 2026-09-08. The rest remains the live 0.2.9 capture.
+ * capture was available. The 0.2.13 dialog contract and 0.2.14 app-state contract were generated
+ * from the monolith production registry. The rest remains the live 0.2.9 capture.
  */
 
 type SpecProperty = {
@@ -145,8 +146,8 @@ const KNOWN_READ_REQUIREDNESS_EXCEPTIONS: Readonly<Record<string, readonly strin
 };
 
 describe('external client API contract (captured openapi fixture)', () => {
-  it('is the authoritative 0.2.13 producer contract', () => {
-    expect(spec.info.version).toBe('0.2.13');
+  it('is the authoritative 0.2.14 producer contract', () => {
+    expect(spec.info.version).toBe('0.2.14');
   });
 
   describe('Operation ↔ operationEnvelopeSchema', () => {
@@ -453,11 +454,85 @@ describe('external client API contract (captured openapi fixture)', () => {
     });
   });
 
+  describe('app-state contract', () => {
+    const appState = specSchema('AppState');
+
+    it('pins the producer properties, required fields, and shared window references', () => {
+      expect(Object.keys(appState.properties ?? {}).sort()).toEqual([
+        'activeActivities',
+        'blockedBy',
+        'blockingWindows',
+        'progressWindows',
+        'state',
+        'uiSnapshotAvailable',
+      ]);
+      expect([...(appState.required ?? [])].sort()).toEqual([
+        'activeActivities',
+        'state',
+        'uiSnapshotAvailable',
+      ]);
+      expect(appState.properties?.blockingWindows?.items?.$ref).toBe(
+        '#/components/schemas/WindowInfo',
+      );
+      expect(appState.properties?.progressWindows?.items?.$ref).toBe(
+        '#/components/schemas/WindowInfo',
+      );
+    });
+
+    it('normalizes omitted window arrays and preserves shared dialog action context', () => {
+      expect(desktopStateSchema.parse({ state: 'IDLE', uiSnapshotAvailable: true })).toEqual({
+        state: 'IDLE',
+        uiSnapshotAvailable: true,
+        activeActivities: [],
+        blockingWindows: [],
+        progressWindows: [],
+      });
+
+      const parsed = desktopStateSchema.parse({
+        state: 'BLOCKED',
+        blockedBy: 'MODAL_DIALOG',
+        uiSnapshotAvailable: true,
+        activeActivities: [],
+        blockingWindows: [
+          {
+            objectName: 'modal',
+            title: 'Save changes',
+            className: 'QMessageBox',
+            detailedTextTruncated: true,
+            actions: [{ kind: 'button', label: 'Save' }, { kind: 'close' }],
+          },
+        ],
+      });
+      expect(parsed.blockingWindows[0].actions).toEqual([
+        { kind: 'button', label: 'Save' },
+        { kind: 'close' },
+      ]);
+      expect(parsed.blockingWindows[0].detailedTextTruncated).toBe(true);
+    });
+
+    it('rejects BLOCKED without a cause and IDLE without complete empty evidence', () => {
+      expect(
+        desktopStateSchema.safeParse({ state: 'BLOCKED', uiSnapshotAvailable: true }).success,
+      ).toBe(false);
+      expect(
+        desktopStateSchema.safeParse({ state: 'IDLE', uiSnapshotAvailable: false }).success,
+      ).toBe(false);
+      expect(
+        desktopStateSchema.safeParse({
+          state: 'IDLE',
+          uiSnapshotAvailable: true,
+          activeActivities: ['QUERYING'],
+        }).success,
+      ).toBe(false);
+    });
+  });
+
   describe('routes', () => {
     it.each([
       EXTERNAL_API_ROUTES.health,
       EXTERNAL_API_ROUTES.app,
       EXTERNAL_API_ROUTES.appDialogs,
+      EXTERNAL_API_ROUTES.appState,
       EXTERNAL_API_ROUTES.appInvokeDialogAction,
       EXTERNAL_API_ROUTES.root,
       EXTERNAL_API_ROUTES.workbook,
@@ -572,8 +647,22 @@ describe('external client API contract (captured openapi fixture)', () => {
       ).toContain('409');
     });
 
-    it('projects the 0.2.13 worksheet refresh-now Operation contract', () => {
-      expect(spec.info.version).toBe('0.2.13');
+    it('documents the app-state read with the shared AppState response', () => {
+      const path = spec.paths[EXTERNAL_API_ROUTES.appState] as {
+        get?: {
+          operationId?: string;
+          responses?: Record<string, { content?: Record<string, { schema?: { $ref?: string } }> }>;
+        };
+      };
+
+      expect(path.get?.operationId).toBe('getAppState');
+      expect(path.get?.responses?.['200']?.content?.['application/json']?.schema?.$ref).toBe(
+        '#/components/schemas/AppState',
+      );
+    });
+
+    it('retains the worksheet refresh-now Operation contract in 0.2.14', () => {
+      expect(spec.info.version).toBe('0.2.14');
 
       const pathItem = spec.paths[EXTERNAL_API_ROUTES.worksheetRefreshNow] as {
         post?: {

--- a/src/desktop/externalApi/externalApiHttp.test.ts
+++ b/src/desktop/externalApi/externalApiHttp.test.ts
@@ -82,6 +82,43 @@ describe('ExternalApiHttp', () => {
     expect(server.requests.at(-1)?.authorization).toBe('Bearer valid-token');
   });
 
+  it('sets redirect manual on every request', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(new Response(null, { status: 200 }));
+    const client = new ExternalApiHttp(makeInstance(server.baseUrl), { fetchFn });
+
+    await client.getOk(EXTERNAL_API_ROUTES.health);
+
+    expect(fetchFn).toHaveBeenCalledOnce();
+    expect(fetchFn.mock.calls[0][1]).toMatchObject({
+      method: 'GET',
+      redirect: 'manual',
+    });
+  });
+
+  it.each([300, 301, 302, 303, 304, 305, 306, 307, 308, 399])(
+    'rejects HTTP %i without following or reading a redirect target',
+    async (status) => {
+      const redirected = {
+        status,
+        ok: false,
+        headers: new Headers({ location: 'http://example.invalid/steal-token' }),
+        json: vi.fn(),
+        text: vi.fn(),
+      } as unknown as Response;
+      const fetchFn = vi.fn().mockResolvedValue(redirected);
+      const client = new ExternalApiHttp(makeInstance(server.baseUrl), { fetchFn });
+
+      const result = await client.getOk(EXTERNAL_API_ROUTES.health);
+
+      expect(result.isErr()).toBe(true);
+      expect(result.unwrapErr().type).toBe('invalid-response');
+      expect(fetchFn).toHaveBeenCalledOnce();
+      expect(fetchFn.mock.calls[0][1]?.redirect).toBe('manual');
+      expect(redirected.json).not.toHaveBeenCalled();
+      expect(redirected.text).not.toHaveBeenCalled();
+    },
+  );
+
   it('returns the workbook document XML and version headers on GET', async () => {
     const result = await http.getXml(EXTERNAL_API_ROUTES.workbookDocument);
     expect(result.isOk()).toBe(true);

--- a/src/desktop/externalApi/externalApiHttp.ts
+++ b/src/desktop/externalApi/externalApiHttp.ts
@@ -35,6 +35,8 @@ const DEFAULT_POLL_DEADLINE_MS = 300_000;
 const DEFAULT_RETRY_AFTER_SECONDS = 1;
 const HTTP_ACCEPTED = 202;
 const HTTP_SERVICE_UNAVAILABLE = 503;
+const HTTP_REDIRECT_MIN = 300;
+const HTTP_REDIRECT_MAX = 399;
 
 // Wire states are UPPER_SNAKE_CASE; unknown values count as non-terminal per the spec.
 const TERMINAL_STATES = new Set(['SUCCEEDED', 'FAILED', 'CANCELLED']);
@@ -450,8 +452,17 @@ export class ExternalApiHttp {
         method,
         headers,
         body: options.body,
+        redirect: 'manual',
         signal,
       });
+      if (res.status >= HTTP_REDIRECT_MIN && res.status <= HTTP_REDIRECT_MAX) {
+        return Err({
+          type: 'invalid-response',
+          error: new Error(
+            `External Client API rejected an unexpected HTTP ${res.status} redirect.`,
+          ),
+        });
+      }
       return Ok(res);
     } catch (error) {
       return Err({ type: 'network', error, aborted: signal.aborted });

--- a/src/desktop/externalApi/externalApiToolExecutor.ts
+++ b/src/desktop/externalApi/externalApiToolExecutor.ts
@@ -43,6 +43,8 @@ import {
   datasourceListSchema,
   datasourceRefreshDataRoute,
   datasourceRefreshExtractRoute,
+  DesktopState,
+  desktopStateSchema,
   DialogList,
   dialogListSchema,
   ExportAsWorkbookRequest,
@@ -320,6 +322,12 @@ export class ExternalApiToolExecutor {
   async getActiveDialogs(signal: AbortSignal): Promise<Result<DialogList, ExecuteCommandError>> {
     return this.readExternalApi((http) =>
       http.getJson(EXTERNAL_API_ROUTES.appDialogs, dialogListSchema, signal),
+    );
+  }
+
+  async getDesktopState(signal: AbortSignal): Promise<Result<DesktopState, ExecuteCommandError>> {
+    return this.readExternalApi((http) =>
+      http.getJson(EXTERNAL_API_ROUTES.appState, desktopStateSchema, signal),
     );
   }
 

--- a/src/desktop/externalApi/mockExternalApiServer.ts
+++ b/src/desktop/externalApi/mockExternalApiServer.ts
@@ -445,6 +445,7 @@ export async function startMockExternalApiServer(
           health: '/v0/health',
           app: '/v0/app',
           'app-dialogs': '/v0/app/dialogs',
+          'app-state': '/v0/app/state',
           workbook: '/v0/workbook',
           site: '/v0/site',
         },
@@ -471,6 +472,17 @@ export async function startMockExternalApiServer(
 
     if (method === 'GET' && path === EXTERNAL_API_ROUTES.appDialogs) {
       sendJson(res, 200, { dialogs });
+      return;
+    }
+
+    if (method === 'GET' && path === EXTERNAL_API_ROUTES.appState) {
+      sendJson(res, 200, {
+        state: 'IDLE',
+        uiSnapshotAvailable: true,
+        activeActivities: [],
+        blockingWindows: [],
+        progressWindows: [],
+      });
       return;
     }
 

--- a/src/desktop/externalApi/types.ts
+++ b/src/desktop/externalApi/types.ts
@@ -4,7 +4,7 @@ import { z } from 'zod';
  * Types and schemas for the Tableau Desktop "External Client API" (Athena V0).
  *
  * Contract derived from the External Client API rollout, then tightened against the
- * producer OpenAPI contract (OpenAPI 3.1, `info.version` 0.2.13), derived from
+ * producer OpenAPI contract (OpenAPI 3.1, `info.version` 0.2.14), derived from
  * the production registry/generator harness. The dialog contract was canonical-JSON
  * compared on 2026-09-08.
  * Envelope fields the spec marks required are required here; everything else stays
@@ -17,6 +17,7 @@ export const EXTERNAL_API_ROUTES = {
   health: '/v0/health',
   app: '/v0/app',
   appDialogs: '/v0/app/dialogs',
+  appState: '/v0/app/state',
   appInvokeDialogAction: '/v0/app:invokeDialogAction',
   appOpenFile: '/v0/app:openFile',
   appToggleStartPage: '/v0/app:toggleStartPage',
@@ -356,13 +357,29 @@ export function datasourceRefreshExtractRoute(datasourceId: string): string {
 /**
  * Discovery file written by Desktop to `<OS app-local-data>/ExternalApi/<pid>.json`.
  * Only `schemaVersion === 1` is understood. Version fields are optional so a slightly
- * newer/older build still parses; the essentials (pid/baseUrl/token) are required.
+ * newer/older build still parses; the essentials (pid/baseUrl/token) are required. The
+ * producer publishes an origin, not a general URL: plain HTTP on numeric IPv4 loopback with
+ * an explicit valid port and no credentials, path, query, or fragment.
  */
+export function isExternalApiLoopbackOrigin(value: string): boolean {
+  const match = /^http:\/\/127\.0\.0\.1:(\d{1,5})$/.exec(value);
+  if (match === null) {
+    return false;
+  }
+
+  const port = Number(match[1]);
+  return Number.isInteger(port) && port >= 1 && port <= 65_535;
+}
+
+export const externalApiLoopbackOriginSchema = z.string().refine(isExternalApiLoopbackOrigin, {
+  message: 'Expected an exact http://127.0.0.1:<port> loopback origin.',
+});
+
 export const discoveryFileSchema = z.object({
   schemaVersion: z.literal(1),
   instanceId: z.string(),
   pid: z.number(),
-  baseUrl: z.string().url(),
+  baseUrl: externalApiLoopbackOriginSchema,
   tokenType: z.string().optional(),
   token: z.string(),
   applicationVersion: z.string().optional(),
@@ -541,6 +558,43 @@ export const dialogListSchema = z
   })
   .passthrough();
 export type DialogList = z.infer<typeof dialogListSchema>;
+
+/** One app-wide point-in-time snapshot of Desktop activity and modal state. */
+export const desktopStateSchema = z
+  .object({
+    state: z.string().min(1),
+    blockedBy: z.string().min(1).optional(),
+    uiSnapshotAvailable: z.boolean(),
+    activeActivities: z.array(z.string().min(1)).optional().default([]),
+    blockingWindows: z.array(windowInfoSchema).optional().default([]),
+    progressWindows: z.array(windowInfoSchema).optional().default([]),
+  })
+  .passthrough()
+  .superRefine((value, context) => {
+    if (value.state === 'BLOCKED' && value.blockedBy === undefined) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'A BLOCKED state requires blockedBy.',
+        path: ['blockedBy'],
+      });
+    }
+
+    if (
+      value.state === 'IDLE' &&
+      (!value.uiSnapshotAvailable ||
+        value.blockedBy !== undefined ||
+        value.activeActivities.length > 0 ||
+        value.blockingWindows.length > 0 ||
+        value.progressWindows.length > 0)
+    ) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'An IDLE state requires one complete empty UI snapshot.',
+        path: ['state'],
+      });
+    }
+  });
+export type DesktopState = z.infer<typeof desktopStateSchema>;
 
 /** Exact compare-and-act request accepted by `POST /v0/app:invokeDialogAction`. */
 export const invokeDialogActionRequestSchema = z

--- a/src/desktop/knowledge/corpusIntegrity.test.ts
+++ b/src/desktop/knowledge/corpusIntegrity.test.ts
@@ -128,6 +128,44 @@ describe('knowledge corpus integrity', () => {
       ).toMatch(/human fallback|human handoff|ask the user/i);
     }
 
+    for (const document of documents.slice(0, 3)) {
+      expect(document.content, `${document.name} should name the state tool`).toContain(
+        'get-desktop-state',
+      );
+    }
+
+    for (const document of documents.slice(1, 3)) {
+      const content = document.content ?? '';
+      const firstState = content.indexOf('get-desktop-state');
+      const inspection = content.indexOf('get-active-dialogs', firstState);
+      const action = content.indexOf('invoke-dialog-action', inspection);
+      const verification = content.indexOf('get-desktop-state', action);
+      expect(
+        firstState,
+        `${document.name} should detect state before dialog inspection`,
+      ).toBeGreaterThanOrEqual(0);
+      expect(inspection, `${document.name} should inspect after state detection`).toBeGreaterThan(
+        firstState,
+      );
+      expect(action, `${document.name} should act after fresh inspection`).toBeGreaterThan(
+        inspection,
+      );
+      expect(verification, `${document.name} should verify with fresh state`).toBeGreaterThan(
+        action,
+      );
+
+      expect(content).toContain('`LOADING`');
+      expect(content).toContain('`QUERYING`');
+      expect(content).toContain('`EXTRACT_REFRESH`');
+      expect(content).toContain('`DOWNLOADING`');
+      expect(content).toContain('`SERVER_COMMUNICATION`');
+      expect(content).toContain('`PROGRESS_DIALOG`');
+      expect(content).toMatch(/1 second[\s\S]*2 seconds[\s\S]*4 seconds/);
+      expect(content).toMatch(/three rechecks/);
+      expect(content).toMatch(/`MODAL_LOOP`[\s\S]*stop[\s\S]*report/);
+      expect(content).toMatch(/`UI_UNRESPONSIVE`[\s\S]*two rechecks[\s\S]*hand off/);
+    }
+
     const allGuidance = documents.map(({ content }) => content ?? '').join('\n');
     const obsoleteClaims = [
       'There is no command that dismisses a dialog',

--- a/src/server.desktop.test.ts
+++ b/src/server.desktop.test.ts
@@ -438,10 +438,10 @@ describe('selectToolsForProfile (TOOL_PROFILE, W60 spike lever 1 / preamble P1)'
     expect(selected.map((t) => t.name)).toContain('execute-tableau-command');
   });
 
-  it('TOOL_PROFILE=dynamic-authoring registers exactly the 67-tool modern surface with scoped XML fallbacks', () => {
+  it('TOOL_PROFILE=dynamic-authoring registers exactly the 68-tool modern surface with scoped XML fallbacks', () => {
     const selected = selectToolsForProfile(allTools(), 'dynamic-authoring');
     expect(new Set(selected.map((t) => t.name))).toEqual(DYNAMIC_AUTHORING_TOOL_PROFILE);
-    expect(selected).toHaveLength(67);
+    expect(selected).toHaveLength(68);
     // The full dynamic dialect, semantically named — every author-* verb present,
     // plus the ask-for-help, command-discovery, deterministic fast-path, and the two
     // knowledge doors the system prompt's "consult the expertise library" law routes to.
@@ -734,6 +734,7 @@ describe('API-version tool gate (interim minApiVersion floor)', () => {
     expect(floors.get('refresh-datasource-extract')).toBe('0.2.8');
     expect(floors.get('get-active-dialogs')).toBe('0.2.13');
     expect(floors.get('invoke-dialog-action')).toBe('0.2.13');
+    expect(floors.get('get-desktop-state')).toBe('0.2.14');
     expect(floors.get('get-datasource-info')).toBe('0.2.10');
     expect(floors.get('get-datasource-xml')).toBe('0.2.10');
     expect(floors.get('apply-datasource')).toBe('0.2.10');
@@ -823,6 +824,23 @@ describe('API-version tool gate (interim minApiVersion floor)', () => {
       expect(at212).not.toContain(name);
       expect(at213).toContain(name);
     }
+  });
+
+  it('keeps 0.2.13 dialog tools while gating app state until 0.2.14', () => {
+    const profileTools = selectToolsForProfile(
+      desktopToolFactories.map((factory) => factory(new DesktopMcpServer())),
+      'dynamic-authoring',
+    );
+    const namesAt = (apiVersion: string | undefined): string[] =>
+      filterToolsByApiVersion(profileTools, apiVersion).map((tool) => tool.name);
+
+    expect(namesAt('0.2.13')).toContain('get-active-dialogs');
+    expect(namesAt('0.2.13')).toContain('invoke-dialog-action');
+    expect(namesAt('0.2.13')).not.toContain('get-desktop-state');
+    expect(namesAt('0.2.14')).toContain('get-desktop-state');
+    expect(namesAt('0.3.0')).toContain('get-desktop-state');
+    expect(filterToolsByApiVersion(profileTools, undefined)).toBe(profileTools);
+    expect(namesAt(undefined)).toContain('get-desktop-state');
   });
 
   it('gates refresh-auto-updates at 0.2.13 and fails open for an unknown version', () => {

--- a/src/server.desktop.ts
+++ b/src/server.desktop.ts
@@ -113,7 +113,7 @@ export const SPEC_LOOP_TOOL_PROFILE: ReadonlySet<DesktopToolName> = new Set<Desk
  * all, so verified Tableau behavior (e.g. the waterfall subtotal/total exclusion rule,
  * the Top-N-needs-a-context-filter rule) stayed dark on every sing. The corpus is
  * served as MCP resources anyway; these two tiny tools are the only way the model reaches it.
- * Sixty-seven tools cover the full Workout-Wednesday-W44 dialect plus on-demand expertise,
+ * Sixty-eight tools cover the full Workout-Wednesday-W44 dialect plus on-demand expertise,
  * first-class workbook/data reads/navigation, scoped datasource/dashboard/story cached-XML
  * fallbacks, dialog inspection and action handling, and a narrow whole-workbook cached-XML
  * fallback. Standalone validation and unrelated info/site tools stay out. This is the
@@ -174,6 +174,7 @@ export const DYNAMIC_AUTHORING_TOOL_PROFILE: ReadonlySet<DesktopToolName> =
     'redo-workbook',
     'ask-user',
     'list-instances',
+    'get-desktop-state',
     'get-active-dialogs',
     'invoke-dialog-action',
     'list-available-fields',

--- a/src/tools/desktop/api/getDesktopState.test.ts
+++ b/src/tools/desktop/api/getDesktopState.test.ts
@@ -1,0 +1,137 @@
+import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { Err, Ok } from 'ts-results-es';
+
+import { makeExecutorMock } from '../../../desktop/externalApi/executor.mock.js';
+import { DesktopState } from '../../../desktop/externalApi/types.js';
+import * as sessionResolution from '../../../desktop/session/sessionResolution.js';
+import { DesktopMcpServer } from '../../../server.desktop.js';
+import invariant from '../../../utils/invariant.js';
+import { Provider } from '../../../utils/provider.js';
+import { getMockRequestHandlerExtra } from '../toolContext.mock.js';
+import { getDesktopStateTool } from './getDesktopState.js';
+
+vi.mock('../../../desktop/session/sessionResolution.js');
+
+describe('get-desktop-state tool', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('declares the read contract and 0.2.14 API floor', () => {
+    const tool = getDesktopStateTool(new DesktopMcpServer());
+
+    expect(tool.name).toBe('get-desktop-state');
+    expect(tool.minApiVersion).toBe('0.2.14');
+    expect(tool.description).toContain('strongest observed blocking cause');
+    expect(tool.description).toContain('fresh exact identity and actions from get-active-dialogs');
+    expect(tool.paramsSchema).toMatchObject({ session: expect.any(Object) });
+    expect(tool.annotations).toEqual({
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    });
+  });
+
+  it('uses canonical session resolution and forwards the request signal', async () => {
+    vi.mocked(sessionResolution.resolveSession).mockReturnValue(Ok('999'));
+    const state: DesktopState = {
+      state: 'IDLE',
+      uiSnapshotAvailable: true,
+      activeActivities: [],
+      blockingWindows: [],
+      progressWindows: [],
+    };
+    const getDesktopState = vi.fn().mockResolvedValue(Ok(state));
+    const executor = makeExecutorMock({ getDesktopState });
+    const controller = new AbortController();
+    const extra = {
+      ...getMockRequestHandlerExtra(),
+      signal: controller.signal,
+      getExecutor: vi.fn().mockResolvedValue(executor),
+    };
+
+    const result = await invokeTool({ session: undefined }, extra);
+
+    expect(parseResult(result)).toEqual(state);
+    expect(sessionResolution.resolveSession).toHaveBeenCalledWith(undefined);
+    expect(extra.getExecutor).toHaveBeenCalledWith('999');
+    expect(getDesktopState).toHaveBeenCalledExactlyOnceWith(controller.signal);
+  });
+
+  it('relays shared dialog context and future fields unchanged', async () => {
+    vi.mocked(sessionResolution.resolveSession).mockReturnValue(Ok('999'));
+    const state = {
+      state: 'BLOCKED',
+      blockedBy: 'MODAL_DIALOG',
+      uiSnapshotAvailable: true,
+      activeActivities: ['QUERYING', 'FUTURE_ACTIVITY'],
+      blockingWindows: [
+        {
+          objectName: 'connectionError',
+          title: 'Connection failed',
+          className: 'QMessageBox',
+          detailedTextTruncated: true,
+          actions: [{ kind: 'button' as const, label: 'Retry' }, { kind: 'close' as const }],
+          futureWindowField: { native: true },
+        },
+      ],
+      progressWindows: [],
+      futureEnvelopeField: ['preserved'],
+    };
+    const extra = {
+      ...getMockRequestHandlerExtra(),
+      getExecutor: vi
+        .fn()
+        .mockResolvedValue(
+          makeExecutorMock({ getDesktopState: vi.fn().mockResolvedValue(Ok(state)) }),
+        ),
+    };
+
+    expect(parseResult(await invokeTool({ session: '999' }, extra))).toEqual(state);
+  });
+
+  it('maps a stable 404 to the endpoint-unavailable read error', async () => {
+    vi.mocked(sessionResolution.resolveSession).mockReturnValue(Ok('999'));
+    const extra = {
+      ...getMockRequestHandlerExtra(),
+      getExecutor: vi.fn().mockResolvedValue(
+        makeExecutorMock({
+          getDesktopState: vi.fn().mockResolvedValue(
+            Err({
+              type: 'command-failed' as const,
+              error: {
+                code: 'not-found',
+                message: 'No route matches GET /v0/app/state',
+                recoverable: false,
+              },
+            }),
+          ),
+        }),
+      ),
+    };
+
+    const result = await invokeTool({ session: undefined }, extra);
+
+    expect(result.isError).toBe(true);
+    invariant(result.content[0].type === 'text');
+    expect(result.content[0].text).toContain('Desktop state endpoint');
+    expect(result.content[0].text).toContain('too old for this read');
+    expect(result.content[0].text).toContain('Do not retry');
+  });
+});
+
+async function invokeTool(
+  args: { session: string | undefined },
+  extra: ReturnType<typeof getMockRequestHandlerExtra>,
+): Promise<CallToolResult> {
+  const tool = getDesktopStateTool(new DesktopMcpServer());
+  const callback = await Provider.from(tool.callback);
+  return await callback(args, extra);
+}
+
+function parseResult(result: CallToolResult): DesktopState {
+  expect(result.isError).toBe(false);
+  invariant(result.content[0].type === 'text');
+  return JSON.parse(result.content[0].text) as DesktopState;
+}

--- a/src/tools/desktop/api/getDesktopState.ts
+++ b/src/tools/desktop/api/getDesktopState.ts
@@ -1,0 +1,50 @@
+import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+
+import { DesktopState } from '../../../desktop/externalApi/types.js';
+import { runExternalApiTool } from '../../../desktop/wrappers/readHarness.js';
+import { DesktopMcpServer } from '../../../server.desktop.js';
+import { sessionParam } from '../params.js';
+import { DesktopTool } from '../tool.js';
+
+const paramsSchema = {
+  session: sessionParam(),
+};
+
+const title = 'Get Tableau Desktop State';
+
+export const getDesktopStateTool = (server: DesktopMcpServer): DesktopTool<typeof paramsSchema> => {
+  const tool = new DesktopTool({
+    server,
+    name: 'get-desktop-state',
+    minApiVersion: '0.2.14',
+    title,
+    description:
+      'Report whether Tableau Desktop is idle or blocked, the strongest observed blocking cause, all active native activities, UI snapshot completeness, and visible modal or progress window content. When a modal needs action, obtain fresh exact identity and actions from get-active-dialogs before considering invoke-dialog-action.',
+    paramsSchema,
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
+    callback: async ({ session }, extra): Promise<CallToolResult> => {
+      return await tool.logAndExecute<DesktopState>({
+        extra,
+        args: { session },
+        callback: async () =>
+          await runExternalApiTool({
+            session,
+            extra,
+            callback: async (_executor, _signal, call) =>
+              await call(
+                'Desktop state',
+                async (executor, signal) => await executor.getDesktopState(signal),
+                { stableNotFoundMeansRouteMissing: true },
+              ),
+          }),
+      });
+    },
+  });
+
+  return tool;
+};

--- a/src/tools/desktop/toolName.ts
+++ b/src/tools/desktop/toolName.ts
@@ -1,5 +1,6 @@
 export const desktopToolNames = [
   'list-instances',
+  'get-desktop-state',
   'get-active-dialogs',
   'invoke-dialog-action',
   'get-workbook-xml',

--- a/src/tools/desktop/tools.ts
+++ b/src/tools/desktop/tools.ts
@@ -19,6 +19,7 @@ import { getDashboardInfoTool } from './api/getDashboardInfo.js';
 import { getGetDashboardXmlTool } from './api/getDashboardXml.js';
 import { getDatasourceInfoTool } from './api/getDatasourceInfo.js';
 import { getGetDatasourceXmlTool } from './api/getDatasourceXml.js';
+import { getDesktopStateTool } from './api/getDesktopState.js';
 import { getHealthTool } from './api/getHealth.js';
 import { getSiteInfoTool } from './api/getSiteInfo.js';
 import { getStoryboardInfoTool } from './api/getStoryboardInfo.js';
@@ -99,6 +100,7 @@ import { getSearchWorkbookExamplesTool } from './local/search/searchWorkbookExam
 
 export const desktopToolFactories = [
   getListInstancesTool,
+  getDesktopStateTool,
   getActiveDialogsTool,
   getInvokeDialogActionTool,
   getGetWorkbookXmlTool,

--- a/src/tools/toolName.test.ts
+++ b/src/tools/toolName.test.ts
@@ -4,7 +4,11 @@ import { isWebToolName, webToolNames } from './web/toolName.js';
 
 describe('ToolName', () => {
   it('registers each dialog tool name exactly once', () => {
-    for (const toolName of ['get-active-dialogs', 'invoke-dialog-action'] as const) {
+    for (const toolName of [
+      'get-desktop-state',
+      'get-active-dialogs',
+      'invoke-dialog-action',
+    ] as const) {
       expect(desktopToolNames.filter((name) => name === toolName)).toHaveLength(1);
       expect(isDesktopToolName(toolName)).toBe(true);
     }

--- a/tests/e2e/desktop/getDesktopState.test.ts
+++ b/tests/e2e/desktop/getDesktopState.test.ts
@@ -1,0 +1,581 @@
+import { spawnSync } from 'node:child_process';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { CallToolResultSchema } from '@modelcontextprotocol/sdk/types.js';
+
+import {
+  desktopStateSchema,
+  dialogListSchema,
+  invokeDialogActionResultSchema,
+} from '../../../src/desktop/externalApi/types.js';
+import { buildVariant } from '../build.js';
+import { McpClient } from '../mcpClient.js';
+
+const INITIAL_TOKEN = 'fixture-desktop-state-token';
+const REFRESHED_TOKEN = 'fixture-refreshed-state-token';
+const DECOY_TOKEN = 'fixture-decoy-state-token';
+const SESSION = String(process.pid);
+const DECOY_PID = process.ppid;
+const MISSING_PID = 99_999_991;
+
+const dialog = {
+  objectName: 'saveChangesDialog',
+  title: 'Save Changes',
+  className: 'QMessageBox',
+  messageText: 'Save the workbook?',
+  informativeText: 'Unsaved work may be lost.',
+  detailedText: 'Workbook: Regional Sales',
+  detailedTextTruncated: true,
+  buttons: ['Discard', 'Cancel'],
+  actions: [
+    { kind: 'button' as const, label: 'Discard' },
+    { kind: 'button' as const, label: 'Cancel' },
+    { kind: 'close' as const },
+  ],
+};
+
+type ResponseMode = 'idle' | 'lifecycle' | 'not-found' | 'invalid' | 'hang' | 'unauthorized';
+
+type ObservedRequest = {
+  server: 'target' | 'decoy';
+  method: string | undefined;
+  url: string | undefined;
+  authorization: string | undefined;
+  contentType: string | undefined;
+  body: string;
+};
+
+describe('get-desktop-state real stdio MCP boundary', () => {
+  let client: McpClient | undefined;
+  let targetServer: Server | undefined;
+  let decoyServer: Server | undefined;
+  let tempHome: string | undefined;
+  let discoveryDir: string;
+  let targetBaseUrl: string;
+  let decoyBaseUrl: string;
+  let currentDiscoveryToken = INITIAL_TOKEN;
+  let acceptedToken = INITIAL_TOKEN;
+  let refreshDiscoveryOnUnauthorized: string | undefined;
+  let mode: ResponseMode;
+  let dialogOpen: boolean;
+  let abortedRequests: number;
+  let requests: Array<ObservedRequest>;
+
+  beforeAll(async () => {
+    await buildVariant('desktop');
+    tempHome = await mkdtemp(join(tmpdir(), 'tableau-mcp-desktop-state-'));
+    discoveryDir = join(tempHome, 'ExternalApi');
+    await mkdir(discoveryDir, { recursive: true });
+
+    targetServer = await startServer((request, response) => handleTarget(request, response));
+    decoyServer = await startServer((request, response) => handleDecoy(request, response));
+    targetBaseUrl = serverBaseUrl(targetServer);
+    decoyBaseUrl = serverBaseUrl(decoyServer);
+
+    await writeDiscovery({
+      pid: process.pid,
+      baseUrl: targetBaseUrl,
+      token: currentDiscoveryToken,
+      instanceId: 'headless-state-target',
+      startedAt: '2026-09-11T10:00:00Z',
+    });
+    await writeDiscovery({
+      pid: DECOY_PID,
+      baseUrl: decoyBaseUrl,
+      token: DECOY_TOKEN,
+      instanceId: 'headless-state-newer-decoy',
+      startedAt: '2026-09-11T11:00:00Z',
+    });
+
+    client = new McpClient({
+      variant: 'desktop',
+      env: {
+        HOME: tempHome,
+        LOCALAPPDATA: tempHome,
+        XDG_DATA_HOME: tempHome,
+        TABLEAU_EXTERNAL_API_DISCOVERY_DIR: discoveryDir,
+        MAX_REQUEST_TIMEOUT_MS: '5000',
+      },
+    });
+    await client.connect();
+  });
+
+  afterAll(async () => {
+    const cleanupErrors: Array<unknown> = [];
+    try {
+      if (client) await client.close();
+    } catch (error) {
+      cleanupErrors.push(error);
+    }
+
+    for (const server of [targetServer, decoyServer]) {
+      if (!server) continue;
+      try {
+        await closeServer(server);
+      } catch (error) {
+        cleanupErrors.push(error);
+      }
+    }
+
+    if (tempHome) {
+      try {
+        await rm(tempHome, { recursive: true, force: true });
+      } catch (error) {
+        cleanupErrors.push(error);
+      }
+    }
+
+    if (cleanupErrors.length > 0) {
+      throw new AggregateError(cleanupErrors, 'Failed to clean up the desktop-state E2E harness.');
+    }
+  });
+
+  beforeEach(() => {
+    mode = 'idle';
+    dialogOpen = true;
+    abortedRequests = 0;
+    requests = [];
+    acceptedToken = currentDiscoveryToken;
+    refreshDiscoveryOnUnauthorized = undefined;
+  });
+
+  it('selects the exact requested PID among multiple live discovery candidates', async () => {
+    mode = 'lifecycle';
+    const tools = await requireClient().listTools();
+    expect(tools).toContain('get-desktop-state');
+    expect(tools).toContain('get-active-dialogs');
+    expect(tools).toContain('invoke-dialog-action');
+
+    const before = await readState();
+    expect(before).toEqual({
+      state: 'BLOCKED',
+      blockedBy: 'MODAL_DIALOG',
+      uiSnapshotAvailable: true,
+      activeActivities: ['QUERYING'],
+      blockingWindows: [dialog],
+      progressWindows: [],
+    });
+
+    const inspected = await requireClient().callTool('get-active-dialogs', {
+      schema: dialogListSchema,
+      toolArgs: { session: SESSION },
+    });
+    expect(inspected.dialogs).toEqual(before.blockingWindows);
+
+    const selectedDialog = inspected.dialogs[0];
+    const selectedAction = selectedDialog.actions?.[0];
+    expect(selectedAction).toEqual({ kind: 'button', label: 'Discard' });
+    expect(
+      await requireClient().callTool('invoke-dialog-action', {
+        schema: invokeDialogActionResultSchema,
+        toolArgs: {
+          session: SESSION,
+          dialog: {
+            objectName: selectedDialog.objectName,
+            title: selectedDialog.title,
+            className: selectedDialog.className,
+          },
+          action: selectedAction,
+        },
+      }),
+    ).toEqual({
+      outcome: 'dismissed',
+      dialog: {
+        objectName: dialog.objectName,
+        title: dialog.title,
+        className: dialog.className,
+      },
+      action: { kind: 'button', label: 'Discard' },
+      dialogs: [],
+    });
+    expect(await readState()).toMatchObject({ state: 'IDLE', blockingWindows: [] });
+
+    expect(requests.filter(({ server }) => server === 'decoy')).toEqual([]);
+    expect(requests.map(({ method, url }) => `${method} ${url}`)).toEqual([
+      'GET /v0/app/state',
+      'GET /v0/app/dialogs',
+      'POST /v0/app:invokeDialogAction',
+      'GET /v0/app/state',
+    ]);
+  });
+
+  it('rescans discovery once after 401 and retries with the refreshed token', async () => {
+    acceptedToken = REFRESHED_TOKEN;
+    refreshDiscoveryOnUnauthorized = REFRESHED_TOKEN;
+
+    expect(await readState()).toMatchObject({ state: 'IDLE' });
+
+    const stateRequests = targetStateRequests();
+    expect(stateRequests).toHaveLength(2);
+    expect(stateRequests.map(({ authorization }) => authorization)).toEqual([
+      `Bearer ${INITIAL_TOKEN}`,
+      `Bearer ${REFRESHED_TOKEN}`,
+    ]);
+    expect(JSON.stringify(stateRequests)).not.toContain(DECOY_TOKEN);
+  });
+
+  it('maps a missing app-state route without disclosing discovery credentials', async () => {
+    mode = 'not-found';
+
+    const result = await rawStateCall(SESSION);
+    const text = toolErrorText(result);
+
+    expect(text).toContain('Desktop state endpoint');
+    expect(text).toContain('too old for this read');
+    expect(text).not.toContain(INITIAL_TOKEN);
+    expect(text).not.toContain(REFRESHED_TOKEN);
+    expect(text).not.toContain(DECOY_TOKEN);
+  });
+
+  it('rejects an invalid producer payload without disclosing discovery credentials', async () => {
+    mode = 'invalid';
+
+    const text = toolErrorText(await rawStateCall(SESSION));
+
+    expect(text).toContain('"type":"invalid-response"');
+    expect(text).not.toContain(INITIAL_TOKEN);
+    expect(text).not.toContain(REFRESHED_TOKEN);
+    expect(text).not.toContain(DECOY_TOKEN);
+  });
+
+  it('does not expose a 401 response body after the one allowed rescan', async () => {
+    mode = 'unauthorized';
+
+    const text = toolErrorText(await rawStateCall(SESSION));
+
+    expect(text).toContain('401 after a rescan');
+    expect(text).not.toContain(INITIAL_TOKEN);
+    expect(text).not.toContain(REFRESHED_TOKEN);
+    expect(text).not.toContain(DECOY_TOKEN);
+    expect(targetStateRequests()).toHaveLength(2);
+  });
+
+  it('propagates an MCP request timeout to the hanging External API read', async () => {
+    mode = 'hang';
+    let thrown: unknown;
+
+    try {
+      await requireClient().client.callTool(
+        { name: 'get-desktop-state', arguments: { session: SESSION } },
+        undefined,
+        { timeout: 100 },
+      );
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeDefined();
+    expect(String(thrown)).toMatch(/timed out|timeout/i);
+    expect(JSON.stringify(thrown)).not.toContain(currentDiscoveryToken);
+    await waitUntil(() => abortedRequests > 0);
+  });
+
+  it('propagates explicit MCP cancellation to the hanging External API read', async () => {
+    mode = 'hang';
+    const controller = new AbortController();
+    const cancellation = setTimeout(() => controller.abort(), 50);
+    let thrown: unknown;
+
+    try {
+      await requireClient().client.callTool(
+        { name: 'get-desktop-state', arguments: { session: SESSION } },
+        undefined,
+        { signal: controller.signal, timeout: 5000 },
+      );
+    } catch (error) {
+      thrown = error;
+    } finally {
+      clearTimeout(cancellation);
+    }
+
+    expect(thrown).toBeDefined();
+    expect(String(thrown)).toMatch(/abort/i);
+    expect(JSON.stringify(thrown)).not.toContain(currentDiscoveryToken);
+    await waitUntil(() => abortedRequests > 0);
+  });
+
+  it('fails closed for missing and dead discovery records without contacting another PID', async () => {
+    const deadProcess = spawnSync(process.execPath, ['-e', 'process.exit(0)']);
+    if (deadProcess.error || deadProcess.status !== 0) {
+      throw (
+        deadProcess.error ?? new Error(`Could not create a terminated PID: ${deadProcess.status}`)
+      );
+    }
+    const deadPid = deadProcess.pid;
+
+    await writeDiscovery({
+      pid: deadPid,
+      baseUrl: targetBaseUrl,
+      token: 'dead-discovery-token',
+      instanceId: 'dead-discovery',
+      startedAt: '2026-09-11T12:00:00Z',
+    });
+
+    const missingText = toolErrorText(await rawStateCall(String(MISSING_PID)));
+    const deadText = toolErrorText(await rawStateCall(String(deadPid)));
+
+    expect(missingText).toContain(String(MISSING_PID));
+    expect(deadText).toContain(String(deadPid));
+    expect(missingText).not.toContain(currentDiscoveryToken);
+    expect(deadText).not.toContain('dead-discovery-token');
+    expect(requests).toEqual([]);
+  });
+
+  async function handleTarget(request: IncomingMessage, response: ServerResponse): Promise<void> {
+    const body = await readBody(request);
+    requests.push({
+      server: 'target',
+      method: request.method,
+      url: request.url,
+      authorization: request.headers.authorization,
+      contentType: request.headers['content-type'],
+      body,
+    });
+
+    if (mode === 'hang') {
+      trackAbortedResponse(request, response);
+      return;
+    }
+
+    if (mode === 'unauthorized' || request.headers.authorization !== `Bearer ${acceptedToken}`) {
+      if (refreshDiscoveryOnUnauthorized !== undefined) {
+        currentDiscoveryToken = refreshDiscoveryOnUnauthorized;
+        refreshDiscoveryOnUnauthorized = undefined;
+        await writeDiscovery({
+          pid: process.pid,
+          baseUrl: targetBaseUrl,
+          token: currentDiscoveryToken,
+          instanceId: 'headless-state-target',
+          startedAt: '2026-09-11T10:00:00Z',
+        });
+      }
+      sendText(response, 401, currentDiscoveryToken);
+      return;
+    }
+
+    if (request.method === 'GET' && request.url === '/v0/app/state') {
+      if (mode === 'not-found') {
+        sendJson(response, 404, {
+          type: 'problem',
+          title: 'Not found',
+          status: 404,
+          instance: '/v0/app/state',
+          code: 'not-found',
+          detail: 'No route matches GET /v0/app/state',
+        });
+      } else if (mode === 'invalid') {
+        sendJson(response, 200, { state: 'IDLE', uiSnapshotAvailable: false });
+      } else if (mode === 'lifecycle' && dialogOpen) {
+        sendJson(response, 200, {
+          state: 'BLOCKED',
+          blockedBy: 'MODAL_DIALOG',
+          uiSnapshotAvailable: true,
+          activeActivities: ['QUERYING'],
+          blockingWindows: [dialog],
+          progressWindows: [],
+        });
+      } else {
+        sendJson(response, 200, {
+          state: 'IDLE',
+          uiSnapshotAvailable: true,
+          activeActivities: [],
+          blockingWindows: [],
+          progressWindows: [],
+        });
+      }
+      return;
+    }
+
+    if (request.method === 'GET' && request.url === '/v0/app/dialogs') {
+      sendJson(response, 200, { dialogs: dialogOpen ? [dialog] : [] });
+      return;
+    }
+
+    if (request.method === 'POST' && request.url === '/v0/app:invokeDialogAction') {
+      const parsed = JSON.parse(body) as { dialog: Record<string, unknown>; action: unknown };
+      expect(parsed).toEqual({
+        dialog: {
+          objectName: dialog.objectName,
+          title: dialog.title,
+          className: dialog.className,
+        },
+        action: { kind: 'button', label: 'Discard' },
+      });
+      dialogOpen = false;
+      sendJson(response, 200, {
+        outcome: 'dismissed',
+        dialog: parsed.dialog,
+        action: parsed.action,
+        dialogs: [],
+      });
+      return;
+    }
+
+    sendJson(response, 404, {
+      code: 'not-found',
+      status: 404,
+      instance: request.url,
+    });
+  }
+
+  async function handleDecoy(request: IncomingMessage, response: ServerResponse): Promise<void> {
+    requests.push({
+      server: 'decoy',
+      method: request.method,
+      url: request.url,
+      authorization: request.headers.authorization,
+      contentType: request.headers['content-type'],
+      body: await readBody(request),
+    });
+    sendJson(response, 200, {
+      state: 'IDLE',
+      uiSnapshotAvailable: true,
+      activeActivities: [],
+      blockingWindows: [],
+      progressWindows: [],
+    });
+  }
+
+  function trackAbortedResponse(request: IncomingMessage, response: ServerResponse): void {
+    let counted = false;
+    const countOnce = (): void => {
+      if (!counted && !response.writableEnded) {
+        counted = true;
+        abortedRequests += 1;
+      }
+    };
+    request.once('aborted', countOnce);
+    response.once('close', countOnce);
+  }
+
+  async function writeDiscovery(args: {
+    pid: number;
+    baseUrl: string;
+    token: string;
+    instanceId: string;
+    startedAt: string;
+  }): Promise<void> {
+    await writeFile(
+      join(discoveryDir, `${args.pid}.json`),
+      JSON.stringify({
+        schemaVersion: 1,
+        instanceId: args.instanceId,
+        pid: args.pid,
+        baseUrl: args.baseUrl,
+        tokenType: 'Bearer',
+        token: args.token,
+        applicationVersion: 'headless-fixture',
+        apiVersion: '0.2.14',
+        startedAt: args.startedAt,
+      }),
+      'utf8',
+    );
+  }
+
+  async function readState(): Promise<ReturnType<typeof desktopStateSchema.parse>> {
+    return await requireClient().callTool('get-desktop-state', {
+      schema: desktopStateSchema,
+      toolArgs: { session: SESSION },
+    });
+  }
+
+  async function rawStateCall(
+    session: string,
+  ): Promise<Awaited<ReturnType<McpClient['client']['callTool']>>> {
+    return await requireClient().client.callTool({
+      name: 'get-desktop-state',
+      arguments: { session },
+    });
+  }
+
+  function requireClient(): McpClient {
+    if (!client) throw new Error('MCP client was not initialized.');
+    return client;
+  }
+
+  function targetStateRequests(): Array<ObservedRequest> {
+    return requests.filter(
+      ({ server, method, url }) =>
+        server === 'target' && method === 'GET' && url === '/v0/app/state',
+    );
+  }
+});
+
+async function startServer(
+  handler: (request: IncomingMessage, response: ServerResponse) => Promise<void>,
+): Promise<Server> {
+  const server = createServer((request, response) => {
+    void handler(request, response).catch((error) => {
+      if (!response.headersSent) {
+        sendJson(response, 500, { error: String(error) });
+      } else if (!response.writableEnded) {
+        response.end();
+      }
+    });
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', resolve);
+  });
+  return server;
+}
+
+function serverBaseUrl(server: Server): string {
+  const address = server.address() as AddressInfo;
+  return `http://127.0.0.1:${address.port}`;
+}
+
+function readBody(request: IncomingMessage): Promise<string> {
+  return new Promise((resolve) => {
+    let body = '';
+    request.on('data', (chunk) => {
+      body += String(chunk);
+    });
+    request.on('end', () => resolve(body));
+  });
+}
+
+function sendJson(response: ServerResponse, status: number, body: unknown): void {
+  response.writeHead(status, { 'content-type': 'application/json' });
+  response.end(JSON.stringify(body));
+}
+
+function sendText(response: ServerResponse, status: number, body: string): void {
+  response.writeHead(status, { 'content-type': 'text/plain' });
+  response.end(body);
+}
+
+function toolErrorText(result: unknown): string {
+  const parsed = CallToolResultSchema.parse(result);
+  expect(parsed.isError).toBe(true);
+  expect(parsed.content[0]?.type).toBe('text');
+  return parsed.content[0]?.type === 'text' ? parsed.content[0].text : JSON.stringify(parsed);
+}
+
+async function waitUntil(predicate: () => boolean, timeoutMs = 2000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() >= deadline) {
+      throw new Error('Timed out waiting for the hanging External API request to be aborted.');
+    }
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+}
+
+async function closeServer(server: Server): Promise<void> {
+  server.closeIdleConnections();
+  server.closeAllConnections();
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => {
+      if (error && (error as NodeJS.ErrnoException).code !== 'ERR_SERVER_NOT_RUNNING') {
+        reject(error);
+      } else {
+        resolve();
+      }
+    });
+  });
+}

--- a/tests/e2e/mcpClient.ts
+++ b/tests/e2e/mcpClient.ts
@@ -4,6 +4,7 @@ import { ErrorCode, Implementation, McpError } from '@modelcontextprotocol/sdk/t
 import { z } from 'zod';
 
 import { Variant } from '../../src/scripts/variants.js';
+import type { DesktopToolName } from '../../src/tools/desktop/toolName.js';
 import { WebToolName } from '../../src/tools/web/toolName.js';
 import invariant from '../../src/utils/invariant.js';
 import { getDefaultEnv } from '../testEnv.js';
@@ -80,7 +81,7 @@ export class McpClient {
   /**
    * Calls the MCP tool with the provided arguments.
    *
-   * @param {WebToolName} toolName The name of the tool to call
+   * @param {WebToolName | DesktopToolName} toolName The name of the tool to call
    * @param {({
    *     schema: Z;
    *     contentType?: 'text' | 'image';
@@ -94,7 +95,7 @@ export class McpClient {
    * @returns {*}  {Promise<z.infer<Z>>} The tool call result
    */
   async callTool<Z extends z.ZodTypeAny = z.ZodNever>(
-    toolName: WebToolName,
+    toolName: WebToolName | DesktopToolName,
     {
       schema,
       contentType,


### PR DESCRIPTION
## Decision

RULE WE NOW KEEP: Desktop clients use a single read-only state snapshot to decide whether an agentic workflow may continue, and obtain fresh dialog identity and actions before invoking any dialog action.

## Description

Adds the `get-desktop-state` Desktop tool backed by `GET /v0/app/state` at External Client API 0.2.14. The tool preserves the structured `IDLE` or `BLOCKED` state, strongest blocking cause, active application activities, UI snapshot completeness, and visible modal or progress window content returned by Tableau Desktop.

The Desktop recovery guidance now follows a bounded state-to-inspect-to-act-to-state sequence and keeps dialog actions tied to fresh exact dialog context. The package version is updated to 2.68.7.

## Motivation and Context

An agent needs to distinguish active work from an actionable modal, an opaque modal loop, and an unresponsive UI before deciding whether to wait, inspect a dialog, or hand control to the user. This closes the detection and reporting gap while preserving the existing safety rule that dialog actions are never guessed or blindly retried.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Other (please describe):

## How Has This Been Tested?

- `scripts/agent-check`
- `npm run build:desktop`
- `npx vitest run src/tools/desktop/api/getDesktopState.test.ts src/desktop/externalApi/discovery.test.ts src/desktop/externalApi/externalApiHttp.test.ts src/desktop/externalApi/externalApiContract.test.ts src/desktop/knowledge/corpusIntegrity.test.ts src/server.desktop.test.ts src/tools/toolName.test.ts`
- `npx vitest run --config ./vitest.config.e2e.ts tests/e2e/desktop/getDesktopState.test.ts`
- `npx tsc --noEmit`

## Related Issues

Related to #900.

## Checklist

- [x] I have updated the version in the package.json file by using `npm run version`. For example, use `npm run version:patch` for a patch version bump.
- [x] I have made any necessary changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have documented any breaking changes in the PR description. For example, renaming a config environment variable or changing its default value.

## Contributor Agreement

By submitting this pull request, I confirm that:

- [x] I have read the [CONTRIBUTING guidelines](../../CONTRIBUTING.md) for this project and followed its Contribution Checklist.
